### PR TITLE
feat(core): give the timelock refund a floor it cannot open before

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1382,6 +1382,51 @@ count. **Every extra condition is a new way for money to become permanently stuc
 is the one failure this program exists to make impossible. This is why BUILD-PLAN says
 ship it first. Do not add a condition to it.
 
+**Which makes `refundUnlockAt` the only thing protecting the pot, so it has a floor.**
+Because the refund is unconditional once it opens, a date set before the season ends is not
+a smaller version of the same design — it is a different one. Refunding decrements
+`total_deposited` but touches neither `member_count` nor the `Membership`, so a losing
+manager who withdrew in week 6 would keep their roster, their standings place and their
+claim on the pot, and play out the season with nothing at risk. Until 2026-08-11 the only
+checks were `> 0` off-chain and `> now` on-chain: a commissioner could have set it to next
+Tuesday.
+
+`validateLeagueRules` now refuses a league whose refund opens before
+`earliestRefundUnlock(...)` — the draft, plus the last scheduled week, plus the paying
+correction window, plus **sixty days**. Every term is already in the frozen rules, so this
+adds no field and **does not move the golden hash**.
+
+**The check is at creation, never at refund**, and that distinction is the whole design.
+A creation-time rule can only refuse to _make_ a league; a rule on `refund_stake` could
+trap money in one that already exists.
+
+**Sixty days, not thirty.** The floor is measured from the draft because that is the only
+real timestamp the rules carry, and the rules do not record the gap between the draft and
+kickoff — eighteen days in 2026 — so the estimate lands early. Worked through: a 10-day
+buffer puts the floor at Jan 5, _before_ the Jan 10 settlement, which is actively broken;
+30 days gives a fortnight of real margin; 60 gives about six weeks. The sizing follows from
+the failure modes being asymmetric — too late is members waiting longer for money they will
+certainly get back, too early is the pot being taken by whoever transacts first, in a
+program with no authority field and nothing to claw it back with. An uncertain estimate
+rounds toward the side where being wrong is merely annoying.
+
+**It also separates payout from refund without either instruction knowing about the
+other.** D6 will draw on the same vault, and the grace window is the gap between "winners
+can be paid" and "the escape hatch opens" — so the two cannot both be legal at once. If
+settlement misses that window, refunds open and everyone recovers their stake, which is the
+correct failure and not a bug.
+
+`CreateLeagueForm` seeds its refund field from the **same function**, so the form cannot
+suggest a date the server will refuse. It used to hardcode `2027-03-01` under a comment
+reading "two weeks after the championship" — wrong by six weeks, and a constant sitting
+next to a draft date the commissioner can move.
+
+**Still open, and a separate decision:** `RULES.md` promises auto-dissolve for a league
+that never fills, and dissolve by unanimous consent. **Neither exists** — the program has
+exactly five instructions and none of them is one. The timelock is silently doing that job,
+which for a league that never drafted means waiting months for money that was never at
+stake.
+
 **`deposit` takes no amount argument.** It moves `league.buy_in` and nothing else, so
 "everyone stakes the identical amount" is structural rather than a check that could be
 reordered around. A member who wants to overpay has no instruction that permits it.

--- a/apps/web/src/components/CreateLeagueForm.tsx
+++ b/apps/web/src/components/CreateLeagueForm.tsx
@@ -4,11 +4,14 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   buildNflPprRules,
+  earliestRefundUnlock,
   hashLeagueRules,
   MAX_BUY_IN_BASE_UNITS,
   MIN_BUY_IN_BASE_UNITS,
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
+  NFL_DEFAULT_SCHEDULE,
+  NFL_DEFAULT_SETTLEMENT,
   NFL_WINNER_TAKE_ALL_PAYOUT,
 } from "@rostr/core";
 import type { LeagueRules, PotRules } from "@rostr/core";
@@ -68,11 +71,49 @@ const MAX_BUY_IN_USDC = MAX_BUY_IN_BASE_UNITS / 1_000_000;
  */
 const TRADE_DEADLINE_WEEKS = [8, 9, 10, 11, 12, 13, 14];
 
-/** Two weeks after the championship, so a stuck league can always be unwound. */
-const DEFAULT_REFUND_UNLOCK = "2027-03-01T00:00";
+/** The Aug 22 deadline: leagues must be draftable by then. */
+const DEFAULT_DRAFT_AT = "2026-08-22T14:00";
 
 function localToUnix(value: string): number {
   return Math.floor(new Date(value).getTime() / 1000);
+}
+
+function unixToLocalInput(seconds: number): string {
+  const d = new Date(seconds * 1000);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+/**
+ * The earliest date `validateLeagueRules` will accept, for this draft date.
+ *
+ * **Derived, not typed out.** It was `"2027-03-01T00:00"` with a comment saying
+ * "two weeks after the championship" — which was wrong by six weeks, and worse,
+ * it was a constant sitting next to a draft date the commissioner can move. Push
+ * the draft back a fortnight and a hardcoded refund date silently becomes
+ * illegal, and the creator gets a validation error about a field they never
+ * touched.
+ *
+ * Calling the same function the validator calls means the form cannot suggest a
+ * date the server will refuse. The floor already carries sixty days of grace, so
+ * offering it directly is safe rather than borderline — and a commissioner who
+ * wants later can pick later.
+ */
+function defaultRefundUnlock(draftAt: string): string {
+  const scheduledAt = localToUnix(draftAt);
+  if (!Number.isFinite(scheduledAt)) return "";
+
+  return unixToLocalInput(
+    earliestRefundUnlock({
+      draftScheduledAt: scheduledAt,
+      regularSeasonWeeks: NFL_DEFAULT_SCHEDULE.regularSeasonWeeks,
+      playoffWeeks: NFL_DEFAULT_SCHEDULE.playoffWeeks,
+      payingFinalizationHours: NFL_DEFAULT_SETTLEMENT.payingFinalizationHours,
+    }),
+  );
 }
 
 export function CreateLeagueForm() {
@@ -80,20 +121,29 @@ export function CreateLeagueForm() {
 
   const [name, setName] = useState("");
   const [visibility, setVisibility] = useState<"PRIVATE" | "PUBLIC">("PRIVATE");
-  const [draftAt, setDraftAt] = useState("2026-08-22T14:00");
+  const [draftAt, setDraftAt] = useState(DEFAULT_DRAFT_AT);
   const [mode, setMode] = useState<"FAST" | "SLOW">("SLOW");
   const [pickSeconds, setPickSeconds] = useState(14_400);
   const [tradeDeadlineWeek, setTradeDeadlineWeek] = useState(11);
   const [withPot, setWithPot] = useState(false);
   const [buyIn, setBuyIn] = useState("25");
   const [payoutShape, setPayoutShape] = useState<"SPLIT" | "WINNER_TAKE_ALL">("SPLIT");
-  const [refundUnlock, setRefundUnlock] = useState(DEFAULT_REFUND_UNLOCK);
+  // Seeded from the draft date, and follows it until the commissioner sets one
+  // themselves. Moving the draft back a fortnight would otherwise leave a refund
+  // date the server refuses, and the error would name a field they never touched.
+  const [refundUnlock, setRefundUnlock] = useState(() => defaultRefundUnlock(DEFAULT_DRAFT_AT));
+  const [refundTouched, setRefundTouched] = useState(false);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [problems, setProblems] = useState<readonly string[]>([]);
 
   const clocks = mode === "FAST" ? FAST_CLOCKS : SLOW_CLOCKS;
+
+  function changeDraftAt(next: string): void {
+    setDraftAt(next);
+    if (!refundTouched) setRefundUnlock(defaultRefundUnlock(next));
+  }
 
   function switchMode(next: "FAST" | "SLOW"): void {
     setMode(next);
@@ -233,7 +283,7 @@ export function CreateLeagueForm() {
             type="datetime-local"
             required
             value={draftAt}
-            onChange={(e) => setDraftAt(e.target.value)}
+            onChange={(e) => changeDraftAt(e.target.value)}
             className="rounded border border-white/15 bg-transparent px-3 py-2"
           />
           <span className="mt-1 block text-xs text-white/40">
@@ -388,7 +438,10 @@ export function CreateLeagueForm() {
                 <input
                   type="datetime-local"
                   value={refundUnlock}
-                  onChange={(e) => setRefundUnlock(e.target.value)}
+                  onChange={(e) => {
+                    setRefundTouched(true);
+                    setRefundUnlock(e.target.value);
+                  }}
                   className="rounded border border-white/15 bg-transparent px-3 py-2"
                 />
                 <span className="mt-1 block text-xs text-white/40">

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,7 +63,7 @@ export {
 } from "./rules/nfl-ppr.js";
 
 export { encodeLeagueRules, hashLeagueRules, verifyLeagueRulesHash } from "./rules/hash.js";
-export { validateLeagueRules } from "./rules/validate.js";
+export { earliestRefundUnlock, validateLeagueRules } from "./rules/validate.js";
 
 export {
   buildJoinMessage,

--- a/packages/core/src/rules/refund-floor.test.ts
+++ b/packages/core/src/rules/refund-floor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { earliestRefundUnlock } from "./validate.js";
+import { NFL_DEFAULT_SCHEDULE, NFL_DEFAULT_SETTLEMENT } from "./nfl-ppr.js";
+
+/**
+ * The floor itself, separately from the validation that consumes it.
+ *
+ * `CreateLeagueForm` seeds its refund-date field from this same function, which
+ * is the only reason the form cannot suggest a date the server will refuse. It
+ * previously hardcoded `"2027-03-01T00:00"` under a comment claiming "two weeks
+ * after the championship" — wrong by six weeks, and sitting next to a draft date
+ * the commissioner can move.
+ */
+
+const nfl = (draftScheduledAt: number) =>
+  earliestRefundUnlock({
+    draftScheduledAt,
+    regularSeasonWeeks: NFL_DEFAULT_SCHEDULE.regularSeasonWeeks,
+    playoffWeeks: NFL_DEFAULT_SCHEDULE.playoffWeeks,
+    payingFinalizationHours: NFL_DEFAULT_SETTLEMENT.payingFinalizationHours,
+  });
+
+const at = (iso: string) => Math.floor(new Date(iso).getTime() / 1000);
+const day = (seconds: number) => new Date(seconds * 1000).toISOString().slice(0, 10);
+
+describe("earliestRefundUnlock", () => {
+  it("lands well clear of the real settlement date for the 2026 season", () => {
+    // The season this was designed against: draft Aug 22 2026, championship
+    // Jan 3 2027, final payouts Jan 10 after the 168h window. The floor has to
+    // sit comfortably past that last date, because refund and payout drawing on
+    // the same vault at the same time is the failure it exists to prevent.
+    const floor = nfl(at("2026-08-22T14:00:00Z"));
+
+    expect(day(floor)).toBe("2027-02-24");
+    expect(floor).toBeGreaterThan(at("2027-01-10T00:00:00Z"));
+  });
+
+  it("keeps at least a month of clearance past settlement", () => {
+    // The margin is the point, not the exact date. The estimate is knowingly
+    // early — the rules do not record the gap between the draft and kickoff —
+    // so this asserts the buffer actually survives that, rather than that the
+    // arithmetic produces some particular day.
+    const settlement = at("2027-01-10T00:00:00Z");
+    const floor = nfl(at("2026-08-22T14:00:00Z"));
+
+    expect((floor - settlement) / 86_400).toBeGreaterThan(30);
+  });
+
+  it("moves with the draft, so a later draft cannot outrun it", () => {
+    // The bug the form had: a constant refund date beside a movable draft date.
+    // Push the draft back and a fixed date silently becomes illegal.
+    const early = nfl(at("2026-07-01T09:00:00Z"));
+    const late = nfl(at("2026-09-05T14:00:00Z"));
+
+    expect(late - early).toBe(at("2026-09-05T14:00:00Z") - at("2026-07-01T09:00:00Z"));
+  });
+
+  it("uses the last week, not the count of playoff weeks", () => {
+    // Playoff weeks need not follow the regular season immediately, and adding
+    // up lengths would finish early for a league that leaves a gap.
+    const contiguous = earliestRefundUnlock({
+      draftScheduledAt: 0,
+      regularSeasonWeeks: 14,
+      playoffWeeks: [15, 16, 17],
+      payingFinalizationHours: 168,
+    });
+    const gapped = earliestRefundUnlock({
+      draftScheduledAt: 0,
+      regularSeasonWeeks: 14,
+      playoffWeeks: [18, 19, 20],
+      payingFinalizationHours: 168,
+    });
+
+    expect(gapped - contiguous).toBe(3 * 7 * 86_400);
+  });
+
+  it("falls back to the regular season when there are no playoff weeks", () => {
+    // `Math.max(...[])` is -Infinity, which would make the floor NaN and every
+    // comparison against it false — a validation rule that silently stops
+    // validating. The seed guards it.
+    const floor = earliestRefundUnlock({
+      draftScheduledAt: 0,
+      regularSeasonWeeks: 14,
+      playoffWeeks: [],
+      payingFinalizationHours: 168,
+    });
+
+    expect(Number.isFinite(floor)).toBe(true);
+    expect(floor).toBe(14 * 7 * 86_400 + 168 * 3600 + 60 * 86_400);
+  });
+});

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -443,6 +443,58 @@ describe("validateLeagueRules", () => {
     );
   });
 
+  it("rejects a refund unlock before the pot could have settled", () => {
+    // The escape hatch opening mid-season is not a smaller version of it
+    // opening late — it lets a losing manager take their stake back and keep
+    // playing for a pot they no longer stand behind, because refunding does not
+    // remove them from the league.
+    const bad = mutate((d) => {
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt = d.draft.scheduledAt + 30 * 86_400;
+    });
+    expect(validateLeagueRules(bad, NFL)).toContainEqual(expect.stringContaining("too early"));
+  });
+
+  it("says how many days short the refund unlock is", () => {
+    // A creator cannot fix a date they would have to compute themselves, and the
+    // rules are frozen the moment they are written — so the message carries the
+    // shortfall and the earliest legal value rather than only refusing.
+    const bad = mutate((d) => {
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt = 1;
+    });
+    const problems = validateLeagueRules(bad, NFL);
+    expect(problems).toContainEqual(expect.stringMatching(/\d+ days too early/));
+    expect(problems).toContainEqual(expect.stringContaining("earliest permitted value"));
+  });
+
+  it("accepts a refund unlock later than the floor", () => {
+    // A floor, not a prescription. Ten years out is legal, if strange.
+    const late = mutate((d) => {
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt =
+        d.draft.scheduledAt + 3650 * 86_400;
+    });
+    expect(validateLeagueRules(late, NFL)).toEqual([]);
+  });
+
+  it("moves the floor with the league's own schedule", () => {
+    // Derived, not a constant. A league whose playoffs run to week 20 must hold
+    // its refund shut three weeks longer than one ending at 17 — and the
+    // fixture's date, legal by six days at week 17, stops being legal.
+    const longer = mutate((d) => {
+      (d.schedule as { regularSeasonWeeks: number }).regularSeasonWeeks = 17;
+      (d.schedule as { playoffWeeks: number[] }).playoffWeeks = [18, 19, 20];
+    });
+    expect(validateLeagueRules(longer, NFL)).toContainEqual(
+      expect.stringContaining("too early"),
+    );
+  });
+
+  it("does not constrain a free league, which has no pot to protect", () => {
+    const free = mutate((d) => {
+      (d as { pot: unknown }).pot = null;
+    });
+    expect(validateLeagueRules(free, NFL)).toEqual([]);
+  });
+
   it("rejects a non-deterministic final tiebreaker", () => {
     const bad = mutate((d) => {
       (d.schedule as { tiebreakers: string[] }).tiebreakers = ["WIN_PCT", "POINTS_FOR"];

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -26,6 +26,42 @@ const SLOW_PICK_SECONDS = [3600, 14_400, 28_800, 86_400];
 /** The NFL issues official stat corrections for up to seven days. */
 const MIN_PAYING_FINALIZATION_HOURS = 168;
 
+/**
+ * How long after the last prize could possibly be settled the timelock refund
+ * must stay shut.
+ *
+ * `refund_stake` is unconditional after `refundUnlockAt` — by design, because it
+ * is the escape hatch for every failure the program cannot anticipate, and every
+ * condition added to it is a new way for money to become permanently stuck. That
+ * makes the *date* the only thing standing between the pot and a member who has
+ * lost. Set it before the season ends and a losing manager withdraws in week 6
+ * and plays on with nothing at risk: refunding decrements `total_deposited` but
+ * does not touch `member_count` or the membership, so they keep their roster,
+ * their standings place, and their claim on the pot.
+ *
+ * ## Why sixty days rather than a fortnight
+ *
+ * The floor below is computed from the draft, because that is the only real
+ * timestamp the rules carry — and **the rules do not record the gap between the
+ * draft and the first game**. For 2026 that gap is eighteen days (draft Aug 22,
+ * kickoff Sep 9), so the estimate lands about a fortnight *early*. This buffer
+ * absorbs that as well as leaving the payout room to run.
+ *
+ * The two ways of being wrong are not symmetric, which is what decides the size:
+ *
+ * - **Too late** — in the rare case settlement is broken, members wait longer
+ *   for money they will certainly get back. An inconvenience.
+ * - **Too early** — the escape hatch opens while the pot is still owed to the
+ *   winners, and whoever transacts first takes it. Unrecoverable, in a program
+ *   with no authority field and no way to claw anything back.
+ *
+ * One is annoying and one is theft, so an uncertain estimate rounds toward the
+ * annoying side.
+ *
+ * A commissioner may always choose a **later** date; this is a floor.
+ */
+const MIN_REFUND_GRACE_SECONDS = 60 * 24 * 60 * 60;
+
 function validateScoring(rules: LeagueRules, sport: SportDef, out: string[]): void {
   const known = statKeysByKey(sport);
   const seen = new Set<string>();
@@ -314,6 +350,71 @@ function validateTrades(rules: LeagueRules, out: string[]): void {
   }
 }
 
+/**
+ * The earliest instant a league's timelock refund may open.
+ *
+ * Every term comes from the frozen rules, so this needs no calendar, no provider
+ * and no new field — which matters, because adding a field would move the golden
+ * hash and break the `rules_hash` of every league already anchored.
+ *
+ * ```
+ *   draft.scheduledAt
+ * + (regularSeasonWeeks + playoffWeeks.length) weeks
+ * + payingFinalizationHours          the correction window on the last prize
+ * + MIN_REFUND_GRACE_SECONDS
+ * ```
+ *
+ * **It is an approximation, and knowingly a conservative one.** The rules do not
+ * record when the season starts, only when the draft is, so the weeks are
+ * counted from a point some way before kickoff and the estimate lands early. See
+ * `MIN_REFUND_GRACE_SECONDS` for why the buffer is sized to swallow that.
+ *
+ * The last playoff week is used rather than `regularSeasonWeeks + playoffWeeks
+ * .length` being assumed contiguous — a league may define playoff weeks that do
+ * not immediately follow the regular season, and counting the array's length
+ * would then finish early.
+ */
+export function earliestRefundUnlock(input: {
+  readonly draftScheduledAt: number;
+  readonly regularSeasonWeeks: number;
+  readonly playoffWeeks: readonly number[];
+  readonly payingFinalizationHours: number;
+}): number {
+  // `Math.max` over both, because either could be the later one: a league with
+  // no playoff weeks at all finishes at the end of its regular season.
+  const lastWeek = Math.max(input.regularSeasonWeeks, ...input.playoffWeeks, 0);
+
+  return (
+    input.draftScheduledAt +
+    lastWeek * 7 * 24 * 60 * 60 +
+    input.payingFinalizationHours * 60 * 60 +
+    MIN_REFUND_GRACE_SECONDS
+  );
+}
+
+function refundUnlockFloor(rules: LeagueRules): number {
+  return earliestRefundUnlock({
+    draftScheduledAt: rules.draft.scheduledAt,
+    regularSeasonWeeks: rules.schedule.regularSeasonWeeks,
+    playoffWeeks: rules.schedule.playoffWeeks,
+    payingFinalizationHours: rules.settlement.payingFinalizationHours,
+  });
+}
+
+function validateRefundUnlock(rules: LeagueRules, refundUnlockAt: number, out: string[]): void {
+  const floor = refundUnlockFloor(rules);
+  if (refundUnlockAt >= floor) return;
+
+  const short = Math.ceil((floor - refundUnlockAt) / (24 * 60 * 60));
+
+  out.push(
+    `pot.refundUnlockAt is ${short} day${short === 1 ? "" : "s"} too early: the timelock ` +
+      `refund is unconditional once it opens, so a date before the last prize has settled ` +
+      `lets a losing member withdraw and keep playing for a pot they no longer stand behind. ` +
+      `The earliest permitted value is ${floor}.`,
+  );
+}
+
 function validatePot(rules: LeagueRules, out: string[]): void {
   const pot = rules.pot;
   if (pot === null) return;
@@ -339,7 +440,11 @@ function validatePot(rules: LeagueRules, out: string[]): void {
     }
   }
   if (pot.tokenMint.length === 0) out.push("pot requires a token mint");
-  if (pot.refundUnlockAt <= 0) out.push("pot requires a refund unlock time");
+  if (pot.refundUnlockAt <= 0) {
+    out.push("pot requires a refund unlock time");
+  } else {
+    validateRefundUnlock(rules, pot.refundUnlockAt, out);
+  }
 
   // A fee is permitted to be zero — a league that pays us nothing is a valid
   // league — but never negative, never fractional, and never unbounded.


### PR DESCRIPTION
> Stacked on #64 (docs-only) because both touch `CLAUDE.md`. Retarget to `main` when that merges.

`refund_stake` is unconditional once `refundUnlockAt` passes, and that's deliberate — it's the escape hatch for every failure the program can't anticipate, and each condition added to it is a new way for money to become permanently stuck.

**Which makes the date the only thing protecting the pot.** And the date had almost no constraints:

- `pot.refundUnlockAt <= 0` → error ([validate.ts](packages/core/src/rules/validate.ts))
- `args.refund_unlock_at > now` ([lib.rs:188](programs/rostr-escrow/src/lib.rs#L188))

A commissioner could set it to next Tuesday.

## Why that isn't a milder version of the same design

Refunding decrements `total_deposited` but touches **neither `member_count` nor the `Membership`**. So a losing manager who withdrew in week 6 keeps their roster, their standings place, and their claim on the pot — and plays out the season with nothing at risk. Everyone else's money is still in the vault. Theirs isn't.

## The rule

```
floor = draft.scheduledAt
      + last scheduled week
      + payingFinalizationHours
      + 60 days
```

Every term is already in the frozen rules, so this **adds no field and does not move the golden hash** — the fixture test still passes unchanged.

**The check is at creation, never at refund**, and that distinction is the whole design. A creation-time rule can only refuse to *make* a league. A rule on `refund_stake` could trap money in one that already exists.

## Why 60 days and not 30

The floor is measured from the draft, because that's the only real timestamp the rules carry — and **the rules don't record the gap between the draft and kickoff**. In 2026 that's 18 days, so the estimate lands early.

| Buffer | Floor | Verdict |
|---|---|---|
| 10 days | Jan 5 2027 | **Broken** — before the Jan 10 settlement |
| 30 days | Jan 25 2027 | Works, ~2 weeks of real margin |
| 60 days | Feb 24 2027 | ~6 weeks |

The sizing follows from the failure modes being asymmetric:

- **Too late** — members wait longer for money they will certainly get back. An inconvenience.
- **Too early** — the escape hatch opens while the pot is owed to winners, and whoever transacts first takes it. Unrecoverable, in a program with no authority field.

One is annoying, one is theft. An uncertain estimate rounds toward annoying.

## It also solves the D6 race for free

Payout and refund will draw on the same vault with no mutual exclusion and no `settled` flag. The grace window is the gap between "winners can be paid" and "the escape hatch opens" — so the two can't both be legal at once, **without either instruction knowing about the other**. Miss the window and refunds open and everyone recovers their stake, which is the correct failure rather than a bug.

## The form was lying

`CreateLeagueForm` hardcoded `"2027-03-01T00:00"` under a comment reading *"two weeks after the championship"*. It's six weeks, and worse, it was a constant sitting beside a draft date the commissioner can move — push the draft back a fortnight and it silently becomes illegal, and the creator gets an error about a field they never touched. It now seeds from `earliestRefundUnlock`, the same function the validator calls, and follows the draft date until the commissioner sets one themselves.

## Verification

`pnpm test` **1130 passing**, `typecheck`, `lint`, `format:check`, `next build` clean.

The three new validation tests were **mutation-checked**: stub the comparison to always pass and exactly those three fail.

`earliestRefundUnlock` has its own tests, including one for `playoffWeeks: []` — `Math.max(...[])` is `-Infinity`, which would make the floor `NaN` and every comparison against it false, turning the rule into one that silently stops validating.

## Not addressed

`RULES.md` promises auto-dissolve for a league that never fills, and dissolve by unanimous consent. **Neither exists** — the program has five instructions and none is one. The timelock is quietly doing that job, which for a league that never drafted means waiting months for money that was never at stake. Needs Rust and an owner decision; flagged in `CLAUDE.md` rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
