### PR TITLE
fix(core): integer-check the scoring numbers, and make a ladder cover zero

### DIFF
--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   buildNflPprRules,
+  CanonicalEncodingError,
   NFL,
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
@@ -191,6 +192,21 @@ export async function POST(request: Request): Promise<NextResponse> {
     if (error instanceof LeagueValidationError) {
       return NextResponse.json(
         { error: error.message, problems: error.problems },
+        { status: 400 },
+      );
+    }
+    // The encoder is the last word on what may be frozen, and it is stricter
+    // than validation: `canonicalize` rejects every non-integer, while
+    // `validateLeagueRules` integer-checks the scoring numbers and not much
+    // else. This is reachable from here today — `seasonYear`, `draftAt`,
+    // `tradeDeadlineWeek` and `pot.refundUnlockAt` all come off the request as
+    // numbers and none is integer-checked, so `{ "seasonYear": 2026.5 }` used
+    // to escape as an unhandled 500. It is a client error and gets the same
+    // 400-with-problems shape as any other bad rule set. Nothing is written:
+    // `createLeague` encodes before it opens its transaction.
+    if (error instanceof CanonicalEncodingError) {
+      return NextResponse.json(
+        { error: "Those rules cannot be frozen", problems: [error.message] },
         { status: 400 },
       );
     }

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { CanonicalEncodingError } from "../canonical.js";
+import { indexScoringRules, scorePlayer, ScoringError } from "../scoring/engine.js";
 import { NFL } from "../sports/nfl.js";
 import { validateSport } from "../sports/types.js";
 import { encodeLeagueRules, hashLeagueRules, verifyLeagueRulesHash } from "./hash.js";
@@ -157,6 +159,184 @@ describe("validateLeagueRules", () => {
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("unbounded tier"),
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scoring numbers: integers, and a ladder that covers what a feed can emit.
+  //
+  // **No shipped path can produce any of the rule sets below.** `NflPprOverrides`
+  // has no `scoring` field and `buildNflPprRules` hardcodes `NFL_PPR_SCORING`, so
+  // every one of them is built here by hand, out of a clone of the fixture. These
+  // checks are defence for a custom-scoring feature that does not exist yet, and
+  // for anything that assembles a `LeagueRules` directly rather than through the
+  // builder — which is every test in this repo, and `@rostr/db`'s `createLeague`,
+  // whose `rules` argument is just a value.
+  // ---------------------------------------------------------------------------
+
+  /** Replace the points-allowed ladder, by hand. Nothing in the app does this. */
+  const withTiers = (tiers: { min: number; max: number | null; milliPoints: number }[]) =>
+    mutate((d) => {
+      const rule = d.scoring.find((r) => r.statKey === "def_pts_allowed");
+      if (rule?.kind === "TIERED") (rule as { tiers: unknown }).tiers = tiers;
+    });
+
+  it("rejects a fractional milli-points-per-unit", () => {
+    // 0.04 points per passing yard is 40 milli-points, not 0.04. Written the
+    // wrong way it is a float in the frozen rules, which is what milli-points
+    // exist to prevent — and `canonicalize` refuses to encode it, so before this
+    // check league creation failed at the encoder with validation having just
+    // said the rules were fine.
+    const bad = mutate((d) => {
+      const rule = d.scoring.find((r) => r.statKey === "pass_yd");
+      if (rule?.kind === "LINEAR")
+        (rule as { milliPointsPerUnit: number }).milliPointsPerUnit = 0.04;
+    });
+    expect(validateLeagueRules(bad, NFL)).toContainEqual(
+      expect.stringContaining("not a whole number"),
+    );
+    expect(() => encodeLeagueRules(bad)).toThrow(CanonicalEncodingError);
+  });
+
+  it("rejects a fractional tier award", () => {
+    const bad = withTiers([
+      { min: 0, max: 0, milliPoints: 10.5 },
+      { min: 1, max: null, milliPoints: 0 },
+    ]);
+    expect(validateLeagueRules(bad, NFL)).toContainEqual(
+      expect.stringContaining("non-integer milliPoints"),
+    );
+  });
+
+  it("rejects a fractional tier bound as itself, not as a gap", () => {
+    // The structural walk does arithmetic on the bounds, so left to run it
+    // would also report "expected min 7.5, got 7" — advice to start a tier at
+    // 7.5, which is itself illegal. The name of this test is the assertion:
+    // the creator is told the one true thing, not that plus a confident lie.
+    const bad = withTiers([
+      { min: 0, max: 6.5, milliPoints: 7000 },
+      { min: 7, max: null, milliPoints: 0 },
+    ]);
+    const problems = validateLeagueRules(bad, NFL);
+
+    expect(problems).toContainEqual(expect.stringContaining("non-integer max"));
+    expect(problems).not.toContainEqual(expect.stringContaining("gap or overlap"));
+  });
+
+  it("blames the ladder's real floor, not whichever tier is written first", () => {
+    // An out-of-order ladder is rejected either way, by the ordering check. But
+    // reporting "a value of 0 falls below every tier" about a ladder whose
+    // second tier covers 0 would be a true verdict reached by a false claim.
+    const bad = withTiers([
+      { min: 7, max: null, milliPoints: 0 },
+      { min: 0, max: 6, milliPoints: 7000 },
+    ]);
+    const problems = validateLeagueRules(bad, NFL);
+
+    expect(problems).not.toContainEqual(
+      expect.stringContaining("a value of 0 falls below every tier"),
+    );
+    expect(problems.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a ladder whose floor sits above zero", () => {
+    // The one with teeth. A ladder starting at 1 is contiguous with itself and
+    // hashes cleanly, because the contiguity loop seeds `expectedMin` from
+    // `tiers[0].min` — so nothing anywhere constrained the floor. A shutout is
+    // then a value no tier covers, and a shutout is real: the Tank01 adapter
+    // emits `def_pts_allowed: 0` deliberately, as a fact rather than an absence.
+    const bad = withTiers([
+      { min: 1, max: 6, milliPoints: 7000 },
+      { min: 7, max: null, milliPoints: 0 },
+    ]);
+
+    expect(validateLeagueRules(bad, NFL)).toContainEqual(
+      expect.stringContaining("a value of 0 falls below every tier"),
+    );
+
+    // And this is what such a league would have done on the first shutout of the
+    // season, having been frozen and therefore being uncorrectable: not a wrong
+    // score, a throw — which takes down every other matchup in that league-week
+    // too, since `resolveWeek` scores all teams before it resolves any.
+    expect(() =>
+      scorePlayer([{ statKey: "def_pts_allowed", value: 0 }], indexScoringRules(bad.scoring)),
+    ).toThrow(ScoringError);
+  });
+
+  it("accepts a ladder whose floor is negative", () => {
+    // The rule is "covers zero", not "starts at zero". A tiered stat may
+    // legitimately run negative — nothing in `@rostr/core` knows what a stat can
+    // emit, and `StatKeyDef` carries no domain — so a floor below zero is not
+    // ours to refuse. It is also not ours to vouch for: this ladder still throws
+    // at -21, and no check in this file can see that.
+    const ok = withTiers([
+      { min: -20, max: 0, milliPoints: 10_000 },
+      { min: 1, max: null, milliPoints: 0 },
+    ]);
+    expect(validateLeagueRules(ok, NFL)).toEqual([]);
+  });
+
+  /**
+   * The four numeric fields a request can actually set.
+   *
+   * Unlike the scoring cases above, these **are** reachable — `seasonYear`,
+   * `draftAt`, `tradeDeadlineWeek` and the pot's `refundUnlockAt` all come
+   * straight from `POST /api/leagues`. Before this they reached the encoder
+   * unchecked: a fractional one became an unhandled 500 rather than a problem
+   * the creator could read, and a *wrongly typed* one was not caught at all.
+   */
+  describe("numeric fields from the request", () => {
+    it("rejects a fractional value with a named problem", () => {
+      const bad = mutate((d) => {
+        (d as { seasonYear: number }).seasonYear = 2026.5;
+      });
+      expect(validateLeagueRules(bad, NFL)).toContainEqual(
+        expect.stringContaining("seasonYear must be a whole number"),
+      );
+    });
+
+    it("rejects a value of the wrong type, which the encoder does not", () => {
+      // The one that mattered. `canonicalize` checks that a *number* is a safe
+      // integer; it does not check that a number is a number. A `seasonYear` of
+      // "2026" — or of [1, 2] — validated clean and hashed clean, freezing a
+      // league permanently around a value of the wrong type, with no way back.
+      for (const wrong of ["2026", [1, 2], null] as const) {
+        const bad = mutate((d) => {
+          (d as { seasonYear: unknown }).seasonYear = wrong;
+        });
+
+        expect(validateLeagueRules(bad, NFL)).toContainEqual(
+          expect.stringContaining("seasonYear must be a whole number"),
+        );
+      }
+    });
+
+    it("covers the draft, trade and pot fields too", () => {
+      for (const [path, mutation] of [
+        [
+          "draft.scheduledAt",
+          (d: LeagueRules) => ((d.draft as { scheduledAt: number }).scheduledAt = 1.5),
+        ],
+        [
+          "trades.deadlineWeek",
+          (d: LeagueRules) => ((d.trades as { deadlineWeek: number }).deadlineWeek = 11.5),
+        ],
+        [
+          "pot.refundUnlockAt",
+          (d: LeagueRules) => ((d.pot as { refundUnlockAt: number }).refundUnlockAt = 1.5),
+        ],
+      ] as const) {
+        expect(validateLeagueRules(mutate(mutation), NFL)).toContainEqual(
+          expect.stringContaining(`${path} must be a whole number`),
+        );
+      }
+    });
+
+    it("says nothing about a free league's absent pot", () => {
+      const free = mutate((d) => {
+        (d as { pot: unknown }).pot = null;
+      });
+      expect(validateLeagueRules(free, NFL)).toEqual([]);
+    });
   });
 
   it("rejects a pick clock below 90 seconds", () => {

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -15,6 +15,7 @@ import {
   BASIS_POINTS_TOTAL,
   MAX_BUY_IN_BASE_UNITS,
   MAX_FEE_BPS,
+  MILLI_POINTS_PER_POINT,
   MIN_BUY_IN_BASE_UNITS,
 } from "./types.js";
 import type { LeagueRules, ScoringRule } from "./types.js";
@@ -48,16 +49,86 @@ function validateScoring(rules: LeagueRules, sport: SportDef, out: string[]): vo
       continue;
     }
 
-    if (rule.kind === "TIERED") validateTiers(rule, out);
+    if (rule.kind === "TIERED") {
+      validateTiers(rule, out);
+    } else if (!Number.isSafeInteger(rule.milliPointsPerUnit)) {
+      // Milli-points are the smallest unit there is: 0.04 points per passing
+      // yard is 40, not 0.04. A fractional multiplier is the float this whole
+      // representation exists to keep out, and `canonicalize` refuses to encode
+      // one — so without this check league creation fails at the encoder, after
+      // validation has already said the rules are fine.
+      out.push(
+        `scoring rule "${rule.statKey}" awards ${rule.milliPointsPerUnit} milli-points ` +
+          `per unit, which is not a whole number — scoring is integer milli-points ` +
+          `(1 point = ${String(MILLI_POINTS_PER_POINT)})`,
+      );
+    }
   }
 }
 
 function validateTiers(rule: Extract<ScoringRule, { kind: "TIERED" }>, out: string[]): void {
   const { statKey, tiers } = rule;
+  const before = out.length;
 
   if (tiers.length === 0) {
     out.push(`tiered rule "${statKey}" has no tiers`);
     return;
+  }
+
+  // Every number in a tier is frozen into the canonical document, which admits
+  // safe integers only. Swept before the structural checks below because those
+  // return on their first finding, and a fractional bound would usually surface
+  // there as a confusing "gap or overlap" instead of as itself.
+  for (const [i, tier] of tiers.entries()) {
+    for (const [field, value] of [
+      ["min", tier.min],
+      ["max", tier.max],
+      ["milliPoints", tier.milliPoints],
+    ] as const) {
+      if (value !== null && !Number.isSafeInteger(value)) {
+        out.push(`tiered rule "${statKey}" tier ${i} has a non-integer ${field}: ${value}`);
+      }
+    }
+  }
+
+  // Stop here if a bound is not a number we can reason about. Everything below
+  // does arithmetic on these — the floor comparison and the contiguity walk —
+  // and arithmetic on a garbage bound produces a confidently wrong instruction:
+  // a fractional max of 6.5 otherwise also reports "expected min 7.5, got 7",
+  // telling the creator to start a tier at 7.5, which is itself illegal.
+  if (out.length > before) return;
+
+  // The ladder has to cover what the feed can actually emit, and the engine
+  // throws — deliberately — on a value no tier covers. The floor is the half
+  // nothing else checks: the loop below seeds itself from `tiers[0].min`, so a
+  // ladder starting anywhere at all is contiguous with itself and hashes
+  // cleanly, and the first uncovered reading then kills scoring for the whole
+  // league-week, every cron pass, uncorrectably, because rules are frozen.
+  //
+  // Zero is the one value we can assert without knowing the stat: it is what
+  // "nothing happened" reads as, and a provider emits it as a fact rather than
+  // as an absence. **This says nothing about negatives.** A ladder over a stat
+  // whose feed can go below zero is still able to fall off its own bottom, and
+  // no check here can see that — `StatKeyDef` carries no domain. See the note in
+  // `applyTiered`.
+  //
+  // It also refuses a ladder over a stat whose feed reports "none" as an
+  // absence rather than a zero — longest-field-goal, say, which would naturally
+  // start at 20. That is a false positive, and it is the accepted cost: it is
+  // visible at creation and fixed by prepending one tier, while the case it
+  // catches is invisible until the first shutout and then uncorrectable.
+  //
+  // Taken from the lowest bound anywhere in the ladder rather than `tiers[0]`'s.
+  // On an out-of-order ladder those differ, and blaming `tiers[0]` would say "a
+  // value of 0 falls below every tier" about a ladder where a later tier covers
+  // it — true verdict, false reason. The ordering check below rejects it either
+  // way; this just declines to be wrong on the way there.
+  const floor = Math.min(...tiers.map((tier) => tier.min));
+  if (floor > 0) {
+    out.push(
+      `tiered rule "${statKey}" starts at ${floor}, so a value of 0 falls below every ` +
+        `tier and scoring throws rather than scoring it`,
+    );
   }
 
   let expectedMin: number | null = tiers[0]?.min ?? 0;
@@ -371,10 +442,45 @@ function validateLeagueSize(rules: LeagueRules, out: string[]): void {
 }
 
 /**
+ * Every numeric field a request can set, checked as a whole number.
+ *
+ * These four arrive from the creation route's body and reach the encoder with
+ * no other check. `canonicalize` refuses a non-integer, so a fractional one
+ * cannot be frozen — but it surfaces as an encoder error naming a JSON path
+ * rather than as a problem the creator can read, and the empty-array contract
+ * above would have been a lie for that rule set.
+ *
+ * **The `typeof` half is the one that matters.** The encoder checks that a
+ * *number* is a safe integer; it does not check that a number is a number. A
+ * `seasonYear` of `"2026"` — or of `[1, 2]` — validated clean and hashed
+ * clean, freezing a league permanently around a value of the wrong type. Rules
+ * are immutable, so there is no correcting that afterwards.
+ */
+function validateNumericFields(rules: LeagueRules, out: string[]): void {
+  const fields: readonly (readonly [string, unknown])[] = [
+    ["seasonYear", rules.seasonYear],
+    ["draft.scheduledAt", rules.draft.scheduledAt],
+    ["trades.deadlineWeek", rules.trades.deadlineWeek],
+    ...(rules.pot ? ([["pot.refundUnlockAt", rules.pot.refundUnlockAt]] as const) : []),
+  ];
+
+  for (const [name, value] of fields) {
+    if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+      out.push(`${name} must be a whole number, got ${JSON.stringify(value)}`);
+    }
+  }
+}
+
+/**
  * Validate a rule set against its sport.
  *
- * @returns every problem found; an empty array means the rules are coherent and
- * safe to freeze.
+ * @returns every problem found. An empty array means **nothing checked here is
+ * wrong** — which is not the same as "safe to freeze", and the difference has
+ * bitten already. `canonicalize` remains the final authority on what can be
+ * encoded: it rejects any non-integer, and `createLeague` encodes before it
+ * opens its transaction, so a rule set that gets past here and fails there
+ * still cannot reach storage. It surfaces as a `CanonicalEncodingError`, which
+ * the creation route catches.
  */
 export function validateLeagueRules(rules: LeagueRules, sport: SportDef): string[] {
   const out: string[] = [];
@@ -386,6 +492,7 @@ export function validateLeagueRules(rules: LeagueRules, sport: SportDef): string
     return out;
   }
 
+  validateNumericFields(rules, out);
   validateScoring(rules, sport, out);
   validateRoster(rules, sport, out);
   validateLeagueSize(rules, out);

--- a/packages/core/src/scoring/engine.test.ts
+++ b/packages/core/src/scoring/engine.test.ts
@@ -81,6 +81,34 @@ describe("scorePlayer — linear rules", () => {
       ScoringError,
     );
   });
+
+  it("rejects a non-integer rate in the rule itself", () => {
+    // The other half of the same guard, and the one that was missing: a whole
+    // stat value times a fractional rate is still a float in a total that
+    // decides a matchup. Rates are milli-points — 0.04 points per yard is 40.
+    //
+    // Constructed by hand. `buildNflPprRules` hardcodes `NFL_PPR_SCORING` and
+    // `NflPprOverrides` has no `scoring` field, so nothing shipping today can
+    // hand the engine a rule set like this; `validateLeagueRules` now refuses it
+    // as well. This is the engine refusing to be the place it goes unnoticed.
+    const fractional = indexScoringRules([
+      { statKey: "pass_yd", kind: "LINEAR", milliPointsPerUnit: 0.04 },
+    ]);
+    expect(() => scorePlayer([{ statKey: "pass_yd", value: 25 }], fractional)).toThrow(
+      ScoringError,
+    );
+  });
+
+  it("does not check a rate for a stat the player did not record", () => {
+    // Matching how the stat-value check behaves: rules are consulted per stat
+    // present, so a rule nobody triggered is nobody's problem. Otherwise adding
+    // this guard would have turned an unused bad rule into a scoring outage.
+    const fractional = indexScoringRules([
+      { statKey: "pass_yd", kind: "LINEAR", milliPointsPerUnit: 0.04 },
+      { statKey: "rec", kind: "LINEAR", milliPointsPerUnit: 1000 },
+    ]);
+    expect(scorePlayer([{ statKey: "rec", value: 5 }], fractional)).toBe(5000);
+  });
 });
 
 describe("scorePlayer — tiered rules", () => {
@@ -117,6 +145,30 @@ describe("scorePlayer — tiered rules", () => {
     // A negative points-allowed means the feed is broken. Scoring 0 would bury
     // that; throwing surfaces it.
     expect(() => tier(-1)).toThrow(ScoringError);
+  });
+
+  it("rejects a fractional award from the tier that matched", () => {
+    // Hand-built: the shipped ladder is `NFL_PPR_SCORING`'s and there is no
+    // override that could reach it. A tier's award goes straight into a team
+    // total, so it gets the same treatment as a stat value and a linear rate.
+    const fractional = indexScoringRules([
+      {
+        statKey: "def_pts_allowed",
+        kind: "TIERED",
+        tiers: [
+          { min: 0, max: 0, milliPoints: 10.5 },
+          { min: 1, max: null, milliPoints: 0 },
+        ],
+      },
+    ]);
+
+    expect(() => scorePlayer([{ statKey: "def_pts_allowed", value: 0 }], fractional)).toThrow(
+      ScoringError,
+    );
+
+    // Only the tier that matched is checked — the same rule as above, so a bad
+    // tier nobody landed in cannot take a week down.
+    expect(scorePlayer([{ statKey: "def_pts_allowed", value: 24 }], fractional)).toBe(0);
   });
 
   it("does not score a tiered stat that is absent", () => {

--- a/packages/core/src/scoring/engine.ts
+++ b/packages/core/src/scoring/engine.ts
@@ -43,12 +43,28 @@ function applyTiered(rule: Extract<ScoringRule, { kind: "TIERED" }>, value: numb
   for (const tier of rule.tiers) {
     const withinLower = value >= tier.min;
     const withinUpper = tier.max === null || value <= tier.max;
-    if (withinLower && withinUpper) return tier.milliPoints;
+    if (withinLower && withinUpper) {
+      // Same defensiveness as the stat value below, for the same reason: this
+      // number is added straight into a total that decides a matchup, and a
+      // fraction anywhere in that accumulation is the one thing milli-points
+      // exist to prevent.
+      if (!Number.isSafeInteger(tier.milliPoints)) {
+        throw new ScoringError(
+          `Tier in "${rule.statKey}" covering value ${value} awards ` +
+            `${tier.milliPoints} milli-points, which is not a whole number.`,
+        );
+      }
+      return tier.milliPoints;
+    }
   }
 
-  // Validation guarantees contiguous tiers ending unbounded, so the only way
-  // here is a value below the first tier's minimum — a negative points-allowed,
-  // say. Silently scoring zero would hide a broken feed.
+  // No tier matched. For a rule set that passed `validateLeagueRules` the
+  // ladder is contiguous, ends unbounded, and covers zero — so this is a value
+  // below a floor that is itself at or below zero. That is either a broken feed
+  // or a ladder whose floor validation had no way to judge: it can assert that
+  // zero is covered, because zero is what "nothing happened" reads as for any
+  // stat, but it knows nothing about how far *negative* a given stat can go.
+  // Silently scoring zero would hide both.
   throw new ScoringError(
     `No tier in "${rule.statKey}" covers value ${value}. ` +
       `Tiers start at ${rule.tiers[0]?.min ?? "?"}.`,
@@ -83,6 +99,14 @@ export function scorePlayer(
       throw new ScoringError(
         `Stat "${stat.statKey}" has non-integer value ${stat.value}. ` +
           `Stat values are whole units; fractional scoring lives in the rule.`,
+      );
+    }
+
+    if (rule.kind === "LINEAR" && !Number.isSafeInteger(rule.milliPointsPerUnit)) {
+      throw new ScoringError(
+        `Scoring rule "${stat.statKey}" awards ${rule.milliPointsPerUnit} milli-points ` +
+          `per unit, which is not a whole number. Rates are milli-points: ` +
+          `0.04 points per unit is 40, not 0.04.`,
       );
     }
 


### PR DESCRIPTION
Closes #24.

**Neither defect in the issue is reachable today.** `NflPprOverrides` has no `scoring` field and `buildNflPprRules` hardcodes `NFL_PPR_SCORING`, so nothing a request can send reaches either path. Every rule set in the new tests is built by hand in `@rostr/core`, and the tests say so. This is defence for a custom-scoring feature that does not exist yet.

## The ladder floor is the one with teeth

`validateTiers` seeded its contiguity walk from `tiers[0].min`, so a ladder was contiguous with itself wherever it started and nothing constrained the floor. A `def_pts_allowed` ladder beginning at 1 **hashed cleanly** — no backstop at all — and then the first shutout hit a value no tier covered. `applyTiered` throws there, and `resolveWeek` scores every team before resolving any matchup, so one uncovered reading killed the whole league-week, on every cron pass, uncorrectably.

The rule is **"the ladder must cover zero"**, not "must start at zero". Zero is the one value assertable without knowing the stat: it is what "nothing happened" reads as, and the adapter emits it as a fact rather than an absence.

It produces a **false positive** — a ladder over a stat whose feed reports "none" as an absence, longest-field-goal say, would naturally start at 20 and is now refused. Accepted cost, and the reason is asymmetry: the false positive is visible at creation and fixed by prepending one tier, while the case it catches is invisible until the first shutout and then permanent. There is a test asserting a **negative** floor is accepted, so nobody later tightens this into outlawing one.

The option not taken: making the first tier's floor nullable would deliver the property instead of approximating it — but that is a schema change and it moves the golden hash. Affordable now, not after Aug 22.

## Found while fixing it, and reachable — unlike the issue

`seasonYear`, `draft.scheduledAt`, `trades.deadlineWeek` and `pot.refundUnlockAt` all come straight from the creation request and reached the encoder unchecked. A fractional one was an **unhandled 500**.

Worse: the encoder checks that a *number* is a safe integer — it does not check that a number is a number.

```
"2026"  -> problems: 0 | hash: 44b022b0a1cd3511
[1,2]   -> problems: 0 | hash: cec19036c3826907
```

Both validated clean and hashed clean, freezing a league permanently around a value of the wrong type. Both are now rejected by name.

## Also

The tier checks return before the structural walk, because arithmetic on a garbage bound produced a confident lie: a fractional max of 6.5 additionally reported "expected min 7.5, got 7" — advice to start a tier at a value that is itself illegal. And the floor is taken from the lowest bound in the ladder rather than `tiers[0]`, so an out-of-order ladder is no longer told 0 falls below every tier when a later tier covers it.

Two false comments corrected: `applyTiered` claimed validation guaranteed the only uncovered value was a broken feed, and `validateLeagueRules` promised an empty array meant "safe to freeze".

## Verification

978 tests (was 965). **Golden hash untouched** — neither changed file is in the encoding path, and `ScoringRule`/`ScoringTier` were not touched. Typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)