### PR TITLE
fix(db): reject a partial lineup update that duplicates a starting player

### DIFF
--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -221,6 +221,58 @@ describe("setLineup", () => {
     expect(saved.filter((s) => s.playerId !== null)).toHaveLength(9);
   });
 
+  it("rejects a partial update that duplicates a player already starting elsewhere", async () => {
+    // The write touches only the sent slots, so validation must catch a player
+    // who already starts in a slot this update does not overwrite — otherwise he
+    // ends up in two, and the duplicate crashes scoring for the whole league
+    // when the week resolves.
+    const fx = await setup();
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, FULL),
+      now: BEFORE_ANYTHING,
+    });
+
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        // rb-a already starts at RB:0, which this update leaves untouched.
+        assignments: lineupOf(fx, { "FLEX:0": "rb-a" }),
+        now: BEFORE_ANYTHING,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_LINEUP" });
+  });
+
+  it("allows moving a player when the same update vacates his old slot", async () => {
+    // The counter-case the duplicate check must not break: rb-a moves to FLEX
+    // while RB:0 is reassigned in the same request, so he is not in two slots.
+    const fx = await setup();
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, FULL),
+      now: BEFORE_ANYTHING,
+    });
+
+    const saved = await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, { "FLEX:0": "rb-a", "RB:0": "rb-c" }),
+      now: BEFORE_ANYTHING,
+    });
+
+    expect(saved.find((s) => s.slotType === "FLEX")?.playerId).toBe(fx.players.get("rb-a"));
+    expect(saved.find((s) => s.slotType === "RB" && s.slotIndex === 0)?.playerId).toBe(
+      fx.players.get("rb-c"),
+    );
+  });
+
   it("reads back every slot, empty ones included", async () => {
     // A caller should see the shape of the lineup, not only the filled parts.
     const fx = await setup();

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -190,13 +190,45 @@ export async function setLineup(
   const roster = await loadRosterForWeek(db, input.teamId, season, input.week);
   const current = await loadLineup(db, input.teamId, input.week, stored.rules);
 
-  const problems = validateLineup({
-    assignments: input.assignments,
-    shape: buildRosterShape(stored.rules.roster, NFL),
-    roster,
-    current,
-    now: input.now,
-  });
+  const problems = [
+    ...validateLineup({
+      assignments: input.assignments,
+      shape: buildRosterShape(stored.rules.roster, NFL),
+      roster,
+      current,
+      now: input.now,
+    }),
+  ];
+
+  // The write touches only the submitted slots, so validateLineup — which sees
+  // only those — cannot tell that a submitted player already starts in a slot
+  // this update leaves alone. That would persist him in two slots, and the
+  // duplicate throws in scoring and stalls the whole league's week. Reject a
+  // player who already occupies a different slot this update does not overwrite.
+  const submittedSlots = new Set(
+    input.assignments.map((a) => `${a.slotType}#${a.slotIndex}`),
+  );
+  for (const assignment of input.assignments) {
+    if (assignment.playerId === null) continue;
+    const here = `${assignment.slotType}#${assignment.slotIndex}`;
+    const elsewhere = current.find(
+      (slot) =>
+        slot.playerId === assignment.playerId &&
+        `${slot.slotType}#${slot.slotIndex}` !== here &&
+        !submittedSlots.has(`${slot.slotType}#${slot.slotIndex}`),
+    );
+    if (elsewhere) {
+      problems.push({
+        code: "PLAYER_TWICE",
+        message:
+          `${assignment.playerId} is already starting at ${elsewhere.slotType} ` +
+          `slot ${elsewhere.slotIndex + 1}`,
+        slotType: assignment.slotType,
+        slotIndex: assignment.slotIndex,
+        playerId: assignment.playerId,
+      });
+    }
+  }
 
   if (problems.length > 0) {
     throw new LineupError(


### PR DESCRIPTION
Closes #7.

## Problem

`setLineup` writes only the slots it is sent but validated only those same slots. A one-slot `PUT` naming a player who already starts in a different, untouched slot passed validation and persisted him in two starting slots. Scoring throws on the duplicate (`results.ts`), and the throw is caught per-league in `/api/cron/score-week` as "skipped" — so no matchup in that league is scored or finalized on any run until the row is fixed by hand. One request stalls scoring, standings, and payout for the whole league.

## Fix

`setLineup` now also rejects a submitted player who already occupies a **different** slot that this update does not overwrite. It deliberately does not re-validate untouched slots: a dropped player can still sit in a stored slot (a drop sets `released_at` but does not clear the lineup), so blanket re-validation of the merged lineup would wrongly reject unrelated edits. Moving a player while the same request reassigns his old slot stays legal.

## Tests

- Rejects a partial update that duplicates a player already starting elsewhere (was accepted before).
- Still allows moving a player when the same update vacates his old slot.
- `packages/db/src/lineups.test.ts` + `week.test.ts`: 40 pass; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
