### PR TITLE
fix(db): scope a trade veto to the trade's own league

### DIFF
--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -427,6 +427,27 @@ describe("vetoing", () => {
     });
   });
 
+  it("refuses a veto from a team in another league", async () => {
+    // The electorate is the trade's own league. A team from a different league
+    // is not in it, so its vote must not be counted toward the veto threshold —
+    // otherwise an outsider could force a veto a small league never wanted.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const other = await createUser(fx.client, "other@example.com", "Other");
+    const otherLeague = await createLeague(fx.client, NFL, {
+      name: "Other League",
+      commissionerId: other.id,
+      rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+    });
+    const outsider = (await addTestTeam(fx.client, otherLeague.id, "Outsider")).teamId;
+
+    await expect(vetoTrade(fx.client, tradeId, outsider, MONDAY)).rejects.toMatchObject({
+      code: "NOT_IN_LEAGUE",
+    });
+  });
+
   it("refuses a second vote from the same team", async () => {
     const fx = await setup();
     const tradeId = await propose(fx);

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -45,6 +45,7 @@ export class TradeError extends Error {
       | "TRADE_NOT_FOUND"
       | "NOT_YOUR_TRADE"
       | "NOT_YOUR_PLAYER"
+      | "NOT_IN_LEAGUE"
       | "WRONG_STATE"
       | "TRADES_DISABLED"
       | "PAST_DEADLINE"
@@ -426,10 +427,20 @@ export async function vetoTrade(
     throw new TradeError("A team in the trade cannot vote on it", "INVOLVED_CANNOT_VETO");
   }
 
-  const [team] = await db.query<{ is_bot: boolean }>("SELECT is_bot FROM teams WHERE id = $1", [
-    actingTeamId,
-  ]);
-  if (team?.is_bot) throw new TradeError("Bots do not vote", "BOT_CANNOT_VETO");
+  // Scope the voter to the trade's own league. Without the league join this
+  // found the team by id alone, so a team in a *different* league could cast a
+  // counted vote — its vote raised the tally while the electorate (the trade
+  // league's uninvolved managers) did not, letting an outsider force a veto.
+  const [team] = await db.query<{ is_bot: boolean }>(
+    `SELECT t.is_bot FROM teams t
+       JOIN trades tr ON tr.id = $2
+      WHERE t.id = $1 AND t.league_id = tr.league_id`,
+    [actingTeamId, tradeId],
+  );
+  if (!team) {
+    throw new TradeError("Only a team in this league can vote on its trades", "NOT_IN_LEAGUE");
+  }
+  if (team.is_bot) throw new TradeError("Bots do not vote", "BOT_CANNOT_VETO");
 
   const [existing] = await db.query<{ team_id: string }>(
     "SELECT team_id FROM trade_vetoes WHERE trade_id = $1 AND team_id = $2",


### PR DESCRIPTION
Closes #42.

## Problem

`vetoTrade` looked up the voting team by id alone (`SELECT is_bot FROM teams WHERE id = $1`), never checking it belongs to the trade's league. So a team in a **different** league could cast a counted veto: the tally (`count(*)` of `trade_vetoes`) rose while the electorate (`uninvolvedManagers`, scoped to the trade's league) did not. Enough such votes force a veto the trade's own league never wanted — money-adjacent in a pot league. `vetoTrade`'s only guards were "not the proposer/receiver" and "not a bot", neither of which an outsider trips, and the route passes `body.tradeId` without asserting it belongs to the URL league.

## Fix

The team lookup now joins the trade and requires `teams.league_id = trades.league_id`, rejecting an out-of-league voter with `NOT_IN_LEAGUE`. This closes it at the data layer regardless of what the route passes.

## Tests

- New: a veto from a team in another league is refused (`NOT_IN_LEAGUE`) — it was counted before.
- Full trades suite: 44 pass; `pnpm typecheck` clean. The in-league veto/threshold behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
