### PR TITLE
fix(db): derive the playoff bracket from finalised scores, and sweep paying weeks

### DIFF
--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -5,6 +5,7 @@ import {
   enterPlayoffs,
   PlayoffError,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
   WeekError,
 } from "@rostr/db";
 import { db } from "@/lib/db";
@@ -93,13 +94,20 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     try {
-      const outcome = await resolveLeagueWeek(client, league.id, week, now);
+      // A single explicit week is targeted directly; otherwise sweep every
+      // still-unfinalised week up to the current one, so a paying week (168h
+      // window) finalises even after the pointer has moved past it to the
+      // playoffs. The current week's outcome is what the status line reports.
+      const outcomes = Number.isFinite(requestedWeek)
+        ? [await resolveLeagueWeek(client, league.id, week, now)]
+        : await resolveLeagueWeeksThrough(client, league.id, week, now);
+      const outcome = outcomes.find((o) => o.week === week) ?? outcomes.at(-1);
       scored.push({
         leagueId: league.id,
         name: league.name,
-        matchups: outcome.matchups,
-        finalized: outcome.finalized,
-        ...(outcome.holdReason ? { holdReason: outcome.holdReason } : {}),
+        matchups: outcome?.matchups ?? 0,
+        finalized: outcome?.finalized ?? true,
+        ...(outcome?.holdReason ? { holdReason: outcome.holdReason } : {}),
         ...(bracketGames > 0 ? { bracketGames } : {}),
       });
     } catch (error) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -82,6 +82,7 @@ export {
   type MatchupPhase,
   persistSchedule,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
   WeekError,
   type ResolveWeekOutcome,
 } from "./week.js";

--- a/packages/db/src/playoffs.test.ts
+++ b/packages/db/src/playoffs.test.ts
@@ -96,6 +96,22 @@ async function score(
   );
 }
 
+/** Points written, but `finalized_at` left NULL — a live or within-window score. */
+async function scoreProvisional(
+  fx: Fixture,
+  week: number,
+  homeTeamId: string,
+  homePoints: number,
+  awayPoints: number,
+): Promise<void> {
+  await fx.client.query(
+    `UPDATE matchups
+        SET home_milli_points = $3, away_milli_points = $4
+      WHERE league_id = $1 AND week = $2 AND home_team_id = $5 AND phase <> 'REGULAR'`,
+    [fx.leagueId, week, homePoints, awayPoints, homeTeamId],
+  );
+}
+
 async function fixtures(fx: Fixture, week: number) {
   return fx.client.query<{ home_team_id: string; away_team_id: string; phase: string }>(
     `SELECT home_team_id, away_team_id, phase FROM matchups
@@ -311,6 +327,49 @@ describe("advancing round by round", () => {
     const result = await championship(fx.client, fx.leagueId);
     expect(result.champion).toBeNull();
     expect(result.complete).toBe(false);
+  });
+});
+
+describe("advances and crowns only on finalised results", () => {
+  it("does not lay the next round from a provisional (non-finalised) result", async () => {
+    // A round must not advance off a live or within-correction-window score:
+    // the bracket would lay fixtures off a result that can still change, and off
+    // a game that may not have kicked off (a 0-0 shows as a tie).
+    const fx = await setup();
+    await advancePlayoffs(fx.client, fx.leagueId);
+
+    await scoreProvisional(fx, 15, fx.teams[4]!, 120_000, 100_000);
+    await scoreProvisional(fx, 15, fx.teams[6]!, 90_000, 130_000);
+
+    const outcome = await advancePlayoffs(fx.client, fx.leagueId);
+
+    expect(outcome.written).toBe(0);
+    expect(await fixtures(fx, 16)).toHaveLength(0);
+  });
+
+  it("does not crown a champion from a provisional final, but does once it finalises", async () => {
+    const fx = await setup();
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 15, fx.teams[4]!, 120_000, 100_000);
+    await score(fx, 15, fx.teams[6]!, 90_000, 130_000);
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 16, fx.teams[0]!, 130_000, 100_000);
+    await score(fx, 16, fx.teams[2]!, 100_000, 130_000);
+    await advancePlayoffs(fx.client, fx.leagueId);
+
+    // Week 17 scored but not finalised — still inside the 168h correction window.
+    await scoreProvisional(fx, 17, fx.teams[0]!, 140_000, 120_000);
+    await scoreProvisional(fx, 17, fx.teams[2]!, 90_000, 110_000);
+    await scoreProvisional(fx, 17, fx.teams[5]!, 100_000, 90_000);
+
+    expect((await championship(fx.client, fx.leagueId)).champion).toBeNull();
+
+    // Finalise it, and the champion is derived.
+    await score(fx, 17, fx.teams[0]!, 140_000, 120_000);
+    await score(fx, 17, fx.teams[2]!, 90_000, 110_000);
+    await score(fx, 17, fx.teams[5]!, 100_000, 90_000);
+
+    expect((await championship(fx.client, fx.leagueId)).champion).toBe(fx.teams[0]);
   });
 });
 

--- a/packages/db/src/playoffs.ts
+++ b/packages/db/src/playoffs.ts
@@ -143,7 +143,11 @@ async function bracketFor(
   // there is simply no bracket.
   if (field.length < 2) return null;
 
-  const results = await loadWeekResults(db, leagueId, lastWeek(rules), phase);
+  // Finalised results only. A round advances, and the champion is derived, only
+  // from a settled score — never a live, provisional, or within-correction-window
+  // one. Otherwise the bracket lays fixtures off a 0-0 game that has not kicked
+  // off, and a Week 17 leader is crowned before the game is even played.
+  const results = await loadWeekResults(db, leagueId, lastWeek(rules), phase, true);
 
   return {
     phase,

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -13,6 +13,7 @@ import {
   loadWeekResults,
   persistSchedule,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
 } from "./week.js";
 
 let db: PGliteClient | undefined;
@@ -282,6 +283,48 @@ describe("resolveLeagueWeek", () => {
     await expect(resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING)).rejects.toMatchObject(
       { code: "NO_SCHEDULE" },
     );
+  });
+});
+
+describe("resolveLeagueWeeksThrough", () => {
+  const week1Finalized = async (fx: Fixture): Promise<boolean> => {
+    const [row] = await fx.client.query<{ finalized_at: string | null }>(
+      "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2 LIMIT 1",
+      [fx.leagueId, WEEK],
+    );
+    return row?.finalized_at != null;
+  };
+
+  it("finalises a prior week that the single-week pointer leaves behind", async () => {
+    // Week 1 is final and its 48h window has elapsed, but the pointer is on a
+    // later week. This is exactly how a paying week is abandoned once the season
+    // moves on: resolving only the pointer week never revisits it.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    // Resolving only week 5 (which has fixtures but no finished games) leaves
+    // week 1 unfinalised — the bug.
+    await resolveLeagueWeek(fx.client, fx.leagueId, 5, AFTER_STANDARD);
+    expect(await week1Finalized(fx)).toBe(false);
+
+    // The sweep resolves every unfinalised week up to the pointer, so week 1 is
+    // finalised.
+    const outcomes = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, 5, AFTER_STANDARD);
+    expect(outcomes.find((o) => o.week === WEEK)?.finalized).toBe(true);
+    expect(await week1Finalized(fx)).toBe(true);
+  });
+
+  it("leaves nothing to do once every week through the pointer is finalised", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    // Only week 1 has finished games, so it is the only one that can finalise;
+    // a second sweep finds it already done and nothing else pending to finalise.
+    const again = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    expect(again).toHaveLength(0);
   });
 });
 

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -206,6 +206,42 @@ export async function resolveLeagueWeek(
 }
 
 /**
+ * Resolve every week up to `throughWeek` that still has an unfinalised matchup.
+ *
+ * The scoring cron used to resolve only the single current week. That works for
+ * standings weeks (48h window), whose window closes before the next week's first
+ * kickoff moves the pointer on. It does **not** work for a paying week (168h):
+ * week 15's Thursday game arrives ~4 days after week 14's last game, so the
+ * pointer leaves week 14 three days before its window elapses, and it would never
+ * be finalised — leaving the regular-season prize, and any bracket built from it,
+ * on provisional scores forever. The same abandons week 17 once week-18 games are
+ * ingested.
+ *
+ * Sweeping every still-unfinalised week fixes that. Each call is safe and
+ * idempotent: a finalised week is filtered out here and would in any case be
+ * refused by `resolveLeagueWeek`.
+ */
+export async function resolveLeagueWeeksThrough(
+  db: SqlClient,
+  leagueId: string,
+  throughWeek: number,
+  now: Date,
+): Promise<readonly ResolveWeekOutcome[]> {
+  const weeks = await db.query<{ week: number }>(
+    `SELECT DISTINCT week FROM matchups
+      WHERE league_id = $1 AND week <= $2 AND finalized_at IS NULL
+      ORDER BY week`,
+    [leagueId, throughWeek],
+  );
+
+  const outcomes: ResolveWeekOutcome[] = [];
+  for (const { week } of weeks) {
+    outcomes.push(await resolveLeagueWeek(db, leagueId, Number(week), now));
+  }
+  return outcomes;
+}
+
+/**
  * Why a week may not be finalised yet, or `null` if it may.
  *
  * Two conditions, both necessary: every game must be final, and the correction
@@ -354,7 +390,14 @@ export async function loadWeekResults(
   leagueId: string,
   throughWeek: number,
   phase: MatchupPhase = "REGULAR",
+  finalizedOnly = false,
 ): Promise<readonly MatchupResult[]> {
+  // `finalizedOnly` is what the playoff bracket asks for. Advancement and the
+  // derived champion must key on a settled result, not a provisional one: a
+  // bracket built from live or not-yet-finalised scores advances the wrong team
+  // (and lays orphan fixtures), and a paying week's result can still change
+  // inside the correction window. A finalised matchup always has points, so this
+  // narrows rather than contradicts the `home_milli_points IS NOT NULL` guard.
   const rows = await db.query<{
     week: number;
     home_team_id: string;
@@ -364,7 +407,9 @@ export async function loadWeekResults(
   }>(
     `SELECT week, home_team_id, away_team_id, home_milli_points, away_milli_points
        FROM matchups
-      WHERE league_id = $1 AND week <= $2 AND phase = $3 AND home_milli_points IS NOT NULL
+      WHERE league_id = $1 AND week <= $2 AND phase = $3 AND home_milli_points IS NOT NULL${
+        finalizedOnly ? " AND finalized_at IS NOT NULL" : ""
+      }
       ORDER BY week, id`,
     [leagueId, throughWeek, phase],
   );


### PR DESCRIPTION
Closes #33.

## Problem

Two coupled defects on the money-deciding playoff path.

**The bracket advanced and crowned from non-finalised scores.** `loadWeekResults` filtered `home_milli_points IS NOT NULL`, not `finalized_at`, so `advancePlayoffs` laid the next round and `championship()` derived the winner from live, 0-0-before-kickoff, or within-168h-correction-window results — a champion named before the game is played, flippable by a stat correction, plus orphan fixtures laid off provisional advances.

**Paying weeks never finalised.** The cron resolved only the single current week; a 168h paying week (14, 17) was abandoned by the pointer before its window elapsed, so it never finalised — leaving the prize and the bracket on provisional scores forever. Fixing only the read would leave the champion stuck (the final never finalises), so both are needed.

## Fix

- `loadWeekResults` gains a `finalizedOnly` mode; `bracketFor` uses it, so advancement and the derived champion key on a settled result. The regular-season *seeding* read is unchanged (advancement already gates on the regular season being final).
- `resolveLeagueWeeksThrough` resolves every still-unfinalised week up to the pointer; the scoring cron uses it instead of a single week. Idempotent via the existing `ALREADY_FINAL` guard.

## Tests

- Playoffs: the bracket does not lay the next round from a provisional result, and does not crown a champion from a provisional final — but does once it finalises.
- Week: the sweep finalises a prior week the single-week pointer leaves behind, and finds nothing to do once everything through the pointer is final.
- Full playoffs (21), week (19), matchup suites pass; `pnpm typecheck` clean. The `loadWeekResults` change is a backward-compatible optional parameter, so standings and other callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
