### PR TITLE
fix(web): one declaration of which chain, and check everything against it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,18 +78,23 @@ PINATA_JWT=
 # NOTE: public nodes PRUNE old blocks. Drawing works fine — it happens seconds
 # after the block exists — but verifying a draw months later needs an ARCHIVAL
 # node. Matters before the playoffs, not in August. See docs/SETUP-REQUIRED.md.
-SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+SOLANA_RPC_URL=https://api.devnet.solana.com
 
-# Which cluster this deployment treats as real: mainnet-beta, devnet, localnet.
+# THE declaration of which chain this deployment is on: mainnet-beta, devnet,
+# testnet or localnet. Everything else is checked against it.
 #
 # Joining checks the league's anchor is on THIS cluster. The on-chain address is
 # a PDA derived from the league id, so it is identical everywhere — without this,
 # a league anchored on devnet would satisfy a mainnet join and "the account
 # exists" would be no answer at all.
 #
-# Unset means the cluster is not checked, which is fine locally and wrong in
-# production.
-SOLANA_CLUSTER=mainnet-beta
+# REQUIRED IN PRODUCTION. Unset, it is devnet in development and a refusal in
+# production. It used to mean "do not check the cluster at all", so the one
+# deployment nobody had configured was the one with no check.
+#
+# SOLANA_RPC_URL is verified against this by GENESIS HASH, not by reading its
+# URL — a private RPC's hostname says nothing about which chain is behind it.
+SOLANA_CLUSTER=devnet
 
 # --- Email ----------------------------------------------------------------
 # Sign-in is a link sent by email — no passwords to forget or leak.
@@ -149,6 +154,22 @@ NEXT_PUBLIC_FEE_RECIPIENT=
 # anchored on one cluster and looked for on another — which surfaces as "no
 # league account exists on-chain yet" and no amount of retrying fixes it.
 #
-# Unset, WalletProviders falls back to mainnet-beta, which is the worst default
-# for local development: a real cluster, real fees, and nothing there.
+# Optional. Unset, it is derived from NEXT_PUBLIC_SOLANA_CLUSTER below. Set it
+# when you have a private RPC, which any real deployment does — the public nodes
+# are rate-limited and the draft order draw alone makes ~30 sequential calls.
+#
+# It no longer falls back to mainnet-beta. A build with nothing configured used
+# to point every wallet at real money while the server verified somewhere else.
 NEXT_PUBLIC_SOLANA_RPC_URL=
+
+# Which chain the BROWSER build is for. Must name the same cluster as
+# SOLANA_CLUSTER — they are separate variables only because NEXT_PUBLIC_* is
+# inlined into the bundle at build time and the server's value is not.
+#
+# The two are cross-checked at runtime: the page asks its endpoint for a genesis
+# hash and shows a "wrong network" banner when it disagrees with this. That is
+# the only place the browser's chain becomes a fact rather than a convention,
+# and the browser is where the signing happens.
+#
+# Unset, devnet — the fallback that fails visibly rather than expensively.
+NEXT_PUBLIC_SOLANA_CLUSTER=devnet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,18 +223,17 @@ several of these PRs ship a comment asserting a guarantee the code does not prov
 repo treats comments as specification, so a false comment is a defect in its own right —
 review them as such, and fix the comment before arguing about the code.
 
-**Two program-level problems surfaced that no PR fixes**, both needing Rust and a decision
-before Aug 22:
+**Two program-level problems surfaced that no PR fixes.** One is **fixed**; the other
+still needs Rust and a decision before Aug 22:
 
 - **Seat-squatting (issue #18).** `join_league` is permissionless and there is no eviction
   instruction, so throwaway keypairs can fill a league's seats for a fraction of a SOL and
   permanently block every real member's deposit. Found independently by Squid and by an
   adversarial review of #29. It predates everything here; wiring the app to `join_league` is
   what makes it reachable.
-- **The browser defaults to mainnet.** `WalletProviders.tsx` falls back to
-  `clusterApiUrl("mainnet-beta")` when `NEXT_PUBLIC_SOLANA_RPC_URL` is unset, while the
-  server verifies with `SOLANA_RPC_URL` and the db join gates on `SOLANA_CLUSTER`. Three
-  independent sources of "which chain", no cross-check, and the most dangerous default.
+- **The browser defaulted to mainnet — FIXED**, see "One declaration of which chain"
+  below. Three independent sources of "which chain", no cross-check, and the most
+  dangerous default sitting on the one that signs.
 
 **Next, in order:**
 
@@ -919,6 +918,78 @@ the final pick moves it to IN_SEASON. Nothing else moved state before, so a draf
 stayed FORMING forever — still accepting members, and invisible to every job that works on
 live leagues. The enum is FORMING / DRAFTING / IN_SEASON / PLAYOFFS / SETTLED / DISSOLVED;
 an invented value is not a no-op, Postgres fails the cast and the query errors.
+
+### One declaration of which chain, and everything checked against it
+
+`packages/escrow/src/cluster.ts`, `apps/web/src/lib/cluster.ts`.
+
+**The PDA is byte-identical on every cluster.** A league anchored on devnet and the same
+league anchored on mainnet derive the same address from the same UUID, so "the account
+exists" answers nothing — the only thing separating them is which endpoint you happened
+to ask. `leagues.chain_cluster` records the answer and migration `0014` makes it
+**write-once by trigger**, so a wrong value is permanent and `joinLeague` gates on it.
+
+There were **three independent sources** of that answer and no comparison between any
+two:
+
+| Where               | Variable                     | If unset            |
+| ------------------- | ---------------------------- | ------------------- |
+| Browser — _signs_   | `NEXT_PUBLIC_SOLANA_RPC_URL` | **mainnet-beta**    |
+| Server — _verifies_ | `SOLANA_RPC_URL`             | throws              |
+| Join gate           | `SOLANA_CLUSTER`             | **no check at all** |
+
+The dangerous default was on the one that signs. A commissioner with it unset sent
+`initialize_league` to **mainnet** while the server read devnet, found nothing, and
+returned `NOT_FOUND` — which the route documents as "retry". Retrying cannot work; the
+account is real, it cost mainnet rent, and with no `close` instruction that league can
+never be anchored there again, only recreated under a new id. Worse downstream: `deposit`
+is permissionless once a league exists, so a member could put real USDC into a vault this
+deployment never looks at.
+
+**`SOLANA_CLUSTER` is now the declaration**, required in production and `devnet` in
+development — the same shape as `cronForbidden`, and for the same reason. Devnet is the
+fallback that fails _visibly_: nothing verifies, nobody loses anything, and the missing
+config surfaces in minutes. Defaulting to devnet in _production_ would be its own quiet
+disaster, hence the refusal there.
+
+**The RPC is verified by genesis hash, not by reading its URL.** `resolveCluster` asks the
+node which chain it is. Every real deployment points at a private RPC — the public nodes
+are rate-limited and the order draw alone makes ~30 sequential calls — and a private
+endpoint's hostname says nothing about what is behind it. The constants in
+`GENESIS_HASHES` were **verified against the live public endpoints on 2026-08-11**, not
+recalled; they are genesis blocks, so a change would mean the chain was reset.
+
+**An unrecognised genesis hash resolves to `localnet`, never to a public cluster.** That
+is the fail-safe direction and it only works because callers _compare_ the result against
+the declaration rather than trusting it: declare mainnet, get a fork or a local validator,
+get `localnet`, mismatch, refuse.
+
+**`clusterOf` no longer falls back to `mainnet-beta`** — it throws. That fallback was the
+bug in its purest form: an ordinary devnet endpoint like `https://rostr.rpcpool.com/<key>`
+matched none of its substring branches and was recorded as mainnet, permanently, in the
+column the join gate reads. It survives as an endpoint-_shape_ helper for the program
+tests. Anything writing `chain_cluster` uses `resolveCluster`.
+
+**The cluster is asserted before the anchor route reads a single account**, not just
+before it writes. Every check in that route is taken against whatever `connection` is
+talking to, so a wrong cluster makes `verifyLeagueAnchor` answer `NOT_FOUND` for a league
+that is correctly anchored — and the route calls `NOT_FOUND` a retry. Its return value is
+what gets recorded, so there is no second path by which an unverified cluster reaches the
+write-once column.
+
+**The join route's cluster check is no longer a conditional spread.** An unset
+`SOLANA_CLUSTER` did not relax it, it deleted it, and the deployment guaranteed to have it
+unset is the one nobody configured.
+
+**The browser cross-checks itself at runtime.** `ClusterBanner` asks its endpoint for a
+genesis hash and warns when it disagrees with the build's `NEXT_PUBLIC_SOLANA_CLUSTER` —
+the only place the browser's chain is a fact rather than a convention, and the browser is
+where the signing happens. A banner rather than a block, because the adapter belongs to
+the extension and the server already refuses; a failed lookup says nothing, because
+claiming a mismatch on a network blip trains people to dismiss the real one. The
+comparison lives in `clusterMismatch` in `@rostr/escrow` rather than in the component,
+since `apps/web` cannot test React and a mapping inside a component is verified only by
+being run in production.
 
 ### A private league is now actually private
 

--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import {
   anchorTermMismatches,
-  clusterOf,
   expectedTermsFromRules,
   verifyLeagueAnchor,
 } from "@rostr/escrow";
@@ -9,6 +8,7 @@ import { getChainState, getLeagueRules, recordChainAnchor } from "@rostr/db";
 import { db } from "@/lib/db";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
 import { EscrowConfigError, readOnlyEscrow } from "@/lib/escrow";
+import { assertRpcCluster, ClusterConfigError } from "@/lib/cluster";
 
 /**
  * Recording that a league's rules are anchored on-chain.
@@ -67,6 +67,19 @@ export async function POST(
     }
 
     const { connection, program } = readOnlyEscrow();
+
+    // Before reading a single account, confirm we are reading the right chain.
+    //
+    // This is first, not just before the write, because every check below is
+    // taken against whatever `connection` is talking to: `verifyLeagueAnchor`
+    // reading the wrong cluster answers `NOT_FOUND` for a league that is
+    // correctly anchored, and the route documents `NOT_FOUND` as "retry". The
+    // commissioner would retry forever against a chain their wallet never
+    // touched.
+    //
+    // It also decides the value recorded, so there is no path by which an
+    // unverified cluster reaches the write-once column.
+    const cluster = await assertRpcCluster(connection);
 
     /**
      * What the chain says, checked against what members signed.
@@ -182,11 +195,6 @@ export async function POST(
       );
     }
 
-    // The cluster is read off the endpoint we just queried, not accepted from
-    // the caller. The PDA is identical on every chain, so without it a devnet
-    // anchor is indistinguishable from a mainnet one.
-    const cluster = clusterOf(connection);
-
     await recordChainAnchor(client, id, { signature, cluster });
 
     return NextResponse.json({
@@ -200,7 +208,9 @@ export async function POST(
     if (error instanceof DraftContextError) {
       return NextResponse.json({ error: error.message }, { status: error.status });
     }
-    if (error instanceof EscrowConfigError) {
+    if (error instanceof EscrowConfigError || error instanceof ClusterConfigError) {
+      // 503, not 500: the deployment is misconfigured, the request was sound,
+      // and nothing was written. A retry after the config is fixed succeeds.
       return NextResponse.json({ error: error.message }, { status: 503 });
     }
     throw error;

--- a/apps/web/src/app/api/leagues/[id]/join/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/join/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getJoinMessage, JoinError, joinLeague } from "@rostr/db";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
+import { ClusterConfigError, declaredCluster } from "@/lib/cluster";
 
 /**
  * The message to sign.
@@ -87,12 +88,20 @@ export async function POST(
       // The cluster this deployment considers real. Without it a league
       // anchored on devnet would satisfy a mainnet join, since the PDA is the
       // same everywhere.
-      ...(process.env["SOLANA_CLUSTER"]
-        ? { requireCluster: process.env["SOLANA_CLUSTER"] }
-        : {}),
+      //
+      // **No longer a conditional spread.** An unset `SOLANA_CLUSTER` did not
+      // relax this check, it deleted it — and the deployment guaranteed to have
+      // it unset is the one nobody configured, which is exactly the one that
+      // needs it. `declaredCluster` refuses in production rather than assuming.
+      requireCluster: declaredCluster(),
     });
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
+    if (error instanceof ClusterConfigError) {
+      // 503 and not 500: nothing about the request was wrong, and no member
+      // should be admitted to a league whose chain this deployment cannot name.
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
     if (error instanceof JoinError) {
       return NextResponse.json(
         { error: error.message, code: error.code },

--- a/apps/web/src/components/WalletProviders.tsx
+++ b/apps/web/src/components/WalletProviders.tsx
@@ -1,15 +1,51 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react";
+import {
+  ConnectionProvider,
+  useConnection,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { PhantomWalletAdapter } from "@solana/wallet-adapter-phantom";
 import { SolflareWalletAdapter } from "@solana/wallet-adapter-solflare";
 import { CoinbaseWalletAdapter } from "@solana/wallet-adapter-coinbase";
 import { clusterApiUrl } from "@solana/web3.js";
+import {
+  clusterFromGenesisHash,
+  clusterMismatch,
+  parseCluster,
+  type Cluster,
+} from "@rostr/escrow";
 
 import "@solana/wallet-adapter-react-ui/styles.css";
+
+/**
+ * The chain this build was compiled for.
+ *
+ * `NEXT_PUBLIC_*` is inlined at build time, so this is a property of the
+ * deployment rather than something a visitor can influence.
+ *
+ * **There is no mainnet fallback, and its absence is the point.** This used to
+ * be `?? clusterApiUrl("mainnet-beta")`: a build with nothing configured pointed
+ * every wallet at real money while the server verified against whatever
+ * `SOLANA_RPC_URL` said. The commissioner's `initialize_league` landed on
+ * mainnet, the server read devnet, found nothing, and returned `NOT_FOUND` —
+ * which this route documents as "retry". Retrying cannot work, the account is
+ * real, it cost mainnet rent, and the PDA derives from the league's UUID with no
+ * `close`, so that league can never be anchored there again.
+ *
+ * Devnet is the fallback because it is the one that fails *visibly*: nothing
+ * verifies, nobody loses anything, and the misconfiguration surfaces in minutes.
+ */
+const BUILD_CLUSTER: Cluster =
+  parseCluster(process.env["NEXT_PUBLIC_SOLANA_CLUSTER"]) ?? "devnet";
+
+/** `clusterApiUrl` has no localnet, so that one case is spelled out. */
+function defaultEndpoint(cluster: Cluster): string {
+  return cluster === "localnet" ? "http://127.0.0.1:8899" : clusterApiUrl(cluster);
+}
 
 /**
  * Wallet connection.
@@ -34,7 +70,7 @@ import "@solana/wallet-adapter-react-ui/styles.css";
  */
 export function WalletProviders({ children }: { children: ReactNode }) {
   const endpoint = useMemo(
-    () => process.env["NEXT_PUBLIC_SOLANA_RPC_URL"] ?? clusterApiUrl("mainnet-beta"),
+    () => process.env["NEXT_PUBLIC_SOLANA_RPC_URL"] ?? defaultEndpoint(BUILD_CLUSTER),
     [],
   );
 
@@ -50,8 +86,62 @@ export function WalletProviders({ children }: { children: ReactNode }) {
   return (
     <ConnectionProvider endpoint={endpoint}>
       <WalletProvider wallets={wallets} autoConnect>
-        <WalletModalProvider>{children}</WalletModalProvider>
+        <WalletModalProvider>
+          <ClusterBanner />
+          {children}
+        </WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>
+  );
+}
+
+/**
+ * Asks the endpoint which chain it actually is, and says so when it disagrees
+ * with the one this build was made for.
+ *
+ * `NEXT_PUBLIC_SOLANA_RPC_URL` overrides the cluster's default endpoint, so the
+ * two can still disagree even with both set — a URL is a label somebody typed
+ * and the genesis hash is the chain's own identity. This is the only place the
+ * browser's chain is established as a fact rather than a convention, and the
+ * browser is where the signing happens.
+ *
+ * **A banner, not a block.** It cannot disable a wallet — the adapter belongs to
+ * the extension — and the server already refuses to record an anchor from the
+ * wrong chain, so this is the warning rather than the enforcement. It is shown
+ * unconditionally rather than only on pages with a sign button, because by the
+ * time somebody reaches the anchor panel the mistake has already been made.
+ *
+ * A failed lookup says nothing. An unreachable RPC is its own visible problem
+ * and does not mean the chain is wrong; claiming a mismatch on a network blip
+ * would train people to dismiss the one that matters.
+ */
+function ClusterBanner() {
+  const { connection } = useConnection();
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+
+    connection
+      .getGenesisHash()
+      .then((hash) => {
+        if (live) setMessage(clusterMismatch(BUILD_CLUSTER, clusterFromGenesisHash(hash)));
+      })
+      .catch(() => {});
+
+    return () => {
+      live = false;
+    };
+  }, [connection]);
+
+  if (!message) return null;
+
+  return (
+    <div
+      role="alert"
+      className="border-b border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
+    >
+      <strong className="font-semibold">Wrong network.</strong> {message}
+    </div>
   );
 }

--- a/apps/web/src/lib/cluster.test.ts
+++ b/apps/web/src/lib/cluster.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Connection } from "@solana/web3.js";
+import { GENESIS_HASHES } from "@rostr/escrow";
+import { assertRpcCluster, ClusterConfigError, declaredCluster } from "./cluster.js";
+
+/**
+ * `SOLANA_CLUSTER` is now the one declaration, and the browser and the server
+ * are checked against it. Before this there were three independent sources of
+ * "which chain" and no comparison between any two of them.
+ */
+
+// `vi.stubEnv` rather than assigning `process.env` directly: NODE_ENV is typed
+// read-only, and this restores every variable together rather than one at a
+// time, so a test that forgets one cannot leak into the next.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const asConnection = (rpcEndpoint: string, genesis: string): Connection =>
+  ({
+    rpcEndpoint,
+    getGenesisHash: () => Promise.resolve(genesis),
+  }) as unknown as Connection;
+
+describe("declaredCluster", () => {
+  it.each(["mainnet-beta", "devnet", "testnet", "localnet"])(
+    "returns %s as declared",
+    (value) => {
+      vi.stubEnv("SOLANA_CLUSTER", value);
+      expect(declaredCluster()).toBe(value);
+    },
+  );
+
+  it("defaults to devnet in development", () => {
+    // Devnet and not mainnet, because devnet is the fallback that fails
+    // *visibly*: nothing verifies, nobody loses anything, and the missing
+    // config surfaces in minutes.
+    vi.stubEnv("SOLANA_CLUSTER", "");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(declaredCluster()).toBe("devnet");
+  });
+
+  it("refuses in production rather than defaulting", () => {
+    // The deployment guaranteed to have this unset is the one nobody
+    // configured, which is exactly the one that must not guess.
+    vi.stubEnv("SOLANA_CLUSTER", "");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(() => declaredCluster()).toThrow(ClusterConfigError);
+    expect(() => declaredCluster()).toThrow(/required in production/);
+  });
+
+  it("refuses a value that names no cluster, in every environment", () => {
+    // `mainnet` is the obvious typo for `mainnet-beta`, and silently correcting
+    // it would be guessing about the one thing this file exists to stop
+    // guessing about. It throws in development too — a typo is a mistake
+    // wherever it happens, unlike an absent variable, which is normal locally.
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet");
+    expect(() => declaredCluster()).toThrow(/names no cluster/);
+  });
+});
+
+describe("assertRpcCluster", () => {
+  it("returns the declared cluster when the node agrees", async () => {
+    vi.stubEnv("SOLANA_CLUSTER", "devnet");
+    const connection = asConnection("https://rostr.example/rpc", GENESIS_HASHES.devnet);
+    await expect(assertRpcCluster(connection)).resolves.toBe("devnet");
+  });
+
+  it("refuses when SOLANA_RPC_URL is a different chain than declared", async () => {
+    // The failure this prevents is not a bad request — it is the anchor route
+    // reading mainnet, finding no account, answering NOT_FOUND, and telling a
+    // commissioner whose transaction landed correctly on devnet to retry.
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet-beta");
+    const connection = asConnection("https://rostr.example/rpc", GENESIS_HASHES.devnet);
+
+    await expect(assertRpcCluster(connection)).rejects.toThrow(ClusterConfigError);
+    await expect(assertRpcCluster(connection)).rejects.toThrow(/says mainnet-beta/);
+  });
+
+  it("refuses an unrecognised chain claiming to be a public one", async () => {
+    // A local validator, a fork, or a proxy in front of the wrong node all
+    // arrive here as an unknown genesis hash. None of them may satisfy a
+    // mainnet declaration.
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet-beta");
+    const connection = asConnection(
+      "https://api.mainnet-beta.solana.com",
+      "not-a-real-genesis",
+    );
+
+    await expect(assertRpcCluster(connection)).rejects.toThrow(ClusterConfigError);
+  });
+
+  it("does not reach the network when the declaration is already unusable", async () => {
+    // Ordering matters: a misconfigured deployment should get the config error,
+    // not a timeout from whatever endpoint happened to be set.
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet");
+    const connection = {
+      rpcEndpoint: "https://rostr.example/rpc",
+      getGenesisHash: () => Promise.reject(new Error("should not be called")),
+    } as unknown as Connection;
+
+    await expect(assertRpcCluster(connection)).rejects.toThrow(/names no cluster/);
+  });
+});

--- a/apps/web/src/lib/cluster.ts
+++ b/apps/web/src/lib/cluster.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import type { Connection } from "@solana/web3.js";
+import { parseCluster, resolveCluster, type Cluster } from "@rostr/escrow";
+
+/**
+ * Which chain this deployment runs on. One answer, and everything else is
+ * checked against it.
+ *
+ * There used to be **three independent sources** of that, none of which was
+ * compared with any other:
+ *
+ * | Where                | Variable                       | Unset                 |
+ * | -------------------- | ------------------------------ | --------------------- |
+ * | Browser — *signs*    | `NEXT_PUBLIC_SOLANA_RPC_URL`   | **mainnet-beta**      |
+ * | Server — *verifies*  | `SOLANA_RPC_URL`               | throws                |
+ * | Join gate            | `SOLANA_CLUSTER`               | **no check at all**   |
+ *
+ * The dangerous one was client-side, optional, and defaulted to real money. A
+ * commissioner with it unset signed `initialize_league` against **mainnet**
+ * while the server read devnet, found nothing, and returned `NOT_FOUND` — which
+ * the route documents as "retry". The account is real, it is on the wrong chain,
+ * it cost mainnet rent, and the PDA derives from the league's UUID with no
+ * `close` instruction, so that league can never be anchored there again. Worse
+ * downstream: `deposit` is permissionless once a league exists, so a member
+ * could put real USDC into a vault this deployment never looks at.
+ *
+ * `SOLANA_CLUSTER` is now the declaration and the other two are checked against
+ * it — the server's RPC by its genesis hash, the browser's by the same, at
+ * runtime.
+ */
+export class ClusterConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClusterConfigError";
+  }
+}
+
+/**
+ * The cluster this deployment declares itself to be on.
+ *
+ * **Required in production, `devnet` in development.** This mirrors
+ * `cronForbidden` deliberately — open locally, closed where it counts — because
+ * the alternative shapes are both worse. Defaulting to mainnet is what caused
+ * this; defaulting to devnet in production would silently anchor real leagues on
+ * a chain that gets wiped, which looks like it works right up until it doesn't.
+ *
+ * Refusing costs one line in an env file. There is no reading of an absent
+ * `SOLANA_CLUSTER` that is safe enough to assume in production.
+ */
+export function declaredCluster(): Cluster {
+  const raw = process.env["SOLANA_CLUSTER"];
+  const parsed = parseCluster(raw);
+  if (parsed) return parsed;
+
+  if (raw) {
+    throw new ClusterConfigError(
+      `SOLANA_CLUSTER is "${raw}", which names no cluster. Use one of ` +
+        `mainnet-beta, devnet, testnet, localnet.`,
+    );
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new ClusterConfigError(
+      "SOLANA_CLUSTER is not set. It is required in production: league " +
+        "accounts have the same address on every cluster, so without it a " +
+        "devnet anchor and a mainnet one are indistinguishable.",
+    );
+  }
+
+  return "devnet";
+}
+
+/**
+ * Confirm `SOLANA_RPC_URL` really is the declared cluster, and return it.
+ *
+ * Asks the node for its genesis hash rather than reading its URL. Every real
+ * deployment uses a private RPC — the public endpoints are rate-limited and the
+ * order draw alone makes ~30 sequential calls — and a private endpoint's
+ * hostname says nothing about which chain is behind it. The URL is a label
+ * somebody typed; the genesis hash is the chain's own identity.
+ *
+ * Callers use the **return value** as the cluster to record, so there is no
+ * second path by which an unverified value could reach the database.
+ */
+export async function assertRpcCluster(connection: Connection): Promise<Cluster> {
+  const declared = declaredCluster();
+  const actual = await resolveCluster(connection);
+
+  if (actual !== declared) {
+    throw new ClusterConfigError(
+      `SOLANA_CLUSTER says ${declared} but SOLANA_RPC_URL ` +
+        `(${connection.rpcEndpoint}) is ${actual}. Recording an anchor now ` +
+        `would write the wrong cluster permanently — migration 0014 makes ` +
+        `leagues.chain_cluster write-once, and joinLeague gates on it.`,
+    );
+  }
+
+  return declared;
+}

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -57,11 +57,18 @@ Fund this address, which is the deploy keypair on the main PC:
 AoF2r5NttSS9A8DtzzTyB1nHxSX9PDMa7txowGvHqWn7
 ```
 
-Then `anchor deploy --provider.cluster devnet`, and point **both**
-`SOLANA_RPC_URL` and `NEXT_PUBLIC_SOLANA_RPC_URL` at devnet. They must agree — the
-browser anchors against one and the server verifies against the other, and the PDA is
-identical on every cluster, so a mismatch looks like a league that will not verify
-rather than like a misconfiguration.
+Then `anchor deploy --provider.cluster devnet`, and set **`SOLANA_CLUSTER=devnet`** and
+**`NEXT_PUBLIC_SOLANA_CLUSTER=devnet`**. Those are the declarations; the two RPC URLs are
+optional and are checked against them.
+
+They must agree — the browser anchors against one endpoint and the server verifies
+against the other, and the PDA is identical on every cluster, so a mismatch looks like a
+league that will not verify rather than like a misconfiguration. **The agreement is now
+enforced rather than requested**: the server asks its RPC for a genesis hash before
+recording anything, and the browser shows a "wrong network" banner when its endpoint
+disagrees with the build. `SOLANA_CLUSTER` is **required in production** — unset, it used
+to mean "do not check the cluster", so the deployment nobody had configured was the one
+with no check.
 
 Devnet SOL is free and worth nothing; this is a rate limit, not a cost.
 

--- a/packages/escrow/src/cluster.test.ts
+++ b/packages/escrow/src/cluster.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { Connection } from "@solana/web3.js";
+import {
+  clusterFromGenesisHash,
+  clusterMismatch,
+  GENESIS_HASHES,
+  parseCluster,
+  resolveCluster,
+  type Cluster,
+} from "./cluster.js";
+import { clusterOf } from "./verify.js";
+
+/**
+ * The PDA is byte-identical on every cluster, so "which chain" is not cosmetic
+ * here — it is the only thing separating a devnet anchor from a mainnet stake.
+ * `leagues.chain_cluster` records the answer and migration `0014` makes it
+ * write-once, so a wrong one is permanent.
+ */
+
+const asConnection = (rpcEndpoint: string, genesis?: string): Connection =>
+  ({
+    rpcEndpoint,
+    getGenesisHash: () => Promise.resolve(genesis ?? ""),
+  }) as unknown as Connection;
+
+describe("clusterFromGenesisHash", () => {
+  it.each(Object.entries(GENESIS_HASHES))("identifies %s", (cluster, hash) => {
+    expect(clusterFromGenesisHash(hash)).toBe(cluster);
+  });
+
+  it("never promotes an unrecognised chain to a public one", () => {
+    // The whole safety argument rests on this. A local validator's genesis is
+    // random per ledger, and so is a fork's — neither may be allowed to pass as
+    // devnet or mainnet, because the caller compares this against a *declared*
+    // cluster and refuses on a mismatch.
+    expect(clusterFromGenesisHash("3nHo8B1zpqZ8P4hPGkYbdF2rMFHF6vjqRE7dGgVrxYRt")).toBe(
+      "localnet",
+    );
+    expect(clusterFromGenesisHash("")).toBe("localnet");
+  });
+
+  it("holds the hashes the public endpoints actually serve", () => {
+    // Verified 2026-08-11 by asking the live nodes, not from memory:
+    //   curl -sX POST -H 'Content-Type: application/json' \
+    //     -d '{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"}' \
+    //     https://api.mainnet-beta.solana.com
+    // These are genesis blocks: a change here means the chain was reset, not
+    // that the constant drifted.
+    expect(GENESIS_HASHES).toEqual({
+      "mainnet-beta": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+      devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+      testnet: "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY",
+    });
+  });
+});
+
+describe("parseCluster", () => {
+  it.each(["mainnet-beta", "devnet", "testnet", "localnet"])("accepts %s", (value) => {
+    expect(parseCluster(value)).toBe(value as Cluster);
+  });
+
+  it.each([undefined, null, "", "mainnet", "MAINNET-BETA", "prod"])(
+    "refuses %s rather than guessing",
+    (value) => {
+      // `mainnet` and `MAINNET-BETA` are the plausible typos, and both must be
+      // refused rather than helpfully corrected: the caller's response to null
+      // is to stop, and that is the safe direction.
+      expect(parseCluster(value)).toBeNull();
+    },
+  );
+});
+
+describe("resolveCluster", () => {
+  it("asks the node rather than reading its URL", async () => {
+    // The endpoint says mainnet in every way a human would read it, and the
+    // chain behind it is devnet. This is not a contrived case — it is what a
+    // misconfigured private RPC looks like.
+    const connection = asConnection("https://mainnet.rostr.example/rpc", GENESIS_HASHES.devnet);
+    await expect(resolveCluster(connection)).resolves.toBe("devnet");
+  });
+});
+
+describe("clusterOf", () => {
+  it.each([
+    ["https://api.devnet.solana.com", "devnet"],
+    ["https://api.testnet.solana.com", "testnet"],
+    ["https://api.mainnet-beta.solana.com", "mainnet-beta"],
+    ["http://127.0.0.1:8899", "localnet"],
+    ["http://localhost:8899", "localnet"],
+  ])("reads %s as %s", (endpoint, expected) => {
+    expect(clusterOf(asConnection(endpoint))).toBe(expected);
+  });
+
+  it("throws on an endpoint it cannot classify, rather than answering mainnet", () => {
+    // This was the bug. Every real deployment uses a private RPC — the public
+    // nodes are rate-limited and the order draw alone makes ~30 sequential
+    // calls — so an ordinary devnet endpoint matched no branch and was recorded
+    // as mainnet, permanently, in a column `joinLeague` gates on.
+    expect(() => clusterOf(asConnection("https://rostr.rpcpool.com/abc123"))).toThrow(
+      /Cannot tell which cluster/,
+    );
+  });
+});
+
+describe("clusterMismatch", () => {
+  it("is silent when the browser and the deployment agree", () => {
+    expect(clusterMismatch("devnet", "devnet")).toBeNull();
+  });
+
+  it("names both chains when they differ", () => {
+    const message = clusterMismatch("devnet", "mainnet-beta");
+    expect(message).toContain("mainnet-beta");
+    expect(message).toContain("devnet");
+  });
+
+  it("says why nothing would look wrong, because nothing would", () => {
+    // A wrong-network warning that only says "wrong network" gets dismissed.
+    // The reason it is dangerous here specifically is that the address is the
+    // same on both chains, so every screen keeps rendering normally.
+    expect(clusterMismatch("mainnet-beta", "devnet")).toMatch(/same address on every cluster/);
+  });
+});

--- a/packages/escrow/src/cluster.ts
+++ b/packages/escrow/src/cluster.ts
@@ -1,0 +1,106 @@
+import type { Connection } from "@solana/web3.js";
+
+/**
+ * Which chain a thing is on.
+ *
+ * This matters more here than in most Solana apps, because **the PDA is
+ * byte-identical on every cluster**. A league anchored on devnet and the same
+ * league anchored on mainnet derive the same address from the same UUID, so
+ * "the account exists" answers nothing on its own — a devnet anchor is not an
+ * anchor for a mainnet stake, and the only thing separating them is which
+ * endpoint you happened to ask.
+ *
+ * `leagues.chain_cluster` records the answer, and migration `0014` makes it
+ * **write-once by trigger**. A wrong value there is permanent: `joinLeague`
+ * gates on it, and there is no correcting row to write.
+ */
+export type Cluster = "mainnet-beta" | "devnet" | "testnet" | "localnet";
+
+const CLUSTERS: readonly Cluster[] = ["mainnet-beta", "devnet", "testnet", "localnet"];
+
+/**
+ * The genesis hash of each public cluster — the chain's own cryptographic
+ * identity, asked of the node rather than inferred from its URL.
+ *
+ * **Verified against the live public endpoints on 2026-08-11**, not recalled:
+ *
+ * ```
+ * curl -s -X POST -H 'Content-Type: application/json' \
+ *   -d '{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"}' https://api.devnet.solana.com
+ * ```
+ *
+ * These are genesis blocks, so they are as fixed as anything in this repo — a
+ * value here changing would mean the chain itself was reset.
+ *
+ * **Localnet is deliberately absent.** `solana-test-validator` generates a fresh
+ * genesis per ledger, so there is no constant to pin and no way to tell one
+ * local chain from another. That is fine, and the reason is worth stating: a
+ * local chain has no shared identity to protect and no real money on it. What
+ * matters is that an unrecognised hash can never be mistaken for a *public*
+ * cluster — see `clusterFromGenesisHash`.
+ */
+export const GENESIS_HASHES: Readonly<Record<Exclude<Cluster, "localnet">, string>> = {
+  "mainnet-beta": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+  testnet: "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY",
+};
+
+/**
+ * The cluster a genesis hash identifies, or `"localnet"` for anything else.
+ *
+ * Answering `"localnet"` rather than `null` for an unknown hash is the fail-safe
+ * direction, and it only works because callers *compare* the result against a
+ * declared cluster rather than trusting it. Declare mainnet, get an
+ * unrecognised chain, and this answers `"localnet"` — which does not match, so
+ * the caller refuses. The unrecognised chain is never promoted to a public one.
+ *
+ * Two different private chains do both read as `"localnet"` and so satisfy each
+ * other. That is accepted: a local chain is not a shared identity, and the
+ * guarantee this protects — that a devnet anchor cannot back a mainnet stake —
+ * is untouched by it.
+ */
+export function clusterFromGenesisHash(hash: string): Cluster {
+  for (const [cluster, genesis] of Object.entries(GENESIS_HASHES)) {
+    if (genesis === hash) return cluster as Cluster;
+  }
+  return "localnet";
+}
+
+/** A configured value, or `null` if it names no cluster we know. */
+export function parseCluster(value: string | undefined | null): Cluster | null {
+  if (!value) return null;
+  return CLUSTERS.find((c) => c === value) ?? null;
+}
+
+/**
+ * Ask the chain which chain it is.
+ *
+ * One round trip, and it replaces every form of guessing from the endpoint URL.
+ * A deployment that points at a private RPC — which any real one does, since the
+ * public nodes are rate-limited and the order draw alone makes ~30 sequential
+ * calls — has a URL that says nothing at all about which cluster is behind it.
+ */
+export async function resolveCluster(connection: Connection): Promise<Cluster> {
+  return clusterFromGenesisHash(await connection.getGenesisHash());
+}
+
+/**
+ * The message shown when the chain the browser is connected to is not the one
+ * this deployment runs on, or `null` when they agree.
+ *
+ * Separate from the component that renders it because `apps/web` cannot test
+ * React — `vitest.config.ts` collects `.ts`, there is no jsdom environment, and
+ * a comparison living inside a component would be verified only by being run in
+ * production. The two mapping defects found in the anchor review were both in a
+ * mapping, not in the comparison around it.
+ */
+export function clusterMismatch(declared: Cluster, actual: Cluster): string | null {
+  if (declared === actual) return null;
+
+  return (
+    `Your wallet is connected to ${actual}, but this deployment runs on ` +
+    `${declared}. Signing here would put a transaction on the wrong chain — ` +
+    `and league accounts have the same address on every cluster, so nothing ` +
+    `would look wrong until it was too late.`
+  );
+}

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -8,6 +8,14 @@
 
 export { ESCROW_IDL, type EscrowIdl } from "./idl.js";
 export {
+  GENESIS_HASHES,
+  clusterFromGenesisHash,
+  clusterMismatch,
+  parseCluster,
+  resolveCluster,
+  type Cluster,
+} from "./cluster.js";
+export {
   anchorTermMismatches,
   bytesToHex,
   clusterOf,

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -300,18 +300,34 @@ export function anchorTermMismatches(
 }
 
 /**
- * Which cluster a connection is talking to, as `leagues.chain_cluster` records
- * it.
+ * Which cluster an endpoint's *shape* suggests — a convenience for tests, and
+ * **not** the authority.
  *
- * The PDA is byte-identical on every cluster, so "the account exists" is not an
- * answer on its own — a devnet anchor is not an anchor for a mainnet stake.
- * Derived from the endpoint rather than trusted from a caller, because the point
- * of this module is not taking the client's word for anything.
+ * Use `resolveCluster` for anything that writes `leagues.chain_cluster` or
+ * decides whether a signature counts. It asks the node for its genesis hash,
+ * which is the chain's own identity; this only reads the URL, which is a label
+ * somebody typed.
+ *
+ * **It no longer falls back to `mainnet-beta`, and that fallback was the bug.**
+ * Any real deployment points at a private RPC, because the public nodes are
+ * rate-limited and the order draw alone makes ~30 sequential calls — so a
+ * perfectly ordinary devnet endpoint like `https://rostr.rpcpool.com/<key>`
+ * matched none of the branches above and was recorded as mainnet. `0014` makes
+ * that column write-once, `joinLeague` gates on it, and there is no correcting
+ * row to write: a devnet league would have passed a mainnet join check forever.
+ *
+ * Guessing wrong here is unrecoverable and guessing right saves a caller one
+ * line of configuration, so it throws.
  */
 export function clusterOf(connection: Connection): string {
   const endpoint = connection.rpcEndpoint;
   if (endpoint.includes("devnet")) return "devnet";
   if (endpoint.includes("testnet")) return "testnet";
+  if (endpoint.includes("mainnet")) return "mainnet-beta";
   if (endpoint.includes("localhost") || endpoint.includes("127.0.0.1")) return "localnet";
-  return "mainnet-beta";
+
+  throw new Error(
+    `Cannot tell which cluster ${endpoint} is, and guessing would be recorded ` +
+      `permanently. Set SOLANA_CLUSTER, or use resolveCluster() to ask the node.`,
+  );
 }


### PR DESCRIPTION
> **Stacked on #60.** Base is `feat/enforce-league-visibility`; it will retarget to `main` when that merges. The only real dependency is the `tsconfig` path fix in #60's last commit.

**The PDA is byte-identical on every cluster.** A league anchored on devnet and the same league anchored on mainnet derive the same address from the same UUID, so "the account exists" answers nothing. `leagues.chain_cluster` records which chain, migration `0014` makes it **write-once by trigger**, and `joinLeague` gates on it — so a wrong value is permanent.

There were **three independent sources** of that answer and no comparison between any two:

| Where | Variable | If unset |
|---|---|---|
| Browser — *signs* | `NEXT_PUBLIC_SOLANA_RPC_URL` | **mainnet-beta** |
| Server — *verifies* | `SOLANA_RPC_URL` | throws |
| Join gate | `SOLANA_CLUSTER` | **no check at all** |

## The failure

The dangerous default sat on the one that **signs**. A commissioner with `NEXT_PUBLIC_SOLANA_RPC_URL` unset sent `initialize_league` to **mainnet** while the server read devnet, found nothing, and returned `NOT_FOUND` — which the route documents as "retry".

Retrying cannot work. The account is real, it cost mainnet rent, and with no `close` instruction and a PDA derived from the league's UUID, that league can never be anchored there again — only recreated under a new id. Downstream is worse: `deposit` is permissionless once a league exists, so a member could put real USDC into a vault this deployment never looks at.

## What changed

**`SOLANA_CLUSTER` is the declaration** — required in production, `devnet` in development. Same shape as `cronForbidden`, and for the same reason. Devnet is the fallback that fails *visibly*: nothing verifies, nobody loses anything, and the missing config surfaces in minutes. Defaulting to devnet in *production* would be its own quiet disaster, hence the refusal there.

**The RPC is verified by genesis hash, not by reading its URL.** Every real deployment points at a private RPC — the public nodes are rate-limited and the order draw alone makes ~30 sequential calls — and a private endpoint's hostname says nothing about what is behind it. The constants in `GENESIS_HASHES` were **verified against the live public endpoints on 2026-08-11**, not recalled:

```
curl -sX POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"}' https://api.devnet.solana.com
```

**An unrecognised genesis hash resolves to `localnet`, never to a public cluster.** That is the fail-safe direction and it only works because callers *compare* the result against the declaration rather than trusting it.

**`clusterOf` no longer falls back to `mainnet-beta` — it throws.** That fallback was the bug in its purest form: an ordinary devnet endpoint like `https://rostr.rpcpool.com/<key>` matched none of its substring branches and was recorded as **mainnet**, permanently, in the column the join gate reads. It survives as an endpoint-*shape* helper for the program tests, whose endpoints are all `127.0.0.1` and so unaffected.

**The cluster is asserted before the anchor route reads a single account**, not just before it writes — every check there runs against whatever `connection` is talking to. Its return value is what gets recorded, so no unverified cluster can reach the write-once column.

**The join route's check is no longer a conditional spread.** An unset `SOLANA_CLUSTER` did not relax it, it *deleted* it, and the deployment guaranteed to have it unset is the one nobody configured.

**The browser cross-checks itself at runtime.** `ClusterBanner` asks its endpoint for a genesis hash and warns when it disagrees with the build — the only place the browser's chain is a fact rather than a convention, and the browser is where the signing happens. A banner rather than a block: the adapter belongs to the extension and the server already refuses. A failed lookup says nothing, because claiming a mismatch on a network blip trains people to dismiss the real one.

## Worth flagging

**`.env.example` now defaults to devnet**, where it previously shipped `SOLANA_RPC_URL=https://api.mainnet-beta.solana.com` and `SOLANA_CLUSTER=mainnet-beta`. That file is what someone copies to run locally, and pointing local development at mainnet is the bug class this PR closes. It does not touch the settled decision to run the 2026 pot on mainnet — that is a deployment's `.env`, not the template.

## Verification

`pnpm test` **1099 passing** (1063 before; +36 new), `typecheck`, `lint`, `format:check` clean, and `next build` succeeds — which also exercises the `NEXT_PUBLIC_*` inlining and the `server-only` boundary.

Both load-bearing guards were mutation-checked: replacing the production refusal and the genesis comparison with `false` fails exactly 3 tests.

**Not run here:** `anchor test` — this machine has no Rust toolchain. No Rust changed, and the two program tests that call `clusterOf` do so against `127.0.0.1`, which still classifies as `localnet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
