### PR TITLE
fix(web,db): refuse an unguarded cron, and name the race losers

### DIFF
--- a/apps/web/src/app/api/cron/draft-tick/route.ts
+++ b/apps/web/src/app/api/cron/draft-tick/route.ts
@@ -8,6 +8,7 @@ import {
   purgeIdleRateLimits,
 } from "@rostr/db";
 import { db } from "@/lib/db";
+import { cronForbidden } from "@/lib/cron";
 import { draftBoard } from "@/lib/draft-context";
 
 /**
@@ -42,16 +43,8 @@ export async function GET(request: Request): Promise<NextResponse> {
   // public and does the same work, so the secret was never what stood between an
   // attacker and that. If you are tempted to remove those guards, this comment
   // becomes a lie first.
-  const secret = process.env["CRON_SECRET"];
-  if (secret) {
-    const provided =
-      request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
-      new URL(request.url).searchParams.get("secret");
-
-    if (provided !== secret) {
-      return NextResponse.json({ error: "Not authorised" }, { status: 401 });
-    }
-  }
+  const forbidden = cronForbidden(request);
+  if (forbidden) return forbidden;
 
   const client = db();
   const now = new Date();

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -9,6 +9,7 @@ import {
   WeekError,
 } from "@rostr/db";
 import { db } from "@/lib/db";
+import { cronForbidden } from "@/lib/cron";
 
 /**
  * Score every active league's current week.
@@ -29,16 +30,8 @@ import { db } from "@/lib/db";
  * schedules it.
  */
 export async function GET(request: Request): Promise<NextResponse> {
-  const secret = process.env["CRON_SECRET"];
-  if (secret) {
-    const provided =
-      request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
-      new URL(request.url).searchParams.get("secret");
-
-    if (provided !== secret) {
-      return NextResponse.json({ error: "Not authorised" }, { status: 401 });
-    }
-  }
+  const forbidden = cronForbidden(request);
+  if (forbidden) return forbidden;
 
   const client = db();
   const now = new Date();

--- a/apps/web/src/app/api/cron/trades/route.ts
+++ b/apps/web/src/app/api/cron/trades/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { leaguesWithDueTrades, resolveDueTrades, TradeError } from "@rostr/db";
 import { db } from "@/lib/db";
+import { cronForbidden } from "@/lib/cron";
 
 /**
  * Settle every trade whose veto window has closed.
@@ -15,16 +16,8 @@ import { db } from "@/lib/db";
  * `ACCEPTED` state, so it is never settled twice.
  */
 export async function GET(request: Request): Promise<NextResponse> {
-  const secret = process.env["CRON_SECRET"];
-  if (secret) {
-    const provided =
-      request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
-      new URL(request.url).searchParams.get("secret");
-
-    if (provided !== secret) {
-      return NextResponse.json({ error: "Not authorised" }, { status: 401 });
-    }
-  }
+  const forbidden = cronForbidden(request);
+  if (forbidden) return forbidden;
 
   const client = db();
   const now = new Date();

--- a/apps/web/src/app/api/cron/waivers/route.ts
+++ b/apps/web/src/app/api/cron/waivers/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { leaguesDueForWaivers, processWaivers, WaiverError } from "@rostr/db";
 import { db } from "@/lib/db";
+import { cronForbidden } from "@/lib/cron";
 
 /**
  * Run every league's waivers that are due.
@@ -13,16 +14,8 @@ import { db } from "@/lib/db";
  * is skipped, and a processed claim is never processed twice.
  */
 export async function GET(request: Request): Promise<NextResponse> {
-  const secret = process.env["CRON_SECRET"];
-  if (secret) {
-    const provided =
-      request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
-      new URL(request.url).searchParams.get("secret");
-
-    if (provided !== secret) {
-      return NextResponse.json({ error: "Not authorised" }, { status: 401 });
-    }
-  }
+  const forbidden = cronForbidden(request);
+  if (forbidden) return forbidden;
 
   const client = db();
   const now = new Date();

--- a/apps/web/src/lib/cron.ts
+++ b/apps/web/src/lib/cron.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+
+/**
+ * The shared guard on the four cron routes.
+ *
+ * Extracted because it was four identical copies, and a guard that exists four
+ * times is a guard that will be tightened three times.
+ *
+ * ## What it is actually for
+ *
+ * Not much, and that is worth saying plainly rather than letting the word
+ * "secret" imply otherwise. These endpoints only do what the clock already
+ * permits: `catchUpExpiredPicks` is deterministic and stamped at the missed
+ * deadline, scoring is idempotent and rewrites the same numbers, and
+ * `finalizationHold` decides finalisation independently of who asked. An
+ * unauthorised call cannot produce a wrong pick, a wrong score, or an early
+ * settlement. **The guard is about database load**, and about not handing
+ * anonymous callers a lever on every league at once.
+ *
+ * ## Why it refuses when the secret is missing in production
+ *
+ * It used to run wide open — `if (secret)` and no `else`. That reads as a
+ * convenience for local development and behaves as a silent misconfiguration in
+ * production: forget the variable on a deploy and every cron route is public,
+ * with nothing anywhere saying so. A missing secret is not evidence that no
+ * secret was wanted.
+ *
+ * So: open when unset in development, refused when unset in production. That is
+ * the same shape as the creation route's `FEE_RECIPIENT` check, and for the same
+ * reason — better to fail loudly at the boundary than to run in a state nobody
+ * chose.
+ */
+export function cronForbidden(request: Request): NextResponse | null {
+  const secret = process.env["CRON_SECRET"];
+
+  if (!secret) {
+    if (process.env.NODE_ENV !== "production") return null;
+
+    return NextResponse.json(
+      {
+        error:
+          "CRON_SECRET is not set, so this endpoint refuses rather than running " +
+          "unauthenticated. Set it on the deployment; Vercel sends it as a bearer token.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const provided =
+    request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
+    new URL(request.url).searchParams.get("secret");
+
+  if (provided === null || !sameSecret(provided, secret)) {
+    return NextResponse.json({ error: "Not authorised" }, { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * Constant-time comparison.
+ *
+ * `timingSafeEqual` requires equal lengths — and would otherwise leak the
+ * secret's length by throwing — so both sides are hashed first. Hashing is what
+ * makes the comparison safe to perform at all, not an extra precaution on top
+ * of it.
+ *
+ * Honestly: a remote timing attack on a string compare across HTTP is not a
+ * realistic recovery channel, and this is not the part of the change that
+ * matters. It is here because it costs two lines and removes the question.
+ */
+function sameSecret(provided: string, expected: string): boolean {
+  const a = createHash("sha256").update(provided).digest();
+  const b = createHash("sha256").update(expected).digest();
+
+  return timingSafeEqual(a, b);
+}

--- a/packages/db/src/identity.test.ts
+++ b/packages/db/src/identity.test.ts
@@ -183,4 +183,27 @@ describe("linkWallet", () => {
       (e: unknown) => e instanceof IdentityError && e.code === "INVALID_WALLET",
     );
   });
+
+  it("says WALLET_TAKEN when the unique index refuses, not just when the check does", async () => {
+    // The claimed-check runs on its own, outside any transaction, so two tabs
+    // linking one address can both pass it. The index then refuses the loser —
+    // the right outcome reported as an unhandled 500, because the caller only
+    // maps `IdentityError`.
+    //
+    // The race cannot be staged on single-connection PGlite, so the row is
+    // inserted directly: the check does not see it in the shape it looks for,
+    // and the statement below is the one that has to answer.
+    const client = await fresh();
+    const alice = await createUser(client, "a@example.com", "Alice");
+    const bob = await createUser(client, "b@example.com", "Bob");
+
+    await client.query(
+      "INSERT INTO wallets (user_id, address, is_primary) VALUES ($1, $2, true)",
+      [alice.id, address(1)],
+    );
+
+    await expect(linkWallet(client, bob.id, address(1))).rejects.toSatisfy(
+      (e: unknown) => e instanceof IdentityError && e.code === "WALLET_TAKEN",
+    );
+  });
 });

--- a/packages/db/src/identity.ts
+++ b/packages/db/src/identity.ts
@@ -9,6 +9,7 @@
 import { randomBytes } from "node:crypto";
 import { isValidWalletAddress, sha256Hex } from "@rostr/core";
 import type { SqlClient } from "./client.js";
+import { isUniqueViolation } from "./pg-errors.js";
 
 export class IdentityError extends Error {
   constructor(
@@ -238,12 +239,25 @@ export async function linkWallet(
   );
   const isFirst = Number(count?.n ?? 0) === 0;
 
-  const [row] = await db.query<{ id: string; address: string; is_primary: boolean }>(
-    `INSERT INTO wallets (user_id, address, is_primary)
-     VALUES ($1, $2, $3)
-     RETURNING id, address, is_primary`,
-    [userId, address, isFirst],
-  );
+  // The claimed-check above ran on its own, outside any transaction, so two tabs
+  // linking the same address can both pass it. `UNIQUE (chain, address)` refuses
+  // the loser — which is the right outcome and the wrong error, because the
+  // reason is the one this function already has a name for.
+  let row: { id: string; address: string; is_primary: boolean } | undefined;
+  try {
+    [row] = await db.query<{ id: string; address: string; is_primary: boolean }>(
+      `INSERT INTO wallets (user_id, address, is_primary)
+       VALUES ($1, $2, $3)
+       RETURNING id, address, is_primary`,
+      [userId, address, isFirst],
+    );
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new IdentityError("Wallet is already linked to another account", "WALLET_TAKEN");
+    }
+    throw error;
+  }
+
   return { id: row!.id, address: row!.address, isPrimary: row!.is_primary };
 }
 

--- a/packages/db/src/membership.test.ts
+++ b/packages/db/src/membership.test.ts
@@ -312,6 +312,34 @@ describe("joinLeague", () => {
     ).rejects.toSatisfy((e: unknown) => e instanceof JoinError && e.code === "LEAGUE_FULL");
   });
 
+  it("says LEAGUE_FULL when the slot index refuses, not just when the count does", async () => {
+    // The count and the insert are not atomic against each other, so two people
+    // clicking Join on the last seat both read the same `taken` and both derive
+    // the same slot. `UNIQUE (league_id, slot)` refuses the loser — correctly,
+    // and previously as an unhandled 500, because the route maps only `JoinError`.
+    //
+    // The race cannot be staged on single-connection PGlite. One team present
+    // makes `taken` 1, so the join derives slot 2 — occupying exactly that slot
+    // puts the insert in the state the loser of a real race reaches.
+    const fx = await setup();
+    const m = await member(fx, 1, "a@example.com");
+
+    await fx.client.query(
+      "INSERT INTO teams (league_id, owner_id, is_bot, name, slot) VALUES ($1, NULL, true, $2, 2)",
+      [fx.leagueId, "Squatter"],
+    );
+
+    await expect(
+      joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "A",
+      }),
+    ).rejects.toSatisfy((e: unknown) => e instanceof JoinError && e.code === "LEAGUE_FULL");
+  });
+
   it("records the signature as a permanent proof of consent", async () => {
     const fx = await setup();
     const m = await member(fx, 1, "a@example.com");

--- a/packages/db/src/membership.ts
+++ b/packages/db/src/membership.ts
@@ -11,6 +11,7 @@
 import { buildJoinMessage, isValidWalletAddress, verifyJoinSignature } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getChainState, getLeagueRules } from "./leagues.js";
+import { isUniqueViolation } from "./pg-errors.js";
 import { withTransaction } from "./transaction.js";
 
 export interface JoinLeagueInput {
@@ -196,12 +197,30 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
     const taken = Number(count?.taken ?? 0);
     if (taken >= maxTeams) throw new JoinError("League is full", "LEAGUE_FULL");
 
-    const [team] = await tx.query<{ id: string; slot: number }>(
-      `INSERT INTO teams (league_id, owner_id, is_bot, name, slot)
-       VALUES ($1, $2, false, $3, $4)
-       RETURNING id, slot`,
-      [league.id, input.userId, input.teamName, taken + 1],
-    );
+    // Two people clicking Join on the last seat both read the same `taken` and
+    // both compute the same slot, so `UNIQUE (league_id, slot)` arbitrates and
+    // the loser is refused. That is why the count above cannot admit an extra
+    // member even without a lock — the collision is on the value derived from
+    // the stale read, not on the read itself.
+    //
+    // Translated rather than left to escape: losing that race means the league
+    // filled up, which is `LEAGUE_FULL` and a 409, not a 500. The wrap is around
+    // this one statement so no other uniqueness in the transaction can be
+    // relabelled as a full league.
+    let team: { id: string; slot: number } | undefined;
+    try {
+      [team] = await tx.query<{ id: string; slot: number }>(
+        `INSERT INTO teams (league_id, owner_id, is_bot, name, slot)
+         VALUES ($1, $2, false, $3, $4)
+         RETURNING id, slot`,
+        [league.id, input.userId, input.teamName, taken + 1],
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new JoinError("League is full", "LEAGUE_FULL");
+      }
+      throw error;
+    }
 
     const [membership] = await tx.query<{ id: string }>(
       `INSERT INTO league_memberships (league_id, user_id, team_id, wallet_id, rules_hash, signature)


### PR DESCRIPTION
Closes findings 1 and 3 of #25.

## ⚠️ Merge order

**Stacked on `fix/25-league-scoped-roster` (#56)** for `isUniqueViolation`, which that branch introduces. It will not apply first. Full order: `main` → #39 → #56 → this.

## The cron guard ran open when CRON_SECRET was unset

All four routes, `if (secret)` with no else. That reads as a convenience for local development and behaves as a **silent misconfiguration in production**: forget the variable on a deploy and every cron endpoint is public, with nothing anywhere saying so. A missing secret is not evidence that no secret was wanted.

Now open when unset in development, refused with a 503 when unset in production — the same shape as the creation route's `FEE_RECIPIENT` check.

Extracted to one helper rather than fixed four times. **A guard that exists in four copies is a guard that gets tightened in three of them.**

The compare is constant-time, and that is the part worth *not* overselling: a remote timing attack on a string compare across HTTP is not a realistic recovery channel. It costs two lines and removes the question. What these endpoints actually protect is database load — they only do what the clock already permits, so an unauthorised call cannot produce a wrong pick, a wrong score, or an early settlement. The docstring says so rather than letting the word "secret" imply otherwise.

## The losers of two races got a 500 where a coded error already existed

`joinLeague` counts teams and then inserts, so two people clicking Join on the last seat both read the same count and both derive the same slot; `UNIQUE (league_id, slot)` refuses one. That is also why the count cannot admit an extra member without a lock — the collision is on the value derived from the stale read, not on the read itself.

`linkWallet` is the same shape against `UNIQUE (chain, address)`, and does not even open a transaction.

Both now translate the violation to the error they already had — `LEAGUE_FULL` and `WALLET_TAKEN`, both already mapped to 409 by their routes. Each wrap is around the single statement whose uniqueness is meant, so no other constraint in the transaction can be relabelled as contention.

**Integrity was never at risk here and this does not claim otherwise** — it is the difference between a correct refusal and a crash.

## Verification

974 tests (was 965; +6 from #56, +2 here). Neither race can be staged on single-connection PGlite, so the tests do not pretend to: they put the insert in exactly the state the loser of a real race reaches — the derived slot already occupied, the address already present — and assert the error. Nothing else about a race is asserted.

The cron helper is untested; there are no route tests anywhere in `apps/web`.

Typecheck, lint, format and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)