### PR TITLE
feat(web): enforce league.visibility on every read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -920,6 +920,49 @@ stayed FORMING forever — still accepting members, and invisible to every job t
 live leagues. The enum is FORMING / DRAFTING / IN_SEASON / PLAYOFFS / SETTLED / DISSOLVED;
 an invented value is not a no-op, Postgres fails the cast and the query errors.
 
+### A private league is now actually private
+
+`apps/web/src/lib/visibility.ts` and `league-read.ts`.
+
+`league.visibility` sits in the **frozen, hashed, member-signed** rule set and until
+2026-08-11 was **read back nowhere** — written to the `leagues` row at creation and never
+consulted again; every other occurrence in the repo was a test. That is the same defect
+`botsAllowed` was removed for: a guarantee members signed that did nothing. A rule set
+saying PRIVATE while the standings, the draft board and every team's bench were readable
+by anyone holding a URL was making a promise the code did not keep — and the URL is not a
+secret, it is in browser history, in screenshots, and in whatever chat the invite was
+pasted into.
+
+**Read from the frozen rules, not `leagues.visibility`.** The column is a denormalised
+copy written at creation. Members signed the document, so the document decides, and a
+future bug in that write cannot quietly open a private league. There is a test that
+rewrites the column and asserts the answer does not move.
+
+**404, never 403.** A 403 confirms the league exists, which is the one fact an unguessable
+id protects. Pages call `notFound()` for the same reason — a "this league is private"
+screen is a disclosure.
+
+**Both layers are gated, and only doing one would have been cosmetic.** The `standings`,
+`matchup` and `bracket` **pages query the database directly** while their components fetch
+the API, so gating routes alone leaves the server-rendered half wide open, and gating pages
+alone leaves the API open to anyone with `curl`.
+
+**Two files stay open on purpose** and are named in `league-read.test.ts` with reasons:
+`/leagues/[id]` and `api/leagues/[id]/join`. `RULES.md` requires the full rule set to be
+shown before anyone joins, and an invitee is by definition not yet a member — gating the
+entrance would make "shown before you join" unsatisfiable for exactly the private leagues
+invite links exist for. What is gated is everything reporting how the league is _going_.
+
+**PUBLIC leagues are not gated at all.** `/api/leagues` already publishes their ids, and
+being findable is what public means.
+
+`league-read.test.ts` sweeps every file under `api/leagues/[id]/` and `leagues/[id]/` and
+fails a new one that gates nothing. It went unenforced for months not because anyone
+decided reads were open but because nothing was obliged to ask. **Its `GATES` match the
+refusal, not the identifier** — three routes mention `context.myTeamId` only to label the
+response, and matching the bare name certified them as gated when they were not, which is
+the exact shape of bug the file is named after.
+
 ### The scoreboard
 
 `packages/db/src/matchup.ts`, `/api/leagues/[id]/matchup`, `Scoreboard.tsx` on

--- a/apps/web/src/app/api/leagues/[id]/draft/board/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/board/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { leagueReadForbidden } from "@/lib/league-read";
 import { draftBoard, draftContext, DraftContextError } from "@/lib/draft-context";
 
 /**
@@ -13,6 +14,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
+
+  // `visibility` is a frozen, member-signed rule. See `lib/visibility.ts`.
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
 
   try {
     const context = await draftContext(id);

--- a/apps/web/src/app/api/leagues/[id]/draft/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@rostr/db";
 import { teamOnClock, totalPicks } from "@rostr/core";
 import { db } from "@/lib/db";
+import { leagueReadForbidden } from "@/lib/league-read";
 import { draftBoard, draftContext, DraftContextError } from "@/lib/draft-context";
 
 /** The team picking after `pickNumber`, or `null` if that is the last pick. */
@@ -53,6 +54,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
+
+  // `visibility` is a frozen, member-signed rule. See `lib/visibility.ts`.
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
 
   try {
     const context = await draftContext(id);

--- a/apps/web/src/app/api/leagues/[id]/matchup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/matchup/route.ts
@@ -3,6 +3,7 @@ import { NFL } from "@rostr/core";
 import { currentWeek, loadWeekMatchups, MatchupError } from "@rostr/db";
 import type { MatchupSide } from "@rostr/db";
 import { db } from "@/lib/db";
+import { leagueReadForbidden } from "@/lib/league-read";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
 
 /**
@@ -52,6 +53,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
+
+  // `visibility` is a frozen, member-signed rule. See `lib/visibility.ts`.
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
 
   try {
     const context = await draftContext(id);

--- a/apps/web/src/app/api/leagues/[id]/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from "next/server";
 import { getLeagueRules } from "@rostr/db";
 import { db } from "@/lib/db";
+import { leagueReadForbidden } from "@/lib/league-read";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
+
+  // `visibility` is a frozen, member-signed rule. See `lib/visibility.ts`.
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
   const client = db();
 
   const [league] = await client.query<{

--- a/apps/web/src/app/api/leagues/[id]/standings/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/standings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { computeStandings, consolationField, playoffField } from "@rostr/core";
 import { loadWeekResults } from "@rostr/db";
 import { db } from "@/lib/db";
+import { leagueReadForbidden } from "@/lib/league-read";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
 
 /**
@@ -16,6 +17,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
+
+  // `visibility` is a frozen, member-signed rule. See `lib/visibility.ts`.
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
 
   try {
     const context = await draftContext(id);

--- a/apps/web/src/app/leagues/[id]/bracket/page.tsx
+++ b/apps/web/src/app/leagues/[id]/bracket/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { getLeagueRules, loadWeekResults, playoffState } from "@rostr/db";
 import type { BracketGame, BracketRound } from "@rostr/core";
 import { db } from "@/lib/db";
@@ -25,6 +26,11 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();

--- a/apps/web/src/app/leagues/[id]/draft/page.tsx
+++ b/apps/web/src/app/leagues/[id]/draft/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { DraftRoom } from "@/components/DraftRoom";
 import { db } from "@/lib/db";
 
@@ -10,6 +11,11 @@ export default async function DraftPage({ params }: { params: Promise<{ id: stri
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/app/leagues/[id]/lineup/page.tsx
+++ b/apps/web/src/app/leagues/[id]/lineup/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { LineupEditor } from "@/components/LineupEditor";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
@@ -18,6 +19,11 @@ export default async function LineupPage({
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const user = await currentUser();
   const parsed = Number.parseInt(week ?? "1", 10);

--- a/apps/web/src/app/leagues/[id]/matchup/page.tsx
+++ b/apps/web/src/app/leagues/[id]/matchup/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { getLeagueRules } from "@rostr/db";
 import { Scoreboard } from "@/components/Scoreboard";
 import { db } from "@/lib/db";
@@ -13,6 +14,11 @@ export default async function MatchupPage({ params }: { params: Promise<{ id: st
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();

--- a/apps/web/src/app/leagues/[id]/players/page.tsx
+++ b/apps/web/src/app/leagues/[id]/players/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { getLeagueRules, nextWaiverRun } from "@rostr/db";
 import { PlayerMarket } from "@/components/PlayerMarket";
 import { db } from "@/lib/db";
@@ -13,6 +14,11 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();

--- a/apps/web/src/app/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/leagues/[id]/standings/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { computeStandings, consolationField, playoffField } from "@rostr/core";
 import type { StandingsRow } from "@rostr/core";
 import { getLeagueRules, loadWeekResults, teamForUser } from "@rostr/db";
@@ -29,6 +30,11 @@ export default async function StandingsPage({ params }: { params: Promise<{ id: 
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();

--- a/apps/web/src/app/leagues/[id]/trades/page.tsx
+++ b/apps/web/src/app/leagues/[id]/trades/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { leagueReadAccess } from "@/lib/visibility";
 import { getLeagueRules } from "@rostr/db";
 import { TradeBlock } from "@/components/TradeBlock";
 import { db } from "@/lib/db";
@@ -13,6 +14,11 @@ export default async function TradesPage({ params }: { params: Promise<{ id: str
     [id],
   );
   if (!league) notFound();
+
+  // A private league reports nothing about how it is going to a non-member.
+  // `notFound` rather than a notice: a "this league is private" page confirms
+  // the league exists, which is the fact an unguessable id is protecting.
+  if (!(await leagueReadAccess(id)).ok) notFound();
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();

--- a/apps/web/src/lib/league-read.test.ts
+++ b/apps/web/src/lib/league-read.test.ts
@@ -1,0 +1,107 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every league-scoped route and page is gated, and this is what says so.
+ *
+ * `visibility` went unenforced for months not because anyone decided reads were
+ * open, but because nothing ever asked the question — a route was added, it
+ * loaded a league by id, and no step in review was obliged to notice. So the
+ * check is mechanical: a new file under `api/leagues/[id]/` or `leagues/[id]/`
+ * fails this test until it either gates or is named below with a reason.
+ *
+ * **This proves a call exists, not that it runs on every path.** It is a
+ * tripwire against the omission, not a substitute for reading the handler — the
+ * behaviour is tested in `visibility.test.ts`. Its value is that omission is the
+ * failure mode that actually happened.
+ */
+
+const APP = fileURLToPath(new URL("../app/", import.meta.url));
+
+/**
+ * Any one of these means the file **refuses** somebody.
+ *
+ * Membership and commissionership are *stronger* than the visibility gate — a
+ * handler that already turns non-members away turns away every stranger a
+ * private league would have — so they satisfy this too. `leagueReadAccess` is
+ * the loosest of the four and the only one PUBLIC leagues pass.
+ *
+ * **These match the refusal, not the identifier**, and the difference is the
+ * whole point. Three routes mention `context.myTeamId` merely to label the
+ * response with which team is yours, and matching the bare name marked them
+ * gated when they were not — a check that looks like it asks who is asking and
+ * then does nothing with the answer, which is precisely the defect this file
+ * exists to catch. A test with that hole in it would have been worse than none:
+ * it would have certified the exact shape of bug it is named after.
+ */
+const GATES = [
+  /leagueReadForbidden\(/,
+  /leagueReadAccess\(/,
+  /if \(!\w+\.myTeamId\)/,
+  /if \(!\w+\.isCommissioner\)/,
+];
+
+/**
+ * Deliberately open, each for a reason that is in `RULES.md` rather than in
+ * somebody's head.
+ *
+ * Both are the *entrance*. `CLAUDE.md` and `RULES.md` require the full rule set
+ * to be shown before anyone joins, and an invitee is by definition not yet a
+ * member — gating these would make "shown before you join" unsatisfiable for
+ * exactly the private leagues that invite links exist for.
+ */
+const OPEN: Record<string, string> = {
+  "api/leagues/[id]/join/route.ts":
+    "the join flow itself; rules must be readable before joining",
+  "leagues/[id]/page.tsx": "the league page renders the rules a prospective member signs",
+};
+
+function filesUnder(dir: string, name: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) found.push(...filesUnder(path, name));
+    else if (entry === name) found.push(path);
+  }
+  return found;
+}
+
+const leagueScoped = [
+  ...filesUnder(join(APP, "api/leagues/[id]"), "route.ts"),
+  ...filesUnder(join(APP, "leagues/[id]"), "page.tsx"),
+].map((path) => relative(APP, path).replaceAll("\\", "/"));
+
+describe("league-scoped routes and pages are gated", () => {
+  it("finds the files at all", () => {
+    // Without this, a moved directory turns the sweep below into zero
+    // assertions that pass. The count is a floor, not an exact match, so adding
+    // a route does not fail here — it fails in the sweep, which is the useful
+    // message.
+    expect(leagueScoped.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it.each(leagueScoped)("%s", (path) => {
+    if (path in OPEN) return;
+
+    const source = readFileSync(join(APP, path), "utf8");
+    const gate = GATES.find((g) => g.test(source));
+
+    expect(
+      gate,
+      `${path} reads a league by id and asks nobody who is looking. Call ` +
+        `leagueReadForbidden (routes) or leagueReadAccess (pages), or require ` +
+        `membership — or add it to OPEN with a reason.`,
+    ).toBeDefined();
+  });
+
+  it("has a reason recorded for every open file, and no stale entries", () => {
+    // A file deleted or renamed must not leave a permanent hole behind that the
+    // next file at that path silently inherits.
+    for (const [path, reason] of Object.entries(OPEN)) {
+      expect(leagueScoped, `${path} is in OPEN but does not exist`).toContain(path);
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+});

--- a/apps/web/src/lib/league-read.ts
+++ b/apps/web/src/lib/league-read.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import { leagueReadAccess } from "./visibility";
+
+/**
+ * The API half of the visibility gate.
+ *
+ * Returns a response to send, or `null` to carry on. Split from
+ * `leagueReadAccess` so a server component can ask the same question and answer
+ * it its own way — a page renders a notice, a route returns a status, and
+ * neither should have to know about the other's return type.
+ *
+ * **404 for a private league, not 403.** A 403 confirms the league exists, which
+ * is the one fact an unguessable id is protecting. The distinction costs nothing
+ * to a member, who never sees either.
+ */
+export async function leagueReadForbidden(leagueId: string): Promise<NextResponse | null> {
+  const access = await leagueReadAccess(leagueId);
+  if (access.ok) return null;
+
+  return NextResponse.json({ error: "League not found" }, { status: 404 });
+}

--- a/apps/web/src/lib/visibility.test.ts
+++ b/apps/web/src/lib/visibility.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildNflPprRules, NFL } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import { addTestTeam, createTestDatabase } from "@rostr/db/testing";
+import type { PGliteClient } from "@rostr/db/testing";
+import { createLeague, createUser } from "@rostr/db";
+
+/**
+ * `visibility` is a frozen, member-signed rule, and until this it was enforced
+ * nowhere — written to the `leagues` row at creation and never read back.
+ *
+ * These drive `leagueReadAccess` against a real database with the session
+ * mocked, because the question it answers is entirely "who is asking, and what
+ * did this league's members sign". The routes and pages are thin over it.
+ */
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: 1_756_400_000,
+};
+
+let db: PGliteClient | undefined;
+let viewer: { id: string } | null = null;
+
+vi.mock("./db", () => ({ db: () => db! }));
+vi.mock("./session", () => ({ currentUser: () => Promise.resolve(viewer) }));
+
+const { leagueReadAccess } = await import("./visibility.js");
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+  viewer = null;
+});
+
+async function league(visibility: "PRIVATE" | "PUBLIC"): Promise<string> {
+  db = await createTestDatabase();
+  const { seedSport } = await import("@rostr/db");
+  await seedSport(db, NFL);
+
+  const commissioner = await createUser(db, "commish@example.com", "Commish");
+  const rules = buildNflPprRules({
+    seasonYear: 2026,
+    draft: DRAFT,
+    league: { visibility },
+  }) as LeagueRules;
+
+  const created = await createLeague(db, NFL, {
+    name: "Test League",
+    commissionerId: commissioner.id,
+    rules,
+  });
+  return created.id;
+}
+
+describe("leagueReadAccess", () => {
+  it("lets anyone read a public league", async () => {
+    // Being findable is what public means, and `/api/leagues` already publishes
+    // these ids.
+    const id = await league("PUBLIC");
+    expect(await leagueReadAccess(id)).toEqual({ ok: true, isMember: false });
+  });
+
+  it("refuses a private league to a signed-out stranger", async () => {
+    const id = await league("PRIVATE");
+    expect(await leagueReadAccess(id)).toEqual({ ok: false, reason: "PRIVATE" });
+  });
+
+  it("refuses a private league to a signed-in non-member", async () => {
+    // Having an account is not membership. The link is not the capability.
+    const id = await league("PRIVATE");
+    const stranger = await createUser(db!, "stranger@example.com", "Stranger");
+    viewer = { id: stranger.id };
+
+    expect(await leagueReadAccess(id)).toEqual({ ok: false, reason: "PRIVATE" });
+  });
+
+  it("lets a member read their own private league", async () => {
+    const id = await league("PRIVATE");
+    const member = await addTestTeam(db!, id, "Member");
+    viewer = { id: member.userId };
+
+    expect(await leagueReadAccess(id)).toEqual({ ok: true, isMember: true });
+  });
+
+  it("reports a league that does not exist as not found, not as private", async () => {
+    // Distinct reasons because the caller answers them the same way — a 404 —
+    // and would otherwise have no way to tell a typo'd id from a refusal.
+    await league("PUBLIC");
+    expect(await leagueReadAccess("00000000-0000-4000-8000-000000000000")).toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("reads the frozen rules, not the denormalised column", async () => {
+    // The column is a copy written at creation. Members signed the document, so
+    // the document decides — and a future bug in that write must not be able to
+    // quietly open a private league.
+    const id = await league("PRIVATE");
+    await db!.query("UPDATE leagues SET visibility = 'PUBLIC' WHERE id = $1", [id]);
+
+    expect(await leagueReadAccess(id)).toEqual({ ok: false, reason: "PRIVATE" });
+  });
+});

--- a/apps/web/src/lib/visibility.ts
+++ b/apps/web/src/lib/visibility.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import { getLeagueRules, teamForUser } from "@rostr/db";
+import { db } from "./db";
+import { currentUser } from "./session";
+
+/**
+ * Whether this viewer may read this league.
+ *
+ * `league.visibility` is part of the **frozen, hashed, member-signed** rule set
+ * (`packages/core/src/rules/types.ts`), and until now nothing read it back. It
+ * was written to the `leagues` row at creation and never consulted again — every
+ * other occurrence in the repo is a test.
+ *
+ * That is the same defect `botsAllowed` was removed for: a guarantee members
+ * signed that did nothing. A rule set that says PRIVATE while the standings,
+ * the draft board and every team's bench are readable by anyone holding a URL is
+ * making a promise the code does not keep, and the URL is not a secret — it is
+ * in browser history, in screenshots, and in whatever chat the invite was pasted
+ * into.
+ *
+ * ## What this does not gate
+ *
+ * **The league page itself stays open.** `RULES.md` and `CLAUDE.md` both require
+ * the full rule set to be shown before anyone joins, and an invitee is by
+ * definition not yet a member. Gating the page would make "shown before you
+ * join" impossible to satisfy for the private leagues that are the whole point
+ * of an invite link. What is gated is everything that reports how the league is
+ * *going* — standings, the draft, the scoreboard, the bracket.
+ *
+ * **PUBLIC leagues are not gated at all.** The league list already publishes
+ * their ids (`/api/leagues`), and being findable is what public means.
+ *
+ * ## Read from the rules, not the column
+ *
+ * `leagues.visibility` is a denormalised copy written at creation. The frozen
+ * document is what members signed, so it is the authority — and reading the copy
+ * would mean a future bug in that write could quietly open a private league.
+ */
+export type LeagueReadAccess =
+  | { readonly ok: true; readonly isMember: boolean }
+  | { readonly ok: false; readonly reason: "NOT_FOUND" | "PRIVATE" };
+
+export async function leagueReadAccess(leagueId: string): Promise<LeagueReadAccess> {
+  const client = db();
+
+  const stored = await getLeagueRules(client, leagueId);
+  if (!stored) return { ok: false, reason: "NOT_FOUND" };
+
+  const user = await currentUser();
+  const team = user ? await teamForUser(client, leagueId, user.id) : null;
+  const isMember = team !== null;
+
+  if (isMember || stored.rules.league.visibility !== "PRIVATE") {
+    return { ok: true, isMember };
+  }
+
+  return { ok: false, reason: "PRIVATE" };
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,18 @@
     "incremental": true,
     "skipLibCheck": true,
     "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "paths": {
+      "@/*": ["./src/*"],
+
+      // Test fixtures, and deliberately NOT an entry in `@rostr/db`'s exports
+      // map: adding one there would advertise PGlite and fake leagues as public
+      // API of a package the production app depends on. The program suite
+      // reaches it the same way, through an alias in its vitest config, so this
+      // mirrors `vitest.config.ts` rather than inventing a second arrangement.
+      // Type-level only — a production import would resolve here and then fail
+      // at runtime, which is the direction that fails loudly.
+      "@rostr/db/testing": ["../../packages/db/src/testing.ts"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       // exist to remove, reappearing only for the subpaths.
       { find: "@rostr/db/postgres", replacement: pkgFile("db", "postgres.ts") },
       { find: "@rostr/db/migrate", replacement: pkgFile("db", "migrate.ts") },
+      { find: "@rostr/db/testing", replacement: pkgFile("db", "testing.ts") },
 
       { find: "@rostr/core", replacement: src("core") },
       { find: "@rostr/db", replacement: src("db") },


### PR DESCRIPTION
`league.visibility` is part of the **frozen, hashed, member-signed** rule set and was read back **nowhere** — written to the `leagues` row at creation and never consulted again. Every other occurrence in the repo was a test.

That is the defect `botsAllowed` was removed for: a guarantee members signed that did nothing. A rule set saying PRIVATE while the standings, the draft board, the scoreboard, the bracket and every team's bench were readable by anyone holding a URL is making a promise the code does not keep — and the URL is not a secret. It is in browser history, in screenshots, and in whatever chat the invite was pasted into.

## What changed

**Five API routes** gated by `leagueReadForbidden`: `[id]`, `standings`, `matchup`, `draft`, `draft/board`.
**Seven pages** gated by `leagueReadAccess`: `standings`, `matchup`, `bracket`, `draft`, `lineup`, `players`, `trades`.

**Both layers, because either alone would be cosmetic.** The `standings`, `matchup` and `bracket` *pages* query the database directly while their components fetch the API. Gating routes alone leaves the server-rendered half open; gating pages alone leaves the API open to `curl`.

## Decisions worth reviewing

**Read from the frozen rules, not `leagues.visibility`.** The column is a denormalised copy written at creation. Members signed the document, so the document decides — and a future bug in that write cannot quietly open a private league. There is a test that rewrites the column and asserts the answer does not move.

**404 and `notFound()`, never 403 and never a "this league is private" screen.** A 403 confirms the league exists, which is the one fact an unguessable id protects.

**Two files stay open**, named with reasons in the test: `/leagues/[id]` and `api/leagues/[id]/join`. `RULES.md` requires the rule set shown before anyone joins and an invitee is by definition not yet a member, so gating the entrance would make "shown before you join" unsatisfiable for exactly the private leagues invite links exist for. What is gated is everything reporting how the league is *going*.

**PUBLIC leagues are not gated at all.** `/api/leagues` already publishes their ids, and being findable is what public means.

**Membership and commissionership count as gates.** They are strictly stronger — `lineup`, `players`, `trades`, `draft/queue`, `draft/pick`, `draft/start` and `anchor` already refuse non-members or non-commissioners outright, so they need nothing added.

**Gating `/api/leagues/[id]/draft` is not purely a disclosure change** — that route runs `catchUpExpiredPicks` and makes auto-picks. For a private league it can now only be triggered by a member. The cron is the real mechanism and is untouched, and `CLAUDE.md` already names the public read route as an amplification vector, so this narrows it.

## The sweep test

`league-read.test.ts` walks every file under `api/leagues/[id]/` and `leagues/[id]/` and fails a new one that gates nothing. This went unenforced not because anyone decided reads were open, but because nothing was obliged to ask.

**Its patterns match the refusal, not the identifier**, and that was a real correction mid-work: three routes mention `context.myTeamId` only to *label* the response with which team is yours. Matching the bare name marked them gated when they were not — a check that looks like it asks who is asking and then does nothing with the answer, which is precisely the defect the file is named after. Each of the twelve gates was mutation-checked: strip the call and the test fails.

## Verification

`pnpm test` **1063 passing** (1034 before; +29 from the two new files), `typecheck`, `lint`, `format:check` all clean. No migration, no schema change, so the golden rules hash does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
