### PR TITLE
fix(draft): re-check the clock decision inside the lock it was made outside

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,12 @@ The database decides instead — `SELECT ... FOR UPDATE` on the draft row is the
 and `PRIMARY KEY (draft_id, pick_number)` plus `UNIQUE (draft_id, player_id)` are the
 backstop if anything ever writes outside that lock. Both are tested.
 
+**Serialising is not the same as being right**, and issue #22 was the cost of assuming it
+is. The lock decides who writes first; it cannot make a decision taken before the lock true
+afterwards, and two callers who both read "pick 15 is open" are queued and then _both_
+write — legal rows, different pick numbers, different players, so no constraint fires. What
+catches it is re-reading the decision inside the lock. See "The draft room".
+
 A pick writes the `draft_picks` row, the `roster_entries` row, and the queue cleanup in
 **one transaction**. A pick recorded without a roster entry leaves a team owning a player
 nothing else in the system can see.
@@ -393,15 +399,57 @@ The board is fetched **once** and availability computed client-side by subtracti
 players. A thousand players is ~80 KB and only changes when the stats sync runs; shipping
 it on every 3-second poll would be silly.
 
-**`catchUpExpiredPicks()` runs on every read of the draft.** That is how clocks expire —
-there is no scheduled worker yet. It is deterministic and idempotent, so it does not
-matter who triggers it.
+**`catchUpExpiredPicks()` runs on every read of the draft**, as well as on the cron tick.
+That is how clocks expire. It is safe to run from anywhere, any number of times at once —
+but **it is not safe because the picks are deterministic**, and that is what the comments
+here used to claim (issue #22).
+
+Every caller decides "pick N is overdue" from a read taken _before_ the lock. `FOR UPDATE`
+then queues them and each writes in turn, so N stale callers made N _consecutive_ picks:
+pick N legitimately, then N+1 and N+2 for managers who had just been handed a full ninety
+seconds. Nothing catches that afterwards — the rows are different pick numbers and
+different players, so the primary key and the unique index are both satisfied, there is no
+un-pick, and `createDraftRecord` refuses a redraft. Anyone who knew a league id could
+amplify it, because the read route needs no session.
+
+**So `recordPick` re-checks the decision inside the lock: the expected pick number _and_
+the deadline.** Two guards, and neither replaces the other — the pick number catches a
+snapshot that predates somebody else's pick, the deadline catches a pause-and-resume,
+where the pick on the clock is unchanged and the timer is new.
+
+**Losing that race is a no-op, not a throw.** `catchUpExpiredPicks` returns how many picks
+it made itself. The draft read route catches only `DraftContextError`, so an error there is a
+500 in a polling tab at the exact instant the draft advances.
 
 Each auto-pick is stamped **at the deadline it missed, not at `now`**, and that is
 load-bearing. Stamping `now` restarts the next manager's clock from whenever somebody
 happened to open the page: an hour of nobody watching would cost exactly one pick and
 silently extend every clock after it. Advancing deadline by deadline keeps the draft on
 real time. Tested.
+
+**And a manual pick that arrives after its own deadline is refused** (`CLOCK_EXPIRED`,
+409), not accepted and stamped `now`. It used to be accepted: `makePick` checks the turn
+and not the clock, so five managers each a minute late pushed the draft 300 seconds behind
+the schedule it published, one overrun at a time, added to a baseline that never
+re-anchors. That is precisely the drift the deadline-stamped auto-pick exists to prevent,
+and it is not less drift for having a human behind it. The room disables the Draft button
+when the countdown reads 0:00 — `DraftRoom` owns the deadline for that reason, so the
+countdown and the button share one deadline. They run on separate timers so they can
+differ for up to 250ms, but not about _which_ instant is the deadline. The button is a
+courtesy and the server is the rule.
+
+**That gate is measured against the server's clock, which the draft payload carries as
+`now`.** Measuring it against `Date.now()` reads correctly on a correct machine and locks
+a wrong one out of the entire draft: a browser more than one pick clock fast computes
+every deadline as already passed, disables its own Draft button on every poll, and
+auto-picks every round. Only the _elapsed_-time half of the local clock is used, for the
+timeout, and that stays accurate however wrong the absolute time is. A UI that refuses a
+pick the server would have accepted is worse than the drift this gate exists to prevent.
+
+**Open, and an owner's call, not a bug:** in a 24-hour slow draft a pick a minute late is
+refused for a drift of one minute in twenty-four hours. Defensible and harsh. A grace
+period in SLOW mode would be a reasonable alternative and was deliberately _not_ invented
+here.
 
 **`/api/cron/draft-tick` is what makes clocks real.** Before it existed, expiry happened
 only when somebody _read_ a draft, so a draft nobody had open did not advance and a
@@ -411,7 +459,9 @@ least as often as the shortest pick clock** — a minute, given the 90-second mi
 
 Set `CRON_SECRET` to stop it being hammered. It is not a security boundary in the usual
 sense: the endpoint only does what the clock already permits, so an unauthorised call
-cannot produce a wrong pick. The guard is about database load.
+cannot produce a wrong pick. The guard is about database load. **That holds because of the
+two guards above** — before them, hammering it at a real expiry produced extra picks, and
+the public read route did the same work anyway, so the secret was never what prevented it.
 
 It also purges expired sessions and idle rate-limit buckets, because those need a
 scheduler and nothing else did.

--- a/apps/web/src/app/api/cron/draft-tick/route.ts
+++ b/apps/web/src/app/api/cron/draft-tick/route.ts
@@ -20,7 +20,12 @@ import { draftBoard } from "@/lib/draft-context";
  *
  * Idempotent and deterministic: it makes exactly the picks the clock says are
  * overdue, stamped at the deadlines they missed. Running it twice, or alongside
- * somebody loading the room, changes nothing.
+ * somebody loading the room, changes nothing — because `recordPick` re-checks
+ * the pick number and the deadline inside its lock, so a tick that overlaps a
+ * page load records nothing rather than taking the next manager's pick. It is
+ * not idempotent by virtue of the picks being deterministic; it is idempotent
+ * because a caller that loses the race writes nothing. See
+ * `catchUpExpiredPicks`.
  *
  * Wire it to a scheduler that fires **at least as often as the shortest pick
  * clock** — a minute is right, given the 90-second minimum. On Vercel that is
@@ -30,6 +35,13 @@ export async function GET(request: Request): Promise<NextResponse> {
   // Not a security boundary in the usual sense — this endpoint only does what
   // the clock already permits, so an unauthorised call cannot make a wrong pick.
   // It guards against someone hammering it for the database load.
+  //
+  // That first sentence is only true because of the guards inside `recordPick`.
+  // Hammering an unguarded catch-up at the instant of a real expiry is how you
+  // turn one legitimate auto-pick into several, and the draft read route is
+  // public and does the same work, so the secret was never what stood between an
+  // attacker and that. If you are tempted to remove those guards, this comment
+  // becomes a lie first.
   const secret = process.env["CRON_SECRET"];
   if (secret) {
     const provided =

--- a/apps/web/src/app/api/leagues/[id]/draft/pick/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/pick/route.ts
@@ -7,6 +7,7 @@ const STATUS: Record<string, number> = {
   DRAFT_NOT_FOUND: 404,
   NOT_IN_PROGRESS: 409,
   PICK_RACE_LOST: 409,
+  CLOCK_EXPIRED: 409,
   NOT_ON_CLOCK: 409,
   PLAYER_UNAVAILABLE: 409,
   ROSTER_FULL: 409,
@@ -18,9 +19,16 @@ const STATUS: Record<string, number> = {
  * Make a pick.
  *
  * The team comes from the session, never from the body. Everything else — whose
- * turn it is, whether the player is available, whether the roster can take him —
- * is decided by the engine, which the database then arbitrates. This route only
- * carries the request.
+ * turn it is, whether the player is available, whether the roster can take him,
+ * and whether the clock has already run out — is decided by the engine and the
+ * database. This route only carries the request.
+ *
+ * **A late pick is refused, `CLOCK_EXPIRED`, not accepted.** The deadline passed
+ * means the pick belongs to the auto-pick, stamped at that deadline; accepting a
+ * click that arrives afterwards would stamp the next clock at whenever it landed
+ * and hand every manager below the overrun. The room disables the button when
+ * the countdown reads zero, so reaching this is a click racing its own clock —
+ * but the button is a courtesy and this is the rule.
  */
 export async function POST(
   request: Request,
@@ -52,6 +60,17 @@ export async function POST(
       shape: context.shape,
       now: new Date(),
     });
+
+    if (!pick) {
+      // `null` means the pick this request meant had already been made. A manual
+      // pick names no `expectedPickNumber`, so it is unreachable from here today
+      // — reported rather than asserted away, because the alternative is a `!`
+      // that becomes a crash the day this route does name one.
+      return NextResponse.json(
+        { error: "That pick has already been made", code: "PICK_RACE_LOST" },
+        { status: 409 },
+      );
+    }
 
     return NextResponse.json({ pick }, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/leagues/[id]/draft/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/route.ts
@@ -25,15 +25,28 @@ function nextTeamOnClock(
  * The live draft state.
  *
  * **Advances the clock as a side effect.** Expiry has to happen somewhere, and
- * there is no scheduled worker yet — so any read of the draft first auto-picks
- * anything already overdue. The auto-pick is deterministic and idempotent, so it
- * does not matter who triggers it or how often.
+ * `/api/cron/draft-tick` only fires once a minute — so any read of the draft
+ * first auto-picks anything already overdue.
  *
- * The limitation is real and worth stating: **if nobody looks at a draft, its
- * clock does not advance.** For a slow draft with a 24-hour timer that is
- * harmless; for a fast one, the room is open and being polled. It should still
- * become a scheduled job calling `draftsWithExpiredPicks()` before the season —
- * a draft that stalls because everyone closed the tab is a bad night.
+ * **This route needs no session, and every open tab polls it at one second while
+ * its manager is on the clock or on deck.** So the catch-up runs from many
+ * callers at once, none of them coordinated, at the exact instant a deadline
+ * passes. That is safe because `recordPick` re-checks the pick number and the
+ * deadline inside its lock and records nothing if either moved — it is not safe
+ * merely because the picks are deterministic. See `catchUpExpiredPicks`.
+ *
+ * **It must also stay a no-op rather than a throw when it loses that race**,
+ * which is what `catchUpExpiredPicks` promises. The catch below handles
+ * `DraftContextError` and rethrows everything else, so anything else surfaces as
+ * a 500 in a polling tab at the moment the draft advances — the worst possible
+ * moment for the room to go blank. That includes the race where the winner made
+ * the *final* pick and completed the draft, which is why `recordPick` answers a
+ * named caller with `null` rather than `NOT_IN_PROGRESS`.
+ *
+ * The limitation is real and worth stating: **between cron ticks, a draft nobody
+ * is looking at does not advance.** For a slow draft with a 24-hour timer that
+ * is irrelevant; for a fast one, a minute is the worst case and the room is open
+ * and polling anyway.
  */
 export async function GET(
   _request: Request,
@@ -83,6 +96,11 @@ export async function GET(
         : null;
 
     return NextResponse.json({
+      // The server clock, so the room can measure the pick clock without
+      // trusting the browser's absolute time. A machine whose clock is more
+      // than one pick ahead would otherwise compute every deadline as already
+      // passed and be locked out of manually picking for the whole draft.
+      now: new Date().toISOString(),
       draft: {
         status: draft.status,
         rounds: draft.rounds,

--- a/apps/web/src/components/DraftRoom.tsx
+++ b/apps/web/src/components/DraftRoom.tsx
@@ -115,6 +115,8 @@ function pollInterval(data: DraftResponse | undefined): number {
 }
 
 interface DraftResponse {
+  /** The server clock when this payload was built. See `serverNow` below. */
+  now?: string;
   draft: DraftState | null;
   teams: Team[];
   me: { teamId: string | null; isCommissioner: boolean; queue: string[] };
@@ -192,6 +194,62 @@ export function DraftRoom({ leagueId, leagueName }: { leagueId: string; leagueNa
   const onTheClock = draft?.currentTeamId ?? null;
   const isMyTurn = myTeamId !== null && onTheClock === myTeamId;
 
+  /**
+   * When the pick on the clock expires, in milliseconds.
+   *
+   * Computed here rather than in `ClockBar` because two things need it and they
+   * must not be able to disagree: the countdown, and whether the Draft button
+   * still does anything.
+   */
+  /**
+   * The server clock, as of the last poll.
+   *
+   * The pick clock is the server's, so whether it has run out is the server's
+   * question and must not be asked of the browser's. A machine an hour fast
+   * would otherwise read every deadline as passed and disable its own Draft
+   * button for the entire draft, auto-picking every round.
+   *
+   * Falls back to the local clock only if the field is missing, which means an
+   * older server — the previous behaviour, no worse.
+   */
+  const serverNow = data?.now ? new Date(data.now).getTime() : Date.now();
+
+  const deadline =
+    draft?.clockStartedAt !== null && draft?.clockStartedAt !== undefined
+      ? new Date(draft.clockStartedAt).getTime() + draft.pickSeconds * 1000
+      : null;
+
+  /**
+   * Whether the countdown has reached zero.
+   *
+   * A single timer fired *at* the deadline, not a tick — the button only has to
+   * change once, and re-rendering the whole board four times a second to find
+   * that out would be silly.
+   *
+   * The server refuses a late pick outright (`CLOCK_EXPIRED`), so without this
+   * the button stays live after the clock reads 0:00 and an ordinary manager
+   * clicking a moment late gets a 409 instead of a disabled button. This does
+   * not decide anything — the server does — it stops the room offering an action
+   * it knows will be refused.
+   */
+  const [clockExpired, setClockExpired] = useState(false);
+  useEffect(() => {
+    if (deadline === null) {
+      setClockExpired(false);
+      return;
+    }
+    // Measured against the *server* clock carried in the payload, not the
+    // browser's. Only the elapsed-time half of the local clock is used — for
+    // the timeout below — and that stays accurate however wrong the absolute
+    // time is. A skewed machine must not be locked out of its own picks.
+    const untilDeadline = deadline - serverNow;
+    setClockExpired(untilDeadline <= 0);
+    if (untilDeadline <= 0) return;
+
+    const timer = setTimeout(() => setClockExpired(true), untilDeadline);
+    return () => clearTimeout(timer);
+  }, [deadline, serverNow]);
+
   const post = useCallback(
     async (path: string, body?: unknown, method = "POST"): Promise<void> => {
       setBusy(true);
@@ -236,6 +294,7 @@ export function DraftRoom({ leagueId, leagueName }: { leagueId: string; leagueNa
     <div className="space-y-6">
       <ClockBar
         draft={draft}
+        deadline={deadline}
         teams={teams}
         isMyTurn={isMyTurn}
         isCommissioner={data.me.isCommissioner}
@@ -287,7 +346,7 @@ export function DraftRoom({ leagueId, leagueName }: { leagueId: string; leagueNa
                 <PlayerList
                   players={group.players}
                   queue={queue}
-                  canPick={isMyTurn && draft.status === "IN_PROGRESS"}
+                  canPick={isMyTurn && draft.status === "IN_PROGRESS" && !clockExpired}
                   busy={busy}
                   onPick={(playerId) => void post("/pick", { playerId })}
                   onQueue={(playerId) =>
@@ -335,6 +394,7 @@ export function DraftRoom({ leagueId, leagueName }: { leagueId: string; leagueNa
 
 function ClockBar({
   draft,
+  deadline,
   teams,
   isMyTurn,
   isCommissioner,
@@ -342,16 +402,14 @@ function ClockBar({
   onStart,
 }: {
   draft: DraftState;
+  /** Milliseconds, or `null` when no clock is running. Owned by `DraftRoom`. */
+  deadline: number | null;
   teams: Map<string, Team>;
   isMyTurn: boolean;
   isCommissioner: boolean;
   busy: boolean;
   onStart: () => void;
 }) {
-  const deadline = draft.clockStartedAt
-    ? new Date(draft.clockStartedAt).getTime() + draft.pickSeconds * 1000
-    : null;
-
   // Ticks locally between polls so the countdown is smooth. The server decides
   // expiry; this is only the display.
   const [now, setNow] = useState(() => Date.now());
@@ -426,6 +484,15 @@ function ClockBar({
           {isMyTurn ? "You are on the clock" : `${team?.name ?? "…"} is on the clock`}
           {team?.isBot && <span className="ml-2 text-xs text-white/40">bot</span>}
         </p>
+        {remaining === 0 && (
+          // Says what is about to happen rather than leaving a dead button and a
+          // 0:00 with no explanation. The pick is the auto-pick's from the
+          // deadline onwards, and the server refuses a late manual one.
+          <p className="text-xs text-white/40">
+            {isMyTurn ? "Your time is up — " : "Time is up — "}
+            the auto-pick takes this one, stamped at the deadline it missed.
+          </p>
+        )}
       </div>
 
       {remaining !== null && (

--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -76,6 +76,18 @@ const BEACON = new FixedBeacon([
 const DRAW_TIME = new Date(SCHEDULED.getTime() + 5_000);
 
 /**
+ * The instant pick `n` of a draft started at `SCHEDULED` runs out of clock.
+ *
+ * An auto-pick is legal only at or after its own deadline — `recordPick` refuses
+ * one whose clock is still running, because a caller asking for it is working
+ * from a snapshot another writer has already moved past. So a fixture that plays
+ * a draft out through the auto path has to walk the clock the way a real draft
+ * does: pick `n` is stamped at its deadline, and pick `n + 1`'s clock starts
+ * there.
+ */
+const deadlineOf = (n: number): Date => new Date(SCHEDULED.getTime() + n * 90_000);
+
+/**
  * A pool deep enough that every team can fill a legal lineup, in a realistic
  * cadence rather than blocks by position — a pool that lists sixty running backs
  * first makes "best available" look like "take every running back".
@@ -488,7 +500,7 @@ describe("recordPick", () => {
       source: "MANUAL",
       draftComplete: false,
     });
-    expect(result.nextTeamId).toBe(fx.order[1]);
+    expect(result!.nextTeamId).toBe(fx.order[1]);
   });
 
   it("puts the player on the roster in the same transaction", async () => {
@@ -580,7 +592,7 @@ describe("recordPick", () => {
       leagueId: fx.leagueId,
       pool: fx.pool,
       shape: SHAPE,
-      now: SCHEDULED,
+      now: deadlineOf(1),
     });
 
     expect(result).toMatchObject({ playerId: wanted, source: "QUEUE" });
@@ -597,7 +609,7 @@ describe("recordPick", () => {
       leagueId: fx.leagueId,
       pool: fx.pool,
       shape: SHAPE,
-      now: SCHEDULED,
+      now: deadlineOf(1),
     });
 
     expect(await getQueue(fx.client, fx.order[1]!)).toEqual([]);
@@ -610,11 +622,11 @@ describe("recordPick", () => {
       leagueId: fx.leagueId,
       pool: fx.pool,
       shape: SHAPE,
-      now: SCHEDULED,
+      now: deadlineOf(1),
     });
 
-    expect(result.source).not.toBe("MANUAL");
-    expect(result.source).not.toBe("QUEUE");
+    expect(result!.source).not.toBe("MANUAL");
+    expect(result!.source).not.toBe("QUEUE");
   });
 
   it("starts the season when the draft completes", async () => {
@@ -627,7 +639,7 @@ describe("recordPick", () => {
         leagueId: fx.leagueId,
         pool: fx.pool,
         shape: SHAPE,
-        now: SCHEDULED,
+        now: deadlineOf(i + 1),
       });
     }
 
@@ -676,7 +688,7 @@ describe("recordPick", () => {
         leagueId: fx.leagueId,
         pool: fx.pool,
         shape: SHAPE,
-        now: SCHEDULED,
+        now: deadlineOf(i + 1),
       });
     }
 
@@ -696,7 +708,7 @@ describe("recordPick", () => {
         leagueId: fx.leagueId,
         pool: fx.pool,
         shape: SHAPE,
-        now: SCHEDULED,
+        now: deadlineOf(i + 1),
       });
     }
 
@@ -728,7 +740,7 @@ describe("recordPick", () => {
         leagueId: fx.leagueId,
         pool: fx.pool,
         shape: SHAPE,
-        now: SCHEDULED,
+        now: deadlineOf(i + 1),
       });
     }
 
@@ -829,9 +841,14 @@ describe("clocks", () => {
         leagueId: fx.leagueId,
         pool: fx.pool,
         shape: SHAPE,
-        now: SCHEDULED,
+        now: deadlineOf(i + 1),
       });
     }
+
+    // Assert the draft really did complete before asserting the refusal — with
+    // the clock walked forward per pick, a fixture that quietly recorded nothing
+    // would otherwise still see `startDraft` throw, for the wrong reason.
+    expect((await loadDraft(fx.client, fx.leagueId))?.status).toBe("COMPLETE");
 
     await expect(startDraft(fx.client, fx.leagueId, SCHEDULED)).rejects.toBeInstanceOf(
       DraftPersistenceError,
@@ -1063,6 +1080,211 @@ describe("concurrency guards", () => {
       "SELECT count(*)::int AS count FROM roster_entries",
     );
     expect(after[0]?.count).toBe(before[0]?.count);
+  });
+});
+
+/**
+ * Issue #22. The lock decides who writes first; it cannot make a decision taken
+ * *before* the lock true afterwards. Both guards are checked inside it.
+ *
+ * PGlite is one connection, so a genuine two-writer race cannot run here — and
+ * attempting one produces a different failure entirely (nested BEGIN, unique
+ * violation, everything rolled back). What is testable, and what actually
+ * matters, is that a stale decision is refused. These drive that directly.
+ */
+describe("a decision made before the lock is re-checked inside it", () => {
+  async function running(): Promise<{ fx: Fixture; order: readonly string[] }> {
+    const fx = await setup();
+    const order = await scheduled(fx);
+    await startDraft(fx.client, fx.leagueId, SCHEDULED);
+    return { fx, order };
+  }
+
+  const EXPIRED = new Date(SCHEDULED.getTime() + 91_000);
+
+  it("records nothing when the pick it meant has already been made", async () => {
+    // Caller A committed pick 1 while caller B was between its read and its
+    // lock. B's snapshot says "pick 1 expired"; acting on it would take pick 2
+    // from a manager whose ninety seconds just started.
+    const { fx, order } = await running();
+
+    await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: order[0]!,
+      playerId: anyAvailable(fx, new Set()),
+      pool: fx.pool,
+      shape: SHAPE,
+      now: SCHEDULED,
+    });
+
+    const stale = await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      expectedPickNumber: 1,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: EXPIRED,
+    });
+
+    expect(stale).toBeNull();
+    expect(draftProgress((await loadDraft(fx.client, fx.leagueId))!).picksMade).toBe(1);
+  });
+
+  it("records nothing when the pick number is right but the clock is not", async () => {
+    // The subtle half, and why the pick number alone is not enough: a pause and
+    // resume keeps the same pick on the clock and starts a fresh timer, so a
+    // stale "it expired" passes a pick-number check and would auto-pick a
+    // manager who has just been handed their full ninety seconds.
+    const { fx } = await running();
+
+    const notExpired = await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      expectedPickNumber: 1,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: new Date(SCHEDULED.getTime() + 1_000),
+    });
+
+    expect(notExpired).toBeNull();
+    expect(draftProgress((await loadDraft(fx.client, fx.leagueId))!).picksMade).toBe(0);
+  });
+
+  it("still auto-picks when the decision is genuinely current", async () => {
+    // The control. Both guards must let a real expiry through, or the clock
+    // never advances at all.
+    const { fx } = await running();
+
+    const made = await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      expectedPickNumber: 1,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: EXPIRED,
+    });
+
+    expect(made).not.toBeNull();
+    expect(made?.pickNumber).toBe(1);
+  });
+
+  it("refuses a manual pick whose own clock has run out", async () => {
+    // Accepting it stamps `clock_started_at = now`, so the overrun is added to a
+    // baseline that never re-anchors and every later clock stretches — the exact
+    // drift the deadline-stamped auto-pick exists to prevent.
+    const { fx, order } = await running();
+
+    await expect(
+      recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: order[0]!,
+        playerId: anyAvailable(fx, new Set()),
+        pool: fx.pool,
+        shape: SHAPE,
+        now: new Date(SCHEDULED.getTime() + 300_000),
+      }),
+    ).rejects.toMatchObject({ code: "CLOCK_EXPIRED" });
+
+    expect(draftProgress((await loadDraft(fx.client, fx.leagueId))!).picksMade).toBe(0);
+  });
+
+  it("records nothing when the winner's pick completed the draft", async () => {
+    // The status check runs before both guards, so a lost race to a winner who
+    // *finished* the draft used to throw NOT_IN_PROGRESS — and the read route
+    // has no catch for it, so every polling tab would 500 at the exact instant a
+    // draft ends. A named caller losing a race is a no-op however it lost.
+    const fx = await setup(2);
+    const order = await scheduled(fx);
+    await startDraft(fx.client, fx.leagueId, SCHEDULED);
+
+    const total = totalPicks(order.length, 14);
+    await catchUpExpiredPicks(fx.client, {
+      leagueId: fx.leagueId,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: deadlineOf(total),
+      maxPicks: total,
+    });
+
+    const [row] = await fx.client.query<{ status: string }>(
+      "SELECT status FROM drafts WHERE league_id = $1",
+      [fx.leagueId],
+    );
+    expect(row?.status).toBe("COMPLETE");
+
+    await expect(
+      recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        expectedPickNumber: total,
+        pool: fx.pool,
+        shape: SHAPE,
+        now: deadlineOf(total),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("records nothing when a commissioner paused between the read and the lock", async () => {
+    const { fx } = await running();
+    await pauseDraft(fx.client, fx.leagueId);
+
+    await expect(
+      recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        expectedPickNumber: 1,
+        pool: fx.pool,
+        shape: SHAPE,
+        now: EXPIRED,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("still tells a manual picker the draft is not running", async () => {
+    // The manual path names no expected pick, so it keeps throwing — somebody
+    // clicking on a paused draft wants to be told, not silently ignored.
+    const { fx, order } = await running();
+    await pauseDraft(fx.client, fx.leagueId);
+
+    await expect(
+      recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: order[0]!,
+        playerId: anyAvailable(fx, new Set()),
+        pool: fx.pool,
+        shape: SHAPE,
+        now: SCHEDULED,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_IN_PROGRESS" });
+  });
+
+  it("leaves the clock where the schedule says after a late pick is refused", async () => {
+    // The point of refusing: the next manager's clock still runs from the missed
+    // deadline, not from whenever the late click happened to land.
+    const { fx, order } = await running();
+
+    await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: order[0]!,
+      playerId: anyAvailable(fx, new Set()),
+      pool: fx.pool,
+      shape: SHAPE,
+      // Genuinely late — 300s into a 90s clock. With `SCHEDULED` here the pick
+      // is on time, the refusal never fires, and this asserts nothing.
+      now: new Date(SCHEDULED.getTime() + 300_000),
+    }).catch(() => undefined);
+
+    await catchUpExpiredPicks(fx.client, {
+      leagueId: fx.leagueId,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: new Date(SCHEDULED.getTime() + 300_000),
+    });
+
+    const [row] = await fx.client.query<{ clock_started_at: string }>(
+      "SELECT clock_started_at FROM drafts WHERE league_id = $1",
+      [fx.leagueId],
+    );
+
+    // Every stamp is a multiple of the pick clock from the scheduled start —
+    // never an arbitrary instant somebody happened to click at.
+    const offset = (new Date(row!.clock_started_at).getTime() - SCHEDULED.getTime()) / 1000;
+    expect(offset % 90).toBe(0);
   });
 });
 

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -21,10 +21,20 @@
  *
  * Belt and braces on purpose. The draft is the origin of every roster in the
  * league, and a duplicated player is not something you can fix afterwards.
+ *
+ * **Serialising is not the same as being right, and that distinction is the
+ * whole of `recordPick`'s two guards.** The lock decides who writes first; it
+ * cannot make a decision taken before the lock true afterwards. Two callers who
+ * both read "pick 15 expired" are queued by the lock and then *both* write —
+ * the second one taking pick 16 from a manager who has a full clock in hand.
+ * Neither the primary key nor the unique index catches that: the picks are
+ * different pick numbers and different players, so both are perfectly legal
+ * rows. Only re-reading the decision inside the lock catches it.
  */
 
 import {
   createDraft,
+  currentPickNumber,
   currentTeam,
   generateDraftOrder,
   isComplete,
@@ -65,7 +75,8 @@ export class DraftPersistenceError extends Error {
       | "RULES_MISSING"
       | "NOT_IN_PROGRESS"
       | "ALREADY_STARTED"
-      | "PICK_RACE_LOST",
+      | "PICK_RACE_LOST"
+      | "CLOCK_EXPIRED",
   ) {
     super(message);
     this.name = "DraftPersistenceError";
@@ -506,6 +517,23 @@ export interface RecordPickInput {
   readonly teamId?: string;
   /** Omit for an auto-pick. */
   readonly playerId?: string;
+  /**
+   * The pick number the caller believes is on the clock.
+   *
+   * Everything a caller works out — that a clock had expired, whose turn it was
+   * — it works out from a snapshot read *before* the lock below is taken. Naming
+   * the pick is how the caller says which pick that snapshot was about, so this
+   * transaction can check the belief against the row it is holding rather than
+   * acting on a claim about the past. If the pick has already been made, nothing
+   * is recorded and the answer is `null`.
+   *
+   * Optional because a manual pick already names the picking team and the engine
+   * checks the rotation. **Nothing enforces that an auto-pick supplies it** —
+   * one that does not still gets the deadline guard, which is the half that
+   * protects a manager's clock; the pick number is what makes a lost race a
+   * silent no-op instead of a stolen pick. `catchUpExpiredPicks` supplies it.
+   */
+  readonly expectedPickNumber?: number;
   readonly pool: ReadonlyMap<string, DraftablePlayer>;
   readonly shape: RosterShape;
   readonly now: Date;
@@ -524,13 +552,35 @@ export interface RecordedPick {
 
 /**
  * Record one pick — manual if `teamId` and `playerId` are given, automatic
- * otherwise.
+ * otherwise. `null` means the pick the caller meant had already been made.
  *
  * Both paths run through the same engine and the same write. An auto-pick that
  * took a different code path from a manual one would eventually diverge, and the
  * divergence would read to a manager as "the bot outdrafted me while I slept".
+ *
+ * **The clock decides which of the two paths is legal, and exactly one of them
+ * is legal at any instant.** Before the deadline the pick belongs to its manager
+ * and only a manual pick may take it; at the deadline it passes to the
+ * auto-pick, stamped at the deadline it missed, and a manual pick is too late.
+ * Both halves of that are enforced here, inside the lock, because both were
+ * decided outside it:
+ *
+ *   * A manual pick that arrives late is **refused** (`CLOCK_EXPIRED`) rather
+ *     than accepted and stamped `now`. Accepting it restarts the next manager's
+ *     clock from whenever the late click landed, so one overrun is added to a
+ *     baseline that never re-anchors and every clock after it silently
+ *     stretches. That is the exact drift the deadline-stamped auto-pick exists
+ *     to prevent, and it does not stop being drift because a human caused it.
+ *   * An auto-pick whose clock has *not* expired records nothing. Its caller
+ *     decided "overdue" against a snapshot; if another writer has since made
+ *     that pick, the manager now on the clock has a full timer and taking their
+ *     pick is unrecoverable — there is no un-pick, and `createDraftRecord`
+ *     refuses a redraft.
  */
-export async function recordPick(db: SqlClient, input: RecordPickInput): Promise<RecordedPick> {
+export async function recordPick(
+  db: SqlClient,
+  input: RecordPickInput,
+): Promise<RecordedPick | null> {
   return withTransaction(db, async (tx) => {
     // Serialises every pick in this draft. Held until the transaction ends.
     const [locked] = await tx.query<DraftRow>(
@@ -539,10 +589,57 @@ export async function recordPick(db: SqlClient, input: RecordPickInput): Promise
     );
     if (!locked) throw new DraftPersistenceError("League has no draft", "DRAFT_NOT_FOUND");
     if (locked.status !== "IN_PROGRESS") {
+      // A caller that named a pick decided outside this lock, so a draft that is
+      // no longer running means it lost the race rather than that anything is
+      // wrong: the winner's final pick completed the draft, or a commissioner
+      // paused between the read and here. That is the same lost race the two
+      // guards below treat as a no-op, and it has to answer the same way —
+      // throwing would 500 every polling tab at the exact instant a draft
+      // finishes, because the read route has no catch for it.
+      //
+      // A manual pick names no expected pick, so it still throws and still
+      // surfaces as a 409. Somebody clicking on a paused draft wants to be told.
+      if (input.expectedPickNumber !== undefined) return null;
+
       throw new DraftPersistenceError(`Draft is ${locked.status}`, "NOT_IN_PROGRESS");
     }
 
     const record = await hydrate(tx, locked);
+
+    // ---- The two guards. Both live here, and neither replaces the other. ----
+    //
+    // Nothing extra is read for them: the row was locked above and hydrated on
+    // the line before, so `pickSeconds`, `scheduledAt` and the picks made so far
+    // are already in hand.
+    //
+    // The pick number catches a caller whose snapshot predates a pick somebody
+    // else committed. The deadline catches a caller whose pick number is still
+    // right but whose *clock* is not — a draft paused and resumed keeps the same
+    // pick on the clock and starts a fresh timer, so a stale "it expired" from
+    // before the pause would otherwise pass a pick-number check and auto-pick a
+    // manager who has just been handed their full ninety seconds.
+    if (
+      input.expectedPickNumber !== undefined &&
+      input.expectedPickNumber !== currentPickNumber(record.state)
+    ) {
+      return null;
+    }
+
+    const manual = input.teamId !== undefined && input.playerId !== undefined;
+    const expired = isCurrentPickExpired(record, input.now);
+
+    if (manual && expired) {
+      // `expired` is only true with a clock running, so there is a deadline to
+      // name. Told to the manager rather than "too late", because the number is
+      // the whole answer: it says how late, and it is the instant the auto-pick
+      // will be stamped at.
+      const deadline = new Date(record.clockStartedAt!.getTime() + record.pickSeconds * 1000);
+      throw new DraftPersistenceError(
+        `This pick's clock ran out at ${deadline.toISOString()}; it belongs to the auto-pick now`,
+        "CLOCK_EXPIRED",
+      );
+    }
+    if (!manual && !expired) return null;
 
     const queues =
       input.teamId && input.playerId ? undefined : await loadQueues(tx, input.leagueId);
@@ -688,15 +785,35 @@ export interface CatchUpInput {
 /**
  * Auto-pick everything the clock has already passed.
  *
- * Expiry has to happen somewhere. There is no scheduled worker yet, so this runs
- * whenever anyone reads the draft — the auto-pick is deterministic and
- * idempotent, so it does not matter who triggers it or how often.
+ * Expiry has to happen somewhere. `/api/cron/draft-tick` is the scheduled half,
+ * but this also runs on every read of the draft, so "whoever triggers it" is a
+ * large and uncoordinated set: the cron every minute, and every open tab, at one
+ * second apiece while its manager is on the clock or on deck. The read route
+ * needs no session, so an anonymous caller who knows the league id is in that
+ * set too.
  *
- * **The limitation is real: a draft nobody is looking at does not advance.** For
- * a 24-hour slow draft that is harmless, and a live room is being polled. It
- * should still become a scheduled job over `draftsWithExpiredPicks()` before the
- * season — a draft that stalls because everyone closed the tab is a bad night,
- * and "you had to keep the page open" is not a rule anyone agreed to.
+ * **Safe to run concurrently, and that safety is bought, not free.** The read at
+ * the top of each iteration happens outside the lock the write then takes, so by
+ * the time the write holds the row its decision may be several picks out of
+ * date. Nothing here can prevent that; what prevents the damage is that
+ * `recordPick` re-checks both halves of the decision — the pick number and the
+ * deadline — inside the lock and records nothing if either has moved. Without
+ * that, N callers all seeing pick N expire would make N *consecutive* picks:
+ * pick N legitimately, then picks N+1 and N+2 for managers whose full clock had
+ * just started, unrecoverably, since there is no un-pick and no redraft.
+ *
+ * **Losing that race is a no-op, not an error.** This returns the number of
+ * picks it made itself and throws nothing when another writer got there first —
+ * the draft read route calls it with no try/catch, so a throw would turn every
+ * polling tab into a 500 at the exact instant a draft advances.
+ *
+ * What it makes is still a function of the stored state and the clock alone, so
+ * the picks are the same whoever calls and however often — the count differs
+ * only in that it counts this caller's own work.
+ *
+ * **The old limitation stands for the read path: a draft nobody is looking at
+ * does not advance until the cron fires.** That is why the cron must fire at
+ * least as often as the shortest pick clock.
  */
 export async function catchUpExpiredPicks(db: SqlClient, input: CatchUpInput): Promise<number> {
   const limit = input.maxPicks ?? 200;
@@ -715,14 +832,27 @@ export async function catchUpExpiredPicks(db: SqlClient, input: CatchUpInput): P
     // extended by however long the room sat empty. Advancing deadline by
     // deadline keeps the draft on real time, so the picks that expired are the
     // picks that expire.
+    //
+    // It is also what makes the deadline guard below self-checking: `now` is the
+    // deadline of the pick this iteration means, so once that pick lands the
+    // next clock runs from it and the same instant is no longer expiry.
     const deadline = new Date(draft.clockStartedAt.getTime() + draft.pickSeconds * 1000);
 
-    await recordPick(db, {
+    const recorded = await recordPick(db, {
       leagueId: input.leagueId,
+      expectedPickNumber: currentPickNumber(draft.state),
       pool: input.pool,
       shape: input.shape,
       now: deadline,
     });
+
+    // Somebody else made this pick between the read above and the lock inside.
+    // Nothing to do and nothing wrong: the pick this iteration came to make has
+    // been made, by a caller running this same loop. Stopping rather than
+    // re-reading keeps a lost race read-only — the winner is still inside its
+    // own loop working through the rest of the backlog, and the next tick or
+    // poll takes anything it does not.
+    if (!recorded) break;
     made++;
   }
 


### PR DESCRIPTION
Closes #22. Two related defects.

## The over-pick

`catchUpExpiredPicks` did an unlocked `loadDraft` → `isCurrentPickExpired` → `recordPick`, and inside `recordPick`'s lock the only guards were "draft exists" and "status is IN_PROGRESS". **The lock decides who writes first; it cannot make a decision taken before it true afterwards.** N callers all holding "pick 15 expired" were serialised and then all wrote — the losers taking picks 16 and 17 from managers whose full clock had just started. Unrecoverable: there is no un-pick and `createDraftRecord` refuses a redraft.

Not an edge case. It runs on every read of the draft, on the per-minute cron, and on every open tab polling at 1s. **And the read route requires no session**, so an anonymous caller with the league URL — it is in the public path — can fire parallel GETs at a real expiry and multiply it.

`recordPick` now takes an optional `expectedPickNumber` and re-checks **two** things inside the lock. Both are needed: the pick number catches a snapshot that predates somebody else's commit; the deadline catches a pause and resume, which keeps the same pick on the clock and starts a fresh timer, so a stale "it expired" would otherwise pass a pick-number check and auto-pick a manager holding a full ninety seconds.

## The late manual pick

`makePick` checks the turn and not the clock, so five managers each a minute late produced clock offsets `150,300,450,600,750` where the honest schedule is `90,180,270,360,450` — each overrun added to a baseline that never re-anchors. It was also unfair in a second way: whether a late click won depended on whether a cron tick had landed first, so two identically-late managers got opposite answers.

## Found in review, both reachable

- A lost race to a winner who **completed** the draft, or to a commissioner pausing, hit the status check — which runs before the guards and threw. The read route catches only `DraftContextError`, so that was a **500 in every polling tab at the exact instant a draft finishes**. A named caller has by definition lost the race, so it now answers `null` however it lost.
- The room's Draft-button gate measured against `Date.now()`. That reads correctly on a correct machine and **locks a wrong one out of the whole draft** — a browser more than one pick clock fast computes every deadline as passed and auto-picks every round. The payload now carries the server clock.

Four sites documented `catchUpExpiredPicks` as "deterministic and idempotent, so it does not matter who triggers it or how often". That was false under concurrency. They now say what safety is bought and how.

## Owner's call, not a bug

In a 24-hour slow draft, refusing a pick a minute past the deadline is harsh and the drift it prevents is negligible at that cadence. `CLAUDE.md`'s stated principle and the issue author both say refuse, so that is what this does. A grace period in slow mode is a defensible alternative.

## Verification

973 tests (was 965). Typecheck, lint, format, build clean. Three tests fail on the pre-fix code, verified by stashing. **The concurrency itself cannot be tested** — PGlite is single-connection and forcing a race there produces a different failure — so what is asserted is the property that matters: a stale decision is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)