### PR TITLE
fix(escrow): verify the on-chain economic terms at anchor, not just the hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,31 @@ credentials in `SETUP-REQUIRED.md`, not more code.
 
   **The route does not take the client's word for it.** A signature proves _some_
   transaction happened, not which, so it reads the account back and refuses unless the
-  on-chain hash equals the stored one. The two 409s are deliberately different: `NOT_FOUND`
-  means retry, `HASH_MISMATCH` means the chain holds a different rule set and nobody
-  should join.
+  chain agrees with the signed rules. Three 409s, deliberately different: `NOT_FOUND`
+  means retry; `HASH_MISMATCH` means the chain holds a different rule set; `TERMS_MISMATCH`
+  means the hash matches but the money does not. The last two are not retries — they are
+  leagues nobody should join.
+
+  **A matching hash is not enough, and that is the whole of PR #32.** The program stores
+  the economic terms as a separate copy it has no way to check against the hash, so a
+  creator can anchor the exact document members sign while initialising a hostile buy-in,
+  fee recipient, payout split or `refund_unlock_at`. The last is the worst: `refund_stake`
+  is the only way tokens leave the vault and it requires the clock to have passed, so a
+  far-future value freezes every deposit permanently, and the program permits it — its
+  only check is that the value is in the future.
+
+  Two things about this check are load-bearing. **It re-runs on an already-anchored
+  league** rather than returning early on the stored boolean, because nothing else in the
+  system ever reads the account again and a league recorded before the check existed would
+  otherwise be trusted forever. And **a false positive is unrecoverable** — no setter, no
+  `close`, the PDA derived from the league's UUID — so a wrongly refused league can never
+  be anchored, only recreated under a new id. That is why the fee recipient is compared
+  only when a fee is actually charged: fee-free leagues legitimately carry an empty one.
+
+  `expectedTermsFromRules` and `anchorTermMismatches` live in `@rostr/escrow`, not in the
+  route, because `apps/web` has no test project — a mapping inline in a route is verified
+  only by being run in production, and both defects found in review were in the mapping
+  rather than the comparison.
 
   Verified end to end against a real validator, not reasoned about — see
   `programs/rostr-escrow/tests/anchor.test.ts` below.

--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { anchorTermMismatches, clusterOf, payoutArray, verifyLeagueAnchor } from "@rostr/escrow";
+import {
+  anchorTermMismatches,
+  clusterOf,
+  expectedTermsFromRules,
+  verifyLeagueAnchor,
+} from "@rostr/escrow";
 import { getChainState, getLeagueRules, recordChainAnchor } from "@rostr/db";
 import { db } from "@/lib/db";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
@@ -14,9 +19,18 @@ import { EscrowConfigError, readOnlyEscrow } from "@/lib/escrow";
  * anything. So this reads the account back and confirms it holds *our* rules hash
  * before recording anything.
  *
- * That check is `verifyLeagueAnchor` in `@rostr/escrow` rather than inline here,
- * so it can be tested against a real validator instead of only in production. All
- * that is left in this file is the session, the write, and the status codes.
+ * **A matching hash is not enough.** The program stores the economic terms as a
+ * separate copy it has no way to check against the hash, so a creator can anchor
+ * the benign document members sign while initialising a hostile buy-in, refund
+ * unlock, fee recipient or payout split. The hash would verify and the money
+ * would not be the money anyone agreed to.
+ *
+ * Both checks live in `@rostr/escrow` rather than inline here — `verifyLeagueAnchor`
+ * so it can be exercised against a real validator, `expectedTermsFromRules` and
+ * `anchorTermMismatches` so the mapping and the comparison are covered by the fast
+ * suite. `apps/web` has no test project, so anything inline in this file would be
+ * verified only by being run in production. What is left here is the session, the
+ * write, and the status codes.
  */
 export async function POST(
   request: Request,
@@ -49,12 +63,51 @@ export async function POST(
       return NextResponse.json({ error: "League has no stored rules" }, { status: 404 });
     }
 
+    const { connection, program } = readOnlyEscrow();
+
+    /**
+     * What the chain says, checked against what members signed.
+     *
+     * Both the hash and the terms, in one place, because a caller that checked
+     * one and not the other is exactly the hole this route exists to close.
+     */
+    const inspect = async () => {
+      const verdict = await verifyLeagueAnchor(program, id, stored.hash);
+      return {
+        verdict,
+        mismatches: verdict.ok
+          ? anchorTermMismatches(verdict.league, expectedTermsFromRules(stored.rules))
+          : [],
+      };
+    };
+
     // Already anchored is success, not an error. Anchoring is a second
     // transaction the commissioner signs, so a retry after a lost response is
     // the ordinary case — and the record is write-once anyway, so a second
     // write would raise from a trigger rather than quietly re-point it.
+    //
+    // **It is still re-checked.** Returning early on the stored boolean alone
+    // would mean the terms check never runs for any league anchored before it
+    // existed, and nothing else in the system ever reads the account again —
+    // so a league recorded once would be trusted forever on the strength of a
+    // check that may never have happened.
     const existing = await getChainState(client, id);
     if (existing?.anchoredAt) {
+      const { verdict, mismatches } = await inspect();
+
+      if (!verdict.ok || mismatches.length > 0) {
+        return NextResponse.json(
+          {
+            error:
+              "This league is recorded as anchored, but the account on-chain no longer " +
+              "matches the rules shown here. Nobody should join or deposit.",
+            reason: verdict.ok ? "TERMS_MISMATCH" : verdict.reason,
+            mismatches,
+          },
+          { status: 409 },
+        );
+      }
+
       return NextResponse.json({
         anchored: true,
         alreadyRecorded: true,
@@ -78,8 +131,7 @@ export async function POST(
       );
     }
 
-    const { connection, program } = readOnlyEscrow();
-    const verdict = await verifyLeagueAnchor(program, id, stored.hash);
+    const { verdict, mismatches } = await inspect();
 
     if (!verdict.ok) {
       // Deliberately specific. "Not found" means the transaction has not landed
@@ -114,18 +166,6 @@ export async function POST(
     // terms the signed rules imply against what the account actually holds, and
     // refuse an anchor that diverges: like a hash mismatch, it is a league nobody
     // should join or deposit into, and the account can never be corrected.
-    const pot = stored.rules.pot;
-    const mismatches = anchorTermMismatches(verdict.league, {
-      hasPot: pot !== null,
-      maxTeams: stored.rules.league.maxTeams,
-      buyIn: pot?.buyInBaseUnits ?? "0",
-      refundUnlockAt: pot?.refundUnlockAt ?? 0,
-      tokenMint: pot?.tokenMint ?? "",
-      feeBps: pot?.feeBps ?? 0,
-      feeRecipient: pot?.feeRecipient ?? "",
-      payoutBps: pot ? payoutArray(pot.payout) : [0, 0, 0, 0, 0],
-    });
-
     if (mismatches.length > 0) {
       return NextResponse.json(
         {

--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { clusterOf, verifyLeagueAnchor } from "@rostr/escrow";
+import { anchorTermMismatches, clusterOf, payoutArray, verifyLeagueAnchor } from "@rostr/escrow";
 import { getChainState, getLeagueRules, recordChainAnchor } from "@rostr/db";
 import { db } from "@/lib/db";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
@@ -106,6 +106,37 @@ export async function POST(
             },
             { status: 409 },
           );
+    }
+
+    // The hash matches, but the program stores the economic terms as a separate
+    // copy it cannot check against the hash — so a matching hash does not prove a
+    // matching buy-in, refund unlock, fee recipient or payout split. Compare the
+    // terms the signed rules imply against what the account actually holds, and
+    // refuse an anchor that diverges: like a hash mismatch, it is a league nobody
+    // should join or deposit into, and the account can never be corrected.
+    const pot = stored.rules.pot;
+    const mismatches = anchorTermMismatches(verdict.league, {
+      hasPot: pot !== null,
+      maxTeams: stored.rules.league.maxTeams,
+      buyIn: pot?.buyInBaseUnits ?? "0",
+      refundUnlockAt: pot?.refundUnlockAt ?? 0,
+      tokenMint: pot?.tokenMint ?? "",
+      feeBps: pot?.feeBps ?? 0,
+      feeRecipient: pot?.feeRecipient ?? "",
+      payoutBps: pot ? payoutArray(pot.payout) : [0, 0, 0, 0, 0],
+    });
+
+    if (mismatches.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "The on-chain league holds different terms than the rules shown here. Do not let " +
+            "anyone join or deposit: the account was initialised with terms nobody agreed to.",
+          reason: "TERMS_MISMATCH",
+          mismatches,
+        },
+        { status: 409 },
+      );
     }
 
     // The cluster is read off the endpoint we just queried, not accepted from

--- a/apps/web/src/components/AnchorPanel.tsx
+++ b/apps/web/src/components/AnchorPanel.tsx
@@ -83,7 +83,13 @@ export function AnchorPanel({
             refundUnlockAt: pot.refundUnlockAt,
             payoutBps: payoutArray(pot.payout),
             feeBps: pot.feeBps,
-            feeRecipient: new PublicKey(pot.feeRecipient),
+            // A fee-free league has no recipient — `FEE_RECIPIENT` unset means
+            // leagues are created with `feeBps: 0` and an empty string, and
+            // `new PublicKey("")` throws rather than yielding a default. The
+            // program requires a recipient only when `fee_bps > 0`.
+            feeRecipient: pot.feeRecipient
+              ? new PublicKey(pot.feeRecipient)
+              : PublicKey.default,
             maxTeams,
             payer: wallet.publicKey,
           })

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -8,12 +8,14 @@
 
 export { ESCROW_IDL, type EscrowIdl } from "./idl.js";
 export {
+  anchorTermMismatches,
   bytesToHex,
   clusterOf,
   fetchOnChainLeague,
   hexToBytes,
   verifyLeagueAnchor,
   type AnchorVerdict,
+  type ExpectedTerms,
   type OnChainLeague,
 } from "./verify.js";
 export {

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -11,12 +11,14 @@ export {
   anchorTermMismatches,
   bytesToHex,
   clusterOf,
+  expectedTermsFromRules,
   fetchOnChainLeague,
   hexToBytes,
   verifyLeagueAnchor,
   type AnchorVerdict,
   type ExpectedTerms,
   type OnChainLeague,
+  type RulesLikeTerms,
 } from "./verify.js";
 export {
   PRIZE_ORDER,

--- a/packages/escrow/src/instructions.ts
+++ b/packages/escrow/src/instructions.ts
@@ -67,7 +67,12 @@ export type InitializeLeagueParams = {
   readonly mint: PublicKey;
   /** Base units, as a decimal string — a u64, so never a JS number. */
   readonly buyInBaseUnits: string;
-  readonly refundUnlockAt: number;
+  /**
+   * Unix seconds. A number for ordinary use, or a decimal string for values an
+   * `i64` can hold and a JS number cannot — which a hostile creator may well
+   * choose, and a test must be able to express.
+   */
+  readonly refundUnlockAt: number | string;
   readonly payoutBps: readonly number[];
   readonly feeBps: number;
   readonly feeRecipient: PublicKey;

--- a/packages/escrow/src/verify.test.ts
+++ b/packages/escrow/src/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { anchorTermMismatches } from "./verify.js";
+import { anchorTermMismatches, expectedTermsFromRules } from "./verify.js";
 import type { ExpectedTerms, OnChainLeague } from "./verify.js";
 import { PublicKey } from "@solana/web3.js";
 
@@ -22,7 +22,7 @@ function onChain(overrides: Partial<OnChainLeague> = {}): OnChainLeague {
     hasPot: true,
     buyIn: "5000000",
     tokenMint: MINT,
-    refundUnlockAt: 1_773_000_000,
+    refundUnlockAt: "1773000000",
     feeBps: 100,
     feeRecipient: FEE_TO,
     payoutBps: [6000, 1500, 1000, 1000, 500],
@@ -36,7 +36,7 @@ const EXPECTED: ExpectedTerms = {
   hasPot: true,
   maxTeams: 12,
   buyIn: "5000000",
-  refundUnlockAt: 1_773_000_000,
+  refundUnlockAt: "1773000000",
   tokenMint: MINT,
   feeBps: 100,
   feeRecipient: FEE_TO,
@@ -55,7 +55,7 @@ describe("anchorTermMismatches", () => {
   });
 
   it("catches a refund unlock pushed far past settlement (funds stuck)", () => {
-    const m = anchorTermMismatches(onChain({ refundUnlockAt: 4_102_444_800 }), EXPECTED);
+    const m = anchorTermMismatches(onChain({ refundUnlockAt: "4102444800" }), EXPECTED);
     expect(m).toHaveLength(1);
     expect(m[0]).toMatch(/refundUnlockAt/);
   });
@@ -72,17 +72,22 @@ describe("anchorTermMismatches", () => {
   });
 
   it("catches a reshuffled payout split", () => {
-    const m = anchorTermMismatches(onChain({ payoutBps: [1500, 6000, 1000, 1000, 500] }), EXPECTED);
+    const m = anchorTermMismatches(
+      onChain({ payoutBps: [1500, 6000, 1000, 1000, 500] }),
+      EXPECTED,
+    );
     expect(m).toHaveLength(1);
     expect(m[0]).toMatch(/payoutBps/);
   });
 
   it("catches a different token mint", () => {
     const other = RECIPIENT.toBase58();
-    expect(anchorTermMismatches(onChain({ tokenMint: other }), EXPECTED)[0]).toMatch(/tokenMint/);
+    expect(anchorTermMismatches(onChain({ tokenMint: other }), EXPECTED)[0]).toMatch(
+      /tokenMint/,
+    );
   });
 
-  it("catches an unbounded max_teams", () => {
+  it("catches a max_teams that differs from the signed rules", () => {
     expect(anchorTermMismatches(onChain({ maxTeams: 255 }), EXPECTED)[0]).toMatch(/maxTeams/);
   });
 
@@ -91,7 +96,7 @@ describe("anchorTermMismatches", () => {
     const free = onChain({
       hasPot: false,
       buyIn: "0",
-      refundUnlockAt: 0,
+      refundUnlockAt: "0",
       feeBps: 0,
       payoutBps: [0, 0, 0, 0, 0],
     });
@@ -103,7 +108,7 @@ describe("anchorTermMismatches", () => {
     const free = onChain({
       hasPot: false,
       buyIn: "0",
-      refundUnlockAt: 0,
+      refundUnlockAt: "0",
       tokenMint: PublicKey.default.toBase58(),
       feeBps: 0,
       feeRecipient: PublicKey.default.toBase58(),
@@ -115,9 +120,130 @@ describe("anchorTermMismatches", () => {
 
   it("reports every hostile field at once", () => {
     const m = anchorTermMismatches(
-      onChain({ buyIn: "50000000", feeBps: 500, refundUnlockAt: 4_102_444_800 }),
+      onChain({ buyIn: "50000000", feeBps: 500, refundUnlockAt: "4102444800" }),
       EXPECTED,
     );
     expect(m.length).toBe(3);
+  });
+
+  it("catches an i64::MAX refund unlock — the worst case, and the one that used to throw", () => {
+    // `refund_stake` is the only way tokens leave the vault and it requires the
+    // clock to have passed, so this is a permanent freeze of every deposit. The
+    // program allows it: its only check is that the value is in the future.
+    //
+    // This is a string rather than a number because it does not fit in one.
+    // Decoding the account with `BN.toNumber()` threw here — on precisely the
+    // input this whole check exists to catch — and the throw surfaced as a 500
+    // rather than as a refusal.
+    const m = anchorTermMismatches(
+      onChain({ refundUnlockAt: "9223372036854775807" }),
+      EXPECTED,
+    );
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/refundUnlockAt/);
+    expect(m[0]).toContain("9223372036854775807");
+  });
+
+  it("does not compare a fee recipient when no fee is charged", () => {
+    // With `FEE_RECIPIENT` unset a league is created fee-free, and its rules
+    // carry an empty recipient — which no base58 key can equal. Comparing it
+    // would refuse a legitimate anchor, and because the PDA is one-shot that
+    // league could never be anchored at all.
+    const free = { ...EXPECTED, feeBps: 0, feeRecipient: "" };
+    const chain = onChain({ feeBps: 0, feeRecipient: PublicKey.default.toBase58() });
+    expect(anchorTermMismatches(chain, free)).toEqual([]);
+  });
+
+  it("still catches a fee smuggled in against fee-free rules", () => {
+    // The exemption above must not become a hole: `feeBps` is compared either
+    // way, so a chain that charges a fee the rules do not is still refused.
+    const free = { ...EXPECTED, feeBps: 0, feeRecipient: "" };
+    const chain = onChain({ feeBps: 500, feeRecipient: FEE_TO });
+    const m = anchorTermMismatches(chain, free);
+    expect(m.some((x) => /feeBps/.test(x))).toBe(true);
+  });
+});
+
+/**
+ * The mapping from signed rules to expected terms.
+ *
+ * This is the half that used to live inline in the route, where nothing could
+ * test it — `apps/web` has no test project. Both bugs found in review were here
+ * rather than in the comparison.
+ */
+describe("expectedTermsFromRules", () => {
+  const POT = {
+    tokenMint: MINT,
+    buyInBaseUnits: "5000000",
+    refundUnlockAt: 1_773_000_000,
+    feeBps: 100,
+    feeRecipient: FEE_TO,
+    payout: [
+      { prize: "CHAMPION", basisPoints: 6000 },
+      { prize: "RUNNER_UP", basisPoints: 1500 },
+      { prize: "REGULAR_SEASON", basisPoints: 1000 },
+      { prize: "CONSOLATION", basisPoints: 1000 },
+      { prize: "THIRD_PLACE", basisPoints: 500 },
+    ],
+  };
+
+  it("agrees with an honestly anchored pot league", () => {
+    const expected = expectedTermsFromRules({ league: { maxTeams: 12 }, pot: POT });
+    expect(anchorTermMismatches(onChain(), expected)).toEqual([]);
+  });
+
+  it("orders the payout by PRIZE_ORDER, not by the order the shares arrive in", () => {
+    // Deliberately shuffled. In declaration order this bug is invisible, which
+    // is why the shares are passed out of order here: a mapping that trusted
+    // input order would produce [1000, 500, 6000, 1500, 1000] and reshuffle the
+    // split with no error anywhere.
+    const shuffled = [
+      POT.payout[2],
+      POT.payout[4],
+      POT.payout[0],
+      POT.payout[1],
+      POT.payout[3],
+    ];
+    const expected = expectedTermsFromRules({
+      league: { maxTeams: 12 },
+      pot: { ...POT, payout: shuffled as typeof POT.payout },
+    });
+    expect(expected.payoutBps).toEqual([6000, 1500, 1000, 1000, 500]);
+    expect(anchorTermMismatches(onChain(), expected)).toEqual([]);
+  });
+
+  it("carries a 64-bit refund unlock without losing it", () => {
+    const expected = expectedTermsFromRules({
+      league: { maxTeams: 12 },
+      pot: { ...POT, refundUnlockAt: 4_102_444_800 },
+    });
+    expect(expected.refundUnlockAt).toBe("4102444800");
+  });
+
+  it("builds a free league the way the route does, and it verifies", () => {
+    const expected = expectedTermsFromRules({ league: { maxTeams: 12 }, pot: null });
+    expect(expected.hasPot).toBe(false);
+
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: "0",
+      tokenMint: PublicKey.default.toBase58(),
+      feeBps: 0,
+      feeRecipient: PublicKey.default.toBase58(),
+      payoutBps: [0, 0, 0, 0, 0],
+    });
+    expect(anchorTermMismatches(free, expected)).toEqual([]);
+  });
+
+  it("treats a missing pot key as free, not as a pot", () => {
+    // `pot` is parsed from stored JSON. A document that omits the key yields
+    // `undefined`, and `!== null` would call that a pot league — telling a
+    // genuine free league its rules imply one, unresolvably.
+    const expected = expectedTermsFromRules({
+      league: { maxTeams: 12 },
+      pot: undefined as unknown as null,
+    });
+    expect(expected.hasPot).toBe(false);
   });
 });

--- a/packages/escrow/src/verify.test.ts
+++ b/packages/escrow/src/verify.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { anchorTermMismatches } from "./verify.js";
+import type { ExpectedTerms, OnChainLeague } from "./verify.js";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * The security property: verifying a league anchor by its rules hash is not
+ * enough, because the program stores the economic terms as a separate copy the
+ * hash cannot bind. anchorTermMismatches is what catches a benign-hash /
+ * hostile-terms anchor before it is recorded.
+ */
+
+const MINT = "So11111111111111111111111111111111111111112";
+const FEE_TO = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+
+const RECIPIENT = new PublicKey(FEE_TO);
+
+function onChain(overrides: Partial<OnChainLeague> = {}): OnChainLeague {
+  return {
+    address: PublicKey.default,
+    rulesHash: "a".repeat(64),
+    hasPot: true,
+    buyIn: "5000000",
+    tokenMint: MINT,
+    refundUnlockAt: 1_773_000_000,
+    feeBps: 100,
+    feeRecipient: FEE_TO,
+    payoutBps: [6000, 1500, 1000, 1000, 500],
+    maxTeams: 12,
+    memberCount: 0,
+    ...overrides,
+  };
+}
+
+const EXPECTED: ExpectedTerms = {
+  hasPot: true,
+  maxTeams: 12,
+  buyIn: "5000000",
+  refundUnlockAt: 1_773_000_000,
+  tokenMint: MINT,
+  feeBps: 100,
+  feeRecipient: FEE_TO,
+  payoutBps: [6000, 1500, 1000, 1000, 500],
+};
+
+describe("anchorTermMismatches", () => {
+  it("passes when every term matches the signed rules", () => {
+    expect(anchorTermMismatches(onChain(), EXPECTED)).toEqual([]);
+  });
+
+  it("catches a buy-in that exceeds what members agreed to", () => {
+    const m = anchorTermMismatches(onChain({ buyIn: "50000000" }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/buyIn/);
+  });
+
+  it("catches a refund unlock pushed far past settlement (funds stuck)", () => {
+    const m = anchorTermMismatches(onChain({ refundUnlockAt: 4_102_444_800 }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/refundUnlockAt/);
+  });
+
+  it("catches a redirected fee recipient", () => {
+    const attacker = PublicKey.default.toBase58();
+    const m = anchorTermMismatches(onChain({ feeRecipient: attacker }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/feeRecipient/);
+  });
+
+  it("catches a raised fee", () => {
+    expect(anchorTermMismatches(onChain({ feeBps: 500 }), EXPECTED)[0]).toMatch(/feeBps/);
+  });
+
+  it("catches a reshuffled payout split", () => {
+    const m = anchorTermMismatches(onChain({ payoutBps: [1500, 6000, 1000, 1000, 500] }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/payoutBps/);
+  });
+
+  it("catches a different token mint", () => {
+    const other = RECIPIENT.toBase58();
+    expect(anchorTermMismatches(onChain({ tokenMint: other }), EXPECTED)[0]).toMatch(/tokenMint/);
+  });
+
+  it("catches an unbounded max_teams", () => {
+    expect(anchorTermMismatches(onChain({ maxTeams: 255 }), EXPECTED)[0]).toMatch(/maxTeams/);
+  });
+
+  it("catches a free on-chain account standing in for a pot league", () => {
+    // has_pot=false with zeroed terms, anchored under a pot league's hash.
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: 0,
+      feeBps: 0,
+      payoutBps: [0, 0, 0, 0, 0],
+    });
+    const m = anchorTermMismatches(free, EXPECTED);
+    expect(m.some((x) => /hasPot/.test(x))).toBe(true);
+  });
+
+  it("passes a genuine free league and does not compare its money terms", () => {
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: 0,
+      tokenMint: PublicKey.default.toBase58(),
+      feeBps: 0,
+      feeRecipient: PublicKey.default.toBase58(),
+      payoutBps: [0, 0, 0, 0, 0],
+    });
+    const expectedFree: ExpectedTerms = { ...EXPECTED, hasPot: false };
+    expect(anchorTermMismatches(free, expectedFree)).toEqual([]);
+  });
+
+  it("reports every hostile field at once", () => {
+    const m = anchorTermMismatches(
+      onChain({ buyIn: "50000000", feeBps: 500, refundUnlockAt: 4_102_444_800 }),
+      EXPECTED,
+    );
+    expect(m.length).toBe(3);
+  });
+});

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -20,6 +20,7 @@
 import type { Program } from "@coral-xyz/anchor";
 import type { Connection, PublicKey } from "@solana/web3.js";
 
+import { payoutArray } from "./instructions.js";
 import { leaguePda } from "./program.js";
 import type { RostrEscrow } from "./types.js";
 
@@ -32,8 +33,18 @@ export interface OnChainLeague {
   /** Base units as a decimal string. Zero for a free league. */
   readonly buyIn: string;
   readonly tokenMint: string;
-  /** Unix seconds after which a stake may be withdrawn unilaterally. */
-  readonly refundUnlockAt: number;
+  /**
+   * Unix seconds after which a stake may be withdrawn unilaterally, as a
+   * decimal string.
+   *
+   * A string rather than a number because this is an `i64` the creator chooses
+   * freely — the program requires only that it is in the future, so `i64::MAX`
+   * is a legal value and is exactly the hostile one: it locks every deposit
+   * forever. `BN.toNumber()` **throws** above 2^53, so decoding it as a number
+   * turns the worst case this check exists to catch into an exception thrown
+   * before any comparison happens.
+   */
+  readonly refundUnlockAt: string;
   readonly feeBps: number;
   /** Base58; where the settlement fee is paid. */
   readonly feeRecipient: string;
@@ -88,7 +99,7 @@ export async function fetchOnChainLeague(
     hasPot: boolean;
     buyIn: { toString(): string };
     tokenMint: PublicKey;
-    refundUnlockAt: { toNumber(): number };
+    refundUnlockAt: { toString(): string };
     feeBps: number;
     feeRecipient: PublicKey;
     payoutBps: number[];
@@ -102,7 +113,7 @@ export async function fetchOnChainLeague(
     hasPot: raw.hasPot,
     buyIn: raw.buyIn.toString(),
     tokenMint: raw.tokenMint.toBase58(),
-    refundUnlockAt: raw.refundUnlockAt.toNumber(),
+    refundUnlockAt: raw.refundUnlockAt.toString(),
     feeBps: raw.feeBps,
     feeRecipient: raw.feeRecipient.toBase58(),
     payoutBps: [...raw.payoutBps],
@@ -155,17 +166,24 @@ export async function verifyLeagueAnchor(
 /**
  * The terms a league's *signed rules* say its on-chain account should hold.
  *
- * The caller builds this from the canonical rule set it already has — the escrow
- * package does not depend on the rules schema, so the mapping (and the payout
- * ordering; see `PRIZE_ORDER` / `payoutArray`) stays with the caller. Every field
- * here is one the program stores independently of `rules_hash`.
+ * The caller builds this from the canonical rule set it already has, because the
+ * escrow package does not depend on the rules schema. The payout ordering is
+ * **not** the caller's to invent: apply `payoutArray()` from this package, which
+ * is the one place `PRIZE_ORDER` is applied — serialising from the declaration
+ * order of `PrizeKey` instead reshuffles the split with no error anywhere.
+ *
+ * Every field here is one the program stores independently of `rules_hash`.
+ *
+ * The six money fields are compared only for a pot league; a free league carries
+ * zeroes and defaults for all of them.
  */
 export interface ExpectedTerms {
   readonly hasPot: boolean;
   readonly maxTeams: number;
-  /** Base units as a decimal string. Only compared for a pot league. */
+  /** Base units as a decimal string. */
   readonly buyIn: string;
-  readonly refundUnlockAt: number;
+  /** Unix seconds, as a decimal string — see `OnChainLeague.refundUnlockAt`. */
+  readonly refundUnlockAt: string;
   readonly tokenMint: string;
   readonly feeBps: number;
   readonly feeRecipient: string;
@@ -173,7 +191,54 @@ export interface ExpectedTerms {
 }
 
 /**
- * Every on-chain economic term that disagrees with the signed rules.
+ * The shape of a rule set this needs, and nothing more.
+ *
+ * Structural rather than an import of `LeagueRules`: the escrow package must not
+ * depend on the rules schema, and a structural type keeps the mapping here — in
+ * the fast test suite, next to `payoutArray` — instead of inline in a route that
+ * nothing tests.
+ */
+export interface RulesLikeTerms {
+  readonly league: { readonly maxTeams: number };
+  readonly pot: {
+    readonly tokenMint: string;
+    readonly buyInBaseUnits: string;
+    readonly refundUnlockAt: number;
+    readonly feeBps: number;
+    readonly feeRecipient: string;
+    readonly payout: readonly { readonly prize: string; readonly basisPoints: number }[];
+  } | null;
+}
+
+/**
+ * What a league's signed rules say its account should hold.
+ *
+ * `pot == null` rather than `pot !== null` is deliberate: a stored document that
+ * omits the key parses as `undefined`, and treating that as "has a pot" would
+ * tell a genuine free league its rules imply one — a mismatch it could never
+ * resolve, on the exact league shape this is meant to protect.
+ */
+export function expectedTermsFromRules(rules: RulesLikeTerms): ExpectedTerms {
+  const pot = rules.pot;
+
+  return {
+    hasPot: pot !== null && pot !== undefined,
+    maxTeams: rules.league.maxTeams,
+    buyIn: pot?.buyInBaseUnits ?? "0",
+    refundUnlockAt: String(pot?.refundUnlockAt ?? 0),
+    tokenMint: pot?.tokenMint ?? "",
+    feeBps: pot?.feeBps ?? 0,
+    feeRecipient: pot?.feeRecipient ?? "",
+    payoutBps: pot ? payoutArray(pot.payout) : [0, 0, 0, 0, 0],
+  };
+}
+
+/**
+ * The on-chain economic terms that disagree with the signed rules.
+ *
+ * Not necessarily *every* one: a pot-versus-free divergence is returned alone,
+ * because the money fields of a free account are zeroes that would produce six
+ * more lines all saying the same thing.
  *
  * `verifyLeagueAnchor` proves the chain holds *our hash*; it cannot prove the
  * chain holds *our terms*, because the program stores them as a separate copy it
@@ -206,7 +271,19 @@ export function anchorTermMismatches(
     ne("refundUnlockAt", onChain.refundUnlockAt, expected.refundUnlockAt);
     ne("tokenMint", onChain.tokenMint, expected.tokenMint);
     ne("feeBps", onChain.feeBps, expected.feeBps);
-    ne("feeRecipient", onChain.feeRecipient, expected.feeRecipient);
+
+    // A recipient only means something when there is a fee to pay it. The
+    // program itself requires one only when `fee_bps > 0`, so a fee-free league
+    // legitimately carries a default or empty recipient — and `feeBps` is
+    // compared just above, so a creator cannot use this to smuggle a fee in.
+    //
+    // Without this, a league created while `FEE_RECIPIENT` is unset stores
+    // `feeRecipient: ""`, which no base58 key can equal. That is not a retry:
+    // the PDA is one-shot, so a false mismatch here means the league can never
+    // be anchored at all, only recreated under a new id.
+    if (expected.feeBps > 0 || onChain.feeBps > 0) {
+      ne("feeRecipient", onChain.feeRecipient, expected.feeRecipient);
+    }
 
     if (
       onChain.payoutBps.length !== expected.payoutBps.length ||

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -32,7 +32,13 @@ export interface OnChainLeague {
   /** Base units as a decimal string. Zero for a free league. */
   readonly buyIn: string;
   readonly tokenMint: string;
+  /** Unix seconds after which a stake may be withdrawn unilaterally. */
+  readonly refundUnlockAt: number;
   readonly feeBps: number;
+  /** Base58; where the settlement fee is paid. */
+  readonly feeRecipient: string;
+  /** Payout split in basis points, positional (see `PRIZE_ORDER`). */
+  readonly payoutBps: readonly number[];
   readonly maxTeams: number;
   readonly memberCount: number;
 }
@@ -82,7 +88,10 @@ export async function fetchOnChainLeague(
     hasPot: boolean;
     buyIn: { toString(): string };
     tokenMint: PublicKey;
+    refundUnlockAt: { toNumber(): number };
     feeBps: number;
+    feeRecipient: PublicKey;
+    payoutBps: number[];
     maxTeams: number;
     memberCount: number;
   };
@@ -93,7 +102,10 @@ export async function fetchOnChainLeague(
     hasPot: raw.hasPot,
     buyIn: raw.buyIn.toString(),
     tokenMint: raw.tokenMint.toBase58(),
+    refundUnlockAt: raw.refundUnlockAt.toNumber(),
     feeBps: raw.feeBps,
+    feeRecipient: raw.feeRecipient.toBase58(),
+    payoutBps: [...raw.payoutBps],
     maxTeams: raw.maxTeams,
     memberCount: raw.memberCount,
   };
@@ -138,6 +150,76 @@ export async function verifyLeagueAnchor(
   }
 
   return { ok: true, league };
+}
+
+/**
+ * The terms a league's *signed rules* say its on-chain account should hold.
+ *
+ * The caller builds this from the canonical rule set it already has — the escrow
+ * package does not depend on the rules schema, so the mapping (and the payout
+ * ordering; see `PRIZE_ORDER` / `payoutArray`) stays with the caller. Every field
+ * here is one the program stores independently of `rules_hash`.
+ */
+export interface ExpectedTerms {
+  readonly hasPot: boolean;
+  readonly maxTeams: number;
+  /** Base units as a decimal string. Only compared for a pot league. */
+  readonly buyIn: string;
+  readonly refundUnlockAt: number;
+  readonly tokenMint: string;
+  readonly feeBps: number;
+  readonly feeRecipient: string;
+  readonly payoutBps: readonly number[];
+}
+
+/**
+ * Every on-chain economic term that disagrees with the signed rules.
+ *
+ * `verifyLeagueAnchor` proves the chain holds *our hash*; it cannot prove the
+ * chain holds *our terms*, because the program stores them as a separate copy it
+ * has no way to check against the hash. So a creator can anchor the benign
+ * document members sign while initialising the account with a hostile buy-in,
+ * refund unlock, fee recipient or payout split — and members who verified only
+ * the hash would deposit against terms they never agreed to. Closing that is the
+ * caller's job: derive the expected terms from the same signed rules and assert
+ * the account matches, refusing the anchor otherwise.
+ *
+ * Returns an empty array when everything agrees.
+ */
+export function anchorTermMismatches(
+  onChain: OnChainLeague,
+  expected: ExpectedTerms,
+): string[] {
+  const out: string[] = [];
+  const ne = (label: string, got: unknown, want: unknown): void => {
+    if (got !== want) out.push(`${label}: on-chain ${String(got)}, expected ${String(want)}`);
+  };
+
+  ne("hasPot", onChain.hasPot, expected.hasPot);
+  ne("maxTeams", onChain.maxTeams, expected.maxTeams);
+
+  // The money terms only mean anything for a pot league; a free one carries
+  // zeroes/defaults for all of them, and the hasPot check above already caught a
+  // pot-vs-free divergence.
+  if (expected.hasPot && onChain.hasPot) {
+    ne("buyIn", onChain.buyIn, expected.buyIn);
+    ne("refundUnlockAt", onChain.refundUnlockAt, expected.refundUnlockAt);
+    ne("tokenMint", onChain.tokenMint, expected.tokenMint);
+    ne("feeBps", onChain.feeBps, expected.feeBps);
+    ne("feeRecipient", onChain.feeRecipient, expected.feeRecipient);
+
+    if (
+      onChain.payoutBps.length !== expected.payoutBps.length ||
+      onChain.payoutBps.some((v, i) => v !== expected.payoutBps[i])
+    ) {
+      out.push(
+        `payoutBps: on-chain [${onChain.payoutBps.join(",")}], ` +
+          `expected [${expected.payoutBps.join(",")}]`,
+      );
+    }
+  }
+
+  return out;
 }
 
 /**

--- a/programs/rostr-escrow/tests/anchor.test.ts
+++ b/programs/rostr-escrow/tests/anchor.test.ts
@@ -1,8 +1,10 @@
 import * as anchor from "@coral-xyz/anchor";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+  anchorTermMismatches,
   clusterOf,
   escrowProgram,
+  expectedTermsFromRules,
   hexToBytes,
   initializeFreeLeagueIx,
   initializeLeagueIx,
@@ -189,6 +191,14 @@ describe("create -> anchor -> join", () => {
     expect(wrong.ok).toBe(false);
     if (!wrong.ok) expect(wrong.reason).toBe("HASH_MISMATCH");
 
+    // The economic terms agree too, against an account the program really
+    // wrote. The unit tests compare hand-built objects, so they cannot catch a
+    // field decoded from the wrong type or under the wrong name — this can, and
+    // it is the only place that can.
+    if (verdict.ok) {
+      expect(anchorTermMismatches(verdict.league, expectedTermsFromRules(rules))).toEqual([]);
+    }
+
     await recordChainAnchor(db, league.id, {
       signature,
       cluster: clusterOf(provider.connection),
@@ -244,6 +254,51 @@ describe("create -> anchor -> join", () => {
       league.rulesHash,
     );
     expect(verdict.ok).toBe(true);
+  });
+
+  it("refuses an anchor that carries the signed hash but hostile money terms", async () => {
+    // The attack the terms check exists for, run against a real program.
+    //
+    // The commissioner signs `initialize_league` from their own wallet, so they
+    // choose the account's economic terms — and the program cannot check those
+    // against `rules_hash`, because to it the hash is 32 opaque bytes. So this
+    // anchors the *correct* hash for a league whose signed rules say $23.50,
+    // alongside a $50 buy-in and a refund unlock at `i64::MAX`.
+    //
+    // The hash check passes. It has to: the document really is the one members
+    // read. Only the terms check catches this.
+    const { league, rules } = await createPotLeague("hostile");
+    const pot = rules.pot!;
+
+    const ix = await initializeLeagueIx(program, {
+      leagueId: league.id,
+      rulesHash: hexToBytes(league.rulesHash), // the honest hash
+      mint,
+      buyInBaseUnits: "50000000", // rules say 23500000
+      refundUnlockAt: "9223372036854775807", // funds frozen forever
+      payoutBps: payoutArray(pot.payout),
+      feeBps: pot.feeBps,
+      feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),
+      maxTeams: rules.league.maxTeams,
+      payer: provider.wallet.publicKey,
+    });
+    await provider.sendAndConfirm(new anchor.web3.Transaction().add(ix), [], {
+      commitment: "confirmed",
+    });
+
+    // The hash verifies — which is exactly why this was invisible before.
+    const verdict = await verifyLeagueAnchor(program, league.id, league.rulesHash);
+    expect(verdict.ok).toBe(true);
+
+    if (verdict.ok) {
+      // Decoding i64::MAX must not throw. Reading it as a JS number did, on
+      // this input specifically, which turned the worst case into a 500.
+      expect(verdict.league.refundUnlockAt).toBe("9223372036854775807");
+
+      const mismatches = anchorTermMismatches(verdict.league, expectedTermsFromRules(rules));
+      expect(mismatches.some((m) => /buyIn/.test(m))).toBe(true);
+      expect(mismatches.some((m) => /refundUnlockAt/.test(m))).toBe(true);
+    }
   });
 
   it("anchors a free league through the other instruction", async () => {


### PR DESCRIPTION
Builds on @0x-SquidSol's #32 — his commit is preserved here, with corrections on top. Closes #32.

## The bug

`verifyLeagueAnchor` compared the rules hash and nothing else. The program stores the economic terms as a **separate copy it has no way to check against that hash** — to it, the hash is 32 opaque bytes. The commissioner signs `initialize_league` from their own wallet, so they choose those terms independently of the document members read and sign.

So a creator could anchor the exact rules everyone agreed to, alongside a hostile buy-in, fee recipient, payout split, or `refund_unlock_at`. The hash verifies. Nobody can tell.

The worst of these is `refund_unlock_at`: `refund_stake` is the only way tokens leave the vault and it requires the clock to have passed, so a far-future value freezes every deposit permanently — and the program permits it, because its only check is that the value is in the future.

Verified against the real program, not argued about — `anchor.test.ts` anchors `i64::MAX` with an honest hash, confirms `verifyLeagueAnchor` returns `ok: true`, and confirms only the terms check catches it.

## Corrections to the original patch

Three defects, all found by review rather than by tests:

1. **`refundUnlockAt` was decoded with `BN.toNumber()`.** The field is an `i64`; bn.js throws above 2^53. So `refund_unlock_at = i64::MAX` — precisely the attack this exists to catch — threw inside `fetchOnChainLeague` and surfaced as a **500** rather than a refusal, and broke the pre-existing hash check for that account too. Now carried as a decimal string, like `buyIn` beside it.

2. **A fee-free league was unanchorable.** With `FEE_RECIPIENT` unset, leagues are created with `feeBps: 0` and an empty recipient, which no base58 key can equal. Since the PDA is one-shot, a false mismatch means the league can *never* be anchored — only recreated under a new id. The recipient is now compared only when a fee is actually charged, mirroring the program. `feeBps` is still compared unconditionally, so no fee can be smuggled in. `AnchorPanel` had the mirror image of this bug: `new PublicKey("")` throws.

3. **`pot !== null` treated a missing key as a pot league**, which would tell a genuine free league its rules imply one.

## Structural changes

- The rules-to-terms mapping moved out of the route into `expectedTermsFromRules`. `apps/web` has no test project, so anything inline there is verified only by being run in production — and **both** defects above were in the mapping, not the comparison.
- The route now re-checks an already-anchored league rather than returning early on the stored boolean. Nothing else in the system ever reads the account again, so a league recorded before this check existed would have been trusted forever on a check that never ran.

## Verification

- 928 fast tests, 67 program tests against a local validator, lint, typecheck, format — all green
- The Anchor CI job is path-filtered to `programs/**`, so it does **not** run on this PR. The program suite was run locally on a clean ledger; a reviewer should do the same rather than trust the green checkmark here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)