### PR TITLE
fix(db): run each transaction on one checked-out connection

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -11,4 +11,12 @@ export interface SqlClient {
 
   /** Run a single parameterised statement and return its rows. */
   query<T = Record<string, unknown>>(sql: string, params?: readonly unknown[]): Promise<T[]>;
+
+  /**
+   * Check out a dedicated connection for a transaction, so every statement in it
+   * shares one connection. Present on pool-backed clients (see `PostgresClient`);
+   * absent on a single connection — PGlite, or a connection already checked out —
+   * where the client is used directly. `withTransaction` relies on this.
+   */
+  connect?(): Promise<{ client: SqlClient; release: () => void }>;
 }

--- a/packages/db/src/transaction.test.ts
+++ b/packages/db/src/transaction.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { withTransaction } from "./transaction.js";
+import type { SqlClient } from "./client.js";
+
+/**
+ * These tests model node-postgres pool semantics without a live server.
+ *
+ * `pg.Pool.query` acquires an arbitrary idle connection per call and releases it
+ * immediately, so a `BEGIN` and the statements after it can land on different
+ * connections — which silently voids both transaction atomicity and any
+ * `SELECT ... FOR UPDATE` a caller relies on. PGlite (single connection) hides
+ * this in the existing suite, so it is asserted here directly.
+ *
+ * The load-bearing invariant: every statement in one `withTransaction` must run
+ * on the same connection.
+ */
+
+type Op = { conn: string; sql: string };
+
+/** A single checked-out connection. Every statement records its own id. */
+class FakeConnection implements SqlClient {
+  released = 0;
+  constructor(
+    private readonly id: string,
+    private readonly log: Op[],
+  ) {}
+
+  async exec(sql: string): Promise<void> {
+    this.log.push({ conn: this.id, sql });
+  }
+
+  async query<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+    this.log.push({ conn: this.id, sql });
+    return [] as T[];
+  }
+
+  release(): void {
+    this.released += 1;
+  }
+}
+
+/**
+ * A pool: each top-level statement runs on a fresh ephemeral connection (the
+ * hazard), but `connect()` hands out one pinned connection whose statements all
+ * share an id.
+ */
+class FakePool implements SqlClient {
+  private ephemeral = 0;
+  private pinned: FakeConnection | null = null;
+  constructor(private readonly log: Op[]) {}
+
+  async exec(sql: string): Promise<void> {
+    this.ephemeral += 1;
+    this.log.push({ conn: `ephemeral-${this.ephemeral}`, sql });
+  }
+
+  async query<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+    this.ephemeral += 1;
+    this.log.push({ conn: `ephemeral-${this.ephemeral}`, sql });
+    return [] as T[];
+  }
+
+  async connect(): Promise<{ client: SqlClient; release: () => void }> {
+    const connection = new FakeConnection("pinned", this.log);
+    this.pinned = connection;
+    return { client: connection, release: () => connection.release() };
+  }
+
+  get released(): number {
+    return this.pinned?.released ?? 0;
+  }
+}
+
+/** A single-connection client with no checkout — models PGlite. */
+class SingleConnection implements SqlClient {
+  constructor(private readonly log: Op[]) {}
+
+  async exec(sql: string): Promise<void> {
+    this.log.push({ conn: "single", sql });
+  }
+
+  async query<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+    this.log.push({ conn: "single", sql });
+    return [] as T[];
+  }
+}
+
+function connections(log: Op[]): Set<string> {
+  return new Set(log.map((op) => op.conn));
+}
+
+describe("withTransaction", () => {
+  it("runs BEGIN, the work, and COMMIT on one checked-out connection", async () => {
+    const log: Op[] = [];
+    const pool = new FakePool(log);
+
+    await withTransaction(pool, async (tx) => {
+      await tx.exec("insert one");
+      await tx.query("insert two");
+    });
+
+    expect(log.map((op) => op.sql)).toEqual(["BEGIN", "insert one", "insert two", "COMMIT"]);
+    // The whole point: not scattered across pooled connections.
+    expect(connections(log)).toEqual(new Set(["pinned"]));
+    expect(pool.released).toBe(1);
+  });
+
+  it("rolls back on the same connection and still releases it", async () => {
+    const log: Op[] = [];
+    const pool = new FakePool(log);
+
+    await expect(
+      withTransaction(pool, async (tx) => {
+        await tx.exec("insert one");
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(log.map((op) => op.sql)).toEqual(["BEGIN", "insert one", "ROLLBACK"]);
+    expect(connections(log)).toEqual(new Set(["pinned"]));
+    expect(pool.released).toBe(1);
+  });
+
+  it("falls back to the client itself when it cannot check a connection out", async () => {
+    const log: Op[] = [];
+    const single = new SingleConnection(log);
+
+    await withTransaction(single, async (tx) => {
+      await tx.exec("work");
+    });
+
+    expect(log.map((op) => op.sql)).toEqual(["BEGIN", "work", "COMMIT"]);
+    expect(connections(log)).toEqual(new Set(["single"]));
+  });
+
+  it("rolls back a single-connection client on error", async () => {
+    const log: Op[] = [];
+    const single = new SingleConnection(log);
+
+    await expect(
+      withTransaction(single, async (tx) => {
+        await tx.exec("work");
+        throw new Error("nope");
+      }),
+    ).rejects.toThrow("nope");
+
+    expect(log.map((op) => op.sql)).toEqual(["BEGIN", "work", "ROLLBACK"]);
+  });
+});

--- a/packages/db/src/transaction.ts
+++ b/packages/db/src/transaction.ts
@@ -3,16 +3,29 @@ import type { SqlClient } from "./client.js";
 /**
  * Run `fn` inside a transaction, rolling back if it throws.
  *
- * Note for production: this issues BEGIN/COMMIT on whichever client it is given.
- * That is correct for PGlite (single connection) and for a checked-out
- * node-postgres client, but **not** for a pool — a pool hands each query to an
- * arbitrary connection, so the BEGIN and the work can land on different ones.
- * Check out a client first and pass that.
+ * BEGIN, the work, and COMMIT must all run on one connection — otherwise the
+ * transaction is not atomic and any `SELECT ... FOR UPDATE` inside `fn` holds no
+ * lock. A pool hands each statement to an arbitrary connection, so when the
+ * client can check one out (`connect`), this does, and runs the whole callback
+ * on that pinned connection. PGlite (single connection) and an already
+ * checked-out client have no `connect` and run directly.
  */
 export async function withTransaction<T>(
   db: SqlClient,
   fn: (tx: SqlClient) => Promise<T>,
 ): Promise<T> {
+  if (db.connect) {
+    const { client, release } = await db.connect();
+    try {
+      return await runTransaction(client, fn);
+    } finally {
+      release();
+    }
+  }
+  return runTransaction(db, fn);
+}
+
+async function runTransaction<T>(db: SqlClient, fn: (tx: SqlClient) => Promise<T>): Promise<T> {
   await db.exec("BEGIN");
   try {
     const result = await fn(db);


### PR DESCRIPTION
Closes #2.

## Problem

`withTransaction` issued `BEGIN`/`COMMIT` on whichever client it was given. Every route except `join` and `create` passes the pool, and node-postgres dispatches each `pool.query` to an arbitrary connection — so `BEGIN`, the callback's statements, and `COMMIT` land on different connections. The transaction is not atomic, any `SELECT ... FOR UPDATE` inside the callback holds no lock, and the connection that ran `BEGIN` returns to the pool still inside a transaction. PGlite is a single connection, so the existing suite never exercised this.

Affected paths: `recordPick`, `catchUpExpiredPicks`, `drawDraftOrder`, `setLineup`, `resolveLeagueWeek`, and the waiver add/drop/claim writes.

## Fix

`withTransaction` now checks out a dedicated connection when the client supports it — `PostgresClient` already exposes `connect()` — runs the whole callback on that pinned connection, and releases it in a `finally`. The behavior is centralized here so no call site can reintroduce the bug, rather than fixing each route individually.

Single-connection clients are unchanged: PGlite (`PGliteClient`) and an already checked-out connection (`PooledClient`) have no `connect`, so they take the direct path exactly as before. There is no nested `withTransaction` in the package, so pinning a connection introduces no re-entrancy hazard.

`connect?()` is added to the `SqlClient` interface as an optional method to express this.

## Tests

`transaction.test.ts` models pool-per-statement dispatch without a live server and asserts the load-bearing invariant — every statement in a transaction shares one connection. It fails against the previous implementation (statements scatter across three connections) and passes with this change; it also covers rollback-and-release on error and the single-connection fallback.

- `transaction.test.ts`: 4 pass
- full `@rostr/db` suite: 294 pass
- `pnpm typecheck`: clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)
