### PR TITLE
fix(db): derive the bracket and the regular-season prize from finalised scores

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,8 @@ addresses a bug that is live on `main` right now.** Verified individually on 202
   wallet, so they choose the account's terms independently of the document members sign — a
   hostile `refund_unlock_at` leaves every deposit permanently stuck. **This is the one with
   money at stake.**
-- **#34** — `loadWeekResults` filters `home_milli_points IS NOT NULL`, never `finalized_at`,
+- **#34 — FIXED**, see "The bracket waits for final" below. `loadWeekResults` filtered
+  `home_milli_points IS NOT NULL`, never `finalized_at`,
   so the bracket advances and `championship()` crowns from provisional scores.
 - **#36** — `acceptTrade` checks state and receiver only. Two proposals can name the same
   player, and `resolveTrade` inserts him onto both receivers unconditionally. The
@@ -571,6 +572,38 @@ what D6 will read.
 Fixtures are laid **before** scoring in the cron, not after: Week 15 has no matchups until
 `advancePlayoffs` writes them and `resolveLeagueWeek` refuses a week with no schedule, so
 the other order would cost a full cycle every time a round turns over.
+
+### The bracket waits for final, and the sweep is what makes final happen
+
+`bracketFor` reads **finalised** results only, so a round advances and the champion is
+derived from a settled score — never a live one, a 0-0 before kickoff, or one inside the
+correction window. `championship()` also asks for finalised **seeding**, because the best
+regular-season record is a paid prize (1000 bps) and Week 14 is a 168h week: every game is
+final on the Monday and a correction can flip the holder for another seven days. The
+standings screen deliberately keeps the live read — that table is meant to move.
+
+**The two halves are one change.** Requiring finalised results without the sweep would
+leave the champion permanently underivable: the cron resolved only the pointer week, and
+week 17's 168h window closes _after_ week-18 games move the pointer off it. Week 14 is
+abandoned the same way, four days early, by week 15's Thursday game.
+
+Three properties of `resolveLeagueWeeksThrough` are load-bearing, and each was wrong first:
+
+- **A week that throws is recorded and the sweep continues.** Without it, one old
+  unresolvable week blocks every later week for that league on every run — worse than the
+  bug being fixed, since before the sweep a broken week 3 could not stop week 16 scoring.
+- **Selection and refusal must be complements.** The sweep picks weeks where _no_ row is
+  finalised; `resolveLeagueWeek` refuses weeks where _any_ row is. Selecting on "any row
+  unfinalised" makes a mixed week both guaranteed to be selected and guaranteed to throw.
+  That state is reachable — a smaller consolation bracket starts in a _later_ week, so a
+  week can finalise holding only consolation fixtures and then receive playoff ones.
+- **It is bounded** (`SWEEP_LIMIT`), most-recent-first, and says what it deferred. A tail of
+  never-finalisable weeks would otherwise re-run the full lineup-and-scoring work for each,
+  every ten minutes, forever.
+
+The bracket screen keeps the **unfiltered** score read, so a played-but-not-final game shows
+its real score with no winner marked — and says "waiting on the correction window" rather
+than rendering as a blank page for seven days.
 
 ### One league's failure never stops the others
 

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -69,9 +69,9 @@ export async function GET(request: Request): Promise<NextResponse> {
   const scored: {
     leagueId: string;
     name: string;
-    matchups?: number;
-    finalized?: boolean;
-    holdReason?: string;
+    weeks?: { week: number; matchups: number; finalized: boolean; holdReason?: string }[];
+    failedWeeks?: readonly { readonly week: number; readonly reason: string }[];
+    deferredWeeks?: readonly number[];
     bracketGames?: number;
     bracketProblem?: string;
     skipped?: string;
@@ -121,19 +121,34 @@ export async function GET(request: Request): Promise<NextResponse> {
 
     try {
       // A single explicit week is targeted directly; otherwise sweep every
-      // still-unfinalised week up to the current one, so a paying week (168h
-      // window) finalises even after the pointer has moved past it to the
-      // playoffs. The current week's outcome is what the status line reports.
-      const outcomes = Number.isFinite(requestedWeek)
-        ? [await resolveLeagueWeek(client, league.id, week, now)]
+      // not-yet-finalised week up to the current one, so a paying week (168h
+      // window) finalises even after the pointer has moved past it — week 14 is
+      // abandoned four days early by week 15's Thursday game, and week 17, the
+      // championship week, once week-18 games are ingested.
+      const sweep = Number.isFinite(requestedWeek)
+        ? {
+            outcomes: [await resolveLeagueWeek(client, league.id, week, now)],
+            failures: [],
+            deferred: [],
+          }
         : await resolveLeagueWeeksThrough(client, league.id, week, now);
-      const outcome = outcomes.find((o) => o.week === week) ?? outcomes.at(-1);
+
+      // **Every week reports itself.** Collapsing a sweep to one row meant
+      // publishing an older week's matchup count and hold reason under the
+      // current week's number, and — worse — asserting `finalized: true` for a
+      // week that was never examined, which is the reading an operator would
+      // take as "nothing left to do".
       scored.push({
         leagueId: league.id,
         name: league.name,
-        matchups: outcome?.matchups ?? 0,
-        finalized: outcome?.finalized ?? true,
-        ...(outcome?.holdReason ? { holdReason: outcome.holdReason } : {}),
+        weeks: sweep.outcomes.map((o) => ({
+          week: o.week,
+          matchups: o.matchups,
+          finalized: o.finalized,
+          ...(o.holdReason ? { holdReason: o.holdReason } : {}),
+        })),
+        ...(sweep.failures.length > 0 ? { failedWeeks: sweep.failures } : {}),
+        ...(sweep.deferred.length > 0 ? { deferredWeeks: sweep.deferred } : {}),
         ...(bracketGames > 0 ? { bracketGames } : {}),
         ...(bracketProblem ? { bracketProblem } : {}),
       });

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -5,6 +5,7 @@ import {
   enterPlayoffs,
   PlayoffError,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
   WeekError,
 } from "@rostr/db";
 import { db } from "@/lib/db";
@@ -119,13 +120,20 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     try {
-      const outcome = await resolveLeagueWeek(client, league.id, week, now);
+      // A single explicit week is targeted directly; otherwise sweep every
+      // still-unfinalised week up to the current one, so a paying week (168h
+      // window) finalises even after the pointer has moved past it to the
+      // playoffs. The current week's outcome is what the status line reports.
+      const outcomes = Number.isFinite(requestedWeek)
+        ? [await resolveLeagueWeek(client, league.id, week, now)]
+        : await resolveLeagueWeeksThrough(client, league.id, week, now);
+      const outcome = outcomes.find((o) => o.week === week) ?? outcomes.at(-1);
       scored.push({
         leagueId: league.id,
         name: league.name,
-        matchups: outcome.matchups,
-        finalized: outcome.finalized,
-        ...(outcome.holdReason ? { holdReason: outcome.holdReason } : {}),
+        matchups: outcome?.matchups ?? 0,
+        finalized: outcome?.finalized ?? true,
+        ...(outcome?.holdReason ? { holdReason: outcome.holdReason } : {}),
         ...(bracketGames > 0 ? { bracketGames } : {}),
         ...(bracketProblem ? { bracketProblem } : {}),
       });

--- a/apps/web/src/app/leagues/[id]/bracket/page.tsx
+++ b/apps/web/src/app/leagues/[id]/bracket/page.tsx
@@ -46,8 +46,10 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
 
   const state = seasonOver ? await playoffState(client, id) : null;
 
-  // Points come off the same rows the bracket was built from, so a score shown
-  // beside a fixture is the score that decided it.
+  // **Deliberately unfiltered, unlike the bracket above it.** The ladder advances
+  // only on finalised results; these scores are live, so a played-but-not-yet-final
+  // game shows its real score with no winner marked. That gap is the correction
+  // window, and the screen says so rather than looking broken.
   const scores = new Map<string, { home: number; away: number }>();
   for (const phase of ["PLAYOFF", "CONSOLATION"] as const) {
     for (const row of await loadWeekResults(client, id, 99, phase)) {
@@ -62,6 +64,19 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
       });
     }
   }
+
+  // Every game in the last laid round has a live score, but the ladder has not
+  // resolved — so the week is played and not yet final. Derived from the same two
+  // sources the screen already holds rather than a third query, so it cannot
+  // disagree with what is rendered beside it.
+  const lastRound = state?.playoffs?.bracket.rounds.at(-1);
+  const awaitingFinal =
+    !!lastRound &&
+    lastRound.games.length > 0 &&
+    lastRound.games.every((game) =>
+      scores.has(`${game.week}:${game.homeTeamId}:${game.awayTeamId}`),
+    ) &&
+    lastRound.survivors === null;
 
   const Game = ({ game }: { game: BracketGame }) => {
     const score = scores.get(`${game.week}:${game.homeTeamId}:${game.awayTeamId}`);
@@ -133,6 +148,26 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
           The bracket is drawn when the regular season finishes. Seeding it early would give a
           bracket that changes under the teams in it.
         </p>
+      )}
+
+      {/*
+        The gap between "the final was played" and "the final is final".
+
+        The bracket advances only on finalised results, and the championship week
+        waits 168 hours for official stat corrections. So for seven days the
+        screen holds a played game with a real score and no champion — which
+        reads as a broken page unless it says otherwise. It is not a delay in
+        deciding; it is the week not being decided yet.
+      */}
+      {!state?.champion && awaitingFinal && (
+        <section className="rounded border border-white/10 px-4 py-3">
+          <p className="text-sm text-white/70">Waiting on the correction window.</p>
+          <p className="mt-1 text-xs text-white/50">
+            The games are played, but official stat corrections arrive for up to seven days and
+            this week pays out. No champion is named until the week is final — which is the
+            point: a result that can still change is not a result.
+          </p>
+        </section>
       )}
 
       {state?.champion && (

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -266,7 +266,8 @@ Week 17 is the championship. Single elimination throughout.
 
 **Every round reseeds.** The best surviving seed always draws the worst, which is what
 makes a good regular season worth having. It also means the bracket cannot be drawn in
-advance: who the top seed plays in Week 16 is not known until Week 15 is scored.
+advance: who the top seed plays in Week 16 is not known until Week 15 is **final** —
+scored is not enough, because a score inside the correction window can still change.
 
 **A playoff bye is not a game.** A team on a bye has no fixture, sets no lineup, and
 scores nothing that week. There is no way to be knocked out by sitting out.
@@ -498,11 +499,11 @@ Finalisation is **two-tier**, because the NFL issues official stat corrections f
 **seven days** after a game and a reclassified fumble can flip a matchup long after it
 looked settled:
 
-| Week                                                    | Provisional | Final        | Why                                                                                        |
-| ------------------------------------------------------- | ----------- | ------------ | ------------------------------------------------------------------------------------------ |
-| Regular season 1–13, playoffs 15–16                     | immediately | **T+48h**    | No funds move. A late correction restates standings and the bracket, which is recoverable. |
-| **Week 14** (regular-season prize)                      | immediately | **T+7 days** | Money moves. Must outlast the correction window.                                           |
-| **Week 17** (championship, runner-up, 3rd, consolation) | immediately | **T+7 days** | Money moves. Must outlast the correction window.                                           |
+| Week                                                    | Provisional | Final        | Why                                                                                                                                                |
+| ------------------------------------------------------- | ----------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Regular season 1–13, playoffs 15–16                     | immediately | **T+48h**    | No funds move. The bracket advances only on finalised results, so a correction inside the window restates the round _before_ the next one is laid. |
+| **Week 14** (regular-season prize)                      | immediately | **T+7 days** | Money moves. Must outlast the correction window.                                                                                                   |
+| **Week 17** (championship, runner-up, 3rd, consolation) | immediately | **T+7 days** | Money moves. Must outlast the correction window.                                                                                                   |
 
 Any week that pays out waits the full seven days. Weeks that only affect standings
 finalise in 48 hours so the season keeps moving. A correction arriving after a paying

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -82,6 +82,7 @@ export {
   type MatchupPhase,
   persistSchedule,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
   WeekError,
   type ResolveWeekOutcome,
 } from "./week.js";

--- a/packages/db/src/playoffs.test.ts
+++ b/packages/db/src/playoffs.test.ts
@@ -104,6 +104,22 @@ async function score(
   );
 }
 
+/** Points written, but `finalized_at` left NULL — a live or within-window score. */
+async function scoreProvisional(
+  fx: Fixture,
+  week: number,
+  homeTeamId: string,
+  homePoints: number,
+  awayPoints: number,
+): Promise<void> {
+  await fx.client.query(
+    `UPDATE matchups
+        SET home_milli_points = $3, away_milli_points = $4
+      WHERE league_id = $1 AND week = $2 AND home_team_id = $5 AND phase <> 'REGULAR'`,
+    [fx.leagueId, week, homePoints, awayPoints, homeTeamId],
+  );
+}
+
 async function fixtures(fx: Fixture, week: number) {
   return fx.client.query<{ home_team_id: string; away_team_id: string; phase: string }>(
     `SELECT home_team_id, away_team_id, phase FROM matchups
@@ -472,6 +488,49 @@ describe("advancing round by round", () => {
     const result = await championship(fx.client, fx.leagueId);
     expect(result.champion).toBeNull();
     expect(result.complete).toBe(false);
+  });
+});
+
+describe("advances and crowns only on finalised results", () => {
+  it("does not lay the next round from a provisional (non-finalised) result", async () => {
+    // A round must not advance off a live or within-correction-window score:
+    // the bracket would lay fixtures off a result that can still change, and off
+    // a game that may not have kicked off (a 0-0 shows as a tie).
+    const fx = await setup();
+    await advancePlayoffs(fx.client, fx.leagueId);
+
+    await scoreProvisional(fx, 15, fx.teams[4]!, 120_000, 100_000);
+    await scoreProvisional(fx, 15, fx.teams[6]!, 90_000, 130_000);
+
+    const outcome = await advancePlayoffs(fx.client, fx.leagueId);
+
+    expect(outcome.written).toBe(0);
+    expect(await fixtures(fx, 16)).toHaveLength(0);
+  });
+
+  it("does not crown a champion from a provisional final, but does once it finalises", async () => {
+    const fx = await setup();
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 15, fx.teams[4]!, 120_000, 100_000);
+    await score(fx, 15, fx.teams[6]!, 90_000, 130_000);
+    await advancePlayoffs(fx.client, fx.leagueId);
+    await score(fx, 16, fx.teams[0]!, 130_000, 100_000);
+    await score(fx, 16, fx.teams[2]!, 100_000, 130_000);
+    await advancePlayoffs(fx.client, fx.leagueId);
+
+    // Week 17 scored but not finalised — still inside the 168h correction window.
+    await scoreProvisional(fx, 17, fx.teams[0]!, 140_000, 120_000);
+    await scoreProvisional(fx, 17, fx.teams[2]!, 90_000, 110_000);
+    await scoreProvisional(fx, 17, fx.teams[5]!, 100_000, 90_000);
+
+    expect((await championship(fx.client, fx.leagueId)).champion).toBeNull();
+
+    // Finalise it, and the champion is derived.
+    await score(fx, 17, fx.teams[0]!, 140_000, 120_000);
+    await score(fx, 17, fx.teams[2]!, 90_000, 110_000);
+    await score(fx, 17, fx.teams[5]!, 100_000, 90_000);
+
+    expect((await championship(fx.client, fx.leagueId)).champion).toBe(fx.teams[0]);
   });
 });
 

--- a/packages/db/src/playoffs.ts
+++ b/packages/db/src/playoffs.ts
@@ -75,12 +75,16 @@ export interface PlayoffState {
  * arithmetic. Nothing is cached, because a cached bracket is a second answer
  * that can disagree with the first.
  */
-export async function playoffState(db: SqlClient, leagueId: string): Promise<PlayoffState> {
+export async function playoffState(
+  db: SqlClient,
+  leagueId: string,
+  finalizedSeeding = false,
+): Promise<PlayoffState> {
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new PlayoffError("League has no rules", "LEAGUE_NOT_FOUND");
 
   const rules = stored.rules;
-  const seeds = await seedOrder(db, leagueId, rules);
+  const seeds = await seedOrder(db, leagueId, rules, finalizedSeeding);
 
   const playoffs = await bracketFor(
     db,
@@ -111,8 +115,26 @@ export async function playoffState(db: SqlClient, leagueId: string): Promise<Pla
   };
 }
 
-/** The regular-season standings, which are the bracket's seeding. */
-async function seedOrder(db: SqlClient, leagueId: string, rules: LeagueRules) {
+/**
+ * The regular-season standings, which are the bracket's seeding.
+ *
+ * `finalizedOnly` is off by default because the seeding a *screen* shows should
+ * move with live scores — that is the standings table, and it is meant to.
+ *
+ * `championship()` asks for it on, because the best regular-season record is a
+ * **paid prize** (1000 bps) and deriving it from provisional scores is the same
+ * defect as crowning a champion from them. Week 14 is a 168h paying week: every
+ * game is final on the Monday and the window runs a further seven days, and a
+ * stat correction inside it can flip the holder. `advancePlayoffs` is already
+ * gated on the regular season being complete, so the write path never needed
+ * this; the read path did.
+ */
+async function seedOrder(
+  db: SqlClient,
+  leagueId: string,
+  rules: LeagueRules,
+  finalizedOnly = false,
+) {
   const teams = await db.query<{ id: string }>(
     "SELECT id FROM teams WHERE league_id = $1 ORDER BY slot",
     [leagueId],
@@ -122,6 +144,7 @@ async function seedOrder(db: SqlClient, leagueId: string, rules: LeagueRules) {
     leagueId,
     rules.schedule.regularSeasonWeeks,
     "REGULAR",
+    finalizedOnly,
   );
 
   return computeStandings(
@@ -344,7 +367,10 @@ export async function championship(db: SqlClient, leagueId: string): Promise<Cha
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new PlayoffError("League has no rules", "LEAGUE_NOT_FOUND");
 
-  const state = await playoffState(db, leagueId);
+  // Finalised seeding, because this is the function settlement reads. The
+  // regular-season prize is derived from the seeding, and a prize decided from a
+  // score that can still be corrected is the defect this whole change is about.
+  const state = await playoffState(db, leagueId, true);
   const paid = new Set(
     (stored.rules.pot?.payout ?? [])
       .filter((share) => share.basisPoints > 0)

--- a/packages/db/src/playoffs.ts
+++ b/packages/db/src/playoffs.ts
@@ -143,7 +143,11 @@ async function bracketFor(
   // there is simply no bracket.
   if (field.length < 2) return null;
 
-  const results = await loadWeekResults(db, leagueId, lastWeek(rules), phase);
+  // Finalised results only. A round advances, and the champion is derived, only
+  // from a settled score — never a live, provisional, or within-correction-window
+  // one. Otherwise the bracket lays fixtures off a 0-0 game that has not kicked
+  // off, and a Week 17 leader is crowned before the game is even played.
+  const results = await loadWeekResults(db, leagueId, lastWeek(rules), phase, true);
 
   return {
     phase,

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -292,7 +292,7 @@ describe("resolveLeagueWeeksThrough", () => {
       "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2 LIMIT 1",
       [fx.leagueId, WEEK],
     );
-    return row?.finalized_at != null;
+    return Boolean(row?.finalized_at);
   };
 
   it("finalises a prior week that the single-week pointer leaves behind", async () => {
@@ -309,9 +309,18 @@ describe("resolveLeagueWeeksThrough", () => {
     expect(await week1Finalized(fx)).toBe(false);
 
     // The sweep resolves every unfinalised week up to the pointer, so week 1 is
-    // finalised.
-    const outcomes = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, 5, AFTER_STANDARD);
-    expect(outcomes.find((o) => o.week === WEEK)?.finalized).toBe(true);
+    // finalised. The limit is raised past the default because this fixture has
+    // fourteen weeks of fixtures and none of them finalised — the default of 4
+    // is sized for the real case, where the unfinalised set at any moment is the
+    // paying week plus the playoff weeks that followed it.
+    const sweep = await resolveLeagueWeeksThrough(
+      fx.client,
+      fx.leagueId,
+      5,
+      AFTER_STANDARD,
+      10,
+    );
+    expect(sweep.outcomes.find((o) => o.week === WEEK)?.finalized).toBe(true);
     expect(await week1Finalized(fx)).toBe(true);
   });
 
@@ -321,10 +330,109 @@ describe("resolveLeagueWeeksThrough", () => {
     await finishGames(fx);
     await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
 
-    // Only week 1 has finished games, so it is the only one that can finalise;
-    // a second sweep finds it already done and nothing else pending to finalise.
+    // Bounded by `week <= WEEK`, so weeks 2-14 are out of range rather than
+    // absent — this asserts the pointer bound, not that the season is done.
     const again = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
-    expect(again).toHaveLength(0);
+    expect(again.outcomes).toHaveLength(0);
+    expect(again.failures).toHaveLength(0);
+  });
+
+  it("does not let one unresolvable week stop the weeks after it", async () => {
+    // The regression that matters. Before the sweep existed, a broken week 3
+    // could not stop week 16 from scoring, because the cron touched exactly one
+    // week. A sweep without per-week isolation makes that possible — and the
+    // oldest broken week wins, permanently, because it is re-selected every run.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    // Week 2 cannot resolve: one of its matchups names a team from another
+    // league, so `ensureLineups` never gives it a lineup and `resolveWeek`
+    // refuses rather than scoring the missing side as zero — which would hand
+    // its opponent a free win off our own bug.
+    //
+    // Deleting a lineup would not do it: `ensureLineups` runs first and autofills
+    // one, which is the whole reason that function exists.
+    const other = await createUser(fx.client, "other@example.com", "Other");
+    const otherLeague = await createLeague(fx.client, NFL, {
+      name: "Elsewhere",
+      commissionerId: other.id,
+      rules: fx.rules,
+    });
+    const outsider = await addTestTeam(fx.client, otherLeague.id, "Outsider");
+
+    await fx.client.query(
+      `INSERT INTO matchups (league_id, week, phase, home_team_id, away_team_id)
+       VALUES ($1, 2, 'REGULAR', $2, $3)`,
+      [fx.leagueId, fx.teamIds[0], outsider.teamId],
+    );
+
+    const sweep = await resolveLeagueWeeksThrough(
+      fx.client,
+      fx.leagueId,
+      5,
+      AFTER_STANDARD,
+      10,
+    );
+
+    // Week 2 failed and said so — silence would read as "nothing to do".
+    expect(sweep.failures.some((f) => f.week === 2)).toBe(true);
+    // And week 1 was still resolved and finalised despite it.
+    expect(sweep.outcomes.find((o) => o.week === WEEK)?.finalized).toBe(true);
+    expect(await week1Finalized(fx)).toBe(true);
+  });
+
+  it("skips a part-finalised week rather than wedging on it", async () => {
+    // The sweep selects weeks with no finalised row; `resolveLeagueWeek` refuses
+    // weeks with any finalised row. If those two predicates are not complements,
+    // a mixed week is selected *and* refused — unresolvable by construction, and
+    // with no isolation it takes every later week with it.
+    //
+    // Reachable: a smaller consolation bracket starts in a later week than the
+    // main one, so a week can finalise holding only consolation fixtures and
+    // then receive playoff fixtures on a later advance.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    // Week 1 is finalised; now add an unfinalised row to it.
+    await fx.client.query(
+      `INSERT INTO matchups (league_id, week, phase, home_team_id, away_team_id)
+       SELECT $1, $2, 'PLAYOFF', home_team_id, away_team_id
+         FROM matchups WHERE league_id = $1 AND week = $2 AND phase = 'REGULAR' LIMIT 1`,
+      [fx.leagueId, WEEK],
+    );
+
+    const sweep = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, 5, AFTER_STANDARD);
+
+    // Not selected at all, so it cannot throw and cannot block anything.
+    expect(sweep.outcomes.some((o) => o.week === WEEK)).toBe(false);
+    expect(sweep.failures.some((f) => f.week === WEEK)).toBe(false);
+  });
+
+  it("bounds the sweep and reports what it left behind", async () => {
+    // A league with a long tail of never-finalisable weeks — a postponed game, a
+    // feed that never marks one final — would otherwise re-run the full
+    // lineup-and-scoring work for every one of them, every ten minutes, forever.
+    const fx = await setup();
+    await schedule(fx);
+
+    const sweep = await resolveLeagueWeeksThrough(
+      fx.client,
+      fx.leagueId,
+      10,
+      AFTER_STANDARD,
+      3,
+    );
+
+    expect(sweep.outcomes.length + sweep.failures.length).toBeLessThanOrEqual(3);
+    expect(sweep.deferred.length).toBeGreaterThan(0);
+    // The most recent are taken, because those are the ones with money and an
+    // audience attached; the older ones are named rather than dropped silently.
+    expect(Math.max(...sweep.deferred)).toBeLessThan(
+      Math.min(...sweep.outcomes.map((o) => o.week)),
+    );
   });
 });
 

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -13,6 +13,7 @@ import {
   loadWeekResults,
   persistSchedule,
   resolveLeagueWeek,
+  resolveLeagueWeeksThrough,
 } from "./week.js";
 
 let db: PGliteClient | undefined;
@@ -282,6 +283,48 @@ describe("resolveLeagueWeek", () => {
     await expect(resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING)).rejects.toMatchObject(
       { code: "NO_SCHEDULE" },
     );
+  });
+});
+
+describe("resolveLeagueWeeksThrough", () => {
+  const week1Finalized = async (fx: Fixture): Promise<boolean> => {
+    const [row] = await fx.client.query<{ finalized_at: string | null }>(
+      "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2 LIMIT 1",
+      [fx.leagueId, WEEK],
+    );
+    return row?.finalized_at != null;
+  };
+
+  it("finalises a prior week that the single-week pointer leaves behind", async () => {
+    // Week 1 is final and its 48h window has elapsed, but the pointer is on a
+    // later week. This is exactly how a paying week is abandoned once the season
+    // moves on: resolving only the pointer week never revisits it.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    // Resolving only week 5 (which has fixtures but no finished games) leaves
+    // week 1 unfinalised — the bug.
+    await resolveLeagueWeek(fx.client, fx.leagueId, 5, AFTER_STANDARD);
+    expect(await week1Finalized(fx)).toBe(false);
+
+    // The sweep resolves every unfinalised week up to the pointer, so week 1 is
+    // finalised.
+    const outcomes = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, 5, AFTER_STANDARD);
+    expect(outcomes.find((o) => o.week === WEEK)?.finalized).toBe(true);
+    expect(await week1Finalized(fx)).toBe(true);
+  });
+
+  it("leaves nothing to do once every week through the pointer is finalised", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    // Only week 1 has finished games, so it is the only one that can finalise;
+    // a second sweep finds it already done and nothing else pending to finalise.
+    const again = await resolveLeagueWeeksThrough(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    expect(again).toHaveLength(0);
   });
 });
 

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -206,39 +206,102 @@ export async function resolveLeagueWeek(
 }
 
 /**
- * Resolve every week up to `throughWeek` that still has an unfinalised matchup.
+ * Resolve every week up to `throughWeek` that is not yet finalised.
  *
  * The scoring cron used to resolve only the single current week. That works for
- * standings weeks (48h window), whose window closes before the next week's first
+ * a standings week (48h window), which closes before the next week's first
  * kickoff moves the pointer on. It does **not** work for a paying week (168h):
- * week 15's Thursday game arrives ~4 days after week 14's last game, so the
- * pointer leaves week 14 three days before its window elapses, and it would never
- * be finalised — leaving the regular-season prize, and any bracket built from it,
- * on provisional scores forever. The same abandons week 17 once week-18 games are
- * ingested.
+ * week 14's last game is a Monday night, week 15's first is the Thursday three
+ * days later, so the pointer leaves week 14 with four days of its window still
+ * to run and it is never finalised — leaving the regular-season prize, and any
+ * bracket seeded from it, on provisional scores forever. The same abandons week
+ * 17, the championship week, once week-18 games are ingested.
  *
- * Sweeping every still-unfinalised week fixes that. Each call is safe and
- * idempotent: a finalised week is filtered out here and would in any case be
- * refused by `resolveLeagueWeek`.
+ * Three properties are load-bearing, and each was got wrong first:
+ *
+ * **One week's failure may not stop the others.** A week that throws is recorded
+ * and the sweep continues. Without that, an old unresolvable week blocks every
+ * later week for that league on every run, forever — including the current one,
+ * which is strictly worse than the bug being fixed, because before the sweep
+ * existed a broken week 3 could not stop week 16 from scoring.
+ *
+ * **The selection and the refusal must agree.** This picks weeks where *no* row
+ * is finalised; `resolveLeagueWeek` refuses a week where *any* row is. Selecting
+ * on "any row unfinalised" instead makes a partially finalised week both
+ * guaranteed to be selected and guaranteed to throw — unresolvable by
+ * construction. That state is reachable: a smaller consolation bracket starts in
+ * a later week than the main one, so a week can be finalised holding only
+ * consolation fixtures and then receive playoff fixtures on a later advance.
+ *
+ * **It is bounded.** A league with a long tail of never-finalisable weeks — a
+ * postponed game, a feed that never marked a game final — would otherwise re-run
+ * the full lineup-and-scoring work for every one of them on every pass. The cap
+ * takes the most recent, because those are the ones with money and an audience
+ * attached, and the caller is told what was left behind rather than being left to
+ * infer it from silence.
  */
+export const SWEEP_LIMIT = 4;
+
+export interface SweepOutcome {
+  readonly outcomes: readonly ResolveWeekOutcome[];
+  /** Weeks that threw, so a caller can surface them rather than guess. */
+  readonly failures: readonly { readonly week: number; readonly reason: string }[];
+  /** Older unfinalised weeks the cap left for a later run. */
+  readonly deferred: readonly number[];
+}
+
 export async function resolveLeagueWeeksThrough(
   db: SqlClient,
   leagueId: string,
   throughWeek: number,
   now: Date,
-): Promise<readonly ResolveWeekOutcome[]> {
+  limit: number = SWEEP_LIMIT,
+): Promise<SweepOutcome> {
+  // `NOT EXISTS` rather than `finalized_at IS NULL`: a week is a candidate only
+  // when none of its rows are finalised. See the note above on why the two
+  // predicates have to be complements.
   const weeks = await db.query<{ week: number }>(
-    `SELECT DISTINCT week FROM matchups
-      WHERE league_id = $1 AND week <= $2 AND finalized_at IS NULL
-      ORDER BY week`,
+    `SELECT DISTINCT m.week
+       FROM matchups m
+      WHERE m.league_id = $1
+        AND m.week <= $2
+        AND NOT EXISTS (
+              SELECT 1 FROM matchups f
+               WHERE f.league_id = m.league_id
+                 AND f.week = m.week
+                 AND f.finalized_at IS NOT NULL
+            )
+      ORDER BY m.week`,
     [leagueId, throughWeek],
   );
 
+  const all = weeks.map((row) => Number(row.week));
+  // Ascending, and the *last* `limit` of them — the most recent. Ascending order
+  // matters: a later week's fixtures may not exist until an earlier one
+  // finalises, so resolving out of order would silently skip a round.
+  const take = all.slice(Math.max(0, all.length - limit));
+  const deferred = all.slice(0, Math.max(0, all.length - limit));
+
   const outcomes: ResolveWeekOutcome[] = [];
-  for (const { week } of weeks) {
-    outcomes.push(await resolveLeagueWeek(db, leagueId, Number(week), now));
+  const failures: { week: number; reason: string }[] = [];
+
+  for (const week of take) {
+    try {
+      outcomes.push(await resolveLeagueWeek(db, leagueId, week, now));
+    } catch (error) {
+      failures.push({
+        week,
+        reason:
+          error instanceof WeekError
+            ? error.code
+            : error instanceof Error
+              ? error.message
+              : String(error),
+      });
+    }
   }
-  return outcomes;
+
+  return { outcomes, failures, deferred };
 }
 
 /**

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -206,6 +206,42 @@ export async function resolveLeagueWeek(
 }
 
 /**
+ * Resolve every week up to `throughWeek` that still has an unfinalised matchup.
+ *
+ * The scoring cron used to resolve only the single current week. That works for
+ * standings weeks (48h window), whose window closes before the next week's first
+ * kickoff moves the pointer on. It does **not** work for a paying week (168h):
+ * week 15's Thursday game arrives ~4 days after week 14's last game, so the
+ * pointer leaves week 14 three days before its window elapses, and it would never
+ * be finalised — leaving the regular-season prize, and any bracket built from it,
+ * on provisional scores forever. The same abandons week 17 once week-18 games are
+ * ingested.
+ *
+ * Sweeping every still-unfinalised week fixes that. Each call is safe and
+ * idempotent: a finalised week is filtered out here and would in any case be
+ * refused by `resolveLeagueWeek`.
+ */
+export async function resolveLeagueWeeksThrough(
+  db: SqlClient,
+  leagueId: string,
+  throughWeek: number,
+  now: Date,
+): Promise<readonly ResolveWeekOutcome[]> {
+  const weeks = await db.query<{ week: number }>(
+    `SELECT DISTINCT week FROM matchups
+      WHERE league_id = $1 AND week <= $2 AND finalized_at IS NULL
+      ORDER BY week`,
+    [leagueId, throughWeek],
+  );
+
+  const outcomes: ResolveWeekOutcome[] = [];
+  for (const { week } of weeks) {
+    outcomes.push(await resolveLeagueWeek(db, leagueId, Number(week), now));
+  }
+  return outcomes;
+}
+
+/**
  * Why a week may not be finalised yet, or `null` if it may.
  *
  * Two conditions, both necessary: every game must be final, and the correction
@@ -354,7 +390,14 @@ export async function loadWeekResults(
   leagueId: string,
   throughWeek: number,
   phase: MatchupPhase = "REGULAR",
+  finalizedOnly = false,
 ): Promise<readonly MatchupResult[]> {
+  // `finalizedOnly` is what the playoff bracket asks for. Advancement and the
+  // derived champion must key on a settled result, not a provisional one: a
+  // bracket built from live or not-yet-finalised scores advances the wrong team
+  // (and lays orphan fixtures), and a paying week's result can still change
+  // inside the correction window. A finalised matchup always has points, so this
+  // narrows rather than contradicts the `home_milli_points IS NOT NULL` guard.
   const rows = await db.query<{
     week: number;
     home_team_id: string;
@@ -364,7 +407,9 @@ export async function loadWeekResults(
   }>(
     `SELECT week, home_team_id, away_team_id, home_milli_points, away_milli_points
        FROM matchups
-      WHERE league_id = $1 AND week <= $2 AND phase = $3 AND home_milli_points IS NOT NULL
+      WHERE league_id = $1 AND week <= $2 AND phase = $3 AND home_milli_points IS NOT NULL${
+        finalizedOnly ? " AND finalized_at IS NOT NULL" : ""
+      }
       ORDER BY week, id`,
     [leagueId, throughWeek, phase],
   );


### PR DESCRIPTION
Builds on @0x-SquidSol's #34 — his commit is preserved, with corrections on top. Closes #34, closes #33.

## The bug

`loadWeekResults` filtered `home_milli_points IS NOT NULL`, never `finalized_at`. So `advancePlayoffs` laid the next round, and `championship()` crowned, from live scores — including a 0-0 row written before kickoff, which `buildBracket` resolves by seed. A champion could be named before the game was played, and flipped afterwards by a stat correction.

## Both halves are one change

Requiring finalised results **without** the sweep would leave the champion permanently underivable. The cron resolved only the pointer week, and week 17's 168h window closes *after* week-18 games move the pointer off it. Week 14 is abandoned the same way — four days early, by week 15's Thursday game.

The read fix is his and it is correct. The sweep needed three corrections:

1. **One week's failure must not stop the others.** The loop had no per-week catch, so an old unresolvable week blocked every later week for that league on every run — *including the current one*. That is strictly worse than the bug being fixed: before the sweep existed, a broken week 3 could not stop week 16 from scoring. There is a test.
2. **Selection and refusal must be complements.** The sweep selected weeks with *any* unfinalised row; `resolveLeagueWeek` refuses weeks with *any* finalised row. A mixed week was therefore guaranteed to be selected and guaranteed to throw — unresolvable by construction. **Reachable, not theoretical:** a smaller consolation bracket starts in a later week than the main one, so a week can finalise holding only consolation fixtures and then receive playoff fixtures on a later advance. Now selected with `NOT EXISTS`, and there is a test.
3. **It is bounded.** A tail of never-finalisable weeks — a postponed game, a feed that never marks one final — re-ran the full lineup-and-scoring work for each of them, every ten minutes, forever. Capped most-recent-first, with deferred weeks named rather than dropped silently.

## One more read the original left open

`championship()` → `playoffState()` → `seedOrder` was ungated, so the **best regular-season record — a paid prize at 1000 bps** — was still derived from provisional scores. Week 14 is a 168h paying week: every game is final on the Monday and a correction can flip the holder for another seven days. Same defect, different read. `advancePlayoffs` was already gated on the regular season being complete, so only the read path was exposed. The standings *screen* keeps the live read deliberately — that table is meant to move.

## Docs and screen

- `RULES.md` §5 said the Week 16 pairing is unknown "until Week 15 is **scored**", and that a late correction "restates standings and the bracket, which is recoverable". Neither is true now.
- The status line reported an older week's matchup count under the current week's number, and asserted `finalized: true` for a week never examined. Every week now reports itself.
- The bracket screen keeps its unfiltered score read on purpose, and now says "waiting on the correction window" instead of rendering as a blank page for the seven days between the final being played and being final.

## Verification

945 tests, lint, typecheck, format green. Five sweep tests, including the throwing week and the mixed week — both of which fail against the original sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)