### PR TITLE
fix(db): one owner per league, and stop a stale claim wedging the run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,9 +714,11 @@ so no test in this repo can catch that — it has to be got right by reading.
 recorded as EXPIRED). This is the last line of defence and the only one that does not depend
 on knowing _how_ the player left: accepted twice, dropped through a path that skipped the
 freeze, or claimed off waivers. Upstream checks each close one route; this closes the
-outcome. The `(team_id, player_id)` unique index cannot — it is per-team, so the same player
-on two different teams satisfies it. Without it a manager accepts a trade and cuts the
-player they promised, and execution finds a hole where a roster spot used to be.
+outcome. Without it a manager accepts a trade and cuts the player they promised, and
+execution finds a hole where a roster spot used to be. `0005`'s `(team_id, player_id)` index
+could not catch that at all — it was per-team, so the same player on two different teams
+satisfied it; migration `0022` replaced it with `(league_id, player_id)`, which can, but only
+as a constraint violation. `ASSET_GONE` is still the one that says _which_ asset is gone.
 
 **Execution releases and re-adds roster rows rather than repointing them.**
 `roster_entries` is append-only with `released_at` precisely so any past week's roster is

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -95,7 +95,8 @@ silently change — which is precisely the thing immutability is meant to preven
 ```
 teams             id, league_id, owner_id (nullable), is_bot, name,
                   draft_position, waiver_priority, strikes, abandoned_at
-roster_entries    id, team_id, player_id, acquired_via, acquired_at, released_at
+roster_entries    id, team_id, league_id, player_id, acquired_via, acquired_at,
+                  released_at
 lineups           id, team_id, week, slot_type_id, player_id, locked_at
 ```
 
@@ -105,6 +106,13 @@ an owner, not a separate entity. Keeps every join, standing, and matchup query u
 `roster_entries` is append-only with `released_at`, so full roster history is
 reconstructible for any week. `lineups` records what was actually started, never derived
 after the fact — a settled week must be provable.
+
+`roster_entries.league_id` is the team's own league, **derived by trigger and never
+supplied by a writer**. It is denormalised for one reason: a partial unique index cannot
+join, so the only way to enforce "one active owner per league" — the rule `0005` claimed
+and did not enforce — is to put the league on the row. The composite foreign key
+`(team_id, league_id) -> teams (id, league_id)` is what stops the copy drifting from the
+original. See migration `0022`.
 
 ### Play
 

--- a/packages/db/migrations/0022_one_owner_per_league.sql
+++ b/packages/db/migrations/0022_one_owner_per_league.sql
@@ -1,0 +1,154 @@
+-- A player sits on one active roster per league — enforced, not asserted.
+--
+-- `0005` says, in its own comment above the index:
+--
+--     -- A player may sit on only one active roster per league at a time.
+--     CREATE UNIQUE INDEX roster_entries_one_owner
+--       ON roster_entries (team_id, player_id)
+--       WHERE released_at IS NULL;
+--
+-- The comment says *per league*; the index is *per team*. Two teams in the same
+-- league could each hold the same player active and nothing anywhere refused it.
+-- `0005` is applied and may never be edited, so this file is the correction.
+--
+-- It is not theoretical. `addFreeAgent` checks league-wide ownership on `db`
+-- outside its transaction and inserts inside it; `processWaivers` reads every
+-- roster in the league outside its transaction and writes inside it. Two adds of
+-- the same free agent at the same instant — Wednesday morning, when a whole
+-- league is clicking on the same players — both passed the check and both
+-- inserted. `loadRosterForWeek` and `loadWeekMatchups` arbitrate nothing, so both
+-- teams then start him and both score him, and `RULES.md` §7 does not reopen a
+-- finalised week. Silent, and unrecoverable after the fact.
+--
+-- ## Why a column and not a cleverer index
+--
+-- The rule spans two tables: the league of a roster entry lives on `teams`. A
+-- partial unique index may not contain a subquery or a join, and neither may an
+-- exclusion constraint — both are single-table. So the league has to be *on the
+-- row* for any constraint to see it, exactly as `0020` had to put `league_id` on
+-- `trade_vetoes` to scope a veto to its own league.
+--
+-- Denormalised data is only as good as what keeps it honest, so two things do:
+--
+--   * A **BEFORE INSERT/UPDATE trigger derives it from `teams`.** No writer
+--     supplies it and no writer can get it wrong — including the eight test
+--     fixtures and three production call sites that insert roster rows today,
+--     none of which had to change. A column every writer must remember is a
+--     column somebody eventually forgets, and the forgetting would be silent.
+--   * A **composite foreign key** `(team_id, league_id) -> teams (id, league_id)`
+--     pins the pair even if the trigger were ever dropped, and refuses to let a
+--     team be moved between leagues while it still holds roster rows. The
+--     uniqueness it references, `teams_id_league_unique`, already exists — `0020`
+--     added it for the same reason.
+--
+-- **What it costs.** One primary-key lookup on `teams` per roster insert. Roster
+-- inserts are drafts, waiver awards, free-agent adds and trades: a few thousand a
+-- league a season, against a hot path of reads. The index itself is one more
+-- partial unique index to maintain on the same writes.
+--
+-- ## Locking
+--
+-- Per `migrations/README.md`: the *arbitration* this index provides rests on
+-- Postgres's unique-index behaviour under concurrency — the loser of a race
+-- blocks on the index entry until the winner commits and then fails with 23505.
+-- **PGlite is a single connection and cannot reproduce that**, so the tests here
+-- assert the constraint bites, not that a race resolves. `addFreeAgent` maps the
+-- 23505 to `PLAYER_TAKEN` and `processWaivers` takes a league-row lock so two
+-- runs serialise; both were read rather than raced, and neither is verified by
+-- the suite.
+--
+-- Forward-only, like every migration here.
+
+-- ---------------------------------------------------------------------------
+-- The column, backfilled
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE roster_entries
+  ADD COLUMN IF NOT EXISTS league_id uuid;
+
+UPDATE roster_entries r
+   SET league_id = t.league_id
+  FROM teams t
+ WHERE t.id = r.team_id
+   AND r.league_id IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- Existing data
+-- ---------------------------------------------------------------------------
+
+-- There is no production data yet, but a database that already holds rosters
+-- must migrate rather than fail — and if the bug has already fired, the unique
+-- index below would fail on exactly the rows it exists to prevent.
+--
+-- The earliest acquisition keeps the player and every later active copy is
+-- released. That is the rule the system was trying to apply in the first place
+-- ("first come, first served" is what free agency means), and a later duplicate
+-- exists *only* because the missing index let it through. Releasing rather than
+-- deleting is how this table already retires a row, so past weeks stay
+-- reconstructible.
+--
+-- It does not repair a lineup that already started the released copy, and it
+-- cannot: a finalised week is not reopened. Anything it touches should be looked
+-- at by a human, which is why it is a single deliberate statement here rather
+-- than an ON CONFLICT somewhere in the application.
+UPDATE roster_entries r
+   SET released_at = now()
+ WHERE r.released_at IS NULL
+   AND EXISTS (
+     SELECT 1
+       FROM roster_entries keeper
+      WHERE keeper.league_id = r.league_id
+        AND keeper.player_id = r.player_id
+        AND keeper.released_at IS NULL
+        AND (keeper.acquired_at, keeper.id) < (r.acquired_at, r.id)
+   );
+
+ALTER TABLE roster_entries
+  ALTER COLUMN league_id SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- What keeps it honest
+-- ---------------------------------------------------------------------------
+
+-- Derived, never supplied. A caller's value is overwritten rather than checked:
+-- there is exactly one right answer and `teams` holds it, so accepting a second
+-- opinion would only create a way for the two to disagree.
+CREATE FUNCTION roster_entries_league_from_team() RETURNS trigger AS $$
+DECLARE
+  owning_league uuid;
+BEGIN
+  SELECT t.league_id INTO owning_league FROM teams t WHERE t.id = NEW.team_id;
+  IF owning_league IS NULL THEN
+    RAISE EXCEPTION 'roster_entries.team_id % names no team', NEW.team_id
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+  NEW.league_id := owning_league;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Only the two columns that can make the pair wrong. A release — the common
+-- update on this table — does not fire it.
+CREATE TRIGGER roster_entries_league_derived
+  BEFORE INSERT OR UPDATE OF team_id, league_id ON roster_entries
+  FOR EACH ROW EXECUTE FUNCTION roster_entries_league_from_team();
+
+ALTER TABLE roster_entries
+  ADD CONSTRAINT roster_entries_team_in_league
+  FOREIGN KEY (team_id, league_id) REFERENCES teams (id, league_id);
+
+-- ---------------------------------------------------------------------------
+-- The constraint the comment always claimed
+-- ---------------------------------------------------------------------------
+
+CREATE UNIQUE INDEX roster_entries_one_owner_per_league
+  ON roster_entries (league_id, player_id)
+  WHERE released_at IS NULL;
+
+-- Subsumed: a team is in exactly one league, so any pair of active rows sharing
+-- (team, player) also shares (league, player). Dropped rather than left in place,
+-- because it is the index whose comment claimed the guarantee this file is
+-- adding — and a constraint that promises more than it enforces is the defect
+-- that produced this migration. `roster_entries_team_idx` still covers reads of
+-- a team's active roster.
+DROP INDEX roster_entries_one_owner;

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -36,20 +36,11 @@ import {
 import { deriveOrderSeed } from "@rostr/core";
 import type { DraftablePlayer, DraftPick, DraftState, RosterShape } from "@rostr/core";
 import type { SqlClient } from "./client.js";
+import { isUniqueViolation } from "./pg-errors.js";
 import type { RandomnessBeacon } from "./randomness.js";
 import { withTransaction } from "./transaction.js";
 import { seedWaiverPriority } from "./waivers.js";
 import { generateSeasonSchedule } from "./week.js";
-
-/** Postgres `unique_violation`. */
-function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "23505"
-  );
-}
 
 export class DraftPersistenceError extends Error {
   constructor(

--- a/packages/db/src/pg-errors.ts
+++ b/packages/db/src/pg-errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Postgres error codes this package reacts to.
+ *
+ * Kept in one place because "did we lose a race?" is asked from more than one
+ * module now — the draft, and free agency — and two copies of the predicate is
+ * two chances for one of them to widen quietly.
+ */
+
+/**
+ * Postgres `unique_violation` (23505).
+ *
+ * Narrow deliberately: a unique violation means a constraint arbitrated between
+ * two writers, and nothing else. Any other error is a real fault and must
+ * surface as itself rather than be relabelled as contention — so callers should
+ * wrap the single statement whose uniqueness they mean, not a whole transaction.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "23505"
+  );
+}

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -673,13 +673,15 @@ async function resolveTrade(
       // **Nothing is created that was not destroyed.** The insert used to be
       // unconditional, so if the release matched no row — the player having left
       // that roster since the trade was accepted — a second copy of him appeared
-      // on the receiver, owned by two teams at once. The `(team_id, player_id)`
-      // unique index cannot catch it, being per-team.
+      // on the receiver, owned by two teams at once. `0005`'s per-team unique
+      // index could not catch it; `roster_entries_one_owner_per_league`
+      // (migration `0022`) now does, but as a 23505 rather than as an answer.
       //
       // This is the last line of defence rather than the first, and it is the one
       // that holds regardless of how he left: accepted twice, dropped through a
       // path that did not consult the freeze, or claimed off waivers. Upstream
-      // checks each close one route; this closes the outcome.
+      // checks each close one route; this closes the outcome — and it is still
+      // the only one of them that can say *which* asset is missing.
       if (released.length === 0) {
         throw new TradeError(
           `${asset.player_id} is no longer on team ${asset.from_team_id}'s roster, ` +

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -533,3 +533,214 @@ describe("availablePlayers", () => {
     expect(available.filter((p) => p.availability === "FREE_AGENT")).toHaveLength(3);
   });
 });
+
+// ---------------------------------------------------------------------------
+// One owner per league
+// ---------------------------------------------------------------------------
+
+/**
+ * Migration `0022`, correcting the comment `0005` shipped.
+ *
+ * **These tests do not attempt to reproduce the race.** PGlite is a single
+ * connection, so the interleaving that produced the bug cannot happen here and a
+ * test claiming to show it would be theatre. What is testable — and what the
+ * application code now leans on — is that the constraint exists and refuses, so
+ * that is asserted directly, at the table, with no application code in the way.
+ */
+describe("one owner per league", () => {
+  /** Insert a roster row with no application code in between. */
+  function put(fx: Fixture, teamId: string, playerId: string): Promise<unknown[]> {
+    return fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'FREE_AGENT', $3)`,
+      [teamId, playerId, MONDAY.toISOString()],
+    );
+  }
+
+  it("refuses the same player active on two teams in one league", async () => {
+    // The finding. `0005` claimed this and enforced only the per-team case, so
+    // two managers could hold one player and both start him in the same week.
+    const fx = await setup();
+
+    await expect(put(fx, fx.teams[1]!, fx.players.get("held")!)).rejects.toMatchObject({
+      code: "23505",
+    });
+
+    const owners = await fx.client.query<{ team_id: string }>(
+      `SELECT team_id FROM roster_entries
+        WHERE league_id = $1 AND player_id = $2 AND released_at IS NULL`,
+      [fx.leagueId, fx.players.get("held")!],
+    );
+    expect(owners).toHaveLength(1);
+  });
+
+  it("still refuses the same player twice on one team", async () => {
+    // The guarantee the dropped `roster_entries_one_owner` index did provide.
+    // (league, player) subsumes (team, player) because a team is in one league,
+    // but subsumption is worth a test rather than an argument.
+    const fx = await setup();
+
+    await expect(put(fx, fx.teams[0]!, fx.players.get("held")!)).rejects.toMatchObject({
+      code: "23505",
+    });
+  });
+
+  it("does not reach across leagues", async () => {
+    // League-scoped, not global. Two leagues drafting the same real footballer
+    // is the normal case, and a constraint that stopped it would be a worse bug
+    // than the one it fixed.
+    const fx = await setup();
+
+    const other = await createLeague(fx.client, NFL, {
+      name: "Other League",
+      commissionerId: (await createUser(fx.client, "other@example.com", "Other")).id,
+      rules: fx.rules,
+    });
+    const otherTeam = await addTestTeam(fx.client, other.id, "Elsewhere");
+
+    await expect(put(fx, otherTeam.teamId, fx.players.get("held")!)).resolves.toBeDefined();
+  });
+
+  it("lets a released player be picked up again", async () => {
+    // The index is partial on `released_at IS NULL`, so history does not block a
+    // re-add — which matters because this table is append-only and a player can
+    // legitimately be dropped and re-signed several times in a season.
+    const fx = await setup();
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("fresh")!, MONDAY);
+
+    await expect(put(fx, fx.teams[2]!, fx.players.get("fresh")!)).resolves.toBeDefined();
+
+    // Joined through `teams` rather than reading `roster_entries.league_id`, so
+    // this one assertion holds on the schema either side of migration `0022` —
+    // it is a control, not a demonstration.
+    const rows = await fx.client.query<{ released_at: string | null }>(
+      `SELECT r.released_at FROM roster_entries r
+         JOIN teams t ON t.id = r.team_id
+        WHERE t.league_id = $1 AND r.player_id = $2`,
+      [fx.leagueId, fx.players.get("fresh")!],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.released_at === null)).toHaveLength(1);
+  });
+
+  it("derives league_id from the team rather than trusting the writer", async () => {
+    // The denormalisation only works if it cannot disagree with `teams`. A
+    // writer's value is overwritten, not checked, so there is no second opinion
+    // to reconcile — and no writer has to remember the column.
+    const fx = await setup();
+    const other = await createLeague(fx.client, NFL, {
+      name: "Wrong League",
+      commissionerId: (await createUser(fx.client, "wrong@example.com", "Wrong")).id,
+      rules: fx.rules,
+    });
+
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, league_id, acquired_via, acquired_at)
+       VALUES ($1, $2, $3, 'FREE_AGENT', $4)`,
+      [fx.teams[1]!, fx.players.get("target")!, other.id, MONDAY.toISOString()],
+    );
+
+    const [row] = await fx.client.query<{ league_id: string }>(
+      "SELECT league_id FROM roster_entries WHERE player_id = $1",
+      [fx.players.get("target")!],
+    );
+    expect(row?.league_id).toBe(fx.leagueId);
+  });
+
+  it("fails a claim for a player somebody already holds, rather than wedging", async () => {
+    // This state arises routinely, and that is the whole point of the test.
+    // `clears_at` is a processing instant and the cron is hourly, so a player who
+    // has cleared can be plainly added while a claim for him is still outstanding
+    // — no race required, just an ordinary Wednesday.
+    //
+    // `resolveWaiverClaims` does not consult other teams' rosters, so it would
+    // award that claim; the insert then violates the one-owner index; and with no
+    // catch the run rolls back with the claim still PENDING and the roster
+    // unchanged — so **every later run fails identically, forever**, taking every
+    // unrelated claim in the league with it. Turning a silent corruption into a
+    // permanent league-wide outage is not a fix.
+    const fx = await setup();
+    const playerId = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, playerId, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: playerId,
+      now: MONDAY,
+    });
+
+    // Somebody else ends up holding him before the run.
+    await put(fx, fx.teams[2]!, playerId);
+
+    const wednesday = new Date(MONDAY.getTime() + 2 * DAY);
+    const run = await processWaivers(fx.client, fx.leagueId, wednesday);
+
+    expect(run.awarded).toBe(0);
+    expect(run.failed).toBe(1);
+
+    const owners = await fx.client.query<{ team_id: string }>(
+      `SELECT team_id FROM roster_entries
+        WHERE league_id = $1 AND player_id = $2 AND released_at IS NULL`,
+      [fx.leagueId, playerId],
+    );
+    expect(owners.map((row) => row.team_id)).toEqual([fx.teams[2]]);
+
+    // Resolved, not left for the next run to trip over again.
+    const [claim] = await fx.client.query<{ state: string }>(
+      "SELECT state FROM waiver_claims WHERE league_id = $1 AND add_player_id = $2",
+      [fx.leagueId, playerId],
+    );
+    expect(claim?.state).toBe("FAILED");
+  });
+
+  it("does not take unrelated claims down with a stale one", async () => {
+    // The cost of the old behaviour was never one claim. A rollback discarded
+    // the whole resolution, so a manager whose claim had nothing to do with the
+    // contested player also got nothing, every hour, indefinitely.
+    const fx = await setup();
+    const contested = fx.players.get("held")!;
+    const unrelated = fx.players.get("target")!;
+
+    // Both have to reach waivers to be claimable at all — a free agent is added,
+    // not claimed. Held since well before the drop, so neither takes the
+    // short-tenure route straight back to free agency.
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [fx.teams[1], unrelated, new Date(MONDAY.getTime() - 7 * DAY).toISOString()],
+    );
+
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, contested, MONDAY);
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[1]!, unrelated, MONDAY);
+
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: contested,
+      now: MONDAY,
+    });
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[1]!,
+      addPlayerId: unrelated,
+      now: MONDAY,
+    });
+
+    await put(fx, fx.teams[2]!, contested);
+
+    const run = await processWaivers(
+      fx.client,
+      fx.leagueId,
+      new Date(MONDAY.getTime() + 2 * DAY),
+    );
+
+    expect(run.awarded).toBe(1);
+
+    const [owner] = await fx.client.query<{ team_id: string }>(
+      `SELECT team_id FROM roster_entries
+        WHERE league_id = $1 AND player_id = $2 AND released_at IS NULL`,
+      [fx.leagueId, unrelated],
+    );
+    expect(owner?.team_id).toBe(fx.teams[1]);
+  });
+});

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -41,6 +41,7 @@ import {
 import type { DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
+import { isUniqueViolation } from "./pg-errors.js";
 import { loadDraftBoard } from "./sync.js";
 import { lockedByTrade } from "./trades.js";
 import { withTransaction } from "./transaction.js";
@@ -127,10 +128,12 @@ export async function availabilityOf(
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
 
+  // Keyed on exactly what `roster_entries_one_owner_per_league` is keyed on, so
+  // the answer this gives and the answer the index enforces cannot be derived
+  // from different notions of "in this league".
   const [rostered] = await db.query<{ id: string }>(
     `SELECT r.id FROM roster_entries r
-       JOIN teams t ON t.id = r.team_id
-      WHERE t.league_id = $1 AND r.player_id = $2 AND r.released_at IS NULL`,
+      WHERE r.league_id = $1 AND r.player_id = $2 AND r.released_at IS NULL`,
     [leagueId, playerId],
   );
   if (rostered) return "ROSTERED";
@@ -294,18 +297,48 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
   const stored = await getLeagueRules(db, input.leagueId);
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
 
-  const availability = await availabilityOf(db, input.leagueId, input.addPlayerId, input.now);
-  if (availability === "ROSTERED") {
-    throw new WaiverError("Somebody already has that player", "PLAYER_TAKEN");
-  }
-  if (availability === "ON_WAIVERS") {
-    throw new WaiverError(
-      "That player is on waivers. Put in a claim instead — he is awarded by priority, not by who is fastest.",
-      "NOT_A_FREE_AGENT",
-    );
-  }
-
   await withTransaction(db, async (tx) => {
+    // A shared lock on the league, held for the whole add.
+    //
+    // It does not exclude other adds — `FOR SHARE` does not conflict with itself,
+    // and Wednesday morning is precisely when a league is all adding at once.
+    // What it excludes is `processWaivers`, which takes `FOR UPDATE` on the same
+    // row because it resolves against a league-wide snapshot of every roster.
+    // An add landing mid-run makes that snapshot stale.
+    //
+    // **This is defence in depth, not the thing that makes the run safe.** The
+    // window it closes is the sub-millisecond one *during* a run; the window
+    // that actually matters is the hour between a player clearing waivers and
+    // the next cron, when he reads as a free agent with a claim still
+    // outstanding against him. `processWaivers` closes that itself by dropping
+    // claims for players already held, which it must do whether or not this
+    // lock exists.
+    //
+    // Adds racing *each other* are arbitrated below, by the index, not by a lock.
+    await tx.query("SELECT id FROM leagues WHERE id = $1 FOR SHARE", [input.leagueId]);
+
+    // Inside the transaction, not before it. Read on `db` and written on `tx`,
+    // this answered a question about a moment that had already passed by the time
+    // the insert ran: two managers adding the same free agent both saw
+    // FREE_AGENT, both inserted, and one player ended the week on two rosters —
+    // started, scored twice, and unrecoverable once the week finalised.
+    //
+    // Moving it in narrows the window; it does not close it, because in READ
+    // COMMITTED a concurrent inserter can still commit between this SELECT and
+    // the INSERT below. The index is what closes it. This check survives because
+    // it is the only thing that can tell FREE_AGENT from ON_WAIVERS, and those
+    // need different answers.
+    const availability = await availabilityOf(tx, input.leagueId, input.addPlayerId, input.now);
+    if (availability === "ROSTERED") {
+      throw new WaiverError("Somebody already has that player", "PLAYER_TAKEN");
+    }
+    if (availability === "ON_WAIVERS") {
+      throw new WaiverError(
+        "That player is on waivers. Put in a claim instead — he is awarded by priority, not by who is fastest.",
+        "NOT_A_FREE_AGENT",
+      );
+    }
+
     if (input.dropPlayerId) {
       // Inside the same transaction, so a full roster never briefly holds one
       // player too many and never briefly holds one too few.
@@ -331,11 +364,30 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
       throw new WaiverError("This roster is full — drop someone first", "ROSTER_FULL");
     }
 
-    await tx.query(
-      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
-       VALUES ($1, $2, 'FREE_AGENT', $3)`,
-      [input.teamId, input.addPlayerId, input.now.toISOString()],
-    );
+    // The arbitration, and the only part of it that holds under concurrency.
+    // `roster_entries_one_owner_per_league` (migration `0022`) is unique on
+    // (league, player) among unreleased rows, so of two simultaneous adds the
+    // loser blocks on the index entry until the winner commits and then fails —
+    // which is the same fact the check above reports, arriving later.
+    //
+    // Wrapped around this one statement rather than the transaction, so a unique
+    // violation from anywhere else could not be relabelled as contention.
+    //
+    // Two unique indexes exist on this table — the primary key and the
+    // one-owner-per-league index. The key is `gen_random_uuid()`, so in practice
+    // only the second is reachable here; the constraint name is not matched,
+    // which means a *future* unique index on this table would be silently
+    // reported as `PLAYER_TAKEN`. If one is ever added, narrow this.
+    try {
+      await tx.query(
+        `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+         VALUES ($1, $2, 'FREE_AGENT', $3)`,
+        [input.teamId, input.addPlayerId, input.now.toISOString()],
+      );
+    } catch (cause) {
+      if (!isUniqueViolation(cause)) throw cause;
+      throw new WaiverError("Somebody already has that player", "PLAYER_TAKEN");
+    }
 
     await tx.query("DELETE FROM waiver_wire WHERE league_id = $1 AND player_id = $2", [
       input.leagueId,
@@ -490,6 +542,12 @@ export interface WaiverRunOutcome {
  * and writes its outputs. Everything happens in one transaction, so a run either
  * lands whole or not at all — a half-applied waiver run would leave rosters that
  * no rule produced.
+ *
+ * **The inputs are read inside that transaction too.** They were not, and the gap
+ * was the whole bug: every roster in the league was read on `db`, resolved
+ * against, and written on `tx` — so anything that changed a roster in between
+ * (another run of this function, a free-agent add) was invisible to a decision
+ * that had already been made. Two overlapping runs each awarded the same player.
  */
 export async function processWaivers(
   db: SqlClient,
@@ -499,18 +557,9 @@ export async function processWaivers(
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
 
-  const claims = await db.query<{
-    id: string;
-    team_id: string;
-    add_player_id: string;
-    drop_player_id: string | null;
-  }>(
-    `SELECT id, team_id, add_player_id, drop_player_id
-       FROM waiver_claims WHERE league_id = $1 AND state = 'PENDING'`,
-    [leagueId],
-  );
-
-  const priority = await loadWaiverPriority(db, leagueId);
+  // Reference data, not league state: the same rows for every league and every
+  // run, and nothing a concurrent writer can move underneath us. Loaded before
+  // the transaction so the league lock is held for as little time as possible.
   const board = await loadDraftBoard(db, stored.rules.sportKey, stored.rules.seasonYear);
   const pool = new Map<string, DraftablePlayer>(
     board.map((entry) => [
@@ -518,37 +567,95 @@ export async function processWaivers(
       { playerId: entry.playerId, positions: entry.positions, rank: entry.rank },
     ]),
   );
+  const shape = buildRosterShape(stored.rules.roster, NFL);
 
-  const rosterRows = await db.query<{ team_id: string; player_id: string }>(
-    `SELECT r.team_id, r.player_id FROM roster_entries r
-       JOIN teams t ON t.id = r.team_id
-      WHERE t.league_id = $1 AND r.released_at IS NULL`,
-    [leagueId],
-  );
+  const run = await withTransaction(db, async (tx) => {
+    // One waiver run per league at a time. The cron is hourly and idempotent by
+    // intent, but a slow run and a retry can overlap, and two runs resolving
+    // against the same pre-run rosters both award the same player to different
+    // teams. `addFreeAgent` takes `FOR SHARE` on this row, so an add cannot land
+    // between the read below and the writes either.
+    await tx.query("SELECT id FROM leagues WHERE id = $1 FOR UPDATE", [leagueId]);
 
-  const rosters = new Map<string, DraftablePlayer[]>(priority.map((teamId) => [teamId, []]));
-  for (const row of rosterRows) {
-    const player = pool.get(row.player_id);
-    if (player) rosters.get(row.team_id)?.push(player);
-  }
+    const claims = await tx.query<{
+      id: string;
+      team_id: string;
+      add_player_id: string;
+      drop_player_id: string | null;
+    }>(
+      `SELECT id, team_id, add_player_id, drop_player_id
+         FROM waiver_claims WHERE league_id = $1 AND state = 'PENDING'`,
+      [leagueId],
+    );
 
-  const resolution = resolveWaiverClaims({
-    claims: claims.map((row): WaiverClaim => ({
-      claimId: row.id,
-      teamId: row.team_id,
-      addPlayerId: row.add_player_id,
-      dropPlayerId: row.drop_player_id,
-    })),
-    priority,
-    rosters,
-    pool,
-    shape: buildRosterShape(stored.rules.roster, NFL),
-  });
+    const priority = await loadWaiverPriority(tx, leagueId);
 
-  let awarded = 0;
-  let failed = 0;
+    const rosterRows = await tx.query<{ team_id: string; player_id: string }>(
+      `SELECT r.team_id, r.player_id FROM roster_entries r
+        WHERE r.league_id = $1 AND r.released_at IS NULL`,
+      [leagueId],
+    );
 
-  await withTransaction(db, async (tx) => {
+    const rosters = new Map<string, DraftablePlayer[]>(priority.map((teamId) => [teamId, []]));
+    for (const row of rosterRows) {
+      const player = pool.get(row.player_id);
+      if (player) rosters.get(row.team_id)?.push(player);
+    }
+
+    /**
+     * Players somebody in this league already holds.
+     *
+     * `resolveWaiverClaims` does not consult rosters for ownership — it checks
+     * the pool, what this run has already awarded, and the claiming team's own
+     * shape. So a claim for a player another team picked up *since the claim was
+     * filed* is awarded, and the insert then violates
+     * `roster_entries_one_owner_per_league`.
+     *
+     * That window is not narrow. `clears_at` is a processing instant and the
+     * cron is hourly, so every Wednesday there is a stretch in which a player
+     * with an outstanding claim reads as a free agent and can simply be added.
+     * Nothing cancels the claim when that happens.
+     *
+     * Before the league-scoped index, both writes landed and two teams held him.
+     * After it, the run would abort — and because the claim stays PENDING and
+     * the roster is unchanged, **every later run would abort identically**,
+     * wedging the league's waivers permanently rather than for an hour. Filtering
+     * here is what makes the no-catch policy below honest, and it gives the
+     * manager the true answer: the claim failed because somebody else has him.
+     */
+    const alreadyHeld = new Set(rosterRows.map((row) => row.player_id));
+
+    const resolution = resolveWaiverClaims({
+      claims: claims
+        .filter((row) => !alreadyHeld.has(row.add_player_id))
+        .map((row): WaiverClaim => ({
+          claimId: row.id,
+          teamId: row.team_id,
+          addPlayerId: row.add_player_id,
+          dropPlayerId: row.drop_player_id,
+        })),
+      priority,
+      rosters,
+      pool,
+      shape,
+    });
+
+    let awarded = 0;
+    let failed = 0;
+
+    // Filtered out above, so they never reach `outcomes` — and a claim left
+    // PENDING is retried every hour forever, which is the wedge this is here to
+    // avoid. It really did fail, and for a reason worth telling the manager.
+    for (const row of claims) {
+      if (!alreadyHeld.has(row.add_player_id)) continue;
+
+      await tx.query(
+        "UPDATE waiver_claims SET state = 'FAILED', processed_at = $2 WHERE id = $1",
+        [row.id, now.toISOString()],
+      );
+      failed++;
+    }
+
     for (const outcome of resolution.outcomes) {
       const claim = claims.find((row) => row.id === outcome.claimId)!;
 
@@ -569,6 +676,18 @@ export async function processWaivers(
         );
       }
 
+      // No `try` around this one, unlike `addFreeAgent`. There, a unique
+      // violation is an ordinary outcome to report to one manager; here it would
+      // mean the locked, in-transaction snapshot above was still wrong, and the
+      // honest answer is to roll the whole run back rather than quietly drop a
+      // claim from a resolution that is meant to be replayable.
+      //
+      // That is only defensible because claims for players already held are
+      // dropped before resolving. Without that filter the case is not
+      // exceptional at all — it is every Wednesday — and rolling back would
+      // leave the claim PENDING and the roster unchanged, so the next run would
+      // fail identically. A league whose waivers never process again is a far
+      // worse answer than a dropped claim.
       await tx.query(
         `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
          VALUES ($1, $2, 'WAIVER', $3)`,
@@ -596,7 +715,11 @@ export async function processWaivers(
         teamId,
       ]);
     }
+
+    return { awarded, failed, claims, priorityAfter: resolution.priorityAfter };
   });
+
+  const { awarded, failed, claims } = run;
 
   // Players nobody claimed become free agents once their wire time passes.
   // Removing the row is what makes them free — absent means available.
@@ -619,7 +742,7 @@ export async function processWaivers(
     leagueId,
     awarded,
     failed,
-    priorityAfter: resolution.priorityAfter,
+    priorityAfter: run.priorityAfter,
     cleared: cleared.length,
   };
 }


### PR DESCRIPTION
Closes finding 5 of #25 — the serious one in that group.

## ⚠️ Merge order

Carries migration **`0022`**. `main` has `0020`, and #39 holds `0021`. The runner refuses a migration numbered below the highest applied, so **merge #39 before this**. `fix/25-cron-guard-and-coded-errors` is stacked on this branch and must come after.

## The defect

`roster_entries_one_owner` was `UNIQUE (team_id, player_id)` under a comment claiming *"one active roster **per league**"*. Two teams in one league could both hold a player active, both start him, and both score him. Finalised scores feed seeding, which feeds settlement, and `RULES.md` §7 says a finalised week is not reopened. Silent and unrecoverable.

**The issue filed this for "before Sep 16", believing add/drop was not wired. It is.** And it needs no race at all: `clears_at` is a processing instant while the cron is hourly, so every Wednesday there is a stretch where a player who has cleared reads as a free agent with a claim still outstanding against him. Add him, run waivers, two teams hold him. Reproduced through public calls only, no concurrency.

## The schema

A partial unique index cannot join, so the league has to be on the row. `roster_entries` gains a `league_id` derived by a trigger that **overwrites rather than validates** — no writer supplies it, so no writer can get it wrong, and none of the four production insert sites changed — pinned by `FOREIGN KEY (team_id, league_id) REFERENCES teams` so it survives the trigger being dropped.

The old index is dropped rather than kept: a team is in one league so it is subsumed, and leaving it would leave the constraint whose comment caused this.

The migration backfills and releases later duplicates **before** creating the index, because otherwise it would fail on exactly the rows it exists to prevent.

## A constraint alone would have been a worse bug, and review caught it

`resolveWaiverClaims` never consults other teams' rosters — only the pool, what the run has already awarded, and the claiming team's shape. So it awards a claim for a player somebody already holds, the insert violates the new index, and with no catch the whole run rolls back with the claim still `PENDING` and the roster unchanged. **Every later run then fails identically**: a permanent, league-wide waiver outage that takes every unrelated claim with it, surfacing only as a string in the cron's JSON.

Strictly worse than the corruption it replaced. So `processWaivers` drops claims for players already held before resolving and marks them `FAILED` — which is also the true answer for the manager, and what makes the deliberate absence of a catch on its insert defensible.

Also from review: the `FOR SHARE` comment claimed an add mid-run cost a league "an hour" — it cost permanence, and the lock does not close the window that actually matters. Rewritten as the defence in depth it is. Three other comments corrected.

## Verification

972 tests (was 965). Three of six new tests fail on the pre-fix schema, verified by stashing. The race cannot be staged on single-connection PGlite, so the tests assert at the table that two teams in one league cannot both hold a player active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)