### PR TITLE
fix(db): hold one connection, and one lock, for a migration run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,20 @@
 #   Session   ...pooler.supabase.com:5432  IPv4, persistent clients  <-- this one
 #   Transaction  ...pooler.supabase.com:6543  for serverless/edge only
 #
-# Session pooler behaves like a direct connection (transactions, session state),
-# which is what withTransaction() and the migration runner need.
+# Session pooler behaves like a direct connection: a connection you check out
+# stays yours between statements, and session state persists on it. Both halves
+# are load-bearing. withTransaction() and the migration runner each check one out
+# and run a whole transaction on it, and the migration runner additionally holds
+# a *session* advisory lock for its entire run so two deploys cannot apply the
+# same files at once.
+#
+# The transaction pooler breaks that lock, and the way it breaks is worth
+# knowing. It returns your connection to its own pool between transactions, so
+# the lock guards nothing on the first run — and the unlock afterwards lands on
+# a different backend, where it is a no-op that only WARNS. The lock strands.
+# Every later run then refuses, loudly, blaming a concurrent run that does not
+# exist. So the first symptom is not the failure; the second one is, and it
+# points at the wrong thing.
 #
 # Shape: postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres
 DATABASE_URL=

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -76,6 +76,33 @@ SELECT version, name FROM schema_migrations ORDER BY version;
 against `ls packages/db/migrations`. Same version, different `name` is a
 collision. Then follow case 2 or 3 above.
 
+### "Another migration run holds the lock on this database"
+
+Two runs at once — a deploy and a hand-run, two machines, or a re-triggered CI
+job. The runner takes a **session advisory lock** for the whole of its run and a
+second run finds it taken and stops immediately rather than waiting.
+
+Nothing is wrong and nothing is half-done. Wait for the other run and re-run:
+applied migrations are skipped, so the second run costs one round trip if the
+first one did everything.
+
+It refuses rather than queueing on purpose. Waiting is how a deploy hangs, and
+under the pool's `statement_timeout` the wait would be cut off anyway by an error
+naming the timeout instead of the real cause.
+
+**The lock only works on a session-mode connection.** `DATABASE_URL` must be the
+Supabase _session_ pooler, as `.env.example` says. The transaction pooler returns
+your connection to its own pool between transactions, so a session lock guards
+nothing and is stranded on a backend you no longer hold.
+
+The failure is in two parts and only the second is visible. The first run appears
+to succeed, unguarded. The unlock then lands on a different backend, where
+`pg_advisory_unlock` returns false with a WARNING rather than an error — so the
+lock is never released. **Every later run refuses, blaming a concurrent run that
+does not exist**, and the advice in the section above ("wait for it and re-run")
+never comes true. If migrations start refusing on a database that has no other
+deploy touching it, check the port before anything else.
+
 ## `db:status` and `db:migrate` can disagree
 
 `db:status` lists a migration as `PENDING` if its version is absent from
@@ -96,3 +123,15 @@ row locks, `FOR UPDATE`, `ON CONFLICT` racing an insert — cannot be reproduced
 the test suite. Two real bugs have reached production code through that gap. If a
 migration's correctness rests on locking behaviour, say so in its header and
 verify it against a real Postgres before relying on it.
+
+The **runner's** own connection behaviour is the one thing that gap has been
+closed for, in `migrate.pool.test.ts`. It drives the real `pg-pool` with a stub
+`Client` (`pg` accepts one through `options.Client`), so which connection each
+statement lands on is decided by real pool code with no database underneath. That
+technique covers dispatch and ordering only — it says nothing about whether a
+transaction actually commits, which still needs PGlite or a real server.
+
+Two things the runner does are therefore still unverified here and want a real
+Postgres before anyone leans on them: that `SET LOCAL statement_timeout = 0` lets
+a long `CREATE INDEX` run to completion, and that two separate processes racing
+for the advisory lock resolve the way one process asking twice does.

--- a/packages/db/src/migrate.pool.test.ts
+++ b/packages/db/src/migrate.pool.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Migration dispatch — which connection does each statement land on?
+ *
+ * This is the one property about the runner that PGlite cannot show. PGlite is a
+ * single connection, so every statement shares a session no matter what the
+ * runner does; the question only exists in front of a pool, and there is no real
+ * Postgres in this suite.
+ *
+ * So this drives the **real** `pg-pool` — the code that actually makes the
+ * dispatch decision — with a stub `Client`, which `pg` supports through
+ * `options.Client`. The stub runs no SQL. It records which connection object
+ * received each statement and answers the one query the runner reads back
+ * (`pg_try_advisory_lock`). Nothing about connection assignment is stubbed, so a
+ * runner that went back to dispatching per statement would fail these.
+ *
+ * What this still cannot cover, and a real Postgres would: that the DDL and the
+ * `schema_migrations` row actually commit or roll back together, that
+ * `SET LOCAL statement_timeout = 0` really lets a slow `CREATE INDEX` finish, and
+ * that two processes racing for the advisory lock resolve the way one process
+ * asking twice does.
+ */
+
+import { EventEmitter } from "node:events";
+import { Pool } from "pg";
+import type { PoolConfig } from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate, MigrationError } from "./migrate.js";
+import type { Migration } from "./migrate.js";
+import { PostgresClient } from "./postgres.js";
+
+interface Statement {
+  readonly conn: string;
+  readonly sql: string;
+}
+
+interface Scenario {
+  /** A statement containing any of these fragments fails, as a SQL error would. */
+  failOn: readonly string[];
+  /** What `pg_try_advisory_lock` answers. */
+  lockGranted: boolean;
+  /** Called after each statement is recorded, so a test can create pool traffic. */
+  onStatement?: (sql: string) => void;
+}
+
+let log: Statement[] = [];
+let scenario: Scenario = { failOn: [], lockGranted: true };
+let connCounter = 0;
+
+/**
+ * The narrowest stand-in for `pg.Client` that pg-pool will drive.
+ *
+ * `_queryable` / `_ending` / `isConnected` are read by pg-pool when it decides
+ * whether a released connection goes back to the idle set or is destroyed
+ * (`pg-pool/index.js:392`), so they are part of the contract rather than padding.
+ */
+class StubClient extends EventEmitter {
+  readonly connId = `conn#${++connCounter}`;
+  _queryable = true;
+  _ending = false;
+  connection: undefined;
+
+  isConnected(): boolean {
+    return true;
+  }
+  ref(): void {}
+  unref(): void {}
+
+  connect(cb: (err: Error | null) => void): void {
+    setImmediate(() => {
+      cb(null);
+    });
+  }
+
+  query(
+    text: string,
+    values?: unknown[] | ((err: Error | null, res?: { rows: unknown[] }) => void),
+    cb?: (err: Error | null, res?: { rows: unknown[] }) => void,
+  ): Promise<{ rows: unknown[] }> | undefined {
+    const callback = typeof values === "function" ? values : cb;
+    const sql = String(text).replace(/\s+/g, " ").trim();
+    log.push({ conn: this.connId, sql });
+
+    const failed = scenario.failOn.some((fragment) => sql.includes(fragment));
+    const rows = sql.includes("pg_try_advisory_lock") ? [{ locked: scenario.lockGranted }] : [];
+
+    scenario.onStatement?.(sql);
+
+    if (callback) {
+      setImmediate(() => {
+        // A SQL error, as node-postgres surfaces one: the connection itself is
+        // still usable, which is why `_queryable` stays true.
+        callback(failed ? new Error(`stub failure: ${sql}`) : null, { rows });
+      });
+      return undefined;
+    }
+    return failed
+      ? Promise.reject(new Error(`stub failure: ${sql}`))
+      : Promise.resolve({ rows });
+  }
+
+  end(cb?: () => void): Promise<void> {
+    this._ending = true;
+    if (cb) setImmediate(cb);
+    return Promise.resolve();
+  }
+}
+
+let pool: Pool | undefined;
+
+function stubbedClient(max = 10): { client: PostgresClient; pool: Pool } {
+  // `Client` is typed `new () => ClientBase`, and neither the constructor
+  // signature pg-pool actually uses nor the full `ClientBase` surface is worth
+  // satisfying for a stub that answers three statements.
+  const created = new Pool({
+    Client: StubClient as unknown as PoolConfig["Client"],
+    max,
+  });
+  pool = created;
+  return { client: new PostgresClient(created), pool: created };
+}
+
+afterEach(async () => {
+  await pool?.end();
+  pool = undefined;
+  log = [];
+  scenario = { failOn: [], lockGranted: true };
+  connCounter = 0;
+});
+
+function mig(version: number, sql: string): Migration {
+  return {
+    version,
+    name: `m${version}`,
+    filename: `${String(version).padStart(4, "0")}_m${version}.sql`,
+    sql,
+    checksum: String(version).padEnd(64, "0"),
+  };
+}
+
+/** Which connections received a statement containing `fragment`. */
+function connsFor(fragment: string): string[] {
+  return [...new Set(log.filter((s) => s.sql.includes(fragment)).map((s) => s.conn))];
+}
+
+const sqlLog = (): string[] => log.map((s) => s.sql);
+
+describe("migrate on a pool", () => {
+  it("runs the whole migration set on one connection", async () => {
+    // Necessary but not sufficient, and worth saying so: on an otherwise idle
+    // pool pg-pool hands back the connection just released, so this held before
+    // the fix too — by luck, not by construction. The next test removes the luck.
+    const { client } = stubbedClient();
+
+    await migrate(client, [
+      mig(9001, "CREATE TABLE a (id int)"),
+      mig(9002, "CREATE TABLE b (id int)"),
+    ]);
+
+    expect(log.length).toBeGreaterThan(0);
+    expect([...new Set(log.map((s) => s.conn))]).toHaveLength(1);
+  });
+
+  it("lets no other query into the middle of a migration's transaction", async () => {
+    // The property, stated the way it actually bites. Dispatching per statement
+    // does not merely risk splitting the transaction across connections — it
+    // leaves a connection sitting in the idle pool with an **open transaction on
+    // it**, so the next unrelated query served by that connection runs inside
+    // the migration's transaction and is rolled back with it.
+    //
+    // `max: 1` makes the ordering deterministic rather than a race: a competing
+    // query issued while the migration is mid-transaction either slots between
+    // the runner's statements (per-statement dispatch) or waits for the run to
+    // release its connection (a held checkout). No timing tolerance either way.
+    const { client, pool: created } = stubbedClient(1);
+    const competing: Promise<unknown>[] = [];
+
+    scenario = {
+      ...scenario,
+      onStatement: (sql) => {
+        if (sql === "BEGIN") competing.push(created.query("SELECT competing"));
+      },
+    };
+
+    await migrate(client, [mig(9001, "CREATE TABLE a (id int)")]);
+    await Promise.all(competing);
+
+    const order = sqlLog();
+    const commit = order.indexOf("COMMIT");
+    const intruder = order.indexOf("SELECT competing");
+
+    expect(commit).toBeGreaterThanOrEqual(0);
+    expect(intruder).toBeGreaterThan(commit);
+  });
+
+  it("rolls a failing migration back on the connection that opened it", async () => {
+    // The regression this fix exists for. Before it, every statement went
+    // through `pool.query`, which destroys a connection whose query errored — so
+    // the ROLLBACK was issued on a brand-new connection with no transaction on
+    // it, and only pg-pool's destruction of the erroring connection aborted the
+    // real one.
+    const { client } = stubbedClient();
+    scenario = { ...scenario, failOn: ["CREATE TABLE nope"] };
+
+    await expect(
+      migrate(client, [mig(9001, "CREATE TABLE ok (id int); CREATE TABLE nope (id bad)")]),
+    ).rejects.toThrow(MigrationError);
+
+    expect(connsFor("ROLLBACK")).toHaveLength(1);
+    expect(connsFor("ROLLBACK")).toEqual(connsFor("BEGIN"));
+    expect(connsFor("ROLLBACK")).toEqual(connsFor("CREATE TABLE nope"));
+    expect(sqlLog()).not.toContain("COMMIT");
+  });
+
+  it("lifts statement_timeout inside the transaction, not around it", async () => {
+    // Inside, so COMMIT/ROLLBACK reverts it and the connection cannot carry the
+    // exemption back into the pool where a request would inherit it.
+    const { client } = stubbedClient();
+    await migrate(client, [mig(9001, "CREATE INDEX slow ON t (c)")]);
+
+    const order = sqlLog();
+    const begin = order.indexOf("BEGIN");
+    const set = order.indexOf("SET LOCAL statement_timeout = 0");
+    const ddl = order.indexOf("CREATE INDEX slow ON t (c)");
+    const commit = order.indexOf("COMMIT");
+
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(set).toBeGreaterThan(begin);
+    expect(ddl).toBeGreaterThan(set);
+    expect(commit).toBeGreaterThan(ddl);
+  });
+
+  it("takes the lock before it reads schema_migrations, and gives it back", async () => {
+    const { client } = stubbedClient();
+    await migrate(client, [mig(9001, "CREATE TABLE a (id int)")]);
+
+    const order = sqlLog();
+    const lock = order.findIndex((s) => s.includes("pg_try_advisory_lock"));
+    const read = order.findIndex((s) => s.includes("SELECT version, name, checksum"));
+    const unlock = order.findIndex((s) => s.includes("pg_advisory_unlock"));
+
+    expect(lock).toBe(0);
+    expect(read).toBeGreaterThan(lock);
+    expect(unlock).toBe(order.length - 1);
+    expect(connsFor("pg_advisory_unlock")).toEqual(connsFor("pg_try_advisory_lock"));
+  });
+
+  it("gives the lock back even when a migration fails", async () => {
+    // Otherwise the connection carries a session lock back into the pool and
+    // every later run that lands on a different one refuses forever.
+    const { client } = stubbedClient();
+    scenario = { ...scenario, failOn: ["CREATE TABLE nope"] };
+
+    await expect(migrate(client, [mig(9001, "CREATE TABLE nope (id bad)")])).rejects.toThrow(
+      MigrationError,
+    );
+
+    expect(sqlLog().at(-1)).toContain("pg_advisory_unlock");
+  });
+
+  it("refuses when another run already holds the lock", async () => {
+    const { client } = stubbedClient();
+    scenario = { ...scenario, lockGranted: false };
+
+    // Matched on the diagnostic rather than the prose: the message must carry
+    // the `pg_locks` query, because a refusal an operator cannot act on is the
+    // same dead end as no message at all — a stranded lock and a live run look
+    // identical from here.
+    await expect(migrate(client, [mig(9001, "CREATE TABLE a (id int)")])).rejects.toThrow(
+      /classid = 1919906676/,
+    );
+
+    // Refused before anything was read or written, not partway through — and no
+    // unlock, because unlocking a lock this session never held would report a
+    // warning about someone else's lock.
+    expect(sqlLog()).toEqual(["SELECT pg_try_advisory_lock($1, $2) AS locked"]);
+  });
+});

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -22,6 +22,19 @@ const MIGRATIONS_DIR = fileURLToPath(new URL("../migrations", import.meta.url));
 
 const FILENAME_PATTERN = /^(\d{4})_([a-z0-9_]+)\.sql$/;
 
+/**
+ * The advisory lock one migration run holds for its whole length, as a
+ * `(class, id)` pair.
+ *
+ * Advisory locks share a single namespace per database and nothing else in this
+ * repo takes one, so the numbers are arbitrary. `0x726f7374` is "rost" in ASCII,
+ * which is a mnemonic for whoever reads this file — but `pg_locks.classid`
+ * renders it as **1919906676**, so that is the number to grep for when working
+ * out what is blocking a deploy. The refusal message below quotes it directly.
+ */
+const MIGRATION_LOCK_CLASS = 0x726f7374;
+const MIGRATION_LOCK_ID = 1;
+
 export interface Migration {
   readonly version: number;
   readonly name: string;
@@ -100,10 +113,116 @@ export interface MigrateResult {
  * Re-running is safe: applied migrations are skipped. If an already-applied file
  * has been edited since, this throws rather than silently diverging — the schema
  * in the database would no longer match the schema in the repo.
+ *
+ * Running two at once is **refused**, not serialised — *when this is given a
+ * pool*. The run then checks out one connection for its whole length, holds a
+ * session advisory lock on it, and a second run that finds the lock taken says
+ * so and exits. Re-run it afterwards: forward-only migrations make that a no-op.
+ *
+ * Given a client that is already a single connection (PGlite in tests, or one a
+ * caller checked out), there is no lock — see below.
  */
 export async function migrate(
   db: SqlClient,
   migrations: readonly Migration[] = loadMigrations(),
+): Promise<MigrateResult> {
+  // Every statement below has to reach the same connection, and a pool hands
+  // each one to an arbitrary connection — the docstring on
+  // `PostgresClient.connect` states this rule and this function was the one
+  // place in the repo still breaking it. Two things rest on it:
+  //
+  //   - **Each migration's DDL and its `schema_migrations` row are one
+  //     transaction.** A `BEGIN` binds to a session, so if the DDL lands on a
+  //     different connection it runs outside that transaction and commits on its
+  //     own. Should the row then fail to write, the schema has changed without
+  //     being recorded, and the next run re-applies the same file and dies on
+  //     "already exists" — which forward-only migrations have no way back from.
+  //   - **The advisory lock is a *session* lock.** Taken on one connection and
+  //     released from another, it excludes nobody and is left behind on a
+  //     connection that goes on serving other work.
+  //
+  // This deliberately does not go through `withTransaction`. That checks a
+  // connection out and releases it per call, so the lock and each migration's
+  // transaction would land on different ones; the loop needs a transaction per
+  // migration on a connection held across the whole run.
+  if (!db.connect) {
+    // One connection already, and it is the caller's: PGlite in tests, or a
+    // client someone has checked out and passed in. Run on it directly, exactly
+    // as `withTransaction` does.
+    //
+    // **No lock, and that is a real gap rather than a proof of safety.** For
+    // PGlite it is safe for a reason particular to PGlite: a private in-process
+    // database with no second session to race. For a caller-supplied connection
+    // it is not safe, it is simply undecidable from here — we cannot know
+    // whether they are mid-transaction, already hold the lock, or want it. The
+    // two callers in this repo are `cli.ts` (a pool, so locked) and
+    // `createTestDatabase` (PGlite). A third caller passing a checked-out
+    // connection would silently get no mutual exclusion.
+    return applyPending(db, migrations);
+  }
+
+  const { client, release } = await db.connect();
+  try {
+    await acquireMigrationLock(client);
+    try {
+      return await applyPending(client, migrations);
+    } finally {
+      // Give the lock back before the connection returns to the pool. A session
+      // lock left on it is inherited by whoever checks it out next, and every
+      // later run that lands on a different connection would then refuse
+      // forever. This can only fail if the session is already gone — which drops
+      // the lock anyway — so it must not mask the error that killed it.
+      await client
+        .query("SELECT pg_advisory_unlock($1, $2)", [MIGRATION_LOCK_CLASS, MIGRATION_LOCK_ID])
+        .catch(() => undefined);
+    }
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Claim the run, or refuse.
+ *
+ * `pg_try_advisory_lock` rather than `pg_advisory_lock`, which waits: waiting is
+ * how a deploy hangs, and under the pool's `statement_timeout` the wait would be
+ * cut short anyway by an error naming the timeout instead of the real cause.
+ * Refusing costs nothing here — the other run is applying these same files, and
+ * re-running once it finishes is a no-op.
+ *
+ * It is taken before `schema_migrations` is created or read, not just around the
+ * writes. Two runs that both read the pending set before either applies anything
+ * would both decide to apply it; and concurrent `CREATE TABLE IF NOT EXISTS` can
+ * fail outright on a duplicate key in the catalogue rather than yielding.
+ */
+async function acquireMigrationLock(db: SqlClient): Promise<void> {
+  const [row] = await db.query<{ locked: boolean }>(
+    "SELECT pg_try_advisory_lock($1, $2) AS locked",
+    [MIGRATION_LOCK_CLASS, MIGRATION_LOCK_ID],
+  );
+
+  if (row?.locked !== true) {
+    throw new MigrationError(
+      "Could not take the migration lock on this database, so this run stopped " +
+        "rather than race another one: both would read the same pending set and " +
+        "apply the same files.\n\n" +
+        "Usually another run holds it — wait for it and re-run, which is free " +
+        "because applied migrations are skipped.\n\n" +
+        "If no other run exists, the lock is stranded, and this message is " +
+        "blaming a run that does not exist. Find its holder with:\n" +
+        "  SELECT pid, state FROM pg_locks JOIN pg_stat_activity USING (pid)\n" +
+        "   WHERE locktype = 'advisory' AND classid = 1919906676 AND objid = 1;\n" +
+        "An idle holder can be cleared with pg_terminate_backend(pid). A " +
+        "transaction-mode pooler strands the lock this way on every run — if " +
+        "that is the shape of it, check the port before anything else.",
+    );
+  }
+}
+
+/** The run itself, on a connection the caller has already pinned. */
+async function applyPending(
+  db: SqlClient,
+  migrations: readonly Migration[],
 ): Promise<MigrateResult> {
   await ensureMigrationsTable(db);
 
@@ -160,6 +279,18 @@ export async function migrate(
 
     await db.exec("BEGIN");
     try {
+      // A migration is not a request. The pool sets `statement_timeout` to 30s
+      // (see `postgres.ts`) because a query still running after thirty seconds
+      // is stuck and is holding a connection — but a `CREATE INDEX` on a
+      // populated table legitimately runs for minutes, and being cancelled at
+      // thirty seconds makes that migration one that can never succeed, on the
+      // one database where it matters. Today's tables are empty, so this is
+      // latent rather than broken; `stat_lines` will not be empty for long.
+      //
+      // `SET LOCAL` reverts at COMMIT or ROLLBACK, so the connection cannot
+      // carry the exemption back into the pool and hand it to a request.
+      await db.exec("SET LOCAL statement_timeout = 0");
+
       await db.exec(migration.sql);
       await db.query(
         "INSERT INTO schema_migrations (version, name, checksum) VALUES ($1, $2, $3)",

--- a/packages/db/src/postgres.ts
+++ b/packages/db/src/postgres.ts
@@ -29,7 +29,17 @@ export class PostgresClient implements SqlClient {
    *
    * Required for anything transactional: a pool hands each query to an
    * arbitrary connection, so a BEGIN and the work that follows could land on
-   * different ones. `withTransaction` must be given one of these, not the pool.
+   * different ones. It is also required for session state — a `SET`, or a
+   * session advisory lock — which is meaningless if the next statement is
+   * served by a different session.
+   *
+   * Within this package `withTransaction` and `migrate` each check one out
+   * rather than being given the pool, and they hold it for different spans —
+   * which is why `migrate` does not simply use `withTransaction`. A transaction
+   * lasts one callback; a migration run lasts a lock plus a transaction per
+   * file, and a lock is worthless on a connection that is handed back between
+   * statements. Routes that need a transaction across several calls check out
+   * directly too.
    */
   async connect(): Promise<{ client: SqlClient; release: () => void }> {
     const connection = await this.pool.connect();
@@ -92,6 +102,11 @@ export function createPostgresClient(connectionString: string): PostgresClient {
       // usefully, and while it runs it holds a pooled connection and any locks
       // it took. Bounding it server-side is the only thing that helps once a
       // query is already stuck.
+      //
+      // Migrations are the exception and lift it per transaction (`migrate.ts`),
+      // because `db:migrate` runs on this same pool: a `CREATE INDEX` on a
+      // populated table runs for minutes and would otherwise be cancelled here,
+      // leaving a migration that can never succeed.
       statement_timeout: 30_000,
 
       // The failure this actually guards against: a transaction that opened,


### PR DESCRIPTION
Closes #23.

`migrate` issued BEGIN, the migration SQL, the `schema_migrations` insert and COMMIT as four separate `pool.query` calls, so each could land on a different connection. It was the last `BEGIN` outside `withTransaction` in the repo — the transaction fix that merged this week does not reach it, because `migrate` does not call it — sitting next to a docstring stating the rule it broke.

## The issue's stated impact does not hold, and this does not claim it

The tested "rolls back a failing migration" guarantee comes from Postgres's implicit transaction around a multi-statement query, plus transactional DDL: **it passes with no BEGIN at all**, proven against real PGlite. On the failure path pg-pool destroys the erroring connection, which aborts its transaction server-side anyway.

## What was actually reachable, in order

1. **No mutual exclusion at all.** Two runs both read the pending set and both apply. Not a connection problem — a missing lock, and on a two-machine project the likely one.
2. **A 30-second statement timeout applied to migrations**, because they ran on the app's pool. A `CREATE INDEX` on a populated table that takes longer is cancelled, and that migration can then **never** succeed. Latent while the tables are empty; not latent once `stat_lines` has a season in it. Beyond the issue's scope, fixed here because a run that pins a connection is the only place `SET LOCAL statement_timeout = 0` can go.
3. **A connection left in the idle pool with an open transaction on it** — the sharpest framing, and what the strongest new test shows: unrelated work gets handed that connection, joins the migration's transaction, and is rolled back with it.

## The fix

One checked-out connection for the whole run, a session `pg_try_advisory_lock`, a transaction per migration on that connection, unlock, release. Try-lock rather than the blocking form because waiting is how a deploy hangs; session-level rather than transaction-level because an xact lock drops at the first COMMIT and reopens the window; `SET LOCAL` rather than `SET` so the exemption cannot leak into the pool if the run dies.

Given a client that is already one connection it runs directly and takes no lock. Safe for PGlite; **not safe in general, and the comment says so** rather than implying otherwise.

Review corrected five documentation defects, including a `connect` docstring this fix introduced claiming two callers when there are four, and a refusal message asserting a cause it had not established. It now carries the `pg_locks` query that distinguishes a live run from a stranded lock — because a transaction-mode pooler strands it on every run, and the second symptom points at the wrong thing.

## Verification

972 tests (was 965). 7 new tests drive **real pg-pool** with a stub Client, so connection assignment is real pool code; 6 fail on the pre-fix runner. The 7th is labelled as passing either way, because LIFO reuse already gave the happy path one connection by luck.

What needs a real Postgres is stated in the test file: that DDL and its `schema_migrations` row commit together, that the timeout exemption lets a slow `CREATE INDEX` finish, and that two processes race the lock as one process asking twice does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)