### PR TITLE
fix(db): re-validate trade assets on accept, and refuse to mint one on execute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,7 +628,22 @@ trade is vetoed before anyone votes. `isVetoed` short-circuits it.
 
 **Accepting freezes the players; it does not move them.** Between acceptance and execution
 they are in escrow: `lockedByTrade` is consulted by `dropPlayer` (which throws
-`IN_A_TRADE`) and by `proposeTrade`. Without it a manager accepts a trade and cuts the
+`IN_A_TRADE`), by `proposeTrade`, and by `acceptTrade` — the proposal's checks are stale by
+the time anyone accepts.
+
+**In `acceptTrade`, take every row lock first and read the freeze set second.** The obvious
+order is wrong and looks right: two concurrent accepts of the same player both read an
+empty freeze set _before_ either takes a lock, the loser then blocks, wakes after the winner
+commits, re-checks a snapshot that predates it, and passes. Both trades reach ACCEPTED. The
+lock would be doing real work and guarding a value already read. PGlite is single-connection,
+so no test in this repo can catch that — it has to be got right by reading.
+
+**Execution refuses rather than inserting when the release matches no row** (`ASSET_GONE`,
+recorded as EXPIRED). This is the last line of defence and the only one that does not depend
+on knowing _how_ the player left: accepted twice, dropped through a path that skipped the
+freeze, or claimed off waivers. Upstream checks each close one route; this closes the
+outcome. The `(team_id, player_id)` unique index cannot — it is per-team, so the same player
+on two different teams satisfies it. Without it a manager accepts a trade and cuts the
 player they promised, and execution finds a hole where a roster spot used to be.
 
 **Execution releases and re-adds roster rows rather than repointing them.**

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -36,6 +36,8 @@ const DRAFT: DraftRules = {
 
 const HOUR = 3600 * 1000;
 const MONDAY = new Date("2026-10-12T18:00:00Z");
+/** Past the 48-hour veto window, so an accepted trade is due to resolve. */
+const AFTER_WINDOW = new Date(MONDAY.getTime() + 49 * HOUR);
 
 interface Fixture {
   client: PGliteClient;
@@ -418,9 +420,111 @@ describe("no double-spend across trades", () => {
 
     await acceptTrade(fx.client, a.tradeId, fx.teams[1]!, MONDAY);
 
-    await expect(acceptTrade(fx.client, b.tradeId, fx.teams[2]!, MONDAY)).rejects.toMatchObject({
-      code: "PLAYER_IN_ANOTHER_TRADE",
+    await expect(acceptTrade(fx.client, b.tradeId, fx.teams[2]!, MONDAY)).rejects.toMatchObject(
+      {
+        code: "PLAYER_IN_ANOTHER_TRADE",
+      },
+    );
+
+    // The error code is not the property. **The property is that the player ends
+    // up owned by exactly one team** — a test that stops at the throw passes
+    // just as happily against a fix that closes this route and leaves another
+    // open, which is what happened here.
+    const trades = await listTrades(fx.client, fx.leagueId);
+    expect(trades.find((t) => t.tradeId === b.tradeId)?.state).toBe("PROPOSED");
+
+    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+
+    const owners = await fx.client.query<{ team_id: string }>(
+      "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+      [p1],
+    );
+    expect(owners).toHaveLength(1);
+  });
+
+  it("refuses to execute a trade whose asset left the roster after acceptance", async () => {
+    // The last line of defence, and the only one that does not depend on knowing
+    // *how* he left. Execution used to release from the old team — matching no
+    // row — and then insert onto the new one unconditionally, so the player
+    // existed twice. Every route to that outcome ends here.
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+
+    const trade = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
     });
+    await acceptTrade(fx.client, trade.tradeId, fx.teams[1]!, MONDAY);
+
+    // Straight to the table, standing in for any path that releases him without
+    // consulting the freeze — a free-agent add's drop leg does exactly this.
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL",
+      [fx.teams[0]!, p1],
+    );
+
+    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+
+    // Recorded, not retried hourly for the rest of the season, and not executed.
+    expect(resolution?.outcome).toBe("EXPIRED");
+
+    const owners = await fx.client.query<{ team_id: string }>(
+      "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+      [p1],
+    );
+    expect(owners).toHaveLength(0);
+
+    // And the other side of the trade did not move either — all or nothing.
+    const p2Owners = await fx.client.query<{ team_id: string }>(
+      "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+      [fx.players.get("p2")!],
+    );
+    expect(p2Owners.map((row) => row.team_id)).toEqual([fx.teams[1]!]);
+  });
+
+  it("settles the other trades even when one cannot execute", async () => {
+    // One trade that can never execute must not stop the rest from settling —
+    // the same rule as every other loop in this repo.
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+    const p3 = fx.players.get("p3")!;
+
+    const broken = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
+    });
+    const healthy = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[2]!,
+      receiverTeamId: fx.teams[3]!,
+      proposerGives: [p3],
+      receiverGives: [fx.players.get("p4")!],
+      week: 5,
+      now: MONDAY,
+    });
+
+    await acceptTrade(fx.client, broken.tradeId, fx.teams[1]!, MONDAY);
+    await acceptTrade(fx.client, healthy.tradeId, fx.teams[3]!, MONDAY);
+
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL",
+      [fx.teams[0]!, p1],
+    );
+
+    const resolutions = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+
+    expect(resolutions.find((r) => r.tradeId === broken.tradeId)?.outcome).toBe("EXPIRED");
+    expect(resolutions.find((r) => r.tradeId === healthy.tradeId)?.outcome).toBe("EXECUTED");
   });
 
   it("refuses to accept a trade whose offered player was dropped after it was proposed", async () => {

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -389,6 +389,66 @@ describe("the freeze between acceptance and execution", () => {
   });
 });
 
+describe("no double-spend across trades", () => {
+  it("refuses a second accept that commits a player already in an accepted trade", async () => {
+    // Two proposals can each offer the same player — only an *accepted* trade
+    // freezes him. If the second accept is not re-checked, both trades execute
+    // and the player is inserted onto two rosters, minted from nothing.
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+
+    const a = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
+    });
+    const b = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[2]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p3")!],
+      week: 5,
+      now: MONDAY,
+    });
+
+    await acceptTrade(fx.client, a.tradeId, fx.teams[1]!, MONDAY);
+
+    await expect(acceptTrade(fx.client, b.tradeId, fx.teams[2]!, MONDAY)).rejects.toMatchObject({
+      code: "PLAYER_IN_ANOTHER_TRADE",
+    });
+  });
+
+  it("refuses to accept a trade whose offered player was dropped after it was proposed", async () => {
+    const fx = await setup();
+    const p1 = fx.players.get("p1")!;
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      receiverTeamId: fx.teams[1]!,
+      proposerGives: [p1],
+      receiverGives: [fx.players.get("p2")!],
+      week: 5,
+      now: MONDAY,
+    });
+
+    await fx.client.query(
+      `UPDATE roster_entries SET released_at = $3
+        WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
+      [fx.teams[0], p1, MONDAY.toISOString()],
+    );
+
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "NOT_YOUR_PLAYER",
+    });
+  });
+});
+
 describe("vetoing", () => {
   it("counts a vote", async () => {
     const fx = await setup();

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -55,7 +55,8 @@ export class TradeError extends Error {
       | "BOT_CANNOT_VETO"
       | "INVOLVED_CANNOT_VETO"
       | "ALREADY_VETOED"
-      | "ROSTER_WOULD_OVERFLOW",
+      | "ROSTER_WOULD_OVERFLOW"
+      | "ASSET_GONE",
   ) {
     super(message);
     this.name = "TradeError";
@@ -344,14 +345,21 @@ export async function acceptTrade(
     // stale: since then a player could have been dropped, or committed to a
     // different trade that was accepted first. Skipping this is what lets one
     // player be committed to two accepted trades and duplicated onto two rosters
-    // when both execute. The row lock serialises two accepts racing for the same
-    // player; the freeze set then catches whichever loses.
+    // when both execute.
+    //
+    // **Order is the whole of the concurrency argument.** Take every row lock
+    // first, and only then read the freeze set. Read the other way round — the
+    // obvious way round — and two concurrent accepts of the same player both
+    // compute an empty freeze set *before* either takes a lock; the loser then
+    // blocks, wakes after the winner commits, re-checks a snapshot that predates
+    // it, and passes. Both trades reach ACCEPTED and the player is minted. The
+    // lock would be doing real work and guarding a value already read.
     const assets = await tx.query<{ from_team_id: string; player_id: string }>(
       "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1",
       [tradeId],
     );
-    const frozen = await lockedByTrade(tx, row!.league_id);
 
+    // Pass one: ownership, and take the lock on every asset.
     for (const asset of assets) {
       const [owned] = await tx.query<{ id: string }>(
         `SELECT id FROM roster_entries
@@ -365,6 +373,12 @@ export async function acceptTrade(
           "NOT_YOUR_PLAYER",
         );
       }
+    }
+
+    // Pass two, with every lock now held, so a competing accept has either
+    // already committed and is visible here, or is still blocked behind us.
+    const frozen = await lockedByTrade(tx, row!.league_id);
+    for (const asset of assets) {
       if (frozen.has(asset.player_id)) {
         throw new TradeError(
           `${asset.player_id} is already committed to an accepted trade`,
@@ -537,10 +551,38 @@ export async function resolveDueTrades(
       continue;
     }
 
-    out.push(await resolveTrade(db, row.id, stored.rules, now, pastDeadline));
+    // One trade that cannot execute must not stop the rest from settling —
+    // the same rule as every other loop over leagues or weeks in this repo.
+    //
+    // An asset that has left its roster is not recoverable: the trade can never
+    // execute, and rosters are untouched. That is exactly what EXPIRED means, so
+    // it is recorded as that rather than left ACCEPTED to be retried hourly for
+    // the rest of the season.
+    try {
+      out.push(await resolveTrade(db, row.id, stored.rules, now, pastDeadline));
+    } catch (error) {
+      if (!(error instanceof TradeError) || error.code !== "ASSET_GONE") throw error;
+
+      await tradeCannotExecute(db, row.id, now);
+      out.push({ tradeId: row.id, outcome: "EXPIRED", vetoes: 0, required: 0 });
+    }
   }
 
   return out;
+}
+
+/**
+ * A trade that can never execute, recorded rather than retried.
+ *
+ * Separate from the veto and deadline paths because the reason differs and a
+ * reader should be able to tell them apart, even though the state is the same:
+ * nothing moved, and nothing will.
+ */
+async function tradeCannotExecute(db: SqlClient, tradeId: string, now: Date): Promise<void> {
+  await db.query("UPDATE trades SET state = 'EXPIRED', resolved_at = $2 WHERE id = $1", [
+    tradeId,
+    now.toISOString(),
+  ]);
 }
 
 async function resolveTrade(
@@ -586,11 +628,30 @@ async function resolveTrade(
       // append-only with `released_at` precisely so any past week's roster can be
       // reconstructed — a trade that edited history would make a settled week
       // unverifiable.
-      await tx.query(
+      const released = await tx.query<{ id: string }>(
         `UPDATE roster_entries SET released_at = $3
-          WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
+          WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL
+        RETURNING id`,
         [asset.from_team_id, asset.player_id, now.toISOString()],
       );
+
+      // **Nothing is created that was not destroyed.** The insert used to be
+      // unconditional, so if the release matched no row — the player having left
+      // that roster since the trade was accepted — a second copy of him appeared
+      // on the receiver, owned by two teams at once. The `(team_id, player_id)`
+      // unique index cannot catch it, being per-team.
+      //
+      // This is the last line of defence rather than the first, and it is the one
+      // that holds regardless of how he left: accepted twice, dropped through a
+      // path that did not consult the freeze, or claimed off waivers. Upstream
+      // checks each close one route; this closes the outcome.
+      if (released.length === 0) {
+        throw new TradeError(
+          `${asset.player_id} is no longer on team ${asset.from_team_id}'s roster, ` +
+            `so this trade cannot be executed`,
+          "ASSET_GONE",
+        );
+      }
 
       await tx.query(
         `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -338,12 +338,48 @@ export async function acceptTrade(
     vetoWindowEndsAt(Math.floor(now.getTime() / 1000), stored.rules.trades) * 1000,
   );
 
-  await db.query(
-    "UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2 WHERE id = $1 AND state = 'PROPOSED'",
-    [tradeId, deadline.toISOString()],
-  );
+  return withTransaction(db, async (tx) => {
+    // Re-validate every asset now, not only at propose time. Accepting is the
+    // moment the trade freezes for execution, and the proposal's checks are
+    // stale: since then a player could have been dropped, or committed to a
+    // different trade that was accepted first. Skipping this is what lets one
+    // player be committed to two accepted trades and duplicated onto two rosters
+    // when both execute. The row lock serialises two accepts racing for the same
+    // player; the freeze set then catches whichever loses.
+    const assets = await tx.query<{ from_team_id: string; player_id: string }>(
+      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1",
+      [tradeId],
+    );
+    const frozen = await lockedByTrade(tx, row!.league_id);
 
-  return loadTrade(db, tradeId);
+    for (const asset of assets) {
+      const [owned] = await tx.query<{ id: string }>(
+        `SELECT id FROM roster_entries
+          WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL
+          FOR UPDATE`,
+        [asset.from_team_id, asset.player_id],
+      );
+      if (!owned) {
+        throw new TradeError(
+          `${asset.player_id} is no longer on team ${asset.from_team_id}'s roster`,
+          "NOT_YOUR_PLAYER",
+        );
+      }
+      if (frozen.has(asset.player_id)) {
+        throw new TradeError(
+          `${asset.player_id} is already committed to an accepted trade`,
+          "PLAYER_IN_ANOTHER_TRADE",
+        );
+      }
+    }
+
+    await tx.query(
+      "UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2 WHERE id = $1 AND state = 'PROPOSED'",
+      [tradeId, deadline.toISOString()],
+    );
+
+    return loadTrade(tx, tradeId);
+  });
 }
 
 /** Decline an offer. Only the team it was made to. */


### PR DESCRIPTION
Builds on @0x-SquidSol's #36 — his commit is preserved, with corrections on top. Closes #36, closes #35.

## The bug

`proposeTrade` freezes a player only against *accepted* trades, so two proposals can each offer him. `acceptTrade` re-checked nothing, and `resolveTrade` released him once and inserted him onto **both** receivers. The `(team_id, player_id)` unique index cannot catch it — it is per-team, so the same player on two different teams satisfies it.

## The ordering was wrong, and it looked right

The original reads `lockedByTrade` **before** the per-asset `SELECT … FOR UPDATE`. Under READ COMMITTED, two concurrent accepts of the same player both compute an empty freeze set *before* either takes a lock. The loser blocks, wakes after the winner commits, re-checks a snapshot that predates it, and passes. **Both trades reach ACCEPTED and the mint happens anyway** — the lock was doing real work and guarding a value already read.

Locks are now taken in a first pass and the freeze set read in a second, so a competing accept has either already committed and is visible, or is still blocked behind us.

The comment claimed "the row lock serialises two accepts racing for the same player". It did not. **PGlite is single-connection, so no test in this repo can catch this** — `withTransaction` takes the no-`connect` path there and two concurrent transactions cannot exist. That is recorded in CLAUDE.md as something that has to be got right by reading, because the suite will stay green either way.

## The backstop that does not care how he left

`resolveTrade` now refuses when the release matches no row (`ASSET_GONE`), instead of inserting anyway. This is the only check that holds regardless of route — accepted twice, dropped through a path that skipped the freeze, or claimed off waivers. Upstream checks each close one route; this closes the outcome.

It records `EXPIRED` — rosters untouched, which is exactly what that state means — rather than leaving the trade `ACCEPTED` to be retried hourly for the rest of the season. And one trade that cannot execute no longer stops the others in the batch from settling.

## Tests assert outcomes, not error codes

The original tests stopped at the throw, which passes just as happily against a fix that closes one route and leaves another open. These assert that the player ends up owned by **exactly one team**, that the losing trade stays `PROPOSED`, and that a healthy trade in the same batch still executes. All four fail on unfixed `main`.

## Known and not fixed here

- **A free-agent add's drop leg bypasses the freeze.** `addFreeAgent`, `submitClaim` and `processWaivers` do not consult `lockedByTrade`, so a committed player can be released to free agency without ever hitting `IN_A_TRADE`. The execution backstop above means this no longer mints a player, but he should not be droppable at all. Separate PR.
- `acceptTrade` performs no deadline check, so a stale proposal can be accepted and freeze both rosters for a full veto window for a trade guaranteed to expire. Pre-existing.

942 tests, lint, typecheck, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)