### PR TITLE
fix(db): refuse TRUNCATE on the immutable rule tables

### DIFF
--- a/packages/db/migrations/0017_immutable_rules_no_truncate.sql
+++ b/packages/db/migrations/0017_immutable_rules_no_truncate.sql
@@ -1,0 +1,26 @@
+-- Immutable rule tables must also refuse TRUNCATE.
+--
+-- The immutability triggers in 0004 are BEFORE UPDATE OR DELETE ... FOR EACH ROW.
+-- Row-level triggers do not fire on TRUNCATE, so `TRUNCATE league_rules` (or the
+-- two denormalised copies) would wipe the hashed rules without any trigger
+-- firing — while the on-chain hash and members' signatures still point at them.
+-- 0007 revokes TRUNCATE from the Data-API roles, but the app connects as the
+-- owning role, which is not stopped by that grant. A statement-level trigger is.
+
+CREATE FUNCTION reject_rule_truncate() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'league rules are immutable and cannot be truncated';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER league_rules_no_truncate
+  BEFORE TRUNCATE ON league_rules
+  FOR EACH STATEMENT EXECUTE FUNCTION reject_rule_truncate();
+
+CREATE TRIGGER league_scoring_rules_no_truncate
+  BEFORE TRUNCATE ON league_scoring_rules
+  FOR EACH STATEMENT EXECUTE FUNCTION reject_rule_truncate();
+
+CREATE TRIGGER league_roster_slots_no_truncate
+  BEFORE TRUNCATE ON league_roster_slots
+  FOR EACH STATEMENT EXECUTE FUNCTION reject_rule_truncate();

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -202,6 +202,20 @@ describe("league_rules immutability", () => {
     ).rejects.toThrow(/immutable/i);
   });
 
+  it("rejects TRUNCATE at the database level", async () => {
+    // Row-level BEFORE UPDATE/DELETE triggers do not fire on TRUNCATE, so without
+    // a statement-level guard the app's own role could wipe the immutable rules
+    // while the on-chain hash still pointed at them.
+    const client = await fresh();
+    const leagueId = await seedLeague(client, HASH);
+    await client.query(
+      "INSERT INTO league_rules (league_id, rule_json, canonical, hash) VALUES ($1, $2, $3, $4)",
+      [leagueId, JSON.stringify({ a: 1 }), '{"a":1}', HASH],
+    );
+
+    await expect(client.query("TRUNCATE league_rules")).rejects.toThrow(/immutable/i);
+  });
+
   it("rejects a rule set whose hash disagrees with its league", async () => {
     const client = await fresh();
     const leagueId = await seedLeague(client, HASH);


### PR DESCRIPTION
Closes #15.

## Problem

The immutability triggers on `league_rules`, `league_scoring_rules`, and `league_roster_slots` (0004) are `BEFORE UPDATE OR DELETE ... FOR EACH ROW`. Row-level triggers do not fire on `TRUNCATE`, so `TRUNCATE league_rules` wiped the hashed rules with no trigger firing, while the on-chain hash still pointed at them. 0007 revokes TRUNCATE from the Data-API roles, but the app's own owning role is not restricted by that.

## Fix

A forward-only migration (`0017`) adds statement-level `BEFORE TRUNCATE ... FOR EACH STATEMENT` triggers on the three frozen tables, using a separate trigger function (`OLD`/`NEW` are unavailable in a TRUNCATE trigger).

## Tests

- New: `TRUNCATE league_rules` is rejected (succeeded before). Confirms PGlite honors statement-level TRUNCATE triggers.
- Full migration + immutability suite: 18 pass; `pnpm typecheck` clean. No code truncates these tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
