### PR TITLE
fix(db): rank the autofill from one projection source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,25 @@ you need one of each. What matters is who is the best one left at a position.
 touchdown, so a provider's number on the draft board would disagree with the number that
 decides matchups. The same `scorePlayer()` produces both.
 
+**And read from one source — `PRIMARY_PROJECTION_SOURCE`.** `player_projections` is keyed
+on `(player, season, week, source, stat_key)` so a second opinion never overwrites the
+first, and `scorePlayer` folds over every row — so an unfiltered read projects a
+dual-covered player at roughly double and leaves single-covered players alone. That is a
+reordering, and the ranking is what decides who starts. It reaches every manager, not only
+abandoned teams: `autofill_enabled` defaults to true and the autofill also fills gaps in a
+hand-set lineup.
+
+**It is a separate constant from `PRIMARY_STAT_SOURCE`, on purpose.** One vendor satisfies
+both today, but the choices have opposite drivers: a stats source is picked for factual
+accuracy under §7's two-provider agreement gate, and a projections source is picked for
+model quality and is _exempt_ from that gate — §7 says a projection is an opinion, and
+opinions cannot pass an agreement test. Coupled, swapping the stats oracle would silently
+re-rank every autolineup.
+
+`loadProjections` used to default to _every_ source (`COALESCE($3, p.source)`), and the
+draft board is its only caller and omitted the argument — so the board would have doubled
+too. An optional filter defaulting to "all" is not a filter.
+
 One provider call covers the whole season — `getNFLProjections` with **no `week`**.
 See [`docs/TANK01.md`](docs/TANK01.md), which records the verbatim response shape.
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -95,6 +95,7 @@ export {
   loadRosterForWeek,
   loadWeekLineups,
   loadWeekStats,
+  PRIMARY_PROJECTION_SOURCE,
   PRIMARY_STAT_SOURCE,
   setLineup,
   type SetLineupInput,

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -12,9 +12,11 @@ import {
   ensureLineups,
   loadAverages,
   loadLineup,
+  loadProjectedPoints,
   loadRosterForWeek,
   loadWeekLineups,
   loadWeekStats,
+  PRIMARY_PROJECTION_SOURCE,
   PRIMARY_STAT_SOURCE,
   setLineup,
 } from "./lineups.js";
@@ -943,5 +945,104 @@ describe("one source decides the score", () => {
 
     // 300 passing yards at 0.04/yd is 12 points, once.
     expect(averages.get(qb)).toBe(12_000);
+  });
+});
+
+describe("one source ranks the autofill", () => {
+  /**
+   * The projection sibling of the stat double-count.
+   *
+   * `player_projections` is keyed on `(player, season, week, source, stat_key)`
+   * precisely so a second opinion does not overwrite the first, and `scorePlayer`
+   * folds over every row — so an unfiltered read projects a dual-covered player
+   * at roughly double while single-covered players stay as they are. That is a
+   * *reordering*, and the ranking is what decides who starts.
+   *
+   * Wider than it looks: `autofill_enabled` defaults to true and the autofill
+   * also fills gaps in a hand-set lineup, so this reaches every manager in a
+   * league, not only abandoned teams.
+   */
+  const projStatId = async (fx: Fixture, key: string): Promise<string> => {
+    const [row] = await fx.client.query<{ id: string }>(
+      `SELECT k.id FROM stat_keys k JOIN sports s ON s.id = k.sport_id
+        WHERE s.key = $1 AND k.key = $2`,
+      [NFL.key, key],
+    );
+    return row!.id;
+  };
+
+  const project = async (
+    fx: Fixture,
+    playerId: string,
+    key: string,
+    value: number,
+    source: string,
+    week = WEEK,
+  ): Promise<void> => {
+    await fx.client.query(
+      `INSERT INTO player_projections (player_id, season, week, source, stat_key_id, value)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [playerId, SEASON, week, source, await projStatId(fx, key), value],
+    );
+  };
+
+  it("projects a player once when two providers both cover him", async () => {
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await project(fx, qb, "pass_yd", 300, PRIMARY_PROJECTION_SOURCE);
+    await project(fx, qb, "pass_yd", 300, "sportsdataio");
+
+    const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
+
+    // 300 yards at 0.04/yd is 12 points. Unfiltered this was 24.
+    expect(projected.get(qb)).toBe(12_000);
+  });
+
+  it("selects the named source rather than adding to it", async () => {
+    // Proves the parameter picks one opinion. A fix that summed and then halved,
+    // or averaged, would pass the test above and fail this one.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await project(fx, qb, "pass_yd", 300, PRIMARY_PROJECTION_SOURCE);
+    await project(fx, qb, "pass_yd", 100, "sportsdataio");
+
+    const other = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules, "sportsdataio");
+
+    expect(other.get(qb)).toBe(4_000);
+  });
+
+  it("keeps the second opinion on the table", async () => {
+    // Migration 0013 exists so a second opinion never overwrites the first.
+    // Filtering at read time preserves that; narrowing the key would not, and
+    // this fails if anyone later "simplifies" it that way.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await project(fx, qb, "pass_yd", 300, PRIMARY_PROJECTION_SOURCE);
+    await project(fx, qb, "pass_yd", 250, "sportsdataio");
+
+    const rows = await fx.client.query<{ source: string }>(
+      "SELECT source FROM player_projections WHERE player_id = $1 AND week = $2",
+      [qb, WEEK],
+    );
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it("does not mix the season aggregate into a weekly projection", async () => {
+    // Week 0 is the season total the draft board uses. The weekly read is exact
+    // equality on week, so the two can never be summed — a regression pin rather
+    // than a fix, since this already held.
+    const fx = await setup();
+    const qb = fx.players.get("sun-qb")!;
+
+    await project(fx, qb, "pass_yd", 4000, PRIMARY_PROJECTION_SOURCE, 0);
+    await project(fx, qb, "pass_yd", 300, PRIMARY_PROJECTION_SOURCE, WEEK);
+
+    const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
+
+    expect(projected.get(qb)).toBe(12_000);
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -74,6 +74,29 @@ import { withTransaction } from "./transaction.js";
  * So: a line of code, changed by a reviewed commit, identical everywhere.
  */
 export const PRIMARY_STAT_SOURCE = "tank01";
+/**
+ * The provider whose *projections* rank the autofill.
+ *
+ * Deliberately separate from `PRIMARY_STAT_SOURCE`, even though one vendor
+ * satisfies both today. The two choices have opposite drivers: a stats source is
+ * chosen for factual accuracy and sits under the two-provider agreement gate in
+ * `docs/RULES.md` §7; a projections source is chosen for model quality and is
+ * **exempt** from that gate — §7 is explicit that a projection is an opinion, and
+ * opinions could never pass an agreement test. Coupling them would mean that
+ * swapping the stats oracle silently re-ranks every autolineup.
+ *
+ * The filter itself is not optional. `player_projections` is keyed on
+ * `(player, season, week, source, stat_key)` precisely so a second opinion does
+ * not overwrite the first (migration 0013), and `scorePlayer` folds over every
+ * row it is handed — so reading unfiltered projects a dual-covered player at
+ * roughly double and leaves single-covered players alone. That is a *reordering*,
+ * not a scale, and the ranking is what decides who starts.
+ *
+ * `DECISIONS.md` puts it best: store the projection used, **with its source**,
+ * and the decision is as reproducible as anything else in the system. A number
+ * summed across two vendors is reproducible from neither.
+ */
+export const PRIMARY_PROJECTION_SOURCE = "tank01";
 
 export class LineupError extends Error {
   constructor(
@@ -471,13 +494,14 @@ export async function loadProjectedPoints(
   season: number,
   week: number,
   rules: LeagueRules,
+  source: string = PRIMARY_PROJECTION_SOURCE,
 ): Promise<ReadonlyMap<string, number>> {
   const rows = await db.query<{ player_id: string; key: string; value: number }>(
     `SELECT p.player_id, k.key, p.value
        FROM player_projections p
        JOIN stat_keys k ON k.id = p.stat_key_id
-      WHERE p.season = $1 AND p.week = $2`,
-    [season, week],
+      WHERE p.season = $1 AND p.week = $2 AND p.source = $3`,
+    [season, week, source],
   );
 
   const byPlayer = new Map<string, StatLine[]>();

--- a/packages/db/src/sync.test.ts
+++ b/packages/db/src/sync.test.ts
@@ -423,7 +423,10 @@ describe("syncProjections", () => {
 
     expect(await syncProjections(client, provider, "nfl", 2026)).toMatchObject({ inserted: 2 });
 
-    const loaded = await loadProjections(client, "nfl", 2026);
+    // The fake provider stamps 'fake', so the read has to name it — the default
+    // is the real provider, deliberately, so a caller who forgets gets nothing
+    // rather than everything.
+    const loaded = await loadProjections(client, "nfl", 2026, "fake");
     expect(loaded.size).toBe(1);
   });
 
@@ -442,8 +445,8 @@ describe("syncProjections", () => {
 
     // The season projection is what the draft board reads; the week is what the
     // autofill ranks on. One must not overwrite the other.
-    const season = await loadProjections(client, "nfl", 2026);
-    const week3 = await loadProjections(client, "nfl", 2026, undefined, 3);
+    const season = await loadProjections(client, "nfl", 2026, "fake");
+    const week3 = await loadProjections(client, "nfl", 2026, "fake", 3);
 
     expect(season.get([...season.keys()][0]!)?.[0]?.value).toBe(1231);
     expect(week3.get([...week3.keys()][0]!)?.[0]?.value).toBe(78);

--- a/packages/db/src/sync.ts
+++ b/packages/db/src/sync.ts
@@ -12,6 +12,7 @@
 
 import type { StatsProvider } from "@rostr/stats";
 import type { SqlClient } from "./client.js";
+import { PRIMARY_PROJECTION_SOURCE } from "./lineups.js";
 import { loadSportIds } from "./sports.js";
 
 export interface SyncResult {
@@ -412,7 +413,13 @@ export async function loadProjections(
   db: SqlClient,
   sportKey: string,
   season: number,
-  source?: string,
+  // **Defaults to one source, and that is a change.** This used to be
+  // `COALESCE($3, p.source)` — omitting the argument meant *no filter*, so every
+  // vendor's rows came back and the caller summed them. The draft board's only
+  // call site omits it, so a second projections provider would have doubled the
+  // numbers the board is sorted by. An optional filter that defaults to "all"
+  // is not a filter; the caller who most needs it is the one who forgets.
+  source: string = PRIMARY_PROJECTION_SOURCE,
   week: number = SEASON_AGGREGATE_WEEK,
 ): Promise<ReadonlyMap<string, readonly { statKey: string; value: number }[]>> {
   const ids = await loadSportIds(db, sportKey);
@@ -424,8 +431,8 @@ export async function loadProjections(
       WHERE p.season = $1
         AND p.week = $4
         AND k.sport_id = $2
-        AND p.source = COALESCE($3, p.source)`,
-    [season, ids.sportId, source ?? null, week],
+        AND p.source = $3`,
+    [season, ids.sportId, source, week],
   );
 
   const byPlayer = new Map<string, { statKey: string; value: number }[]>();


### PR DESCRIPTION
Closes #44.

## Verified before fixing

Three agents checked the issue independently. Its diagnosis is right, with two corrections and one refutation:

- **"N sources → N×" only holds for LINEAR rules.** For TIERED rules `applyTiered` runs once *per row*, so the tier is re-awarded rather than the values being added — different and less predictable.
- **There is a second affected reader the issue doesn't mention.** `loadProjections` filters with `COALESCE($3, p.source)`, so omitting the argument means **no filter at all** — and the draft board is its only caller and omits it.
- **Refuted:** I suspected the week-0 season aggregate could be summed with a weekly row, which would have been a *live, single-source* bug. It can't — the read is exact equality on `week`, and week 0 is unreachable on both call paths. There is a test pinning it, which passes either way.

## Why it matters more than "projections double"

Only **dual-covered** players double, so it permutes the ranking rather than scaling it — and the ranking decides who starts. Scope is wider than abandoned teams: `autofill_enabled` defaults to **true**, and the autofill also fills gaps in a hand-set lineup, so it reaches every manager in a league. Nothing downstream distinguishes an auto-filled lineup from a hand-set one, so it flows into standings, seeds, the bracket, and the prizes `championship()` derives.

The draft board case is an **August** concern rather than a January one: `DraftRoom` sorts the visible board projection-first, ADP second. Auto-picks are unaffected — they rank on `player_rankings_current`, a different table that does filter.

## A separate constant, on purpose

`PRIMARY_PROJECTION_SOURCE` is deliberately **not** `PRIMARY_STAT_SOURCE`, even though one vendor satisfies both today. The two choices have opposite drivers: a stats source is picked for factual accuracy and sits under RULES.md §7's two-provider agreement gate; a projections source is picked for model quality and is **exempt** from that gate — §7 is explicit that a projection is an opinion, and opinions could never pass an agreement test.

Coupling them would mean swapping the stats oracle silently re-ranks every autolineup.

This also rules out cross-source aggregation, which would compose one player from two vendors' models — the same class of mistake CLAUDE.md's kicker-floor warning names, and it would falsify DECISIONS.md's "store the projection used, **with its source**, and the decision is as reproducible as anything else".

## Tests

Two of four fail on unfixed code. The other two are regression pins that pass either way, by design:

- Two providers covering one player projects 12 points, not 24
- Naming the other source selects it rather than adding to it (a fix that summed-then-halved would pass the first test and fail this)
- Both opinions still present in the table
- The week-0 aggregate is not mixed into a weekly projection

961 tests, lint, typecheck, format green. Stacked on #49, now merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)