### PR TITLE
fix(draft): a failed RPC lookup is not a skipped slot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,40 @@ skipped slots. Roughly twenty RPC calls; a linear walk would be millions. **Veri
 of an old draw needs an archival RPC node** — public nodes prune, and a pruned range
 looks the same as a stalled chain.
 
+**A failed lookup is not a skipped slot, and conflating them moved the draw** (issue
+#20). `rpc()` used to collapse a transport error, an HTTP 429/500, and a JSON-RPC error
+body into one code, and `blockTime` read all three as "this slot was skipped" — so one
+transient fault on the boundary slot silently settled the search one block late. The
+draw is written once, the trigger freezes it, and `verify()` then reports the league's
+own recorded order as wrong forever. `blockTime` now returns `null` **only** for a
+recognised "no block there" answer — a JSON-RPC `-32007`/`-32009`, a `null` result
+that is actually **present** in the body, or a message saying _skipped_ **on a code in
+the same -3200x family** — and throws on everything else. Both narrowings are load-bearing
+and were found by review, not design: an absent `result` and `result: null` both read as
+`undefined`, so collapsing them let a bare `{"jsonrpc":"2.0","id":1}` from a proxy pass
+as a gap; and an ungated message check reads `{code: -32603, message: "…was skipped by
+the proxy"}` as a gap too. **Fail closed:** an
+unrecognised error is a failure, not a gap. That direction is deliberate, because
+refusing costs a retry (the block is fetched outside the transaction, so a throw writes
+nothing, and the answer is deterministic once the block exists) while guessing costs the
+league its verifiability. The exact wire format for a skipped slot has **not** been
+checked against a live node — see the comment on `SKIPPED_SLOT_CODES`, which says so.
+
+`verify()` throws for the same reason instead of answering `false`. Its `false` is
+published as "this league's order was rigged", and a 429 during an audit must not be
+able to say that.
+
+Each RPC call gets **three attempts** with a 200ms doubling backoff, on 429, on 5xx, and
+on a _transient JSON-RPC error body_ — `-32004`/`-32014` (a load-balanced backend a few
+slots behind the one `getSlot` answered from) or a provider that delivers a rate limit as
+HTTP 200 with the limit in the body. That last shape is not a thrown error, so it
+originally bypassed the retry loop entirely — the retry never fired for the case it was
+added for. ~30 unpaced sequential calls at a free public endpoint will meet a rate limit
+eventually, and now that a rate limit fails the draw rather than being swallowed, one in
+thirty would send the commissioner back to the button. Pacing was rejected: it slows
+every draw to absorb a burst three attempts already handles, and each call is an
+idempotent read of immutable history.
+
 `FixedBeacon` is test-only. It makes the seed predictable, which is the entire thing the
 real one exists to prevent.
 

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -288,6 +288,12 @@ export async function drawDraftOrder(
  * checks the result against the stored positions, and — if the beacon is a real
  * one — confirms the recorded slot really is the first block at or after the
  * scheduled time.
+ *
+ * **A problem means the draw was checked and failed. An unreachable node throws
+ * instead**, the same as an unreachable database does two lines below. The two
+ * must not be collapsed: this function's output is an accusation, and a public
+ * one at that, so "the RPC 429'd" must never be rendered as "slot 12345 is not
+ * the first block at or after the scheduled time".
  */
 export async function verifyDraftOrder(
   db: SqlClient,

--- a/packages/db/src/randomness.test.ts
+++ b/packages/db/src/randomness.test.ts
@@ -26,18 +26,38 @@ interface Counter {
   calls: number;
 }
 
-function chainFetch(counter: Counter, options: { tip?: number } = {}): typeof globalThis.fetch {
+const reply = (result: unknown) =>
+  new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/** A well-formed JSON-RPC error body — HTTP 200, as a real node sends it. */
+const rpcError = (error: { code?: number; message: string }) =>
+  new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+interface ChainOptions {
+  tip?: number;
+  /**
+   * A fault injected into `getBlockTime` only.
+   *
+   * Return a `Response` to send it in place of the chain's answer, throw to
+   * simulate a transport failure, or return `undefined` to let the call through.
+   * `getBlockTime` is the method that matters because it is the only one routed
+   * through the skipped-slot path.
+   */
+  blockTimeFault?: (slot: number) => Response | undefined;
+}
+
+function chainFetch(counter: Counter, options: ChainOptions = {}): typeof globalThis.fetch {
   const tip = options.tip ?? TIP;
 
   return (async (_url: string, init?: RequestInit) => {
     counter.calls++;
     const body = JSON.parse(String(init?.body)) as { method: string; params: unknown[] };
-
-    const reply = (result: unknown) =>
-      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
 
     switch (body.method) {
       case "getSlot":
@@ -45,27 +65,18 @@ function chainFetch(counter: Counter, options: { tip?: number } = {}): typeof gl
 
       case "getBlockTime": {
         const slot = body.params[0] as number;
+        const fault = options.blockTimeFault?.(slot);
+        if (fault) return fault;
+
         if (slot > tip || slot < 0 || isSkipped(slot)) {
-          return new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: 1,
-              error: { code: -32009, message: "Slot was skipped" },
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
+          return rpcError({ code: -32009, message: `Slot ${slot} was skipped` });
         }
         return reply(timeOf(slot));
       }
 
       case "getBlock": {
         const slot = body.params[0] as number;
-        if (isSkipped(slot)) {
-          return new Response(
-            JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "Slot was skipped" } }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
-        }
+        if (isSkipped(slot)) return rpcError({ message: "Slot was skipped" });
         return reply({ blockhash: `hash-for-slot-${slot}`, blockTime: timeOf(slot) });
       }
 
@@ -75,10 +86,15 @@ function chainFetch(counter: Counter, options: { tip?: number } = {}): typeof gl
   }) as unknown as typeof globalThis.fetch;
 }
 
-const beaconFor = (counter: Counter, options: { tip?: number } = {}) =>
+const beaconFor = (counter: Counter, options: ChainOptions & { attempts?: number } = {}) =>
   new SolanaBeacon({
     endpoint: "https://example.invalid",
     fetchImpl: chainFetch(counter, options),
+    // Backoff is real wall-clock time and nothing here measures it; the number
+    // of round trips is what these tests assert on.
+    sleepImpl: () => Promise.resolve(),
+    // Left unset unless a test pins it, so the production default is what runs.
+    ...(options.attempts === undefined ? {} : { attempts: options.attempts }),
   });
 
 describe("SolanaBeacon.firstBlockAtOrAfter", () => {
@@ -217,17 +233,326 @@ describe("SolanaBeacon.verify", () => {
   });
 });
 
-describe("SolanaBeacon transport", () => {
-  it("surfaces an RPC error rather than guessing", async () => {
-    const failing = (async () =>
-      new Response("upstream exploded", { status: 502 })) as unknown as typeof globalThis.fetch;
+/**
+ * A failed lookup is not a skipped slot.
+ *
+ * These all aim at one slot — the boundary, the block the rule actually names —
+ * because that is the slot where the difference shows. A fault anywhere else is
+ * absorbed by the search; a fault there decides which block the league drafts
+ * from. And the answer is written once, frozen by migration 0010's trigger, and
+ * checked forever after by `verify()`, so a draw moved by one block is not a bad
+ * afternoon, it is a league whose order can never be verified again.
+ *
+ * The rule for every case below: a slot the chain skipped is tolerated, and
+ * anything we cannot tell apart from a working node saying "no block here" is
+ * refused. Refusing costs a retry — `drawDraftOrder` fetches the block outside
+ * its transaction, so a throw writes nothing, and the answer is deterministic
+ * once the block exists.
+ */
+describe("SolanaBeacon: a failed lookup is not a skipped slot", () => {
+  const TARGET_SECONDS = GENESIS + 200_000;
+  const TARGET = new Date(TARGET_SECONDS * 1000);
+  const BOUNDARY = firstBlockAtOrAfter(TARGET_SECONDS);
 
-    const beacon = new SolanaBeacon({
-      endpoint: "https://example.invalid",
-      fetchImpl: failing,
+  /** Where the search lands if `BOUNDARY` is treated as a slot with no block. */
+  const nextVisible = (slot: number): number => {
+    let next = slot + 1;
+    while (isSkipped(next)) next++;
+    return next;
+  };
+
+  it("refuses when the transport fails on the boundary slot", async () => {
+    // The regression this file exists for. Swallowed, this returns
+    // `nextVisible(BOUNDARY)` — a real block, at or after the target, wrong.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) => {
+        if (slot === BOUNDARY) throw new TypeError("fetch failed");
+        return undefined;
+      },
     });
 
-    await expect(beacon.firstBlockAtOrAfter(new Date())).rejects.toBeInstanceOf(BeaconError);
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toMatchObject({
+      name: "BeaconError",
+      code: "RPC_FAILED",
+    });
+  });
+
+  it("refuses when the node rate-limits the boundary slot", async () => {
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY ? new Response("slow down", { status: 429 }) : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toBeInstanceOf(BeaconError);
+  });
+
+  it("refuses when the node 500s on the boundary slot", async () => {
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY ? new Response("upstream exploded", { status: 502 }) : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toBeInstanceOf(BeaconError);
+  });
+
+  it("refuses a JSON-RPC error it does not recognise, rather than reading it as a gap", async () => {
+    // Fail closed. An unknown error code says nothing about whether the chain
+    // skipped that slot, and guessing "skipped" is the guess that moves the draw.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY ? rpcError({ code: -32602, message: "Invalid params" }) : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toMatchObject({
+      code: "RPC_FAILED",
+    });
+  });
+
+  it("refuses a 200 carrying neither a result nor an error", async () => {
+    // `payload.result` is `undefined` both when the key is absent and when it is
+    // present and null, and the second means "no block there". Collapsing them
+    // let a bare envelope from a proxy read as a skipped slot — the original
+    // defect, surviving the first fix.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY
+          ? new Response(JSON.stringify({ jsonrpc: "2.0", id: 1 }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toMatchObject({
+      code: "RPC_FAILED",
+    });
+  });
+
+  it("still reads an explicit null result as a skipped slot", async () => {
+    // The control for the test above: `result: null` present is the node
+    // answering "nothing there", and must keep working.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) => (slot === BOUNDARY ? reply(null) : undefined),
+    });
+
+    expect((await beacon.firstBlockAtOrAfter(TARGET)).slot).toBe(nextVisible(BOUNDARY));
+  });
+
+  it("refuses an internal error whose message merely contains the word skipped", async () => {
+    // The loose message branch is the one hedge against an unverified wire
+    // format, and unguarded it is fail-open: this shape is a real one, and
+    // reading it as a gap moves the draw and freezes it.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY
+          ? rpcError({
+              code: -32603,
+              message: "Internal error: request was skipped by the proxy",
+            })
+          : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toMatchObject({
+      code: "RPC_FAILED",
+    });
+  });
+
+  it("still accepts a skip reported with no code at all", async () => {
+    // The control for the gate: the hedge has to keep working where the code is
+    // absent, which is the case it exists for.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY ? rpcError({ message: `Slot ${slot} was skipped` }) : undefined,
+    });
+
+    expect((await beacon.firstBlockAtOrAfter(TARGET)).slot).toBe(nextVisible(BOUNDARY));
+  });
+
+  it("refuses a body that is not JSON, however healthy the status", async () => {
+    // A captive portal or proxy answering 200 with HTML.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY
+          ? new Response("<html>hello</html>", {
+              status: 200,
+              headers: { "Content-Type": "text/html" },
+            })
+          : undefined,
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toBeInstanceOf(BeaconError);
+  });
+
+  it("still tolerates a slot the chain really skipped", async () => {
+    // The other half, and the reason this cannot simply throw on everything:
+    // Solana reports a skipped slot as a JSON-RPC *error*, so a search that
+    // treated every error as a failure would never finish on the real chain.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY
+          ? rpcError({ code: -32007, message: `Slot ${slot} was skipped, or missing` })
+          : undefined,
+    });
+
+    expect((await beacon.firstBlockAtOrAfter(TARGET)).slot).toBe(nextVisible(BOUNDARY));
+  });
+
+  it("tolerates a node that reports a skipped slot as a null result", async () => {
+    // Unverified against a live node, which is why both shapes are accepted:
+    // some nodes are documented as answering `null` rather than erroring, and a
+    // draw that refused on the normal case would be worse than the bug.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) => (slot === BOUNDARY ? reply(null) : undefined),
+    });
+
+    expect((await beacon.firstBlockAtOrAfter(TARGET)).slot).toBe(nextVisible(BOUNDARY));
+  });
+
+  it("verify throws on an unreachable node rather than calling the draw wrong", async () => {
+    // `false` from verify is published as "this league's order was rigged".
+    // A 429 during an audit must not be able to say that.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) =>
+        slot === BOUNDARY ? new Response("slow down", { status: 429 }) : undefined,
+    });
+
+    await expect(beacon.verify(BOUNDARY, TARGET)).rejects.toBeInstanceOf(BeaconError);
+  });
+
+  it("verify still answers false for a slot that holds no block", async () => {
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: (slot) => (slot === BOUNDARY ? reply(null) : undefined),
+    });
+
+    expect(await beacon.verify(BOUNDARY, TARGET)).toBe(false);
+  });
+});
+
+describe("SolanaBeacon retries", () => {
+  const TARGET_SECONDS = GENESIS + 200_000;
+  const TARGET = new Date(TARGET_SECONDS * 1000);
+  const BOUNDARY = firstBlockAtOrAfter(TARGET_SECONDS);
+
+  it("rides out a rate limit delivered as a 200 with the limit in the body", async () => {
+    // Several providers answer this way. It is not a `BeaconError`, so it used
+    // to bypass the retry loop entirely — the retry never fired for the exact
+    // case it was added for.
+    const oneBodyRateLimit = () => {
+      let spent = false;
+      return (slot: number): Response | undefined => {
+        if (slot !== BOUNDARY || spent) return undefined;
+        spent = true;
+        return rpcError({ code: 429, message: "Too many requests" });
+      };
+    };
+
+    await expect(
+      beaconFor({ calls: 0 }, { attempts: 1, blockTimeFault: oneBodyRateLimit() }) //
+        .firstBlockAtOrAfter(TARGET),
+    ).rejects.toBeInstanceOf(BeaconError);
+
+    expect(
+      (
+        await beaconFor({ calls: 0 }, { blockTimeFault: oneBodyRateLimit() }) //
+          .firstBlockAtOrAfter(TARGET)
+      ).slot,
+    ).toBe(BOUNDARY);
+  });
+
+  it("rides out a backend that has not caught up to the tip", async () => {
+    // Public endpoints are load-balanced: getSlot can answer from one node and
+    // getBlockTime from another a few slots behind, which reports -32004. That
+    // lands on the first getBlockTime of every draw, so without a retry it
+    // would fail draws outright.
+    const oneLaggingBackend = () => {
+      let spent = false;
+      return (slot: number): Response | undefined => {
+        if (slot !== BOUNDARY || spent) return undefined;
+        spent = true;
+        return rpcError({ code: -32004, message: `Block not available for slot ${slot}` });
+      };
+    };
+
+    await expect(
+      beaconFor({ calls: 0 }, { attempts: 1, blockTimeFault: oneLaggingBackend() }) //
+        .firstBlockAtOrAfter(TARGET),
+    ).rejects.toBeInstanceOf(BeaconError);
+
+    expect(
+      (
+        await beaconFor({ calls: 0 }, { blockTimeFault: oneLaggingBackend() }) //
+          .firstBlockAtOrAfter(TARGET)
+      ).slot,
+    ).toBe(BOUNDARY);
+  });
+
+  it("rides out a single rate limit rather than failing the draw", async () => {
+    // ~30 unpaced sequential calls at a public endpoint; one 429 in thirty is
+    // ordinary, and now that a 429 fails the draw instead of being silently
+    // read as a gap, it would otherwise send the commissioner back to the
+    // button. Every call here is an idempotent read of immutable history.
+    const oneRateLimit = () => {
+      let spent = false;
+      return (slot: number): Response | undefined => {
+        if (slot !== BOUNDARY || spent) return undefined;
+        spent = true;
+        return new Response("slow down", { status: 429 });
+      };
+    };
+
+    // Without the retry the identical fault fails the draw, which is what makes
+    // this a retry test rather than a coincidence.
+    await expect(
+      beaconFor(
+        { calls: 0 },
+        { attempts: 1, blockTimeFault: oneRateLimit() },
+      ).firstBlockAtOrAfter(TARGET),
+    ).rejects.toBeInstanceOf(BeaconError);
+
+    const block = await beaconFor({ calls: 0 }, { blockTimeFault: oneRateLimit() }) //
+      .firstBlockAtOrAfter(TARGET);
+
+    expect(block.slot).toBe(BOUNDARY);
+  });
+
+  it("does not retry a request the node called malformed", async () => {
+    // A 400 is not going to become a 200. Repeating it just makes the
+    // commissioner wait longer for the same answer.
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      blockTimeFault: () => new Response("bad request", { status: 400 }),
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toBeInstanceOf(BeaconError);
+
+    // One `getSlot`, one `getBlockTime`, and no second go at it.
+    expect(counter.calls).toBe(2);
+  });
+
+  it("gives up after a bounded number of attempts", async () => {
+    const counter = { calls: 0 };
+    const beacon = beaconFor(counter, {
+      attempts: 4,
+      blockTimeFault: () => new Response("slow down", { status: 429 }),
+    });
+
+    await expect(beacon.firstBlockAtOrAfter(TARGET)).rejects.toBeInstanceOf(BeaconError);
+
+    // One `getSlot`, then four attempts at the first `getBlockTime`.
+    expect(counter.calls).toBe(5);
   });
 });
 

--- a/packages/db/src/randomness.ts
+++ b/packages/db/src/randomness.ts
@@ -48,6 +48,11 @@ export interface RandomnessBeacon {
    * Whether `slot` really is the first block at or after `time`.
    *
    * What a sceptic runs. Two calls, no search.
+   *
+   * `false` means the check ran and the slot failed it. An implementation that
+   * cannot reach its source **throws** rather than answering `false`, because
+   * "I could not check" is not "this draw is wrong" and a caller that publishes
+   * one as the other accuses an honest commissioner of rigging the draft.
    */
   verify(slot: number, time: Date): Promise<boolean>;
 }
@@ -61,6 +66,15 @@ export interface SolanaBeaconOptions {
   readonly endpoint: string;
   /** Injectable for tests. Defaults to global `fetch`. */
   readonly fetchImpl?: typeof globalThis.fetch;
+  /**
+   * Attempts per RPC call, including the first. Defaults to `RPC_ATTEMPTS`.
+   *
+   * Injectable so a test can pin how many round trips it expects rather than
+   * inferring them from a constant it does not control.
+   */
+  readonly attempts?: number;
+  /** Injectable for tests, so retry backoff costs no wall-clock time. */
+  readonly sleepImpl?: (ms: number) => Promise<void>;
 }
 
 /** Mainnet averages ~400ms per slot. Used only to seed the search. */
@@ -77,16 +91,175 @@ const SEARCH_MARGIN_SLOTS = 250_000;
  */
 const MAX_SKIP_WALK = 500;
 
+/**
+ * Attempts per RPC call, including the first.
+ *
+ * A search is ~30 sequential `getBlockTime` calls with no pacing, and the
+ * deployed shape points them at whatever `SOLANA_RPC_URL` names — often a free
+ * public endpoint that rate-limits. Since a failed call now *fails the draw*
+ * rather than being quietly read as a skipped slot, one 429 in thirty would
+ * send the commissioner back to the button. Three attempts costs at most 600ms
+ * of added latency *per call* — so a search where every call retries twice adds
+ * about sixteen seconds, not six hundred milliseconds. That only happens
+ * against an endpoint that is failing almost everything, where the draw should
+ * be refusing anyway, but it is why the ceiling is three and not ten.
+ *
+ * It is deliberately small and deliberately not a pacing delay: pacing would
+ * slow every draw to protect against a burst that three attempts already
+ * absorbs, and every call here is an idempotent read of immutable history, so
+ * repeating one cannot produce a different answer.
+ */
+const RPC_ATTEMPTS = 3;
+
+/** First backoff step; doubles per attempt. */
+const RETRY_BASE_MS = 200;
+
+/**
+ * Whether an HTTP status is worth a second attempt.
+ *
+ * 429 is the one that matters. A 4xx that is not 429 is the node telling us the
+ * request is wrong, and repeating it wastes the commissioner's time.
+ */
+const isRetryableStatus = (status: number): boolean => status === 429 || status >= 500;
+
+interface JsonRpcErrorBody {
+  readonly code?: number;
+  readonly message?: string;
+}
+
+/**
+ * The outcome of one JSON-RPC round trip that reached the node and came back
+ * well-formed. Transport and HTTP failures never appear here — they throw.
+ */
+type RpcOutcome<T> =
+  | { readonly ok: true; readonly result: T }
+  | { readonly ok: false; readonly error: JsonRpcErrorBody };
+
+/**
+ * JSON-RPC error codes meaning "that slot holds no block".
+ *
+ * -32007 is the live-ledger form ("Slot N was skipped, or missing due to ledger
+ * jump to recent snapshot") and -32009 the long-term-storage form.
+ *
+ * A slot the node has *pruned* is a different answer — agave reports that as
+ * -32001 `BlockCleanedUp`, which is deliberately **not** listed here, so a
+ * pruned range now fails loudly instead of being walked past. That is the right
+ * direction (a pruned range cannot be verified, and pretending otherwise is how
+ * an unverifiable draw gets recorded), but it means the archival-node guidance
+ * on `NOT_FOUND` is now reached only through a genuine long walk. UNVERIFIED
+ * against a live node from this repo.
+ *
+ * **What is assumed here, plainly, because it has not been checked against a
+ * live node from this repo:** that these are the codes a node answers a skipped
+ * slot with, and that some nodes may instead answer with a `null` *result* and
+ * no error at all. Both are accepted — and, critically, *nothing else is*.
+ *
+ * That asymmetry is the whole point. Reading a failure as "skipped" moves the
+ * draw to the next block; `drawDraftOrder` writes it, migration 0010's trigger
+ * freezes it, and `verify()` then calls the league's own recorded draw wrong
+ * forever. Reading a skip as a failure makes the draw refuse, which costs a
+ * commissioner one more click and corrupts nothing. So an error we do not
+ * recognise is a failure.
+ */
+const SKIPPED_SLOT_CODES: readonly number[] = [-32007, -32009];
+
+/**
+ * Codes that mean "ask again", not "no block there".
+ *
+ * -32004 and -32014 are a backend that has not caught up: public endpoints are
+ * load-balanced, so `getSlot` can answer from one node and `getBlockTime` from
+ * another a few slots behind. 429 appears here because some providers deliver a
+ * rate limit as HTTP 200 with the limit in the error body, where the HTTP-status
+ * retry never sees it.
+ */
+const TRANSIENT_RPC_CODES: readonly number[] = [-32004, -32014, 429];
+
+function isTransientRpcError(error: JsonRpcErrorBody): boolean {
+  return typeof error.code === "number" && TRANSIENT_RPC_CODES.includes(error.code);
+}
+
+/**
+ * Whether a JSON-RPC error body means "no block at that slot".
+ *
+ * The message check is the loose branch, and it is here on purpose: the exact
+ * code is unverified (see above), so a node using a third code in the same
+ * family would otherwise make every draw fail.
+ *
+ * **It is gated on the code being absent or in the -3200x family**, because
+ * unguarded it is genuinely fail-open: an internal error whose message merely
+ * contains the word — `{code: -32603, message: "request was skipped by the
+ * proxy"}` is a real shape — would move the draw a block and freeze it. A
+ * failure must never be read as a gap, so the hedge only applies where the code
+ * itself already says "something about this slot".
+ */
+function isSkippedSlot(error: JsonRpcErrorBody): boolean {
+  const code = typeof error.code === "number" ? error.code : null;
+  if (code !== null && SKIPPED_SLOT_CODES.includes(code)) return true;
+  if (code !== null && (code > -32000 || code <= -32010)) return false;
+
+  return /\bskipped\b/i.test(error.message ?? "");
+}
+
+const describeRpcError = (error: JsonRpcErrorBody): string =>
+  `${error.message ?? "unknown error"} (code ${error.code ?? "none"})`;
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export class SolanaBeacon implements RandomnessBeacon {
   private readonly endpoint: string;
   private readonly doFetch: typeof globalThis.fetch;
+  private readonly attempts: number;
+  private readonly sleep: (ms: number) => Promise<void>;
 
   constructor(options: SolanaBeaconOptions) {
     this.endpoint = options.endpoint;
     this.doFetch = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    // Guarded rather than clamped: Math.max(1, NaN) is NaN, and `attempt >= NaN`
+    // is never true, which would retry forever with doubling backoff.
+    const attempts = options.attempts ?? RPC_ATTEMPTS;
+    this.attempts = Number.isFinite(attempts)
+      ? Math.max(1, Math.floor(attempts))
+      : RPC_ATTEMPTS;
+    this.sleep = options.sleepImpl ?? realSleep;
   }
 
-  private async rpc<T>(method: string, params: unknown[]): Promise<T> {
+  /**
+   * One JSON-RPC call, retried while the failure looks transient.
+   *
+   * **A JSON-RPC error body is returned, not thrown.** For `getBlockTime` it is
+   * the node's real answer about the slot ("nothing there") and only the caller
+   * knows whether that answer is expected — which is exactly the distinction
+   * this whole file turns on. Everything that is *not* an answer about the slot
+   * — an unreachable node, an HTTP status, a body that is not JSON — throws,
+   * because none of it says anything about whether the chain skipped a slot.
+   */
+  private async call<T>(method: string, params: unknown[]): Promise<RpcOutcome<T>> {
+    for (let attempt = 1; ; attempt++) {
+      const outcome = await this.attemptCall<T>(method, params);
+
+      // A transient failure arrives in two shapes and both have to be retried.
+      // An HTTP 429 comes back as a `BeaconError`; the *same* rate limit from a
+      // provider that answers 200 with `{"error":{"code":429}}` comes back as an
+      // error body, which is not a `BeaconError` and so used to skip the loop
+      // entirely — the retry never fired for the case it was added for.
+      const retryable =
+        outcome instanceof BeaconError || (!outcome.ok && isTransientRpcError(outcome.error));
+      if (!retryable) return outcome;
+
+      if (attempt >= this.attempts) {
+        if (outcome instanceof BeaconError) throw outcome;
+        return outcome;
+      }
+      await this.sleep(RETRY_BASE_MS * 2 ** (attempt - 1));
+    }
+  }
+
+  /** One round trip. Returns the outcome, or the `BeaconError` to retry on. */
+  private async attemptCall<T>(
+    method: string,
+    params: unknown[],
+  ): Promise<RpcOutcome<T> | BeaconError> {
     let response: Response;
     try {
       response = await this.doFetch(this.endpoint, {
@@ -95,37 +268,84 @@ export class SolanaBeacon implements RandomnessBeacon {
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
       });
     } catch (cause) {
-      throw new BeaconError(`Solana RPC ${method} failed`, "RPC_FAILED", { cause });
+      return new BeaconError(`Solana RPC ${method} failed`, "RPC_FAILED", { cause });
     }
 
     if (!response.ok) {
-      throw new BeaconError(`Solana RPC ${method} returned ${response.status}`, "RPC_FAILED");
+      const failure = new BeaconError(
+        `Solana RPC ${method} returned ${response.status}`,
+        "RPC_FAILED",
+      );
+      if (!isRetryableStatus(response.status)) throw failure;
+      return failure;
     }
 
-    const payload = (await response.json()) as { result?: T; error?: { message?: string } };
-    if (payload.error) {
-      throw new BeaconError(
-        `Solana RPC ${method}: ${payload.error.message ?? "unknown error"}`,
+    let payload: { result?: T; error?: JsonRpcErrorBody };
+    try {
+      payload = (await response.json()) as { result?: T; error?: JsonRpcErrorBody };
+    } catch (cause) {
+      // A proxy or captive portal answering 200 with HTML. Not an answer about
+      // the slot, so it must not be mistaken for one.
+      return new BeaconError(`Solana RPC ${method} returned a non-JSON body`, "RPC_FAILED", {
+        cause,
+      });
+    }
+
+    if (payload.error) return { ok: false, error: payload.error };
+
+    // Neither a result nor an error is not an answer about the slot, and it must
+    // not decay into one. `result` absent and `result: null` are different
+    // facts — the second says "no block there", the first says the node did not
+    // answer — and `payload.result` collapses both to `undefined`, so the check
+    // has to be on the key rather than the value. Without it a proxy returning
+    // a bare `{"jsonrpc":"2.0","id":1}` reads as a skipped slot, which is the
+    // whole defect this file was rewritten to remove.
+    if (!("result" in payload)) {
+      return new BeaconError(
+        `Solana RPC ${method} answered with neither a result nor an error`,
         "RPC_FAILED",
       );
     }
 
-    return payload.result as T;
+    return { ok: true, result: payload.result as T };
+  }
+
+  /** A call whose JSON-RPC error body is never an expected answer. */
+  private async rpc<T>(method: string, params: unknown[]): Promise<T> {
+    const outcome = await this.call<T>(method, params);
+    if (!outcome.ok) {
+      throw new BeaconError(
+        `Solana RPC ${method}: ${describeRpcError(outcome.error)}`,
+        "RPC_FAILED",
+      );
+    }
+    return outcome.result;
   }
 
   /**
-   * A slot's block time, or `null` if that slot was skipped.
+   * A slot's block time, or `null` when the node says that slot holds no block.
    *
-   * Skipped slots are normal — a leader that misses its turn produces no block —
-   * so the search below has to tolerate gaps rather than treat them as errors.
+   * `null` means exactly one thing — **the chain skipped this slot** — because
+   * that is the only thing the callers below can do anything sensible with: they
+   * read it as "keep walking" and move on to the next slot. Skipped slots are
+   * normal; a leader that misses its turn produces no block.
+   *
+   * Everything else throws. A node that is unreachable, rate-limiting, or
+   * answering with an error we do not recognise has told us nothing about the
+   * slot, and walking past it on that basis moves the draw to a different block
+   * — permanently, since the order is written once and frozen by a trigger.
+   * See `SKIPPED_SLOT_CODES` for what counts as "the slot was skipped" and what
+   * is assumed in deciding that.
    */
   private async blockTime(slot: number): Promise<number | null> {
-    try {
-      return await this.rpc<number | null>("getBlockTime", [slot]);
-    } catch (error) {
-      if (error instanceof BeaconError && error.code === "RPC_FAILED") return null;
-      throw error;
-    }
+    const outcome = await this.call<number | null>("getBlockTime", [slot]);
+    if (outcome.ok) return outcome.result ?? null;
+    if (isSkippedSlot(outcome.error)) return null;
+
+    throw new BeaconError(
+      `Solana RPC getBlockTime(${slot}): ${describeRpcError(outcome.error)}`,
+      "RPC_FAILED",
+    );
   }
 
   /**
@@ -191,6 +411,14 @@ export class SolanaBeacon implements RandomnessBeacon {
     };
   }
 
+  /**
+   * Two calls, no search — and it throws rather than guessing.
+   *
+   * `null` here is a real finding: the recorded slot holds no block, so it
+   * cannot be the block the order was drawn from. A node that failed to answer
+   * is not a finding, and `blockTime` throws on that rather than handing back a
+   * `null` this would read as proof of a rigged draw.
+   */
   async verify(slot: number, time: Date): Promise<boolean> {
     const target = Math.floor(time.getTime() / 1000);
 
@@ -211,6 +439,10 @@ export class SolanaBeacon implements RandomnessBeacon {
    *
    * Skipped slots are normal — a leader that misses its turn produces no block —
    * so every lookup has to tolerate gaps rather than treat them as failures.
+   *
+   * The walk covers gaps and nothing else. A lookup that genuinely failed throws
+   * out of `blockTime` and out of here, rather than being counted as one more
+   * skipped slot and stepped over.
    */
   private async blockAtOrBefore(slot: number): Promise<{ slot: number; time: number }> {
     for (let current = slot; current >= 0 && current > slot - MAX_SKIP_WALK; current--) {


### PR DESCRIPTION
Closes #20.

`rpc()` collapsed a thrown fetch, an HTTP 429/500/502, and a JSON-RPC error body into one `RPC_FAILED` code, and `blockTime` read all three as "this slot was skipped". A skipped slot genuinely *is* reported as a JSON-RPC error, so the swallow was not gratuitous — but it made a rate limit indistinguishable from a gap.

One transient fault on the boundary slot settled the binary search a block late. `drawDraftOrder` writes it, migration `0010`'s trigger freezes it, and `verify()` then reports the league's own order unverifiable **forever**. Reproduced end to end against real PGlite: wrong slot written, audit fails, all three repair paths correctly refuse.

Fairness survives — the wrong block is still unpredictable and the commissioner does not control the RPC endpoint. **Verifiability does not**, and that is the whole stated value of drawing from a chain.

## The fix

`blockTime` returns `null` only for a recognised "no block there" and throws on everything else. Fail closed: refusing costs a retry (the block is fetched outside the transaction, and the answer is deterministic once it exists) while guessing costs the league its verifiability.

Two narrowings came out of review rather than design, and **both were reproduced before being fixed**:

- An absent `result` and `result: null` both read as `undefined`, so collapsing them let a bare `{"jsonrpc":"2.0","id":1}` from a proxy pass as a gap — the original defect, surviving the first fix.
- The message hedge is gated on the code being in the same `-3200x` family, because ungated it reads `{code: -32603, message: "…was skipped by the proxy"}` as a gap.

Retries are three attempts, 200ms doubling, on 429, 5xx, **and a transient JSON-RPC error body** — that last shape does not throw, so it originally bypassed the retry loop entirely, meaning the retry never fired for the rate-limit case it was added for.

`verify()` needed no change: with `blockTime` throwing, a transient fault during an audit propagates instead of answering `false`. Its `false` is published as "this order was rigged".

The test it replaces was green for the wrong reason — it 502'd every call including the initial `getSlot`, which is not routed through the swallow, so it never exercised the guessing path.

Migration `0010` untouched.

## Verification

982 tests (was 965). Typecheck, lint, format clean. Nine new tests fail on the pre-fix code, verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)