### PR TITLE
test(db): prove a six-member pot league can never settle

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -28,9 +28,12 @@ import { EscrowConfigError, readOnlyEscrow } from "@/lib/escrow";
  * Both checks live in `@rostr/escrow` rather than inline here — `verifyLeagueAnchor`
  * so it can be exercised against a real validator, `expectedTermsFromRules` and
  * `anchorTermMismatches` so the mapping and the comparison are covered by the fast
- * suite. `apps/web` has no test project, so anything inline in this file would be
- * verified only by being run in production. What is left here is the session, the
- * write, and the status codes.
+ * suite, which needs no credentials and no chain. What is left here is the session,
+ * the write, and the status codes.
+ *
+ * `apps/web` does now have a test project (`pnpm test:web`), but it requires a
+ * database and would require a validator to reach this route — so keeping the
+ * checkable parts checkable without either is still the right split.
  */
 export async function POST(
   request: Request,

--- a/packages/db/src/playoffs.test.ts
+++ b/packages/db/src/playoffs.test.ts
@@ -237,6 +237,76 @@ describe("laying the first round", () => {
   });
 });
 
+describe("a pot league too small for a consolation bracket", () => {
+  /**
+   * Six members and the default rules is a league that can never settle.
+   *
+   * `consolationField` is `standings.slice(playoffTeams)`, and `playoffTeams`
+   * defaults to 6 — so at six members the consolation field is empty, at seven
+   * it is one team, and `bracketFor` returns null for both. That is correct on
+   * its own terms: there is no bracket to play.
+   *
+   * But CONSOLATION is a **paid** prize in the default payout, and `complete`
+   * requires every paid prize to have a holder. So the league plays a full
+   * postseason, crowns a champion — and never becomes complete, which is the
+   * flag settlement will read. Validation only compares `playoffTeams` against
+   * `maxTeams`, never against how many people actually joined, and the rules are
+   * frozen at creation, so an affected league cannot be corrected afterwards.
+   *
+   * This test asserts the defect rather than the desired behaviour. It is here
+   * so the decision is visible and so whatever fix is chosen has something to
+   * flip. See CLAUDE.md, "One league's failure never stops the others".
+   */
+  const POT = {
+    tokenMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    buyInBaseUnits: "25000000",
+    payout: [
+      { prize: "CHAMPION", basisPoints: 6000 },
+      { prize: "RUNNER_UP", basisPoints: 1500 },
+      { prize: "REGULAR_SEASON", basisPoints: 1000 },
+      { prize: "CONSOLATION", basisPoints: 1000 },
+      { prize: "THIRD_PLACE", basisPoints: 500 },
+    ],
+    refundUnlockAt: 1_773_000_000,
+    feeBps: 100,
+    feeRecipient: "6dNUCTMTgoHhbfgDzKtiPvBpJ2LzMwGqBpKmUDgQtNMK",
+  } as unknown as LeagueRules["pot"];
+
+  it("crowns a champion and still never completes", async () => {
+    const base = buildNflPprRules({ seasonYear: 2026, draft: DRAFT });
+    // No bots where there is money: a bot has no wallet and paid no buy-in.
+    const fx = await setup({ pot: POT, league: { ...base.league, maxBots: 0 } }, 6);
+
+    // Seeds are t0, t2, t4, t1, t3, t5 — the three winners on points, then the
+    // three losers. All six make the playoffs; nobody is left for consolation.
+    const state = await playoffState(fx.client, fx.leagueId);
+    expect(state.playoffs?.field).toHaveLength(6);
+    expect(state.consolation).toBeNull();
+
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 15, fx.teams[4]!, 120_000, 100_000); // seed 3 beats seed 6
+    await score(fx, 15, fx.teams[1]!, 120_000, 100_000); // seed 4 beats seed 5
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 16, fx.teams[0]!, 130_000, 100_000); // seed 1 beats seed 4
+    await score(fx, 16, fx.teams[2]!, 130_000, 100_000); // seed 2 beats seed 3
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 17, fx.teams[0]!, 140_000, 120_000); // final
+    await score(fx, 17, fx.teams[4]!, 110_000, 90_000); // third place
+
+    const result = await championship(fx.client, fx.leagueId);
+
+    // Every prize this league can decide *is* decided.
+    expect(result.champion).toBe(fx.teams[0]);
+    expect(result.runnerUp).toBe(fx.teams[2]);
+    expect(result.thirdPlace).toBe(fx.teams[4]);
+    expect(result.regularSeason).toBe(fx.teams[0]);
+
+    // And the one it cannot is paid, so the league never settles.
+    expect(result.consolation).toBeNull();
+    expect(result.complete).toBe(false);
+  });
+});
+
 describe("small leagues (fewer teams than the playoff field)", () => {
   /** The first round the bracket actually plays, with its byes and pairings. */
   const firstRound = async (fx: Fixture) => {


### PR DESCRIPTION
Evidence for the blocker recorded in CLAUDE.md. **Asserts the defect, not the desired behaviour** — deliberately, so the decision has something to flip and a regression has something to catch.

## The problem

`consolationField` is `standings.slice(playoffTeams)` and `playoffTeams` defaults to 6. So a **six-member** league has an empty consolation field and a **seven-member** one has a single team. `bracketFor` returns `null` for both — correct on its own terms, there is no bracket to play.

But CONSOLATION is a **paid prize** in the default payout, and `championship().complete` requires every paid prize to have a holder.

The test plays a full postseason with six members: all six make the playoffs, every round is advanced and scored. Champion, runner-up, third place and the regular-season prize are all decided. `complete` is `false`, and always will be.

Validation only compares `playoffTeams` against `maxTeams` — never against how many people actually joined — and rules are frozen at creation, so an affected league **cannot be corrected, only recreated**.

## The decision this needs

Three options, all product calls rather than review findings:

1. **A minimum-members gate** before the draft — a league below `playoffTeams + 2` cannot start.
2. **Drop the consolation share** when the field cannot exist, redistributing it. Changes the payout members signed, so it would have to be decided at creation, not later.
3. **Treat an impossible prize as satisfied** at settlement — `complete` ignores a prize whose bracket is structurally absent.

(1) is the only one that does not touch a signed payout. (3) is the smallest change but means the pot is split across four prizes while the rules say five.

Relevant to Aug 22: this is reachable by any six or seven friends creating a league with the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)