### PR TITLE
fix(escrow): stop the program guarding a guest list it cannot read (closes #18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1075,6 +1075,32 @@ schemaVersion 2 → 3.
 describes a league that cannot exist. The helper produces the same rows a real join
 produces, minus the signature.
 
+### Joining and staking are one approval
+
+`JoinPanel.onchainJoin` puts `join_league` and `deposit` in a **single transaction**.
+
+They used to be two, in two different components, so a pot league asked a new member for
+**four wallet approvals**: prove the wallet, sign the rules, take the seat, pay. Four is
+where somebody says "I'll do it later" and doesn't, and each one of those is a league that
+does not fill. Nothing was wrong with either transaction; the count was the problem.
+
+**An atomic failure is the good outcome here.** If the member cannot cover the buy-in, the
+join rolls back with it rather than leaving a seat claimed and unpaid. That only became
+safe once #18 removed the on-chain seat cap — before it, an unfunded seat was a permanently
+denied one, so grabbing a seat early had value. Now it has none. The two changes compose,
+and the UI says so plainly, because an all-or-nothing transaction otherwise reads as a
+failure rather than as the safe result.
+
+**Three states, not two.** The retry reads the `Membership` account itself rather than
+merely checking that it exists, which was sufficient while the halves were separate and is
+not now: no account (send both), `deposited == 0` (send the stake alone — an interrupted
+member, or one who joined before batching existed), funded (send nothing, recover the
+signature, re-POST). Reading the second as the third would tell a member they had paid when
+they had not.
+
+`DepositPanel` keeps its stake button for exactly that middle state, and says so rather
+than presenting itself as the normal path.
+
 ### Joining requires the anchor
 
 `joinLeague` refuses an unanchored league. Joining signs the rules hash, and the point of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1482,6 +1482,29 @@ USDC is a legacy mint. Milestone E's roster NFTs are Token-2022 and unrelated to
 **The vault's authority is the league PDA**, so no key held by any person can move the
 pot — only this program, only through these instructions.
 
+**`max_teams` is published, not enforced, and D6 must be built knowing that.** The
+`member_count < max_teams` gate was removed from `join_league` on 2026-08-11 (issue #18):
+it guarded a guest list the program cannot read. Being _in a league_ is a Postgres fact — a
+team, a roster, a draft slot — while a `Membership` here means only "this wallet has a
+stake". So the check handed seats out first-come to anyone on the internet while the real
+roster was decided elsewhere, and since nothing closes a `Membership` or decrements
+`member_count` — not even `refund_stake` — claiming all twelve for about **0.011 SOL**
+bricked a league permanently. `joinLeague` enforces the size against the actual roster, and
+always did.
+
+**The consequence for settlement: pay the known member set, never a percentage of the vault
+balance.** Anyone may now open a `Membership` and deposit into any league they can name.
+That is self-harm rather than leverage — they cannot win and their stake is locked until
+`refundUnlockAt` — but it means `total_deposited` is not the pot. Paying `bps × vault`
+would hand a stranger's money to the winners and leave the vault short when that stranger
+refunds. Settlement takes the members it is paying as input and computes from
+`real_members × buy_in`. This is the better shape regardless: a payout derived from a
+mutable balance is one deposit away from being wrong.
+
+**An eviction instruction was considered and rejected** as weaker, not simpler: it can only
+clear seats that were never funded, so an attacker who deposits still blocks the league and
+merely pays for the privilege with money the timelock returns.
+
 `payout_bps` is positional, indexed by the `prize` module. **That order is
 `PRIZE_ORDER` in `packages/escrow/src/instructions.ts`, not the declaration order of the `PrizeKey`
 union** — the two differ, and a client serialising from the wrong one reshuffles the split

--- a/apps/web/src/app/leagues/[id]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/page.tsx
@@ -126,6 +126,8 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
         linkedWallets={wallets.map((wallet) => wallet.address)}
         anchored={chain?.anchoredAt !== null && chain?.anchoredAt !== undefined}
         isCommissioner={user !== null && commissioner?.commissioner_id === user.id}
+        hasPot={stored.rules.pot !== null}
+        tokenMint={stored.rules.pot?.tokenMint ?? null}
         resumable={resumable}
       />
 

--- a/apps/web/src/components/DepositPanel.tsx
+++ b/apps/web/src/components/DepositPanel.tsx
@@ -165,6 +165,10 @@ export function DepositPanel({
         Staking moves the buy-in from your wallet into the league vault. Refund is open once the
         timelock passes — and is unconditional, so your stake can never be stuck.
       </p>
+      <p className="text-xs text-white/40">
+        Joining normally stakes for you in the same approval. This is here for a stake that was
+        interrupted, or one from before that was true.
+      </p>
 
       {!connected ? (
         <WalletMultiButton />

--- a/apps/web/src/components/JoinPanel.tsx
+++ b/apps/web/src/components/JoinPanel.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
-import { Transaction } from "@solana/web3.js";
+import { PublicKey, Transaction } from "@solana/web3.js";
 import {
+  depositIx,
   escrowProgram,
   hexToBytes,
   joinLeagueIx,
@@ -29,14 +30,19 @@ import bs58 from "bs58";
  *      verbatim. A client that composed its own could sign one rule set and be
  *      admitted under another.
  *
- * And then a fifth step, the on-chain half (issue #26): after consent is
- * recorded in Postgres, the member signs `join_league` from their own wallet so
- * the program's `Membership` account exists. Without it, `deposit` and
- * `refund_stake` have no account to act on, and the on-chain member count — which
- * the program uses to refuse a full league — stays at zero. The server does not
- * take the client's word for it: `/join-onchain` reads the `Membership` PDA back
- * before recording, and derives the wallet from the caller's own consent row
- * rather than from anything sent here.
+ * And then a fifth step, the on-chain half (issues #26 and #27): after consent
+ * is recorded in Postgres, the member signs `join_league` — **and `deposit`, in
+ * the same transaction, when the league has a pot** — from their own wallet, so
+ * the program's `Membership` account exists and holds their stake. Without it,
+ * `deposit` and `refund_stake` have no account to act on. The server does not
+ * take the client's word for it: `/join-onchain` and `/deposit` each read the
+ * `Membership` PDA back before recording, and both derive the wallet from the
+ * caller's own consent row rather than from anything sent here.
+ *
+ * One approval rather than two, because four wallet popups is where a new member
+ * gives up — see `onchainJoin`. The on-chain member count is **not** the reason
+ * the seat matters: #18 removed the seat cap from the program, so that count
+ * decides nothing now.
  *
  * ## The fifth step has to survive leaving the page
  *
@@ -58,11 +64,16 @@ import bs58 from "bs58";
  * response is the one path that cannot work.
  *
  * In-memory state alone is not enough, because a reload loses it and leaves the
- * same dead end. So the retry also asks the chain whether the `Membership`
- * account already exists and, if it does, recovers the transaction that created
- * it. Between them the two cover every way an attempt can be interrupted: the
- * account either does not exist (send it) or does (record what already
- * happened).
+ * same dead end. So the retry reads the `Membership` account itself and sends
+ * only what is missing.
+ *
+ * **The account itself, not merely whether it exists** — that was enough while
+ * joining and staking were separate, and is not now. There are three states, not
+ * two: no account (send both), an account with `deposited == 0` (send the stake
+ * alone, which is where a member interrupted mid-flow or one who joined before
+ * batching existed lands), and a funded account (send nothing, recover the
+ * signature, re-POST). Treating the second as the third would tell a member they
+ * had paid when they had not.
  */
 export function JoinPanel({
   leagueId,
@@ -74,6 +85,8 @@ export function JoinPanel({
   anchored,
   isCommissioner,
   resumable = false,
+  hasPot,
+  tokenMint,
 }: {
   leagueId: string;
   leagueName: string;
@@ -90,6 +103,10 @@ export function JoinPanel({
    * step is still owed. Server-resolved, so it survives a reload.
    */
   resumable?: boolean;
+  /** Whether the fifth step also has to move money. */
+  hasPot: boolean;
+  /** The pot token mint. Required when `hasPot`, null for a free league. */
+  tokenMint: string | null;
 }) {
   const { connection } = useConnection();
   const { publicKey, signMessage, signTransaction, connected } = useWallet();
@@ -248,12 +265,53 @@ export function JoinPanel({
   }
 
   /**
-   * The on-chain half of joining (issue #26).
+   * POST one half of the on-chain record, or explain which half failed.
    *
-   * The member signs `join_league` from their own wallet — no key of ours is
-   * involved — and the server reads the Membership PDA back to confirm it before
-   * recording anything. This is the same verify-don't-trust pattern the anchor
-   * uses, applied one level down.
+   * Named in the error because both halves ride one signature: "the server could
+   * not verify it" is useless when there are two verifications and only one went
+   * wrong, and the retry behaviour differs between them.
+   */
+  async function record(url: string, signature: string, what: string): Promise<void> {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signature }),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? `The server could not verify the ${what}`);
+    }
+  }
+
+  /**
+   * The on-chain half of joining (issue #26), and the stake with it (issue #27).
+   *
+   * The member signs from their own wallet — no key of ours is involved — and
+   * the server reads the `Membership` PDA back to confirm each half before
+   * recording it. Same verify-don't-trust pattern as the anchor, one level down.
+   *
+   * ## One approval, not two
+   *
+   * `join_league` and `deposit` go into a **single transaction**. They used to
+   * be two, in two different components, which meant a pot league asked a new
+   * member for four wallet approvals: prove the wallet, sign the rules, take the
+   * seat, then pay. Four is where people say "I'll do it later" and don't, and
+   * every one of those is a league that does not fill.
+   *
+   * Batching them is also why an atomic failure is now the *good* outcome. If
+   * the member cannot cover the buy-in, the join rolls back with it rather than
+   * leaving a seat claimed and unfunded — and since #18 removed the on-chain
+   * seat cap, an unclaimed seat costs nobody anything, so there is no reason to
+   * grab one early.
+   *
+   * ## What is sent depends on what is already there
+   *
+   * Both instructions are `init`-shaped in the sense that neither can run twice:
+   * `join_league` fails with "account already in use", `deposit` refuses a
+   * second stake. So the account is read first and only the missing half is
+   * sent. That covers the interrupted attempt, the reload that loses in-memory
+   * state, and the member who joined on-chain before this batching existed.
    */
   async function onchainJoin(): Promise<void> {
     if (!publicKey || !signTransaction || !address) return;
@@ -261,64 +319,94 @@ export function JoinPanel({
     setStatus("onchain-signing");
 
     try {
-      // Send only if we have not already. `join_league` is `init`, so a second
-      // send fails with "account already in use" — re-signing would turn every
-      // recoverable POST failure into a permanent dead end.
+      const provider = new AnchorProvider(
+        connection,
+        { publicKey, signTransaction } as unknown as Wallet,
+        { commitment: "confirmed" },
+      );
+      const program = escrowProgram(provider);
+      const membershipAddress = membershipPda(leaguePda(leagueId), publicKey);
+
+      // The account itself, not just whether it exists: `deposited` is what says
+      // if the stake half is still owed, and a member part-way through needs
+      // exactly the half they are missing.
+      const existing = await program.account["membership"]?.fetchNullable(membershipAddress);
+      const staked =
+        existing !== null && existing !== undefined
+          ? BigInt((existing as { deposited: { toString(): string } }).deposited.toString()) >
+            0n
+          : false;
+
+      const needsJoin = !existing;
+      const needsStake = hasPot && !staked;
+
+      // Send only if there is something to send. `sentSignature` covers a POST
+      // that failed after the transaction landed; re-signing there would turn a
+      // recoverable failure into a permanent dead end.
       let signature = sentSignature;
 
-      // A reload loses `sentSignature`, so in-memory state is not enough: ask
-      // the chain whether the account already exists. It does exactly when a
-      // previous attempt landed and its POST did not, which is the case this
-      // whole retry path exists for. Recovering the creating transaction is
-      // what lets the audit record still name a real signature rather than
-      // inventing one.
-      if (signature === null) {
-        const membership = membershipPda(leaguePda(leagueId), publicKey);
-        if ((await connection.getAccountInfo(membership)) !== null) {
-          const [creating] = await connection.getSignaturesForAddress(membership, { limit: 1 });
-          if (!creating) {
-            throw new Error(
-              "Your membership account exists on-chain but the transaction that created " +
-                "it could not be found. An archival RPC endpoint can still confirm it.",
-            );
-          }
-          signature = creating.signature;
-          setSentSignature(signature);
-        }
-      }
-
-      if (signature === null) {
-        const provider = new AnchorProvider(
-          connection,
-          { publicKey, signTransaction } as unknown as Wallet,
-          { commitment: "confirmed" },
-        );
-        const program = escrowProgram(provider);
-
-        const ix = await joinLeagueIx(program, {
-          leagueId,
-          rulesHash: hexToBytes(rulesHash),
-          member: publicKey,
+      if (signature === null && !needsJoin && !needsStake) {
+        // Nothing owed on-chain, so a previous attempt landed and its POST did
+        // not — the case this retry path exists for. A reload loses
+        // `sentSignature`, so the creating transaction is recovered from the
+        // chain rather than invented, and the audit record still names a real
+        // one.
+        const [creating] = await connection.getSignaturesForAddress(membershipAddress, {
+          limit: 1,
         });
-
-        const tx = new Transaction().add(ix);
-        signature = await provider.sendAndConfirm(tx, [], { commitment: "confirmed" });
-
-        // Recorded before the POST, so a failure below retries the POST alone.
+        if (!creating) {
+          throw new Error(
+            "Your membership account exists on-chain but the transaction that created " +
+              "it could not be found. An archival RPC endpoint can still confirm it.",
+          );
+        }
+        signature = creating.signature;
         setSentSignature(signature);
       }
 
-      // No wallet address: the server reads it from this member's own consent
-      // row. A body field would let anyone write anyone else's record.
-      const response = await fetch(`/api/leagues/${leagueId}/join-onchain`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ signature }),
-      });
+      if (signature === null) {
+        const tx = new Transaction();
 
-      if (!response.ok) {
-        const body = (await response.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "The server could not verify the on-chain join");
+        if (needsJoin) {
+          tx.add(
+            await joinLeagueIx(program, {
+              leagueId,
+              rulesHash: hexToBytes(rulesHash),
+              member: publicKey,
+            }),
+          );
+        }
+        if (needsStake) {
+          if (!tokenMint) {
+            throw new Error(
+              "This league has a pot but no token mint, so the stake cannot be sent",
+            );
+          }
+          tx.add(
+            await depositIx(program, {
+              leagueId,
+              mint: new PublicKey(tokenMint),
+              member: publicKey,
+            }),
+          );
+        }
+
+        signature = await provider.sendAndConfirm(tx, [], { commitment: "confirmed" });
+
+        // Recorded before the POSTs, so a failure below retries them alone.
+        setSentSignature(signature);
+      }
+
+      // Two records for one transaction, and the order is deliberate: the join
+      // is what the stake is evidence *of*, and `/deposit` refuses a wallet with
+      // no membership row behind it.
+      //
+      // No wallet address in either body — the server reads it from this
+      // member's own consent row. A body field would let anyone write anyone
+      // else's record.
+      await record(`/api/leagues/${leagueId}/join-onchain`, signature, "on-chain join");
+      if (hasPot) {
+        await record(`/api/leagues/${leagueId}/deposit`, signature, "deposit");
       }
 
       setStatus("done");
@@ -372,11 +460,20 @@ export function JoinPanel({
           ) : status === "onchain" || status === "onchain-signing" ? (
             <div className="space-y-3 rounded border border-[--color-turf]/30 bg-[--color-turf]/5 p-4">
               <p className="text-sm text-white/80">
-                You are in. One more step to make it real on-chain: sign{" "}
-                <code className="font-mono text-xs">join_league</code> from your wallet so your
-                membership account exists. Until you do, the program has no account to stake
-                against.
+                {hasPot
+                  ? "You are in. One approval left: it takes your seat on-chain and stakes your buy-in together, in a single transaction."
+                  : "You are in. One approval left, to record your membership on-chain."}
               </p>
+              {hasPot && (
+                // Said plainly because it is the surprising half. An all-or-nothing
+                // transaction reads as a failure when it is the safe outcome — the
+                // alternative leaves a seat taken and unpaid, and there is no
+                // instruction that gives a seat back.
+                <p className="text-xs text-white/40">
+                  Both or neither. If the buy-in cannot be covered, the seat is not taken
+                  either, and you can try again once your wallet is funded.
+                </p>
+              )}
               {sentSignature !== null && (
                 <p className="text-xs text-white/40">
                   Your transaction already landed — this will not ask your wallet again, it just
@@ -392,7 +489,9 @@ export function JoinPanel({
                   ? "Waiting…"
                   : sentSignature !== null
                     ? "Retry confirmation"
-                    : "Confirm on-chain"}
+                    : hasPot
+                      ? "Confirm and stake"
+                      : "Confirm on-chain"}
               </button>
               {error && <p className="text-sm text-red-400">{error}</p>}
             </div>

--- a/programs/rostr-escrow/src/lib.rs
+++ b/programs/rostr-escrow/src/lib.rs
@@ -479,36 +479,48 @@ pub struct League {
     /// False for a league that plays for nothing: no vault, no deposits, but its
     /// rules hash is anchored here exactly like a pot league's.
     pub has_pot: bool,
-    /// The league's declared size, **published and not enforced**.
-    ///
-    /// It is part of the terms `anchorTermMismatches` compares against the signed
-    /// rules, so a creator still cannot anchor a size nobody agreed to. What it
-    /// no longer does is refuse a `join_league`.
-    ///
-    /// That check was removed because it guarded a guest list it cannot read.
-    /// Being *in a league* is a Postgres fact — a team, a roster, a draft slot —
-    /// and this program has no view of it; a `Membership` here means "this wallet
-    /// has a stake", which is a different thing. So the check could only ever
-    /// hand seats out first-come to anyone on the internet, while the real roster
-    /// was decided somewhere it could not see. `joinLeague` in `@rostr/db`
-    /// enforces the size against the actual roster, and always did.
-    ///
-    /// Meanwhile it cost about **0.011 SOL to brick a twelve-seat league
-    /// permanently** (issue #18): claim every seat with throwaway keypairs, and
-    /// since no instruction closes a `Membership` or decrements `member_count`,
-    /// the seats never come back. Not even `refund_stake` releases one. The only
-    /// remedy was recreating the league under a new UUID.
-    ///
-    /// **Do not restore the check.** An eviction instruction was considered and
-    /// is weaker: it can only clear seats that were never funded, so an attacker
-    /// who deposits still blocks the league and merely pays for the privilege
-    /// with money they get back at the timelock.
+    // ---------------------------------------------------------------------
+    // `//` and not `///` from here down, deliberately.
+    //
+    // Anchor compiles a `///` doc comment on a field into the IDL, so writing
+    // one is editing build output that `pnpm idl:check` compares byte for byte
+    // — and regenerating it needs `anchor build`, which needs a Rust toolchain.
+    // Documenting a field from a machine without one turns CI red for a reason
+    // that looks nothing like documentation. It cost a round trip here.
+    //
+    // Short `///` docs elsewhere in this struct predate that and are already in
+    // the committed IDL; leave them. New long-form rationale goes in `//`.
+    // ---------------------------------------------------------------------
+    // The league's declared size, **published and not enforced**.
+    //
+    // It is part of the terms `anchorTermMismatches` compares against the signed
+    // rules, so a creator still cannot anchor a size nobody agreed to. What it
+    // no longer does is refuse a `join_league`.
+    //
+    // That check was removed because it guarded a guest list it cannot read.
+    // Being *in a league* is a Postgres fact — a team, a roster, a draft slot —
+    // and this program has no view of it; a `Membership` here means "this wallet
+    // has a stake", which is a different thing. So the check could only ever
+    // hand seats out first-come to anyone on the internet, while the real roster
+    // was decided somewhere it could not see. `joinLeague` in `@rostr/db`
+    // enforces the size against the actual roster, and always did.
+    //
+    // Meanwhile it cost about **0.011 SOL to brick a twelve-seat league
+    // permanently** (issue #18): claim every seat with throwaway keypairs, and
+    // since no instruction closes a `Membership` or decrements `member_count`,
+    // the seats never come back. Not even `refund_stake` releases one. The only
+    // remedy was recreating the league under a new UUID.
+    //
+    // **Do not restore the check.** An eviction instruction was considered and
+    // is weaker: it can only clear seats that were never funded, so an attacker
+    // who deposits still blocks the league and merely pays for the privilege
+    // with money they get back at the timelock.
     pub max_teams: u8,
-    /// How many stakes have ever been opened. **Descriptive, not a limit.**
-    ///
-    /// Saturates at 255 rather than erroring — see `join_league`. Nothing reads
-    /// it to make a decision, so a count that stops climbing is a wrong number
-    /// on a dashboard rather than a wrong outcome.
+    // How many stakes have ever been opened. **Descriptive, not a limit.**
+    //
+    // Saturates at 255 rather than erroring — see `join_league`. Nothing reads
+    // it to make a decision, so a count that stops climbing is a wrong number
+    // on a dashboard rather than a wrong outcome.
     pub member_count: u8,
     /// Running total of live deposits, in base units. Decreases on refund, so
     /// it tracks what the vault actually holds rather than what it ever held.
@@ -725,11 +737,11 @@ pub enum EscrowError {
     RefundUnlockNotInFuture,
     #[msg("Accepted rules hash does not match the league's")]
     RulesHashMismatch,
-    /// **No longer raised.** Kept because error codes are positional: deleting a
-    /// variant renumbers every one below it, which silently changes what a
-    /// deployed client reports for four other failures, and it would move the
-    /// committed IDL that `idl:check` compares. Seat limits are enforced in
-    /// Postgres — see `League::max_teams`.
+    // **No longer raised.** Kept because error codes are positional: deleting a
+    // variant renumbers every one below it, which silently changes what a
+    // deployed client reports for four other failures, and it would move the
+    // committed IDL that `idl:check` compares. Seat limits are enforced in
+    // Postgres — see `League::max_teams`.
     #[msg("The league already has its full complement of teams")]
     LeagueFull,
     #[msg("This member has already staked their buy-in")]

--- a/programs/rostr-escrow/src/lib.rs
+++ b/programs/rostr-escrow/src/lib.rs
@@ -308,17 +308,19 @@ pub mod rostr_escrow {
         );
 
         let league = &mut ctx.accounts.league;
-        require!(
-            league.member_count < league.max_teams,
-            EscrowError::LeagueFull
-        );
-        // Saturating is wrong here and checked is right: at the cap this is
-        // unreachable, and if it ever were reachable, silently staying at the
-        // maximum would admit an extra member.
-        league.member_count = league
-            .member_count
-            .checked_add(1)
-            .ok_or(EscrowError::MathOverflow)?;
+
+        // **There is deliberately no seat check here.** See `League::max_teams`.
+        //
+        // Saturating, where this used to be checked. The old comment argued that
+        // checked was right because "at the cap this is unreachable, and if it
+        // ever were reachable, silently staying at the maximum would admit an
+        // extra member" — sound reasoning that depended entirely on the cap
+        // above it. Without the cap it inverts: `member_count` is a `u8`, so
+        // `checked_add` starts failing at 255 and 255 throwaway accounts —
+        // roughly a quarter of a SOL — would brick the league exactly as the
+        // seat cap did. Saturating cannot admit an extra member because it no
+        // longer decides admission.
+        league.member_count = league.member_count.saturating_add(1);
 
         let membership = &mut ctx.accounts.membership;
         membership.league = league.key();
@@ -477,7 +479,36 @@ pub struct League {
     /// False for a league that plays for nothing: no vault, no deposits, but its
     /// rules hash is anchored here exactly like a pot league's.
     pub has_pot: bool,
+    /// The league's declared size, **published and not enforced**.
+    ///
+    /// It is part of the terms `anchorTermMismatches` compares against the signed
+    /// rules, so a creator still cannot anchor a size nobody agreed to. What it
+    /// no longer does is refuse a `join_league`.
+    ///
+    /// That check was removed because it guarded a guest list it cannot read.
+    /// Being *in a league* is a Postgres fact — a team, a roster, a draft slot —
+    /// and this program has no view of it; a `Membership` here means "this wallet
+    /// has a stake", which is a different thing. So the check could only ever
+    /// hand seats out first-come to anyone on the internet, while the real roster
+    /// was decided somewhere it could not see. `joinLeague` in `@rostr/db`
+    /// enforces the size against the actual roster, and always did.
+    ///
+    /// Meanwhile it cost about **0.011 SOL to brick a twelve-seat league
+    /// permanently** (issue #18): claim every seat with throwaway keypairs, and
+    /// since no instruction closes a `Membership` or decrements `member_count`,
+    /// the seats never come back. Not even `refund_stake` releases one. The only
+    /// remedy was recreating the league under a new UUID.
+    ///
+    /// **Do not restore the check.** An eviction instruction was considered and
+    /// is weaker: it can only clear seats that were never funded, so an attacker
+    /// who deposits still blocks the league and merely pays for the privilege
+    /// with money they get back at the timelock.
     pub max_teams: u8,
+    /// How many stakes have ever been opened. **Descriptive, not a limit.**
+    ///
+    /// Saturates at 255 rather than erroring — see `join_league`. Nothing reads
+    /// it to make a decision, so a count that stops climbing is a wrong number
+    /// on a dashboard rather than a wrong outcome.
     pub member_count: u8,
     /// Running total of live deposits, in base units. Decreases on refund, so
     /// it tracks what the vault actually holds rather than what it ever held.
@@ -694,6 +725,11 @@ pub enum EscrowError {
     RefundUnlockNotInFuture,
     #[msg("Accepted rules hash does not match the league's")]
     RulesHashMismatch,
+    /// **No longer raised.** Kept because error codes are positional: deleting a
+    /// variant renumbers every one below it, which silently changes what a
+    /// deployed client reports for four other failures, and it would move the
+    /// committed IDL that `idl:check` compares. Seat limits are enforced in
+    /// Postgres — see `League::max_teams`.
     #[msg("The league already has its full complement of teams")]
     LeagueFull,
     #[msg("This member has already staked their buy-in")]

--- a/programs/rostr-escrow/tests/pot.test.ts
+++ b/programs/rostr-escrow/tests/pot.test.ts
@@ -159,7 +159,16 @@ describe("join_league", () => {
     await expect(join(league, member, args.rulesHash)).rejects.toThrow();
   });
 
-  it("refuses members beyond the league's size", async () => {
+  it("seats past the declared size rather than refusing, and that is the fix for #18", async () => {
+    // This asserted `LeagueFull` until 2026-08-11. The check it tested guarded a
+    // guest list the program cannot read: being *in a league* is a Postgres fact
+    // and a `Membership` here only means "this wallet has a stake", so seats went
+    // first-come to anyone on the internet while the real roster was decided
+    // elsewhere. At roughly 0.011 SOL for twelve, and with no instruction that
+    // closes a `Membership` or decrements `member_count`, claiming them all
+    // bricked a league permanently.
+    //
+    // Size is enforced in `joinLeague` against the actual roster, and always was.
     const args = validArgs({ maxTeams: 2 });
     const league = await initialize(args);
 
@@ -168,8 +177,20 @@ describe("join_league", () => {
     }
 
     const extra = await fundedMember(provider, mint, BUY_IN);
-    await expectError(join(league, extra, args.rulesHash), "LeagueFull");
+    await join(league, extra, args.rulesHash);
+
+    const account = await program.account.league.fetch(league);
+    expect(account.memberCount).toBe(3);
+    // Still published, still compared against the signed rules by
+    // `anchorTermMismatches`. Disclosure, not a gate.
+    expect(account.maxTeams).toBe(2);
   });
+
+  // NOT TESTED, deliberately: that `member_count` saturates at 255 instead of
+  // erroring. Reaching it needs 255 real transactions against a validator, which
+  // is minutes of CI for one assertion — and `checked_add` there would be the
+  // same denial vector the seat cap was, so the reasoning is recorded in
+  // `join_league` where the one line lives rather than pretended at here.
 });
 
 describe("deposit", () => {


### PR DESCRIPTION
Closes #18 — the seat-squatting denial, which #63 turned from theoretical into live by putting real members into on-chain seats for the first time.

## The check guarded a list the program cannot read

`join_league` refused a member once `member_count` reached `max_teams`.

But being **in a league** is a Postgres fact — a team, a roster, a draft slot — and this program has no view of it. A `Membership` here means one thing: *this wallet has a stake*. So the gate could only ever hand seats out first-come to anyone on the internet, while the actual roster was decided somewhere it could not see.

**Cost to exploit: about 0.011 SOL for a twelve-seat league.** `Membership` is 82 bytes, rent-exempt ≈ 0.00095 SOL, and the joiner pays it. Under two dollars.

**And it was permanent.** There is no `close` constraint anywhere in the program — zero occurrences — and nothing decrements `member_count`, not even `refund_stake`. Once claimed, seats never come back. The only remedy was recreating the league under a new UUID.

## It also protected nothing

`max_teams` is read in exactly one place: that gate. `deposit` and `refund_stake` never consult it, and the vault is the sum of deposits whatever the count says.

Meanwhile `joinLeague` in `@rostr/db` enforces the size against the real roster — `LEAGUE_FULL`, tested twice, with `UNIQUE (league_id, slot)` behind it as a race backstop. That check was always the one doing the work.

A duplicate of an off-chain rule, guarding no on-chain invariant, creating a permanent denial vector.

## `checked_add` → `saturating_add`, and why the reasoning flipped

The old comment argued checked was right because *"at the cap this is unreachable, and if it ever were reachable, silently staying at the maximum would admit an extra member."*

Sound — and entirely dependent on the cap above it. **Without the cap it inverts.** `member_count` is a `u8`, so `checked_add` starts failing at 255, and roughly a quarter of a SOL of throwaway accounts would brick the league exactly as the seat cap did. Removing one denial vector while leaving a second one four lines below would have been a poor trade.

Saturating cannot admit an extra member, because it no longer decides admission.

## What stays

**`max_teams` stays on the account**, published and still compared against the signed rules by `anchorTermMismatches` — a creator still cannot anchor a size nobody agreed to. It is disclosure now rather than a gate.

**`LeagueFull` stays in the error enum** although nothing raises it. Error codes are positional: deleting a variant renumbers the four below it, silently changing what a deployed client reports for unrelated failures, and it would move the committed IDL that `idl:check` compares. `idl.ts` and `types.ts` are untouched by this PR.

## The alternative, and why not

**Permissionless eviction of un-staked seats** was the other candidate. It is weaker rather than simpler: it can only clear seats that were *never funded*, so an attacker who deposits still blocks the league and merely pays for the privilege with money the timelock hands back. Against a public league anyone can find, that is a toll rather than a fix. It also needs a `has_pot` guard or it lets anyone evict anyone from a free league, where every `Membership` has `deposited == 0` by definition.

Commissioner-gated joins and a server-signed attestation were both rejected on principle — the first reintroduces the authority field `DECISIONS.md` exists to remove, the second creates a server key in a system whose stated property is that none exists. Recorded on #18 so nobody re-proposes them.

## The constraint this puts on D6, written down now

Anyone can now open a `Membership` and deposit into any league they can name. That is self-harm rather than leverage — they cannot win, and the stake is locked until `refundUnlockAt` — but it means **`total_deposited` is not the pot**.

So settlement must pay the **known member set**, never `bps × vault balance`. Otherwise a stranger's deposit inflates the pot, winners are paid from money that is owed back, and the vault comes up short when that stranger refunds.

That is the better shape regardless: a payout derived from a mutable balance is one deposit away from being wrong. It is in `CLAUDE.md` next to the vault authority note, so D6 is not built the wrong way in December and discovered in January.

## Verification

**`anchor test` is not run locally** — no Rust toolchain on this machine. It runs **in CI on this PR**, which is what verifies the change: `pot.test.ts` previously asserted `LeagueFull` for a third member of a two-seat league, and now asserts the join succeeds, `member_count` reads 3, and `max_teams` still reads 2.

`pnpm test` **1120 passing**, typecheck, lint, format clean.

**One thing deliberately not tested**, and said so in the file rather than faked: that `member_count` saturates at 255 instead of erroring. Reaching it needs 255 real transactions against a validator — minutes of CI for one assertion. The reasoning lives in `join_league` beside the one line it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
