### PR TITLE
fix(db): finalise a week whose game never finished, per RULES §10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,13 +495,32 @@ opponent a free win — so the autolineup fills every gap before a week is score
 the pure arithmetic is "Resolving a week" further down.
 
 **Scoring and finalising are separate decisions.** Points are rewritten on every run so a
-manager can watch their week; `finalized_at` is set only once every game is `FINAL` **and**
-the correction window has elapsed. A finalised week is never rescored — in a paying week it
-has already decided money, and a silently changed result afterwards is exactly what the
-window exists to prevent.
+manager can watch their week; `finalized_at` is set once the correction window has elapsed,
+and, _within_ that window, only when every game is `FINAL`. A finalised week is never
+rescored — in a paying week it has already decided money, and a silently changed result
+afterwards is exactly what the window exists to prevent.
 
 The window comes from the rules: 48 hours normally, **168 for weeks 14 and 17**, because
 official NFL stat corrections arrive for up to seven days.
+
+**The window is a ceiling on the wait, not only a floor.** "Every game is `FINAL`" cannot be
+a standing precondition, because a postponed or abandoned game never becomes `FINAL` — one
+of them would hold a week open forever, and weeks 14 and 17 would never settle. `RULES.md`
+§10 answers that in advance ("affected players score 0 for that week; the matchup stands"),
+and the scoring window it names is the one `finalizationHours` already computes, so the
+fallback needs no new rule field and cannot move the golden hash.
+
+**"Affected players score 0" needed no code.** A player whose game was never ingested has no
+stat line, and `results.ts` already scores an absent line as zero. Letting the week finalise
+_was_ the whole implementation — everything else in that sentence was already true.
+
+A week that settles this way says so, in `finalizedWithUnfinishedGames` on
+`ResolveWeekOutcome`, which `/api/cron/score-week` surfaces. **Do not collapse it into
+`finalized: true`.** Settling on complete data and settling because the clock ran out are
+different facts, and only the second is worth waking someone for: those games are now scored
+as they stand, permanently, because a finalised week is never rescored. The cost when the
+feed was merely slow is one game's stats — the same trade the correction window already
+makes against a stat line arriving at T+49h.
 
 Scores read `stat_lines_current`, so a correction that arrived as a new revision is used
 and the superseded one is not. There is a test for that specifically.

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -14,9 +14,15 @@ import { db } from "@/lib/db";
  * Score every active league's current week.
  *
  * Safe to run often — that is how live scores stay current. Each run rewrites
- * points from the latest stat revisions and finalises only once the week's games
- * are all final *and* the correction window has elapsed. A finalised week is
- * skipped, not rescored.
+ * points from the latest stat revisions and finalises once the correction window
+ * has elapsed, which inside that window also requires every game to be final. A
+ * finalised week is skipped, not rescored.
+ *
+ * Past the window a week finalises whether or not every game reached `FINAL` —
+ * `docs/RULES.md` §10, the postponed game — and says so in
+ * `finalizedWithUnfinishedGames`. That field is the only signal that a week
+ * settled on the fallback rather than on complete data, so surface it rather
+ * than collapsing it into `finalized: true`.
  *
  * Hourly is plenty on a normal day; during Sunday games something closer to
  * every ten minutes makes the numbers feel live. `apps/web/vercel.json`
@@ -69,7 +75,13 @@ export async function GET(request: Request): Promise<NextResponse> {
   const scored: {
     leagueId: string;
     name: string;
-    weeks?: { week: number; matchups: number; finalized: boolean; holdReason?: string }[];
+    weeks?: {
+      week: number;
+      matchups: number;
+      finalized: boolean;
+      holdReason?: string;
+      finalizedWithUnfinishedGames?: string;
+    }[];
     failedWeeks?: readonly { readonly week: number; readonly reason: string }[];
     deferredWeeks?: readonly number[];
     bracketGames?: number;
@@ -146,6 +158,9 @@ export async function GET(request: Request): Promise<NextResponse> {
           matchups: o.matchups,
           finalized: o.finalized,
           ...(o.holdReason ? { holdReason: o.holdReason } : {}),
+          ...(o.finalizedWithUnfinishedGames
+            ? { finalizedWithUnfinishedGames: o.finalizedWithUnfinishedGames }
+            : {}),
         })),
         ...(sweep.failures.length > 0 ? { failedWeeks: sweep.failures } : {}),
         ...(sweep.deferred.length > 0 ? { deferredWeeks: sweep.deferred } : {}),

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -147,6 +147,24 @@ const finishGames = (fx: Fixture) =>
     WEEK,
   ]);
 
+/**
+ * Add one more game to a week, at the same kickoff, with a status of its own.
+ *
+ * The fixture ships a single week-1 game, which cannot express "one of them
+ * never happened" — the case `docs/RULES.md` §10 is written for.
+ */
+async function addGame(fx: Fixture, ref: string, status: string, week = WEEK): Promise<void> {
+  const [sport] = await fx.client.query<{ id: string }>(
+    "SELECT id FROM sports WHERE key = $1",
+    [NFL.key],
+  );
+  await fx.client.query(
+    `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status)
+     VALUES ($1, $2, $3, $4, 'BUF', 'CIN', $5, $6)`,
+    [sport!.id, ref, SEASON, week, KICKOFF, status],
+  );
+}
+
 async function schedule(fx: Fixture): Promise<void> {
   await persistSchedule(fx.client, fx.leagueId, generateSchedule(fx.teamIds, 14, "seed"));
 }
@@ -437,11 +455,14 @@ describe("resolveLeagueWeeksThrough", () => {
 });
 
 describe("finalisation", () => {
-  it("holds while games are still in progress", async () => {
+  it("holds while games are still in progress and the window is running", async () => {
+    // Inside the window, an unplayed game is the reason worth reporting — it is
+    // the one an operator can still act on. Outside it the clock wins; see the
+    // postponement tests below.
     const fx = await setup();
     await schedule(fx);
 
-    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
 
     expect(outcome.finalized).toBe(false);
     expect(outcome.holdReason).toMatch(/still in progress/);
@@ -536,6 +557,150 @@ describe("finalisation", () => {
 
     const late = await resolveLeagueWeek(fx.client, fx.leagueId, 14, AFTER_PAYING);
     expect(late.finalized).toBe(true);
+  });
+});
+
+describe("a game that never finishes — docs/RULES.md §10", () => {
+  const finalizedAt = async (fx: Fixture, week = WEEK): Promise<string | null> => {
+    const [row] = await fx.client.query<{ finalized_at: string | null }>(
+      "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2 LIMIT 1",
+      [fx.leagueId, week],
+    );
+    return row?.finalized_at ?? null;
+  };
+
+  it("finalises once the scoring window has passed, unplayed game and all", async () => {
+    // The failure this exists to stop. A postponed game never reaches FINAL, so
+    // a hold keyed on "every game is FINAL" alone is a hold with no end: the
+    // week never finalises, the bracket never advances, and in weeks 14 and 17
+    // nobody is ever paid. Before this change the assertion below was
+    // `finalized: false` with "1 of 2 games are still in progress", at any
+    // instant however far in the future.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await addGame(fx, "g1-postponed", "POSTPONED");
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.holdReason).toBeUndefined();
+    expect(await finalizedAt(fx)).not.toBeNull();
+  });
+
+  it("says it finalised on the fallback rather than on complete data", async () => {
+    // `finalized: true` alone cannot distinguish a settled week from one the
+    // clock ran out on, and only the second is worth an operator's attention:
+    // the missing game's players are now permanently scored at zero, because a
+    // finalised week is never rescored.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await addGame(fx, "g1-postponed", "POSTPONED");
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/1 of 2/);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/RULES\.md §10/);
+  });
+
+  it("reports nothing extra when the week finalised on complete data", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.finalizedWithUnfinishedGames).toBeUndefined();
+  });
+
+  it("scores the missing game's players zero and lets the matchup stand", async () => {
+    // "Affected players score 0" needs no code of its own: a player with no stat
+    // line already scores zero (`results.ts` — absent, empty and zero are three
+    // different things). What §10 needed was for the week to stop waiting. This
+    // asserts the whole rule: qb-0 played and counts, qb-1 did not and scores
+    // nothing, and both matchups are written and final rather than voided.
+    const fx = await setup();
+    await schedule(fx);
+    await score(fx, "qb-0", 300); // 12 points
+    await finishGames(fx);
+    await addGame(fx, "g1-postponed", "POSTPONED");
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    const pointsFor = (teamId: string): number => {
+      const matchup = outcome.results.find((r) =>
+        [r.homeTeamId, r.awayTeamId].includes(teamId),
+      )!;
+      return matchup.homeTeamId === teamId ? matchup.homeMilliPoints : matchup.awayMilliPoints;
+    };
+
+    expect(pointsFor(fx.teamIds[0]!)).toBe(12_000);
+    expect(pointsFor(fx.teamIds[1]!)).toBe(0);
+    expect(outcome.matchups).toBe(2);
+
+    const rows = await fx.client.query<{ finalized_at: string | null }>(
+      "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2",
+      [fx.leagueId, WEEK],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.finalized_at !== null)).toBe(true);
+  });
+
+  it("still holds inside the window, so a slow ingest gets its full 48 hours", async () => {
+    // The fallback is a deadline, not a shortcut. Everything the feed has until
+    // the window closes still lands in the score.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await addGame(fx, "g1-postponed", "POSTPONED");
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
+
+    expect(outcome.finalized).toBe(false);
+    expect(outcome.holdReason).toMatch(/1 of 2 games are still in progress/);
+    expect(outcome.finalizedWithUnfinishedGames).toBeUndefined();
+    expect(await finalizedAt(fx)).toBeNull();
+  });
+
+  it("gives a paying week the full 168 hours before falling back", async () => {
+    // The deadline is the week's own scoring window, so the weeks that pay wait
+    // seven days rather than two — and a game still unmarked after seven days is
+    // an abandoned game rather than a slow feed. Week 14 pays in the default
+    // rules; `finalizationHours` is asserted separately above.
+    const fx = await setup();
+    await schedule(fx);
+    await addGame(fx, "g14", "FINAL", 14);
+    await addGame(fx, "g14-postponed", "POSTPONED", 14);
+
+    // 49h is past the standard window and nowhere near the paying one, so the
+    // paying week is still held by the unplayed game.
+    const early = await resolveLeagueWeek(fx.client, fx.leagueId, 14, AFTER_STANDARD);
+    expect(early.finalized).toBe(false);
+    expect(early.holdReason).toMatch(/1 of 2 games are still in progress/);
+    expect(await finalizedAt(fx, 14)).toBeNull();
+
+    // 169h is past it, so the regular-season prize can be settled rather than
+    // waiting forever on a game that will never be played.
+    const late = await resolveLeagueWeek(fx.client, fx.leagueId, 14, AFTER_PAYING);
+    expect(late.finalized).toBe(true);
+    expect(late.finalizedWithUnfinishedGames).toMatch(/168h after the last kickoff/);
+    expect(await finalizedAt(fx, 14)).not.toBeNull();
+  });
+
+  it("does not finalise a week whose games were never ingested at all", async () => {
+    // §10 zeroes the players of a cancelled *game*. A week with no games is not
+    // that case: there is no kickoff to run a window from, and finalising would
+    // settle every matchup 0–0 rather than only the affected players. It waits.
+    const fx = await setup();
+    await schedule(fx);
+    await fx.client.query("DELETE FROM games WHERE season = $1 AND week = $2", [SEASON, WEEK]);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_PAYING);
+
+    expect(outcome.finalized).toBe(false);
+    expect(outcome.holdReason).toMatch(/no games are scheduled/);
   });
 });
 

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -24,6 +24,16 @@
  * So `resolveLeagueWeek` updates points every time it runs and sets
  * `finalized_at` only once the wait has elapsed. A finalised week is never
  * rescored.
+ *
+ * ## The wait is bounded, because a game may never be played
+ *
+ * `docs/RULES.md` §10 answers the postponed game in advance — "affected players
+ * score 0 for that week, the matchup stands" — and the window above is the
+ * "scoring window" that rule is written against. So once it has elapsed the week
+ * finalises whether or not every game reached `FINAL`, and
+ * {@link ResolveWeekOutcome.finalizedWithUnfinishedGames} says so. Waiting past
+ * it instead would hold the week forever on one abandoned game, which in weeks 14
+ * and 17 means nobody is ever paid.
  */
 
 import { generateSchedule, indexScoringRules, resolveWeek, winnerOf } from "@rostr/core";
@@ -119,6 +129,17 @@ export interface ResolveWeekOutcome {
   readonly finalized: boolean;
   /** Why it was not finalised, when it was not. */
   readonly holdReason?: string;
+  /**
+   * Set when the week finalised on `RULES.md` §10's postponement fallback —
+   * the scoring window elapsed with games still not marked `FINAL`.
+   *
+   * Reported rather than inferred. A week settled on complete data and a week
+   * settled because the clock ran out are different facts about the same
+   * `finalized: true`, and only one of them is worth an operator's attention:
+   * the games that never landed are now permanently scored as they stand,
+   * because a finalised week is never rescored.
+   */
+  readonly finalizedWithUnfinishedGames?: string;
   readonly results: readonly MatchupResult[];
 }
 
@@ -170,7 +191,8 @@ export async function resolveLeagueWeek(
     stored.rules.roster,
   );
 
-  const hold = await finalizationHold(db, stored.rules, week, now);
+  const decision = await finalizationHold(db, stored.rules, week, now);
+  const finalized = decision.hold === null;
 
   await withTransaction(db, async (tx) => {
     for (const result of results) {
@@ -187,7 +209,7 @@ export async function resolveLeagueWeek(
           week,
           result.homeMilliPoints,
           result.awayMilliPoints,
-          hold === null,
+          finalized,
           now.toISOString(),
           result.homeTeamId,
           result.awayTeamId,
@@ -199,8 +221,9 @@ export async function resolveLeagueWeek(
   return {
     week,
     matchups: results.length,
-    finalized: hold === null,
-    ...(hold === null ? {} : { holdReason: hold }),
+    finalized,
+    ...(decision.hold === null ? {} : { holdReason: decision.hold }),
+    ...(decision.fallback ? { finalizedWithUnfinishedGames: decision.fallback } : {}),
     results,
   };
 }
@@ -233,12 +256,17 @@ export async function resolveLeagueWeek(
  * a later week than the main one, so a week can be finalised holding only
  * consolation fixtures and then receive playoff fixtures on a later advance.
  *
- * **It is bounded.** A league with a long tail of never-finalisable weeks — a
- * postponed game, a feed that never marked a game final — would otherwise re-run
- * the full lineup-and-scoring work for every one of them on every pass. The cap
- * takes the most recent, because those are the ones with money and an audience
- * attached, and the caller is told what was left behind rather than being left to
- * infer it from silence.
+ * **It is bounded.** A league with a long tail of weeks that will not finalise —
+ * a week whose games were never ingested at all, or one that throws every pass —
+ * would otherwise re-run the full lineup-and-scoring work for every one of them
+ * on every pass. The cap takes the most recent, because those are the ones with
+ * money and an audience attached, and the caller is told what was left behind
+ * rather than being left to infer it from silence.
+ *
+ * (A postponed game no longer belongs on that list: `finalizationHold` finalises
+ * past the scoring window rather than waiting for a `FINAL` that never comes.
+ * The cap still earns its keep for the cases above, and for a week whose window
+ * simply has not closed yet.)
  */
 export const SWEEP_LIMIT = 4;
 
@@ -304,18 +332,79 @@ export async function resolveLeagueWeeksThrough(
   return { outcomes, failures, deferred };
 }
 
+/** What {@link finalizationHold} decided, and why. */
+interface FinalizationDecision {
+  /** Why the week may not be finalised yet, or `null` if it may. */
+  readonly hold: string | null;
+  /** Set only when it may *despite* games that never reached `FINAL`. */
+  readonly fallback?: string;
+}
+
 /**
- * Why a week may not be finalised yet, or `null` if it may.
+ * Whether a week may be finalised.
  *
- * Two conditions, both necessary: every game must be final, and the correction
- * window must have elapsed since the last kickoff.
+ * Two conditions, and **only one of them is unconditional**: the correction
+ * window must have elapsed since the week's last kickoff. Every game being
+ * `FINAL` holds the week *inside* that window and stops holding it outside,
+ * because a game that is never played never becomes `FINAL` and the wait would
+ * otherwise have no end.
+ *
+ * ## Why the clock outranks the games
+ *
+ * `docs/RULES.md` §10 answers this contingency in advance, as it has to — the
+ * rules are frozen at league creation and cannot be patched in December:
+ *
+ * > An NFL game is cancelled or postponed beyond the scoring window →
+ * > **affected players score 0 for that week. The matchup stands.**
+ *
+ * "The scoring window" is the window this function already computes:
+ * {@link finalizationHours} from the last kickoff, 48h normally and 168h for the
+ * weeks that pay. Reading the rule against any other clock would mean inventing
+ * a second deadline, and it would have to live in the rule set to be verifiable
+ * — which would move the canonical encoding and break every anchored league's
+ * `rules_hash`. So the rule is implemented against the window it names.
+ *
+ * **"Affected players score 0" needs no code here.** A player whose game was
+ * never ingested has no row in `stat_lines_current`, `loadWeekStats` returns no
+ * entry for him, and `scoreTeamLineup` scores an absent stat line as zero
+ * (`packages/core/src/season/results.ts` — "absent, empty and zero are three
+ * different things"). He is already scoring 0; the only thing standing between
+ * that and a settled week was this hold. And "the matchup stands" is what
+ * *not* intervening gets you: no row is voided, no opponent is credited.
+ *
+ * Stats that *did* arrive before a game was abandoned are kept, which the rule
+ * does not speak to either way — see the note in the outcome type and the report
+ * on this change. `stat_lines` is append-only precisely so a settled week stays
+ * auditable, and deleting a partial line would be a larger intervention with no
+ * rule behind it.
+ *
+ * ## What it costs
+ *
+ * A feed that stalls for a full 48 hours finalises the week on whatever stats
+ * arrived, and a finalised week is never rescored — so a late stat line is a
+ * correction that missed its window, exactly like one arriving at T+49h with
+ * every game final. That is the same trade the window already makes, and it is
+ * strictly better than the alternative: holding past the window means the week
+ * never finalises at all, the bracket never advances (it reads finalised results
+ * only), and weeks 14 and 17 never settle. One game's stats against the season's
+ * payouts.
+ *
+ * Two things bound the risk. It is proportionate — 168h, not 48h, in the weeks
+ * that pay, and a game unmarked for seven days is a real abandonment rather than
+ * a slow ingest. And it is visible: the caller is told, rather than left to infer
+ * a clean finalisation from the absence of a hold.
+ *
+ * The residual is a provider that keeps a postponed game in the same week and
+ * moves its kickoff into the future: `last_kickoff` follows it and the window
+ * moves with it. That is right when the game really is played later that week,
+ * and it is the one case where the wait can still exceed the nominal window.
  */
 async function finalizationHold(
   db: SqlClient,
   rules: LeagueRules,
   week: number,
   now: Date,
-): Promise<string | null> {
+): Promise<FinalizationDecision> {
   const rows = await db.query<{ total: number; finished: number; last_kickoff: string | null }>(
     `SELECT count(*)::int AS total,
             count(*) FILTER (WHERE g.status = 'FINAL')::int AS finished,
@@ -328,27 +417,49 @@ async function finalizationHold(
 
   const row = rows[0];
   const total = Number(row?.total ?? 0);
-  if (total === 0) return "no games are scheduled for this week yet";
+  // No games at all is not the postponement case and gets no fallback. There is
+  // no kickoff to run a window from, and a week nobody has ingested would settle
+  // every matchup 0–0 rather than zeroing the players of one abandoned game.
+  if (total === 0) return { hold: "no games are scheduled for this week yet" };
+
+  // `games.kickoff_at` is NOT NULL, so this cannot fire while `total > 0`. It
+  // stays because the clock below is now the only thing that ends the wait, and
+  // a missing clock must hold rather than finalise by default.
+  if (!row?.last_kickoff) return { hold: "no kickoff times are known" };
 
   const finished = Number(row?.finished ?? 0);
-  if (finished < total) return `${total - finished} of ${total} games are still in progress`;
-
-  if (!row?.last_kickoff) return "no kickoff times are known";
-
   const hours = finalizationHours(rules, week);
   const clearsAt = new Date(new Date(row.last_kickoff).getTime() + hours * 3600 * 1000);
 
   if (now < clearsAt) {
+    // Inside the window an unplayed game is the more useful thing to say: it is
+    // the condition an operator can still act on, and the window is running
+    // anyway.
+    if (finished < total) {
+      return { hold: `${total - finished} of ${total} games are still in progress` };
+    }
+
     const paying = rules.settlement.payingWeeks.includes(week);
-    return (
-      `waiting until ${clearsAt.toISOString()} — ${hours}h after the last kickoff` +
-      (paying
-        ? ", because this week pays out and NFL stat corrections arrive for up to seven days"
-        : "")
-    );
+    return {
+      hold:
+        `waiting until ${clearsAt.toISOString()} — ${hours}h after the last kickoff` +
+        (paying
+          ? ", because this week pays out and NFL stat corrections arrive for up to seven days"
+          : ""),
+    };
   }
 
-  return null;
+  if (finished < total) {
+    return {
+      hold: null,
+      fallback:
+        `finalised ${hours}h after the last kickoff with ${total - finished} of ${total} ` +
+        `games not marked FINAL — docs/RULES.md §10: affected players score 0 for the ` +
+        `week and the matchup stands`,
+    };
+  }
+
+  return { hold: null };
 }
 
 /**


### PR DESCRIPTION
Closes finding 6 of #25.

`finalizationHold` returned "N of M games are still in progress" unconditionally — no clock, no ceiling. The 48h/168h window was consulted only *after* every game reached `FINAL`, so a game that never reached it never got that far. One postponed or never-ingested game held the week forever: the cron reported a hold on every pass, the bracket never advanced, and **for weeks 14 and 17 settlement never ran**. The season ends with no champion paid.

## This is a written rule with nothing behind it

`docs/RULES.md` §10 already says what should happen — *"An NFL game is cancelled or postponed beyond the scoring window: affected players score 0 for that week. The matchup stands"* — and `DECISIONS.md` elevates it to a principle, naming Bills–Bengals 2023.

Not a bug in an implementation. A specified contingency with no code, in a system whose premise is that rules cannot be patched mid-season.

## No new rule field

`LeagueRules` feeds the canonical encoding, so a timeout field would move the golden hash and **every anchored league's on-chain `rules_hash` would stop matching** — breaking `verifyLeagueAnchor` and every member's join signature.

The rule says "beyond the scoring window", and the scoring window already exists: `finalizationHours(rules, week)` from the week's last kickoff, which this function already computed and never reached. Golden hash verified unmoved.

## "Affected players score 0" needed no code

Established by reading rather than assumed: `loadWeekStats` returns no entry for a player with no stat line, `scoreTeamLineup` defaults to an empty array, `scorePlayer` folds that to zero. "The matchup stands" is what not intervening already gives. **Ending the hold was the whole implementation.**

Inside the window an unfinished game is still reported first, because that is the state an operator can act on. Only past it does the clock win.

`ResolveWeekOutcome` gains `finalizedWithUnfinishedGames`, surfaced by the cron — `finalized: true` alone cannot distinguish a fallback from a clean finalisation, and only one is worth waking someone for.

## ⚠️ Needs a decision, and it is an interpretation rather than a derivation

A game abandoned at half-time **keeps whatever stats landed**. Read literally, "affected players score 0" would mean superseding a partial stat line — fabricating a revision in an append-only table that exists so a settled week stays auditable — and Bills–Bengals is exactly that case, where most leagues counted the real performances.

If you want literal zeroing it is a second change and it touches stat storage, not this function. Worth deciding while the rules are still editable.

Residual, documented rather than speculatively defended: the deadline is measured from `max(kickoff_at)`, which includes the postponed game, so a provider that pushes a postponed kickoff far into the future moves the window with it.

## Verification

972 tests (was 965). Four fail on the pre-fix code, verified by stashing; three guards pass both ways. Typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)