### PR TITLE
fix(web): reject control characters and backslash in safeRedirect

### DIFF
--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -72,5 +72,13 @@ export function safeRedirect(next: string | null): string {
   if (!next.startsWith("/")) return "/";
   // `//host` and `/\host` are protocol-relative; browsers treat them as absolute.
   if (next.startsWith("//") || next.startsWith("/\\")) return "/";
+  // The URL parser strips tabs, newlines and carriage returns *before* parsing,
+  // so a value like `/<TAB>/evil.com` slips past the checks above and then
+  // resolves to `//evil.com`. A prefix blocklist cannot cover that; reject any
+  // control character (including DEL) or backslash (0x5c) outright.
+  for (let i = 0; i < next.length; i++) {
+    const code = next.charCodeAt(i);
+    if (code <= 0x1f || code === 0x5c || code === 0x7f) return "/";
+  }
   return next;
 }


### PR DESCRIPTION
Closes #11.

## Problem

`safeRedirect` blocked `//host` and `/\host` by prefix but not values containing a tab, newline, or carriage return. The WHATWG URL parser strips those before parsing, so `/<TAB>/evil.com` passed every check and then resolved to `//evil.com` in the verify route's `new URL(next, origin)`. Because `next` rides in the emailed sign-in link and the redirect fires only after a successful sign-in, this is an open redirect that lands a freshly-authenticated user on a look-alike site from a link in their own inbox.

## Fix

A prefix blocklist cannot cover parser normalization, so `safeRedirect` now rejects any control character (0x00–0x1f, 0x7f) or backslash (0x5c) outright. Legitimate paths are unaffected.

## Verification

`apps/web` has no vitest harness (the runner includes only `packages/*/src/**`), so this is verified with a standalone reproduction rather than an in-suite test:

```
tab / newline / carriage return  ->  old resolves OFFSITE, new returns "/"
/leagues/123?tab=roster          ->  unchanged
```

3 bypasses closed, 0 legitimate-path regressions; `pnpm typecheck` clean. Adding a minimal web test project would let lib-level fixes like this be covered directly — flagged in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
