### PR TITLE
fix(db): score from one stat source, and keep the other visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,19 @@ official NFL stat corrections arrive for up to seven days.
 Scores read `stat_lines_current`, so a correction that arrived as a new revision is used
 and the superseded one is not. There is a test for that specifically.
 
+**And from one source — `PRIMARY_STAT_SOURCE`.** The view keys on `source` as well as
+revision, so two providers reporting the same stat are two rows and `scorePlayer` folds over
+both. Unfiltered, every shared stat counted twice — and only for the players both providers
+covered, so the distortion was uneven and reordered the autolineup rather than merely
+inflating scores. A revision only supersedes _within_ a source, so a correction would have
+added rather than replaced.
+
+**Filtering at read time is not the same as ignoring the second provider, and the difference
+is the point.** `RULES.md` §7 requires two independent sources to agree before a paying week
+finalises, and the view is the only place their values sit side by side. Collapsing them in
+the view or averaging them away would delete that comparison at the storage layer and have
+to be undone to ship G4/G5. There is a test asserting both rows survive.
+
 `persistSchedule` refuses to overwrite an existing schedule. Rewriting mid-season changes
 who played whom, and every record derived from it.
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -61,7 +61,7 @@ players           id, sport_id, external_ref, full_name, primary_position_id,
                   eligible_position_ids[], team_ref, status, active
 player_seasons    id, player_id, season, team_ref, bye_week
 stat_lines        id, player_id, season, week, stat_key_id, value,
-                  finalized_at, revision
+                  source, revision
 ```
 
 `external_ref` is the provider's ID. `stat_lines.revision` exists because the NFL

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -95,6 +95,7 @@ export {
   loadRosterForWeek,
   loadWeekLineups,
   loadWeekStats,
+  PRIMARY_STAT_SOURCE,
   setLineup,
   type SetLineupInput,
 } from "./lineups.js";

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -10,10 +10,12 @@ import type { PGliteClient } from "./testing.js";
 import {
   autoFillLineup,
   ensureLineups,
+  loadAverages,
   loadLineup,
   loadRosterForWeek,
   loadWeekLineups,
   loadWeekStats,
+  PRIMARY_STAT_SOURCE,
   setLineup,
 } from "./lineups.js";
 
@@ -621,7 +623,7 @@ describe("scoring a week end to end", () => {
     ] as const) {
       await fx.client.query(
         `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source)
-         VALUES ($1, $2, $3, $4, $5, 'test')`,
+         VALUES ($1, $2, $3, $4, $5, 'tank01')`,
         [fx.players.get("sun-qb"), SEASON, WEEK, statKeys.get(statKey), value],
       );
     }
@@ -832,5 +834,114 @@ describe("the schedule is a precondition for locking", () => {
     });
 
     expect(saved.find((slot) => slot.slotType === "TE")?.playerId).toBe(bye);
+  });
+});
+
+describe("one source decides the score", () => {
+  /**
+   * `stat_lines_current` is `DISTINCT ON (…, source)`, so two providers reporting
+   * the same stat are two rows, and `scorePlayer` folds over whatever it is
+   * handed. Reading unfiltered counted every shared stat twice — and only for the
+   * players both providers covered, so the distortion was uneven and reordered
+   * rankings rather than merely inflating them.
+   *
+   * Latent rather than live: nothing writes `stat_lines` in production yet. The
+   * second provider is a planned, deliberate addition (`docs/RULES.md` §7), which
+   * is exactly why this is fixed before it arrives rather than after — the day it
+   * fires is a paying week.
+   */
+  const statId = async (fx: Fixture, key: string): Promise<string> => {
+    const [row] = await fx.client.query<{ id: string }>(
+      `SELECT k.id FROM stat_keys k JOIN sports s ON s.id = k.sport_id
+        WHERE s.key = $1 AND k.key = $2`,
+      [NFL.key, key],
+    );
+    return row!.id;
+  };
+
+  const writeStat = async (
+    fx: Fixture,
+    playerId: string,
+    key: string,
+    value: number,
+    source: string,
+    revision = 0,
+  ): Promise<void> => {
+    await fx.client.query(
+      `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [playerId, SEASON, WEEK, await statId(fx, key), value, source, revision],
+    );
+  };
+
+  it("counts a stat once when two providers both report it", async () => {
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await writeStat(fx, qb, "pass_yd", 300, PRIMARY_STAT_SOURCE);
+    await writeStat(fx, qb, "pass_yd", 300, "sportsdataio");
+
+    const stats = await loadWeekStats(fx.client, NFL.key, SEASON, WEEK);
+
+    // One entry, not two. Unfiltered this was [300, 300] and scored double.
+    expect(stats.get(qb)).toHaveLength(1);
+    expect(stats.get(qb)?.[0]?.value).toBe(300);
+  });
+
+  it("keeps both providers visible for the agreement gate to compare", async () => {
+    // The guard against a later "simplification" that collapses sources in the
+    // view. `docs/RULES.md` §7 requires two providers to *agree* before a paying
+    // week finalises, and the view is the only place their values sit side by
+    // side. Filtering at read time preserves that; collapsing at storage
+    // destroys it, and would have to be undone to ship G4/G5.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await writeStat(fx, qb, "pass_yd", 300, PRIMARY_STAT_SOURCE);
+    await writeStat(fx, qb, "pass_yd", 305, "sportsdataio");
+
+    const rows = await fx.client.query<{ source: string; value: number }>(
+      `SELECT source, value FROM stat_lines_current
+        WHERE player_id = $1 AND season = $2 AND week = $3`,
+      [qb, SEASON, WEEK],
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => Number(r.value)).sort()).toEqual([300, 305]);
+  });
+
+  it("still takes the latest revision within the chosen source", async () => {
+    // The fix must not be implemented by keying on revision globally: revisions
+    // resolve *within* a source, so a correction replaces rather than adds.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await writeStat(fx, qb, "pass_yd", 300, PRIMARY_STAT_SOURCE, 0);
+    await writeStat(fx, qb, "pass_yd", 250, PRIMARY_STAT_SOURCE, 1);
+    await writeStat(fx, qb, "pass_yd", 999, "sportsdataio", 0);
+
+    const stats = await loadWeekStats(fx.client, NFL.key, SEASON, WEEK);
+
+    expect(stats.get(qb)).toHaveLength(1);
+    expect(stats.get(qb)?.[0]?.value).toBe(250);
+  });
+
+  it("averages a season from one source, so the autolineup ranks honestly", async () => {
+    // `loadAverages` feeds `autoFillLineup`, which is the fallback ranking for
+    // any player without a projection. A doubled average changes *which* players
+    // are started, not only what they score.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await fx.client.query(
+      `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
+       VALUES ($1, $2, 1, $3, 300, $4, 0), ($1, $2, 1, $3, 300, 'sportsdataio', 0)`,
+      [qb, SEASON, await statId(fx, "pass_yd"), PRIMARY_STAT_SOURCE],
+    );
+
+    const averages = await loadAverages(fx.client, [qb], SEASON, 2, fx.rules);
+
+    // 300 passing yards at 0.04/yd is 12 points, once.
+    expect(averages.get(qb)).toBe(12_000);
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -45,6 +45,36 @@ import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { withTransaction } from "./transaction.js";
 
+/**
+ * The provider whose stats decide scores.
+ *
+ * `stat_lines` records the source on every row and the view keys on it, so two
+ * providers reporting the same stat produce two rows. Everything that scores
+ * must therefore say which one it means; nothing may read across them.
+ *
+ * **This is not the agreement gate.** `docs/RULES.md` §7 requires two
+ * independent providers to agree before a paying week finalises — that check
+ * (G4/G5) reads the same view *without* a source filter, compares the two, and
+ * freezes the week on disagreement. This constant only decides which one is
+ * scored in the meantime. If it ever becomes the answer to "which provider is
+ * right", the second provider has stopped being a check.
+ *
+ * A constant rather than league rules, env, or a table:
+ *
+ *   - **Not rules.** They are hashed, signed and frozen for the life of a
+ *     league, so a provider that shut down mid-season would leave every existing
+ *     league permanently unscoreable. The rules already hold the right
+ *     abstraction — `settlement.requiredOracleSources` says *how many* must
+ *     agree, not which.
+ *   - **Not env.** The scoring cron and the web app are separate processes; a
+ *     drifted value would give two different scores for one week, silently.
+ *   - **Not a table yet.** That is administrable state with no administrator,
+ *     and G5 needs its own shape regardless.
+ *
+ * So: a line of code, changed by a reviewed commit, identical everywhere.
+ */
+export const PRIMARY_STAT_SOURCE = "tank01";
+
 export class LineupError extends Error {
   constructor(
     message: string,
@@ -386,6 +416,7 @@ export async function loadAverages(
   season: number,
   week: number,
   rules: LeagueRules,
+  source: string = PRIMARY_STAT_SOURCE,
 ): Promise<ReadonlyMap<string, number | null>> {
   if (playerIds.length === 0 || week <= 1) {
     return new Map(playerIds.map((id) => [id, null]));
@@ -395,8 +426,8 @@ export async function loadAverages(
     `SELECT s.player_id, s.week, k.key, s.value
        FROM stat_lines_current s
        JOIN stat_keys k ON k.id = s.stat_key_id
-      WHERE s.player_id = ANY($1) AND s.season = $2 AND s.week < $3`,
-    [playerIds, season, week],
+      WHERE s.player_id = ANY($1) AND s.season = $2 AND s.week < $3 AND s.source = $4`,
+    [playerIds, season, week, source],
   );
 
   // Group by player and week before scoring: a stat line is per-key, and a
@@ -690,20 +721,34 @@ export async function loadWeekLineups(
  *
  * Reads `stat_lines_current`, so a stat correction that arrived as a new
  * revision is picked up and the superseded one is not.
+ *
+ * **From one source, and that is not the same thing as ignoring the other.**
+ * The view is `DISTINCT ON (player, season, week, stat_key, source)` — one row
+ * *per source* — and `scorePlayer` folds over whatever it is handed. Reading it
+ * unfiltered means every stat two providers both report is counted twice, and
+ * only for the players they both cover, so the distortion is uneven and
+ * reorders rankings rather than merely inflating them.
+ *
+ * `docs/RULES.md` §7 requires two independent providers to *agree* before a
+ * paying week finalises, so the second one is coming deliberately. Both rows
+ * stay in the view, side by side, which is exactly what that agreement gate
+ * (G4/G5) has to read. This picks which one scoring consumes; it does not
+ * decide which one is true, and it must not be turned into that.
  */
 export async function loadWeekStats(
   db: SqlClient,
   sportKey: string,
   season: number,
   week: number,
+  source: string = PRIMARY_STAT_SOURCE,
 ): Promise<ReadonlyMap<string, readonly StatLine[]>> {
   const rows = await db.query<{ player_id: string; key: string; value: number }>(
     `SELECT s.player_id, k.key, s.value
        FROM stat_lines_current s
        JOIN stat_keys k ON k.id = s.stat_key_id
        JOIN sports sp ON sp.id = k.sport_id
-      WHERE sp.key = $1 AND s.season = $2 AND s.week = $3`,
-    [sportKey, season, week],
+      WHERE sp.key = $1 AND s.season = $2 AND s.week = $3 AND s.source = $4`,
+    [sportKey, season, week, source],
   );
 
   const byPlayer = new Map<string, StatLine[]>();

--- a/packages/db/src/matchup.test.ts
+++ b/packages/db/src/matchup.test.ts
@@ -140,7 +140,7 @@ async function score(
 ): Promise<void> {
   await fx.client.query(
     `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
-     VALUES ($1, $2, $3, $4, $5, 'test', $6)`,
+     VALUES ($1, $2, $3, $4, $5, 'tank01', $6)`,
     [fx.players.get(handle), SEASON, WEEK, fx.statKeys.get("pass_yd"), passYards, revision],
   );
 }
@@ -407,7 +407,7 @@ describe("the bench", () => {
     );
     await fx.client.query(
       `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
-       VALUES ($1, $2, $3, $4, 500, 'test', 0)`,
+       VALUES ($1, $2, $3, $4, 500, 'tank01', 0)`,
       [spare!.id, SEASON, WEEK, fx.statKeys.get("pass_yd")],
     );
 

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -136,7 +136,7 @@ async function score(
 ): Promise<void> {
   await fx.client.query(
     `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
-     VALUES ($1, $2, $3, $4, $5, 'test', $6)`,
+     VALUES ($1, $2, $3, $4, $5, 'tank01', $6)`,
     [fx.players.get(handle), SEASON, WEEK, fx.statKeys.get("pass_yd"), passYards, revision],
   );
 }


### PR DESCRIPTION
Closes #19.

## Verified before fixing

The issue's diagnosis is exactly right, and I checked every claim against the code rather than taking it. Two things turned out to differ from the write-up:

- **It is unreachable today, not merely harmless.** Nothing writes `stat_lines` in production at all — every insert in the repo is a test. `packages/stats/` maps provider payloads and never touches the database.
- **The issue understates it.** `revision` and `source` are independent (`revision DESC` is the *last* `ORDER BY` term, so it resolves *within* a source). A correction from provider A would therefore have **added to** provider B rather than replacing it — scoring 22.00 where the providers said 25.0 and 30.0, a number matching neither and no clean multiple.

## Why it matters more than "scores double"

`scorePlayer` folds row by row, so a player **both** providers cover scores 2× while a player only one covers scores 1×. The distortion is **uneven**, which reorders rankings rather than inflating them uniformly. `loadAverages` feeds `autoFillLineup` and is the fallback for any player without a projection, so this changes **which players are started**, not just what they score.

Downstream: team-week points → `matchups` → standings → playoff seeds → `bracketFor` → `championship()` → settlement. Points and `finalized_at` are written in the **same UPDATE**, and a finalised week is never rescored — so a doubled score that finalises is permanent and pays the wrong wallets.

Fixed now, while latent, because the second provider is a planned addition (RULES.md §7, milestone G4/G5) and the day it arrives is a paying week.

## Filtering at read time is not the same as ignoring the second provider

This is the part that ruled out the tidier-looking fixes. RULES.md §7 requires two independent providers to **agree** before a paying week finalises, and `stat_lines_current` is the only place their values sit side by side. Collapsing sources in the view, or averaging them into one number, would delete that comparison **at the storage layer** — and would have to be reverted to ship G4/G5.

So: both rows stay, and the reader picks one. **There is a test asserting both rows survive**, which fails if anyone later "simplifies" this by collapsing the view.

## Why a constant, not a rule or an env var

`PRIMARY_STAT_SOURCE` is a line of code in `@rostr/db`, with an optional per-call override.

- **Not league rules** — they are hashed, signed and frozen, so a provider that shut down mid-season would leave every existing league permanently unscoreable. The rules already hold the right abstraction: `settlement.requiredOracleSources` says *how many* must agree, not which.
- **Not env** — the scoring cron and the web app are separate processes, and a drifted value would give two different scores for one week, silently.

## Tests

Three of the four fail on unfixed code. The fourth — both providers still visible — passes either way **by design**, because it guards against a different wrong fix.

- Two providers reporting 300 yards scores 12 points, not 24
- Both rows still present in `stat_lines_current` for the agreement gate
- A revision still supersedes *within* its source (guards against keying on revision globally)
- A season average from one source, so the autolineup ranks honestly

`docs/DATA-MODEL.md` listed `stat_lines` with a `finalized_at` column that does not exist and omitted `source`. Corrected in the same change.

957 tests, lint, typecheck, format green.

## Not fixed here

`loadProjectedPoints` reads `player_projections` with the same unfiltered-source defect — that is **issue #44**, a different function and a different table, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)