### PR TITLE
fix(db): re-validate a trade's assets on accept, not only propose

### DIFF
--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -389,6 +389,66 @@ describe("the freeze between acceptance and execution", () => {
   });
 });
 
+describe("no double-spend across trades", () => {
+  it("refuses a second accept that commits a player already in an accepted trade", async () => {
+    // Two proposals can each offer the same player — only an *accepted* trade
+    // freezes him. If the second accept is not re-checked, both trades execute
+    // and the player is inserted onto two rosters, minted from nothing.
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+
+    const a = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
+    });
+    const b = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[2]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p3")!],
+      week: 5,
+      now: MONDAY,
+    });
+
+    await acceptTrade(fx.client, a.tradeId, fx.teams[1]!, MONDAY);
+
+    await expect(acceptTrade(fx.client, b.tradeId, fx.teams[2]!, MONDAY)).rejects.toMatchObject({
+      code: "PLAYER_IN_ANOTHER_TRADE",
+    });
+  });
+
+  it("refuses to accept a trade whose offered player was dropped after it was proposed", async () => {
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
+    });
+
+    await fx.client.query(
+      `UPDATE roster_entries SET released_at = $3
+        WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
+      [fx.teams[0], p1, MONDAY.toISOString()],
+    );
+
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "NOT_YOUR_PLAYER",
+    });
+  });
+});
+
 describe("vetoing", () => {
   it("counts a vote", async () => {
     const fx = await setup();

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -338,12 +338,48 @@ export async function acceptTrade(
     vetoWindowEndsAt(Math.floor(now.getTime() / 1000), stored.rules.trades) * 1000,
   );
 
-  await db.query(
-    "UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2 WHERE id = $1 AND state = 'PROPOSED'",
-    [tradeId, deadline.toISOString()],
-  );
+  return withTransaction(db, async (tx) => {
+    // Re-validate every asset now, not only at propose time. Accepting is the
+    // moment the trade freezes for execution, and the proposal's checks are
+    // stale: since then a player could have been dropped, or committed to a
+    // different trade that was accepted first. Skipping this is what lets one
+    // player be committed to two accepted trades and duplicated onto two rosters
+    // when both execute. The row lock serialises two accepts racing for the same
+    // player; the freeze set then catches whichever loses.
+    const assets = await tx.query<{ from_team_id: string; player_id: string }>(
+      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1",
+      [tradeId],
+    );
+    const frozen = await lockedByTrade(tx, row!.league_id);
 
-  return loadTrade(db, tradeId);
+    for (const asset of assets) {
+      const [owned] = await tx.query<{ id: string }>(
+        `SELECT id FROM roster_entries
+          WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL
+          FOR UPDATE`,
+        [asset.from_team_id, asset.player_id],
+      );
+      if (!owned) {
+        throw new TradeError(
+          `${asset.player_id} is no longer on team ${asset.from_team_id}'s roster`,
+          "NOT_YOUR_PLAYER",
+        );
+      }
+      if (frozen.has(asset.player_id)) {
+        throw new TradeError(
+          `${asset.player_id} is already committed to an accepted trade`,
+          "PLAYER_IN_ANOTHER_TRADE",
+        );
+      }
+    }
+
+    await tx.query(
+      "UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2 WHERE id = $1 AND state = 'PROPOSED'",
+      [tradeId, deadline.toISOString()],
+    );
+
+    return loadTrade(tx, tradeId);
+  });
 }
 
 /** Decline an offer. Only the team it was made to. */


### PR DESCRIPTION
Closes #35.

## Problem

`acceptTrade` checked only that the trade was `PROPOSED` and that the caller was the receiver. But `proposeTrade` freezes a player only against *accepted* trades, so two proposals could each offer the same player. Accepting the second re-checked nothing, committing the player to two accepted trades; `resolveTrade` then released him once and inserted him **unconditionally** onto both receivers — an asset minted from nothing (the `(team_id, player_id)` unique index is per-team and doesn't stop it). A player dropped after a proposal was likewise re-added on accept.

## Fix

`acceptTrade` now re-validates every asset inside a transaction: still owned by its `from_team` (`released_at IS NULL`), and not already committed to another accepted trade (`lockedByTrade`). A `FOR UPDATE` row lock serialises two accepts racing for the same player; the freeze set catches whichever loses. This makes the downstream release-then-insert safe — it only ever operates on a player the accepting side still holds and no other accepted trade claims.

## Tests

- Two proposals offering the same player: the second accept is now refused (`PLAYER_IN_ANOTHER_TRADE`) — it succeeded before.
- A trade whose offered player was dropped after the proposal: the accept is now refused (`NOT_YOUR_PLAYER`) — it succeeded before.
- Full trades suite: 45 pass (2 new); `pnpm typecheck` clean. No existing accept/propose/veto/resolve behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
