### PR TITLE
fix(db): size playoff byes to the real field, and isolate a bracket error per league

### DIFF
--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { NFL } from "@rostr/core";
+import { BracketError, NFL } from "@rostr/core";
 import {
   advancePlayoffs,
   enterPlayoffs,
@@ -89,7 +89,10 @@ export async function GET(request: Request): Promise<NextResponse> {
       await enterPlayoffs(client, league.id);
       bracketGames = (await advancePlayoffs(client, league.id)).written;
     } catch (error) {
-      if (!(error instanceof PlayoffError)) throw error;
+      // A league still mid-season refuses (PlayoffError), and a bracket that
+      // cannot be built for this league (BracketError) is this league's problem.
+      // Neither may abort the shared run and stop every other league scoring.
+      if (!(error instanceof PlayoffError) && !(error instanceof BracketError)) throw error;
     }
 
     try {

--- a/packages/db/src/playoffs.test.ts
+++ b/packages/db/src/playoffs.test.ts
@@ -44,7 +44,7 @@ interface Fixture {
  * Seeds end up 1..8 as `t0, t2, t4, t6, t1, t3, t5, t7`. Six make the playoffs;
  * the last two are the consolation bracket.
  */
-async function setup(overrides?: Partial<LeagueRules>): Promise<Fixture> {
+async function setup(overrides?: Partial<LeagueRules>, teamCount = 8): Promise<Fixture> {
   db = await createTestDatabase();
   await seedSport(db, NFL);
 
@@ -60,12 +60,17 @@ async function setup(overrides?: Partial<LeagueRules>): Promise<Fixture> {
   });
 
   const teams: string[] = [];
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < teamCount; i++) {
     teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);
   }
 
-  const points = [200_000, 100_000, 190_000, 90_000, 180_000, 80_000, 170_000, 70_000];
-  for (let i = 0; i < 8; i += 2) {
+  // Distinct, descending totals so the seed order is deterministic. The 8-team
+  // values are kept verbatim because the seeding tests assert against them.
+  const points =
+    teamCount === 8
+      ? [200_000, 100_000, 190_000, 90_000, 180_000, 80_000, 170_000, 70_000]
+      : teams.map((_, i) => 200_000 - i * 5_000);
+  for (let i = 0; i + 1 < teamCount; i += 2) {
     await db.query(
       `INSERT INTO matchups
          (league_id, week, phase, home_team_id, away_team_id,
@@ -226,6 +231,26 @@ describe("laying the first round", () => {
     expect(first.written).toBe(3);
     expect(second.written).toBe(0);
     expect(await fixtures(fx, 15)).toHaveLength(2);
+  });
+});
+
+describe("small leagues (fewer teams than the playoff field)", () => {
+  it("does not crash a five-team league", async () => {
+    // A pot league gets no bots, so five friends is a five-team league. The
+    // frozen bye count is 2 (sized for a six-team field); applied to five teams
+    // it leaves three to pair — odd — and the bracket throws, which the shared
+    // scoring cron then rethrows, taking down every league's scoring with it.
+    const fx = await setup(undefined, 5);
+
+    await expect(advancePlayoffs(fx.client, fx.leagueId)).resolves.toBeDefined();
+    expect((await playoffState(fx.client, fx.leagueId)).playoffs).not.toBeNull();
+  });
+
+  it("does not crash a three-team league", async () => {
+    const fx = await setup(undefined, 3);
+
+    await expect(advancePlayoffs(fx.client, fx.leagueId)).resolves.toBeDefined();
+    expect((await playoffState(fx.client, fx.leagueId)).playoffs).not.toBeNull();
   });
 });
 

--- a/packages/db/src/playoffs.ts
+++ b/packages/db/src/playoffs.ts
@@ -151,10 +151,17 @@ async function bracketFor(
     bracket: buildBracket({
       field,
       weeks: rules.schedule.playoffWeeks,
-      // Only the main bracket carries the league's frozen bye count. The
-      // consolation field is whatever is left over, so its byes are whatever
-      // its own size needs — there is no signed number for it.
-      firstRoundByes: phase === "PLAYOFF" ? rules.schedule.byeSeeds : byesFor(field.length),
+      // The main bracket carries the league's frozen bye count only when the
+      // field is the size it was frozen for. A smaller field — a league that
+      // never reached that many teams (a pot league gets no bots, so five
+      // friends is a five-team playoff) — takes whatever byes its own size needs
+      // to form a valid round, exactly as the consolation bracket does. Applying
+      // the frozen count to a smaller field leaves an odd first round, which
+      // throws — and the scoring cron rethrows it across every league.
+      firstRoundByes:
+        phase === "PLAYOFF" && field.length === rules.schedule.playoffTeams
+          ? rules.schedule.byeSeeds
+          : byesFor(field.length),
       results,
       // Third place is a prize, so it exists only where one is paid. The
       // consolation bracket pays its winner and nobody else.


### PR DESCRIPTION
Closes #37.

## Problem

A league that finished the regular season with fewer teams than the playoff field size threw `BracketError`, and the scoring cron rethrew it — aborting the whole `/api/cron/score-week` run and stopping every other league from being scored, on every run. Pot leagues get `maxBots: 0`, so a five-friend league has exactly five teams; the frozen bye count of 2 leaves three to pair in round one, which is odd, and `buildBracket` throws. Counts of 2, 3, and 5 all threw.

## Fix

- `bracketFor` applies the frozen `byeSeeds` only when the field is the size it was frozen for, and otherwise computes the byes the actual field needs (the same `byesFor` the consolation bracket already uses) — identical for a full six-team field.
- The scoring cron catches `BracketError` alongside `PlayoffError`, so one league's bracket can never abort scoring for the rest.

## Tests

- New: a five-team and a three-team league each compute and advance a bracket without throwing (both threw `BracketError` before). The fixture gained an optional team-count parameter; the 8-team default is unchanged, so the existing seeding/advancement tests are untouched.
- Full playoffs suite: 21 pass; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
