### PR TITLE
fix(escrow): verify the on-chain economic terms at anchor, not just the hash

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { clusterOf, verifyLeagueAnchor } from "@rostr/escrow";
+import { anchorTermMismatches, clusterOf, payoutArray, verifyLeagueAnchor } from "@rostr/escrow";
 import { getChainState, getLeagueRules, recordChainAnchor } from "@rostr/db";
 import { db } from "@/lib/db";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
@@ -106,6 +106,37 @@ export async function POST(
             },
             { status: 409 },
           );
+    }
+
+    // The hash matches, but the program stores the economic terms as a separate
+    // copy it cannot check against the hash — so a matching hash does not prove a
+    // matching buy-in, refund unlock, fee recipient or payout split. Compare the
+    // terms the signed rules imply against what the account actually holds, and
+    // refuse an anchor that diverges: like a hash mismatch, it is a league nobody
+    // should join or deposit into, and the account can never be corrected.
+    const pot = stored.rules.pot;
+    const mismatches = anchorTermMismatches(verdict.league, {
+      hasPot: pot !== null,
+      maxTeams: stored.rules.league.maxTeams,
+      buyIn: pot?.buyInBaseUnits ?? "0",
+      refundUnlockAt: pot?.refundUnlockAt ?? 0,
+      tokenMint: pot?.tokenMint ?? "",
+      feeBps: pot?.feeBps ?? 0,
+      feeRecipient: pot?.feeRecipient ?? "",
+      payoutBps: pot ? payoutArray(pot.payout) : [0, 0, 0, 0, 0],
+    });
+
+    if (mismatches.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "The on-chain league holds different terms than the rules shown here. Do not let " +
+            "anyone join or deposit: the account was initialised with terms nobody agreed to.",
+          reason: "TERMS_MISMATCH",
+          mismatches,
+        },
+        { status: 409 },
+      );
     }
 
     // The cluster is read off the endpoint we just queried, not accepted from

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -8,12 +8,14 @@
 
 export { ESCROW_IDL, type EscrowIdl } from "./idl.js";
 export {
+  anchorTermMismatches,
   bytesToHex,
   clusterOf,
   fetchOnChainLeague,
   hexToBytes,
   verifyLeagueAnchor,
   type AnchorVerdict,
+  type ExpectedTerms,
   type OnChainLeague,
 } from "./verify.js";
 export {

--- a/packages/escrow/src/verify.test.ts
+++ b/packages/escrow/src/verify.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { anchorTermMismatches } from "./verify.js";
+import type { ExpectedTerms, OnChainLeague } from "./verify.js";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * The security property: verifying a league anchor by its rules hash is not
+ * enough, because the program stores the economic terms as a separate copy the
+ * hash cannot bind. anchorTermMismatches is what catches a benign-hash /
+ * hostile-terms anchor before it is recorded.
+ */
+
+const MINT = "So11111111111111111111111111111111111111112";
+const FEE_TO = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+
+const RECIPIENT = new PublicKey(FEE_TO);
+
+function onChain(overrides: Partial<OnChainLeague> = {}): OnChainLeague {
+  return {
+    address: PublicKey.default,
+    rulesHash: "a".repeat(64),
+    hasPot: true,
+    buyIn: "5000000",
+    tokenMint: MINT,
+    refundUnlockAt: 1_773_000_000,
+    feeBps: 100,
+    feeRecipient: FEE_TO,
+    payoutBps: [6000, 1500, 1000, 1000, 500],
+    maxTeams: 12,
+    memberCount: 0,
+    ...overrides,
+  };
+}
+
+const EXPECTED: ExpectedTerms = {
+  hasPot: true,
+  maxTeams: 12,
+  buyIn: "5000000",
+  refundUnlockAt: 1_773_000_000,
+  tokenMint: MINT,
+  feeBps: 100,
+  feeRecipient: FEE_TO,
+  payoutBps: [6000, 1500, 1000, 1000, 500],
+};
+
+describe("anchorTermMismatches", () => {
+  it("passes when every term matches the signed rules", () => {
+    expect(anchorTermMismatches(onChain(), EXPECTED)).toEqual([]);
+  });
+
+  it("catches a buy-in that exceeds what members agreed to", () => {
+    const m = anchorTermMismatches(onChain({ buyIn: "50000000" }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/buyIn/);
+  });
+
+  it("catches a refund unlock pushed far past settlement (funds stuck)", () => {
+    const m = anchorTermMismatches(onChain({ refundUnlockAt: 4_102_444_800 }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/refundUnlockAt/);
+  });
+
+  it("catches a redirected fee recipient", () => {
+    const attacker = PublicKey.default.toBase58();
+    const m = anchorTermMismatches(onChain({ feeRecipient: attacker }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/feeRecipient/);
+  });
+
+  it("catches a raised fee", () => {
+    expect(anchorTermMismatches(onChain({ feeBps: 500 }), EXPECTED)[0]).toMatch(/feeBps/);
+  });
+
+  it("catches a reshuffled payout split", () => {
+    const m = anchorTermMismatches(onChain({ payoutBps: [1500, 6000, 1000, 1000, 500] }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/payoutBps/);
+  });
+
+  it("catches a different token mint", () => {
+    const other = RECIPIENT.toBase58();
+    expect(anchorTermMismatches(onChain({ tokenMint: other }), EXPECTED)[0]).toMatch(/tokenMint/);
+  });
+
+  it("catches an unbounded max_teams", () => {
+    expect(anchorTermMismatches(onChain({ maxTeams: 255 }), EXPECTED)[0]).toMatch(/maxTeams/);
+  });
+
+  it("catches a free on-chain account standing in for a pot league", () => {
+    // has_pot=false with zeroed terms, anchored under a pot league's hash.
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: 0,
+      feeBps: 0,
+      payoutBps: [0, 0, 0, 0, 0],
+    });
+    const m = anchorTermMismatches(free, EXPECTED);
+    expect(m.some((x) => /hasPot/.test(x))).toBe(true);
+  });
+
+  it("passes a genuine free league and does not compare its money terms", () => {
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: 0,
+      tokenMint: PublicKey.default.toBase58(),
+      feeBps: 0,
+      feeRecipient: PublicKey.default.toBase58(),
+      payoutBps: [0, 0, 0, 0, 0],
+    });
+    const expectedFree: ExpectedTerms = { ...EXPECTED, hasPot: false };
+    expect(anchorTermMismatches(free, expectedFree)).toEqual([]);
+  });
+
+  it("reports every hostile field at once", () => {
+    const m = anchorTermMismatches(
+      onChain({ buyIn: "50000000", feeBps: 500, refundUnlockAt: 4_102_444_800 }),
+      EXPECTED,
+    );
+    expect(m.length).toBe(3);
+  });
+});

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -32,7 +32,13 @@ export interface OnChainLeague {
   /** Base units as a decimal string. Zero for a free league. */
   readonly buyIn: string;
   readonly tokenMint: string;
+  /** Unix seconds after which a stake may be withdrawn unilaterally. */
+  readonly refundUnlockAt: number;
   readonly feeBps: number;
+  /** Base58; where the settlement fee is paid. */
+  readonly feeRecipient: string;
+  /** Payout split in basis points, positional (see `PRIZE_ORDER`). */
+  readonly payoutBps: readonly number[];
   readonly maxTeams: number;
   readonly memberCount: number;
 }
@@ -82,7 +88,10 @@ export async function fetchOnChainLeague(
     hasPot: boolean;
     buyIn: { toString(): string };
     tokenMint: PublicKey;
+    refundUnlockAt: { toNumber(): number };
     feeBps: number;
+    feeRecipient: PublicKey;
+    payoutBps: number[];
     maxTeams: number;
     memberCount: number;
   };
@@ -93,7 +102,10 @@ export async function fetchOnChainLeague(
     hasPot: raw.hasPot,
     buyIn: raw.buyIn.toString(),
     tokenMint: raw.tokenMint.toBase58(),
+    refundUnlockAt: raw.refundUnlockAt.toNumber(),
     feeBps: raw.feeBps,
+    feeRecipient: raw.feeRecipient.toBase58(),
+    payoutBps: [...raw.payoutBps],
     maxTeams: raw.maxTeams,
     memberCount: raw.memberCount,
   };
@@ -138,6 +150,76 @@ export async function verifyLeagueAnchor(
   }
 
   return { ok: true, league };
+}
+
+/**
+ * The terms a league's *signed rules* say its on-chain account should hold.
+ *
+ * The caller builds this from the canonical rule set it already has — the escrow
+ * package does not depend on the rules schema, so the mapping (and the payout
+ * ordering; see `PRIZE_ORDER` / `payoutArray`) stays with the caller. Every field
+ * here is one the program stores independently of `rules_hash`.
+ */
+export interface ExpectedTerms {
+  readonly hasPot: boolean;
+  readonly maxTeams: number;
+  /** Base units as a decimal string. Only compared for a pot league. */
+  readonly buyIn: string;
+  readonly refundUnlockAt: number;
+  readonly tokenMint: string;
+  readonly feeBps: number;
+  readonly feeRecipient: string;
+  readonly payoutBps: readonly number[];
+}
+
+/**
+ * Every on-chain economic term that disagrees with the signed rules.
+ *
+ * `verifyLeagueAnchor` proves the chain holds *our hash*; it cannot prove the
+ * chain holds *our terms*, because the program stores them as a separate copy it
+ * has no way to check against the hash. So a creator can anchor the benign
+ * document members sign while initialising the account with a hostile buy-in,
+ * refund unlock, fee recipient or payout split — and members who verified only
+ * the hash would deposit against terms they never agreed to. Closing that is the
+ * caller's job: derive the expected terms from the same signed rules and assert
+ * the account matches, refusing the anchor otherwise.
+ *
+ * Returns an empty array when everything agrees.
+ */
+export function anchorTermMismatches(
+  onChain: OnChainLeague,
+  expected: ExpectedTerms,
+): string[] {
+  const out: string[] = [];
+  const ne = (label: string, got: unknown, want: unknown): void => {
+    if (got !== want) out.push(`${label}: on-chain ${String(got)}, expected ${String(want)}`);
+  };
+
+  ne("hasPot", onChain.hasPot, expected.hasPot);
+  ne("maxTeams", onChain.maxTeams, expected.maxTeams);
+
+  // The money terms only mean anything for a pot league; a free one carries
+  // zeroes/defaults for all of them, and the hasPot check above already caught a
+  // pot-vs-free divergence.
+  if (expected.hasPot && onChain.hasPot) {
+    ne("buyIn", onChain.buyIn, expected.buyIn);
+    ne("refundUnlockAt", onChain.refundUnlockAt, expected.refundUnlockAt);
+    ne("tokenMint", onChain.tokenMint, expected.tokenMint);
+    ne("feeBps", onChain.feeBps, expected.feeBps);
+    ne("feeRecipient", onChain.feeRecipient, expected.feeRecipient);
+
+    if (
+      onChain.payoutBps.length !== expected.payoutBps.length ||
+      onChain.payoutBps.some((v, i) => v !== expected.payoutBps[i])
+    ) {
+      out.push(
+        `payoutBps: on-chain [${onChain.payoutBps.join(",")}], ` +
+          `expected [${expected.payoutBps.join(",")}]`,
+      );
+    }
+  }
+
+  return out;
 }
 
 /**


### PR DESCRIPTION
Addresses #6.

## Problem

`verifyLeagueAnchor` confirmed the chain held our rules hash but checked none of the economic terms — `buy_in`, `refund_unlock_at`, `token_mint`, `fee_bps`, `fee_recipient`, `payout_bps`, `max_teams`. The program stores those as a copy separate from `rules_hash`, and cannot bind them to the hash itself. Because the commissioner signs `initialize_league` from their own wallet, they could anchor the benign document members sign while initialising the account with hostile terms:

- `refund_unlock_at` in 2100 → the timelock refund never unlocks; deposits are **permanently stuck**.
- `fee_recipient` = attacker, `fee_bps` = 500 → the settlement fee is skimmed.
- `buy_in` = $50 against a signed $5.

Three of those fields (`refund_unlock_at`, `fee_recipient`, `payout_bps`) were not even read back off the account.

## Fix

- `OnChainLeague` / `fetchOnChainLeague` now expose `refundUnlockAt`, `feeRecipient`, and `payoutBps`.
- New pure `anchorTermMismatches(onChain, expected)` compares every economic term, using `PRIZE_ORDER` for the payout array (not the `PrizeKey` declaration order, which differs and would pass silently).
- The anchor route derives the expected terms from the same `stored.rules` and rejects a divergent account with `TERMS_MISMATCH` before recording — like a hash mismatch, a league nobody should join. This also catches a free on-chain account standing in for a pot league (`has_pot`) and an out-of-range `max_teams`.

## Why it doesn't break legitimate anchors

`AnchorPanel` builds `initialize_league` from `stored.rules.pot` / `stored.rules.league.maxTeams` — the exact sources the route compares against — so a real anchor matches with zero mismatches. The check fires only on a hand-crafted initialise that diverges from the signed rules.

## Tests

`packages/escrow/src/verify.test.ts` (runs in the main suite, no validator needed): 11 cases — pass on a matching account; catch a hostile buy-in, a year-2100 refund unlock, a redirected fee recipient, a raised fee, a reshuffled payout, a different mint, an unbounded `max_teams`, and a free account posing as a pot league; and confirm a genuine free league passes without its money terms being compared. `pnpm typecheck` clean; 22 escrow tests pass.

The route's RPC integration itself isn't exercised here (no validator in this environment); the security-critical comparison it calls is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
