### PR TITLE
test(web): run the tests in apps/web, which were never collected

### DIFF
--- a/apps/web/src/lib/session.test.ts
+++ b/apps/web/src/lib/session.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { safeRedirect } from "./session.js";
+
+/**
+ * `safeRedirect` had no test until `apps/web` was added to the test run.
+ *
+ * It is the guard on `?next=` for the emailed sign-in link, so the thing it
+ * prevents is a freshly-authenticated user landing on somebody else's site
+ * straight from a link in their inbox — the shape of a convincing phish.
+ *
+ * It has already been wrong once. The first version checked prefixes, and the
+ * URL parser strips tabs, newlines and carriage returns *before* parsing, so
+ * `/\t/evil.example` passed the checks and then resolved to `//evil.example`.
+ * That is the case a prefix blocklist cannot cover and why the loop rejects
+ * every control character rather than a list of known-bad starts.
+ *
+ * A function with that history and no test is the argument for collecting this
+ * directory at all.
+ */
+describe("safeRedirect", () => {
+  it("keeps an ordinary same-site path", () => {
+    expect(safeRedirect("/leagues/abc")).toBe("/leagues/abc");
+    expect(safeRedirect("/")).toBe("/");
+  });
+
+  it("keeps a query string and a fragment", () => {
+    // These are the reason it returns the path rather than rebuilding it: a
+    // sign-in link that drops the user on the right page but loses their filter
+    // is a worse experience than the redirect existing at all.
+    expect(safeRedirect("/leagues/abc?week=3")).toBe("/leagues/abc?week=3");
+    expect(safeRedirect("/players#waivers")).toBe("/players#waivers");
+  });
+
+  it("falls back home for nothing at all", () => {
+    expect(safeRedirect(null)).toBe("/");
+    expect(safeRedirect("")).toBe("/");
+  });
+
+  it("refuses an absolute URL", () => {
+    for (const hostile of [
+      "https://evil.example",
+      "http://evil.example/leagues",
+      "javascript:alert(1)",
+      "data:text/html,<script>",
+    ]) {
+      expect(safeRedirect(hostile), hostile).toBe("/");
+    }
+  });
+
+  it("refuses a protocol-relative URL", () => {
+    // `//host` and `/\host` have no scheme but browsers treat them as absolute,
+    // so they leave the site while looking like a path.
+    expect(safeRedirect("//evil.example")).toBe("/");
+    expect(safeRedirect("//evil.example/leagues")).toBe("/");
+    expect(safeRedirect("/\\evil.example")).toBe("/");
+    expect(safeRedirect("/\\\\evil.example")).toBe("/");
+  });
+
+  it("refuses a control character anywhere in the path", () => {
+    // The regression. The parser strips these before parsing, so each of these
+    // becomes `//evil.example` by the time a browser resolves it — and none of
+    // them starts with a prefix a blocklist would catch.
+    for (const code of [0x00, 0x09, 0x0a, 0x0d, 0x1f, 0x7f]) {
+      const hostile = `/${String.fromCharCode(code)}/evil.example`;
+      expect(safeRedirect(hostile), `U+${code.toString(16).padStart(4, "0")}`).toBe("/");
+    }
+  });
+
+  it("refuses a backslash even mid-path", () => {
+    // Backslash is a path separator to some parsers and not others, which is
+    // exactly the disagreement an attacker wants.
+    expect(safeRedirect("/leagues\\@evil.example")).toBe("/");
+    expect(safeRedirect("/leagues/\\/evil.example")).toBe("/");
+  });
+
+  it("refuses anything not starting with a slash", () => {
+    // A bare host is a relative path to us and an absolute one to a browser
+    // following a `Location` header.
+    expect(safeRedirect("evil.example")).toBe("/");
+    expect(safeRedirect("leagues/abc")).toBe("/");
+  });
+});

--- a/test-stubs/server-only.ts
+++ b/test-stubs/server-only.ts
@@ -1,0 +1,18 @@
+/**
+ * A stand-in for Next's `server-only` marker, for the test runner.
+ *
+ * `import "server-only"` is a build-time assertion, not a runtime import: Next's
+ * bundler resolves it to a module that throws if it is ever pulled into a client
+ * bundle, which is how `db.ts`, `session.ts` and the rest guarantee they never
+ * reach a browser. Outside Next there is nothing to resolve — the package is not
+ * even a declared dependency, it arrives transitively — so vitest cannot load
+ * any file that imports it.
+ *
+ * Stubbed rather than removed from those files. The marker is doing real work in
+ * the build; it is only the test runner that has no bundler to satisfy it, and
+ * weakening a production guarantee to make a test run is the wrong direction.
+ *
+ * Deliberately empty. Anything here would be pretending to be a bundler.
+ */
+
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,24 +1,67 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-const src = (pkg: string): string =>
-  fileURLToPath(new URL(`./packages/${pkg}/src/index.ts`, import.meta.url));
+const pkgFile = (pkg: string, file: string): string =>
+  fileURLToPath(new URL(`./packages/${pkg}/src/${file}`, import.meta.url));
+
+const src = (pkg: string): string => pkgFile(pkg, "index.ts");
 
 export default defineConfig({
   resolve: {
     // Resolve workspace packages to source rather than dist. Tests then never
     // depend on build order, and a stale dist cannot produce a passing or
     // failing run that disagrees with the code in front of you.
-    alias: {
-      "@rostr/core": src("core"),
-      "@rostr/db": src("db"),
-      "@rostr/escrow": src("escrow"),
-      "@rostr/pinning": src("pinning"),
-      "@rostr/stats": src("stats"),
-    },
+    // The array form, not the object one: object keys match exactly, and two of
+    // these need to match a prefix.
+    alias: [
+      // Subpath exports, before the bare name. `@rostr/db` is an exact match and
+      // would not cover `@rostr/db/postgres`, which would then fall through to
+      // node resolution and load `dist` — the stale-build problem these aliases
+      // exist to remove, reappearing only for the subpaths.
+      { find: "@rostr/db/postgres", replacement: pkgFile("db", "postgres.ts") },
+      { find: "@rostr/db/migrate", replacement: pkgFile("db", "migrate.ts") },
+
+      { find: "@rostr/core", replacement: src("core") },
+      { find: "@rostr/db", replacement: src("db") },
+      { find: "@rostr/escrow", replacement: src("escrow") },
+      { find: "@rostr/pinning", replacement: src("pinning") },
+      { find: "@rostr/stats", replacement: src("stats") },
+
+      // The web app's own path alias, mirroring `apps/web/tsconfig.json`. A
+      // route test importing `./route.js` pulls in `@/lib/db` transitively, so
+      // without this the file cannot even be collected, let alone skipped.
+      {
+        find: /^@\/(.*)$/,
+        replacement: `${fileURLToPath(new URL("./apps/web/src/", import.meta.url))}$1`,
+      },
+
+      // See the stub for why this is a stub rather than a change to the five
+      // files that import it.
+      {
+        find: "server-only",
+        replacement: fileURLToPath(new URL("./test-stubs/server-only.ts", import.meta.url)),
+      },
+    ],
   },
   test: {
-    include: ["packages/*/src/**/*.test.ts"],
+    /**
+     * `apps/web` is included, and it was not.
+     *
+     * `apps/web/src/app/api/cron/score-week/route.test.ts` was written to prove
+     * that one league's failure cannot stop the others scoring — a guard that
+     * had already shipped once in a shape that did not hold. Its own docstring
+     * says `apps/web` had no test project "so the guard was argued about rather
+     * than run". It then sat outside this pattern and was never collected, so it
+     * went on being argued about.
+     *
+     * A test that exists and never runs is worse than no test: it reads as
+     * coverage in a diff and in a review, and it is not.
+     *
+     * Most of what it needs is a real Postgres, so it is `skipIf(!DATABASE_URL)`
+     * and still skips here. That is the point — skipped is a state you can see,
+     * and on a machine with the variable set it now actually runs.
+     */
+    include: ["packages/*/src/**/*.test.ts", "apps/web/src/**/*.test.ts"],
     coverage: {
       provider: "v8",
       include: ["packages/*/src/**/*.ts"],


### PR DESCRIPTION
`vitest.config.ts` collected `packages/*/src/**/*.test.ts` only. `apps/web/src/app/api/cron/score-week/route.test.ts` sits outside that pattern and **has never run**.

That file exists to prove one league's failure cannot stop the others scoring — a guard that had already shipped once in a shape that did not hold. Its own docstring says `apps/web` had no test project *"so the guard was argued about rather than run"*. It then went on being argued about, because nothing collected it.

**A test that exists and never runs is worse than no test:** it reads as coverage in a diff and in a review, and it is not.

## Three things were in the way

- **`@rostr/db/postgres` is a subpath export** and the aliases were exact-match objects, so it fell through to node resolution and loaded `dist` — the stale-build problem the aliases exist to remove, surviving for the subpaths. Switched to the array form, subpaths first, which also gives `@/` the prefix match it needs.
- **`server-only` is a Next build-time marker** with no runtime module, and is not a declared dependency — it arrives transitively. Stubbed rather than removed from the five files that import it: the marker does real work in the build, and weakening a production guarantee so a test runs is the wrong direction.
- The route test needs a real Postgres and stays `skipIf(!DATABASE_URL)`. It now **skips visibly** instead of not existing, and runs where the variable is set.

## And a test that needs nothing

`safeRedirect` guards `?next=` on the emailed sign-in link, so what it prevents is a freshly-authenticated user landing on somebody else's site straight from their inbox. It had no test.

**It has already been wrong once.** The first version checked prefixes, and the URL parser strips tabs and newlines *before* parsing, so `/\t/evil.example` passed and then resolved to `//evil.example`. Fixed and merged as #12 — with no test.

Verified by mutation: removing the control-character loop fails exactly the two tests covering that bypass.

## Verification

973 tests + 2 skipped (was 965). Typecheck, lint, format clean. No conflict with the other open branches — this touches `vitest.config.ts`, one new stub, and one new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)