### PR TITLE
fix(db): refuse a migration older than the latest applied version

### DIFF
--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -60,6 +60,25 @@ describe("migrate", () => {
     await expect(migrate(client, tampered)).rejects.toThrow(/forward-only/);
   });
 
+  it("refuses a migration older than the latest applied version", async () => {
+    // Forward-only: two branches can number migrations independently, and if the
+    // higher one deploys first, applying the lower one afterwards would build the
+    // schema in an order it was never tested in.
+    const client = await fresh();
+    const mig = (version: number, name: string) => ({
+      version,
+      name,
+      filename: `${String(version).padStart(4, "0")}_${name}.sql`,
+      sql: `CREATE TABLE t_${name} (id int);`,
+      checksum: String(version).padEnd(64, "0"),
+    });
+
+    await migrate(client, [mig(9999, "later")]);
+
+    await expect(migrate(client, [mig(9998, "earlier")])).rejects.toThrow(MigrationError);
+    await expect(migrate(client, [mig(9998, "earlier")])).rejects.toThrow(/forward-only|older/i);
+  });
+
   it("rolls back a failing migration rather than half-applying it", async () => {
     const client = await fresh();
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -111,6 +111,7 @@ export async function migrate(
     "SELECT version, name, checksum FROM schema_migrations",
   );
   const byVersion = new Map(applied.map((row) => [Number(row.version), row]));
+  const maxApplied = applied.reduce((max, row) => Math.max(max, Number(row.version)), 0);
 
   const didApply: string[] = [];
   const didSkip: string[] = [];
@@ -129,6 +130,18 @@ export async function migrate(
       }
       didSkip.push(migration.filename);
       continue;
+    }
+
+    // Forward-only means forward. A new migration must be newer than everything
+    // already applied; a lower unapplied version means two branches numbered
+    // migrations independently and the higher one deployed first. Applying the
+    // lower one now would build the schema in an order it was never tested in.
+    if (migration.version < maxApplied) {
+      throw new MigrationError(
+        `Migration ${migration.filename} (version ${migration.version}) is older than ` +
+          `the latest applied version (${maxApplied}). ` +
+          `Migrations are forward-only — renumber it above ${maxApplied} and rebase.`,
+      );
     }
 
     await db.exec("BEGIN");


### PR DESCRIPTION
Closes #13.

## Problem

`migrate` applied any migration whose version was absent from `schema_migrations`, regardless of whether a higher version had already been applied. It enforced that applied files are not edited (checksum), but not that new files move forward — the other half of "forward-only." Two branches numbering `0014`/`0015` independently could apply `0014` after `0015` in an environment that deployed `0015` first, building the schema in an untested order with no error.

## Fix

The runner computes the maximum applied version and throws if a pending migration is below it. Migrations load in ascending order already, so a full apply and re-runs are unaffected.

## Tests

- New: applying version N then attempting N−1 is refused (was applied silently before).
- Existing migration suite (full apply, idempotent, edited-file refusal, rollback) unchanged: 18 pass; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
