### PR TITLE
fix(season): lock a player once his own game has kicked off, not just his slot

### DIFF
--- a/packages/core/src/season/lineup.test.ts
+++ b/packages/core/src/season/lineup.test.ts
@@ -308,10 +308,25 @@ describe("locks", () => {
     expect(codes(problems)).toEqual(["SLOT_LOCKED"]);
   });
 
-  it("never locks an empty slot", () => {
-    // A manager who left a slot empty can still fill it on Sunday: nothing has
-    // happened in that slot for anyone to react to. Locking empty slots at the
-    // week's first kickoff would punish forgetting rather than prevent cheating.
+  it("does not lock an empty slot when the incoming player has not kicked off", () => {
+    // A manager who left a slot empty can still fill it after the week's first
+    // kickoff, as long as the player going in has not played yet: nothing has
+    // happened for anyone to react to. rb1's Sunday game is still ahead here.
+    const problems = validateLineup({
+      assignments: [{ slotType: "RB", slotIndex: 0, playerId: "rb1" }],
+      current: [{ slotType: "RB", slotIndex: 0, playerId: null }],
+      shape: SHAPE,
+      roster: MIXED,
+      now: DURING_THURSDAY,
+    });
+
+    expect(problems).toEqual([]);
+  });
+
+  it("rejects starting a player whose own game has already kicked off", () => {
+    // The other half of a per-player lock. An empty slot never locks, but that
+    // must not let a manager leave it empty, watch a player score, and then
+    // start him. rb1 plays Sunday; by SUNDAY_LATE his game is under way.
     const problems = validateLineup({
       assignments: [{ slotType: "RB", slotIndex: 0, playerId: "rb1" }],
       current: [{ slotType: "RB", slotIndex: 0, playerId: null }],
@@ -320,7 +335,21 @@ describe("locks", () => {
       now: SUNDAY_LATE,
     });
 
-    expect(problems).toEqual([]);
+    expect(codes(problems)).toEqual(["PLAYER_LOCKED"]);
+  });
+
+  it("rejects moving an already-played player into a different slot", () => {
+    // The swap variant: wr3's game (SUNDAY_LATE) is under way, so he cannot be
+    // moved into the flex even though the flex itself is empty.
+    const problems = validateLineup({
+      assignments: [{ slotType: "FLEX", slotIndex: 0, playerId: "wr3" }],
+      current: [{ slotType: "FLEX", slotIndex: 0, playerId: null }],
+      shape: SHAPE,
+      roster: MIXED,
+      now: SUNDAY_LATE + 60,
+    });
+
+    expect(codes(problems)).toEqual(["PLAYER_LOCKED"]);
   });
 
   it("never locks a player on a bye", () => {

--- a/packages/core/src/season/lineup.ts
+++ b/packages/core/src/season/lineup.ts
@@ -49,6 +49,7 @@ export type LineupProblemCode =
   | "PLAYER_TWICE"
   | "POSITION_NOT_ELIGIBLE"
   | "SLOT_LOCKED"
+  | "PLAYER_LOCKED"
   | "STARTER_EMPTY";
 
 export interface LineupProblem {
@@ -157,6 +158,27 @@ export function validateLineup(input: ValidateLineupInput): readonly LineupProbl
       problems.push({
         code: "NOT_ON_ROSTER",
         message: `${assignment.playerId} is not on this roster`,
+        slotType: assignment.slotType,
+        slotIndex: assignment.slotIndex,
+        playerId: assignment.playerId,
+      });
+      continue;
+    }
+
+    // A player whose own game has kicked off can only be kept where he already
+    // is, never moved into a slot. The check above guards the player leaving a
+    // slot; without this one, an empty slot — which never locks — would let a
+    // manager start a player after watching him score.
+    if (
+      now !== undefined &&
+      currentBySlot.get(slotKey) !== assignment.playerId &&
+      isSlotLocked(assignment.playerId, roster, now)
+    ) {
+      problems.push({
+        code: "PLAYER_LOCKED",
+        message:
+          `${assignment.playerId}'s game has kicked off — ` +
+          `they can no longer be started in ${assignment.slotType} slot ${assignment.slotIndex + 1}`,
         slotType: assignment.slotType,
         slotIndex: assignment.slotIndex,
         playerId: assignment.playerId,


### PR DESCRIPTION
Closes #4.

## Problem

The per-player kickoff lock in `validateLineup` checked only the player **leaving** a slot, never the one **arriving**. Since an empty slot never locks, a manager could leave a starting slot empty, wait for a bench player's game to be played, and then start him — scoring points from a result already known. `setLineup` validates crafted requests against stored state with `now`, so this was reachable server-side, not just in the UI.

## Fix

`validateLineup` now also rejects an assignment whose **incoming** player's game has already kicked off, unless that player is the one already stored in the slot. Keeping a locked player stays legal, so submitting a full lineup on Sunday does not fail on a Thursday slot that cannot change.

The autolineup is intentionally untouched: `autoFillLineup` writes through `setLineupUnchecked`, which bypasses validation because it must place players at scoring time, when every game has started.

## Tests

The existing "empty slot" test filled a slot with a player whose game had **already** started — which was the hole itself. It now fills with a player still to play (so the legitimate "fill an empty slot after Thursday's kickoff" case is preserved), and two new tests assert the rejection: inserting an already-played player into an empty slot, and moving one into a different slot.

- `packages/core/src/season/lineup.test.ts` and `packages/db/src/lineups.test.ts`: 57 pass
- `pnpm typecheck`: clean

The db-level lock tests (`setLineup` refuses to move a started player; still allows the rest to move) and the autofill tests are unchanged and green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
