### PR TITLE
fix(core,escrow): give the timelock refund a ceiling as well as a floor

### DIFF
--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -13,6 +13,17 @@ import { createDraftRecord, createLeague, LeagueValidationError, seedSport } fro
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 
+/**
+ * How far ahead a draft may be scheduled.
+ *
+ * 300 days rather than a round year, so the resulting maximum stays provably
+ * below the program own horizon: the refund ceiling is at most draft + 365
+ * days, and the program refuses anything past now + 730 days at
+ * initialize_league. 300 + 365 = 665 leaves 65 days of margin, and a rejection
+ * on-chain cannot be retried.
+ */
+const MAX_DRAFT_LEAD_MS = 300 * 24 * 60 * 60 * 1000;
+
 export async function GET(): Promise<NextResponse> {
   const rows = await db().query<{
     id: string;
@@ -77,6 +88,36 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (body.draftAt * 1000 <= Date.now()) {
     return NextResponse.json(
       { error: "The draft must be scheduled in the future" },
+      { status: 400 },
+    );
+  }
+
+  // And not arbitrarily far into it, which is load-bearing rather than tidy.
+  //
+  // `pot.refundUnlockAt`'s ceiling is measured from the draft, so an unbounded
+  // draft date carries the ceiling with it: a draft in 2100 puts the whole legal
+  // refund window in 2100, and a rule set naming a date inside it validates
+  // clean. Members would join and stake now against an escape hatch that opens
+  // in seventy years.
+  //
+  // Without this the only thing catching that league is the program's own
+  // horizon at `initialize_league` — which refuses it, but *fatally*: the rules
+  // are already frozen and the PDA derives from the league's UUID, so it can
+  // never be anchored and therefore never joined, only recreated under a new id.
+  // This turns an unrecoverable failure at anchor time into a 400 before
+  // anything is written.
+  //
+  // Here rather than in `validateDraft` for the same reason the past check is:
+  // it depends on the clock, and re-validating a stored rule set must not become
+  // non-deterministic.
+  if (body.draftAt * 1000 > Date.now() + MAX_DRAFT_LEAD_MS) {
+    return NextResponse.json(
+      {
+        error:
+          "The draft must be scheduled within a year: a league's refund unlock is bounded " +
+          "relative to its draft, so a draft far in the future would let the pot be locked " +
+          "for just as long.",
+      },
       { status: 400 },
     );
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,7 +63,11 @@ export {
 } from "./rules/nfl-ppr.js";
 
 export { encodeLeagueRules, hashLeagueRules, verifyLeagueRulesHash } from "./rules/hash.js";
-export { earliestRefundUnlock, validateLeagueRules } from "./rules/validate.js";
+export {
+  earliestRefundUnlock,
+  latestRefundUnlock,
+  validateLeagueRules,
+} from "./rules/validate.js";
 
 export {
   buildJoinMessage,

--- a/packages/core/src/rules/refund-floor.test.ts
+++ b/packages/core/src/rules/refund-floor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { earliestRefundUnlock } from "./validate.js";
+import { earliestRefundUnlock, latestRefundUnlock } from "./validate.js";
 import { NFL_DEFAULT_SCHEDULE, NFL_DEFAULT_SETTLEMENT } from "./nfl-ppr.js";
 
 /**
@@ -14,6 +14,14 @@ import { NFL_DEFAULT_SCHEDULE, NFL_DEFAULT_SETTLEMENT } from "./nfl-ppr.js";
 
 const nfl = (draftScheduledAt: number) =>
   earliestRefundUnlock({
+    draftScheduledAt,
+    regularSeasonWeeks: NFL_DEFAULT_SCHEDULE.regularSeasonWeeks,
+    playoffWeeks: NFL_DEFAULT_SCHEDULE.playoffWeeks,
+    payingFinalizationHours: NFL_DEFAULT_SETTLEMENT.payingFinalizationHours,
+  });
+
+const nflCeiling = (draftScheduledAt: number) =>
+  latestRefundUnlock({
     draftScheduledAt,
     regularSeasonWeeks: NFL_DEFAULT_SCHEDULE.regularSeasonWeeks,
     playoffWeeks: NFL_DEFAULT_SCHEDULE.playoffWeeks,
@@ -87,5 +95,71 @@ describe("earliestRefundUnlock", () => {
 
     expect(Number.isFinite(floor)).toBe(true);
     expect(floor).toBe(14 * 7 * 86_400 + 168 * 3600 + 60 * 86_400);
+  });
+});
+
+describe("latestRefundUnlock", () => {
+  /**
+   * The ceiling. Two bounds, smaller wins — see `latestRefundUnlock` for why the
+   * draft-anchored cap has to be there at all.
+   */
+  it("gives a 90-day window above the floor for a real season", () => {
+    const draft = at("2026-08-22T14:00:00Z");
+    const floor = nfl(draft);
+    const ceiling = nflCeiling(draft);
+
+    expect(day(ceiling)).toBe("2027-05-25");
+    expect((ceiling - floor) / 86_400).toBe(90);
+  });
+
+  it("is capped against the draft, so the schedule cannot inflate it", () => {
+    // The whole reason the cap exists. Nothing bounds week numbers above, so a
+    // ceiling derived only from the floor would sit in 2043 for this input.
+    const draft = at("2026-08-22T14:00:00Z");
+    const inflated = latestRefundUnlock({
+      draftScheduledAt: draft,
+      regularSeasonWeeks: 14,
+      playoffWeeks: [15, 16, 900],
+      payingFinalizationHours: 168,
+    });
+
+    expect(inflated).toBe(draft + 365 * 86_400);
+    expect(day(inflated)).toBe("2027-08-22");
+  });
+
+  it("is capped against the draft when the correction window is inflated too", () => {
+    // The second unbounded input, which is easy to miss: `validateSettlement`
+    // bounds `payingFinalizationHours` only from below.
+    const draft = at("2026-08-22T14:00:00Z");
+    const inflated = latestRefundUnlock({
+      draftScheduledAt: draft,
+      regularSeasonWeeks: 14,
+      playoffWeeks: [15, 16, 17],
+      payingFinalizationHours: 200_000,
+    });
+
+    expect(inflated).toBe(draft + 365 * 86_400);
+  });
+
+  it("moves with the draft", () => {
+    const early = nflCeiling(at("2026-07-01T09:00:00Z"));
+    const late = nflCeiling(at("2026-09-05T14:00:00Z"));
+
+    expect(late - early).toBe(at("2026-09-05T14:00:00Z") - at("2026-07-01T09:00:00Z"));
+  });
+
+  it("leaves a usable window for every schedule a real league could have", () => {
+    // The unsatisfiable case fires at a last week of 43+. The real NFL tops out
+    // at 22, so there is no schedule between "plausible" and "refused".
+    for (const lastWeek of [17, 18, 22, 30]) {
+      const draft = at("2026-08-22T14:00:00Z");
+      const input = {
+        draftScheduledAt: draft,
+        regularSeasonWeeks: lastWeek - 3,
+        playoffWeeks: [lastWeek - 2, lastWeek - 1, lastWeek],
+        payingFinalizationHours: 168,
+      };
+      expect(latestRefundUnlock(input)).toBeGreaterThan(earliestRefundUnlock(input));
+    }
   });
 });

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -12,7 +12,7 @@ import {
   NFL_WINNER_TAKE_ALL_PAYOUT,
 } from "./nfl-ppr.js";
 import type { LeagueRules, PotRules } from "./types.js";
-import { validateLeagueRules } from "./validate.js";
+import { earliestRefundUnlock, latestRefundUnlock, validateLeagueRules } from "./validate.js";
 
 /**
  * A fully-specified rule set with every free variable pinned. Its hash is a
@@ -466,13 +466,101 @@ describe("validateLeagueRules", () => {
     expect(problems).toContainEqual(expect.stringContaining("earliest permitted value"));
   });
 
-  it("accepts a refund unlock later than the floor", () => {
-    // A floor, not a prescription. Ten years out is legal, if strange.
+  it("accepts a refund unlock later than the floor, within the window", () => {
+    // A floor, not a prescription — a commissioner may want room past the
+    // earliest legal date. 216 days from the draft is ~30 past the floor and
+    // well inside the 90-day window.
     const late = mutate((d) => {
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt = d.draft.scheduledAt + 216 * 86_400;
+    });
+    expect(validateLeagueRules(late, NFL)).toEqual([]);
+  });
+
+  it("rejects a refund unlock far beyond the window", () => {
+    // This exact case used to be asserted as *legal*, by a test of mine, under
+    // the comment "Ten years out is legal, if strange." It is the attack. The
+    // timelock refund is the only way tokens leave the vault, so a date a decade
+    // out is not a long lock but a permanent freeze — and it anchors cleanly,
+    // because the chain and the signed document agree about it.
+    const frozen = mutate((d) => {
       (d.pot as { refundUnlockAt: number }).refundUnlockAt =
         d.draft.scheduledAt + 3650 * 86_400;
     });
-    expect(validateLeagueRules(late, NFL)).toEqual([]);
+    expect(validateLeagueRules(frozen, NFL)).toContainEqual(
+      expect.stringContaining("too late"),
+    );
+  });
+
+  it("says how many days too late, and the latest permitted value", () => {
+    // Same reasoning as the floor's message: a creator cannot act on a bound
+    // they would have to compute themselves, and the rules freeze on write.
+    const frozen = mutate((d) => {
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt = 4_102_444_800; // 2100-01-01
+    });
+    const problems = validateLeagueRules(frozen, NFL);
+    expect(problems).toContainEqual(expect.stringMatching(/\d+ days too late/));
+    expect(problems).toContainEqual(expect.stringContaining("latest permitted value"));
+  });
+
+  it("treats both bounds as inclusive, and never reports both at once", () => {
+    // The floor is `>=` and the ceiling `<=`, so the boundary values are legal
+    // and there is no one-second no-man's-land between them. Reporting both
+    // would be self-contradictory advice to a creator.
+    const at = (pick: (floor: number, ceiling: number) => number) =>
+      mutate((d) => {
+        const input = {
+          draftScheduledAt: d.draft.scheduledAt,
+          regularSeasonWeeks: d.schedule.regularSeasonWeeks,
+          playoffWeeks: d.schedule.playoffWeeks,
+          payingFinalizationHours: d.settlement.payingFinalizationHours,
+        };
+        (d.pot as { refundUnlockAt: number }).refundUnlockAt = pick(
+          earliestRefundUnlock(input),
+          latestRefundUnlock(input),
+        );
+      });
+
+    expect(
+      validateLeagueRules(
+        at((floor) => floor),
+        NFL,
+      ),
+    ).toEqual([]);
+    expect(
+      validateLeagueRules(
+        at((_, ceiling) => ceiling),
+        NFL,
+      ),
+    ).toEqual([]);
+    expect(
+      validateLeagueRules(
+        at((floor) => floor - 1),
+        NFL,
+      ),
+    ).toContainEqual(expect.stringContaining("too early"));
+
+    const over = validateLeagueRules(
+      at((_, ceiling) => ceiling + 1),
+      NFL,
+    );
+    expect(over).toContainEqual(expect.stringContaining("too late"));
+    expect(over.filter((p) => /too early/.test(p))).toEqual([]);
+  });
+
+  it("cannot have its ceiling inflated by the schedule", () => {
+    // Why the ceiling is capped against the draft rather than derived only from
+    // the floor. Nothing bounds week numbers above, so a floor-relative ceiling
+    // would stretch to 2043 for this rule set and the bound would mean nothing.
+    // The cap holds it at draft + 365 days regardless, and the honest answer is
+    // that the schedule is the problem rather than the date.
+    const inflated = mutate((d) => {
+      (d.schedule as { playoffWeeks: number[] }).playoffWeeks = [15, 16, 900];
+      (d.pot as { refundUnlockAt: number }).refundUnlockAt =
+        d.draft.scheduledAt + 3000 * 86_400;
+    });
+    expect(validateLeagueRules(inflated, NFL)).toContainEqual(
+      expect.stringContaining("no legal value exists"),
+    );
   });
 
   it("moves the floor with the league's own schedule", () => {

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -62,6 +62,38 @@ const MIN_PAYING_FINALIZATION_HOURS = 168;
  */
 const MIN_REFUND_GRACE_SECONDS = 60 * 24 * 60 * 60;
 
+/**
+ * How much later than the floor a commissioner may set the refund, ordinarily.
+ *
+ * The floor already sits sixty days past a deliberately conservative settlement
+ * estimate, so this is discretion on top of slack. Ninety days covers a
+ * commissioner who wants room and refuses nothing a real league would pick — for
+ * the default NFL schedule the legal window is ninety days wide.
+ *
+ * **The asymmetry that sized the floor runs the other way here**, which is why
+ * this can be tight where `MIN_REFUND_GRACE_SECONDS` had to be generous. Too
+ * early is theft; too late is a freeze. But a ceiling set too *tight* costs only
+ * a 400 at creation, before anything is frozen and before any money exists — the
+ * creator picks another date. Nothing on this side is unrecoverable, so the
+ * estimate rounds toward the strict end rather than the loose one.
+ */
+const MAX_REFUND_DISCRETION_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * The furthest past its own draft a league's refund may ever open.
+ *
+ * This is the bound that cannot be inflated — see `latestRefundUnlock` for why
+ * the floor-relative one can be. A year past the draft, the season is long
+ * finished and the next season's leagues are forming; anything still locked then
+ * is visibly wrong.
+ *
+ * The unsatisfiable case — a schedule so long that the floor passes this — fires
+ * at a last week of 43 or beyond, against a real NFL calendar that tops out at
+ * 22. There is no schedule between "real" and "refused"; the gap is twenty-one
+ * weeks wide.
+ */
+const MAX_REFUND_HORIZON_SECONDS = 365 * 24 * 60 * 60;
+
 function validateScoring(rules: LeagueRules, sport: SportDef, out: string[]): void {
   const known = statKeysByKey(sport);
   const seen = new Set<string>();
@@ -401,18 +433,111 @@ function refundUnlockFloor(rules: LeagueRules): number {
   });
 }
 
+/**
+ * The latest instant a league's timelock refund may open.
+ *
+ * **Two bounds, and the smaller wins.** They do different jobs:
+ *
+ * - `floor + MAX_REFUND_DISCRETION_SECONDS` is the ordinary one. Ninety days of
+ *   discretion above a floor that already carries sixty days of grace past
+ *   settlement is more than any honest commissioner needs.
+ * - `draft.scheduledAt + MAX_REFUND_HORIZON_SECONDS` is what makes the first one
+ *   mean anything. **The floor is derived from attacker-writable inputs that
+ *   nothing bounds above** — `validateSchedule` bounds week numbers only by
+ *   `> 0` and ascending, and `validateSettlement` bounds
+ *   `payingFinalizationHours` only from below. So `playoffWeeks: [15, 16, 900]`
+ *   validates today and drags a floor-relative ceiling to 2043;
+ *   `payingFinalizationHours: 200_000` drags it to 2048 with an ordinary
+ *   seventeen-week schedule. A ceiling built only on the floor stretches to fit
+ *   whatever the commissioner invents, which moves the hole rather than closing
+ *   it.
+ *
+ * `draft.scheduledAt` is the one term in the floor's formula the other levers
+ * cannot inflate, which is why the cap hangs off it. It is also the right clock
+ * on its own terms: the floor answers "has the money been distributed yet",
+ * necessarily schedule-relative, while the ceiling answers "how long may a
+ * member's capital be trapped" — and that starts when the money goes in, around
+ * the draft, not at settlement.
+ *
+ * Read it and you can see the maximum lock-up without reading any other
+ * function. That locality is the property a floor-relative ceiling gives up.
+ */
+export function latestRefundUnlock(input: {
+  readonly draftScheduledAt: number;
+  readonly regularSeasonWeeks: number;
+  readonly playoffWeeks: readonly number[];
+  readonly payingFinalizationHours: number;
+}): number {
+  return Math.min(
+    earliestRefundUnlock(input) + MAX_REFUND_DISCRETION_SECONDS,
+    input.draftScheduledAt + MAX_REFUND_HORIZON_SECONDS,
+  );
+}
+
+function refundUnlockCeiling(rules: LeagueRules): number {
+  return latestRefundUnlock({
+    draftScheduledAt: rules.draft.scheduledAt,
+    regularSeasonWeeks: rules.schedule.regularSeasonWeeks,
+    playoffWeeks: rules.schedule.playoffWeeks,
+    payingFinalizationHours: rules.settlement.payingFinalizationHours,
+  });
+}
+
 function validateRefundUnlock(rules: LeagueRules, refundUnlockAt: number, out: string[]): void {
   const floor = refundUnlockFloor(rules);
-  if (refundUnlockAt >= floor) return;
+  const ceiling = refundUnlockCeiling(rules);
 
-  const short = Math.ceil((floor - refundUnlockAt) / (24 * 60 * 60));
+  // `pot.refundUnlockAt <= 0` is *false* for a string — `"abc" <= 0` is `false`
+  // — so a non-number reaches here, and `earliestRefundUnlock` then concatenates
+  // rather than adds: a string `scheduledAt` yields a "floor" of 1.7e30. One
+  // garbage comparison was survivable; two that can disagree with each other are
+  // not. `validateNumericFields` has already reported the real problem, so
+  // returning silently loses nothing.
+  if (
+    typeof refundUnlockAt !== "number" ||
+    !Number.isFinite(floor) ||
+    !Number.isFinite(ceiling)
+  ) {
+    return;
+  }
 
-  out.push(
-    `pot.refundUnlockAt is ${short} day${short === 1 ? "" : "s"} too early: the timelock ` +
-      `refund is unconditional once it opens, so a date before the last prize has settled ` +
-      `lets a losing member withdraw and keep playing for a pot they no longer stand behind. ` +
-      `The earliest permitted value is ${floor}.`,
-  );
+  const days = (seconds: number): number => Math.ceil(seconds / (24 * 60 * 60));
+
+  // Checked first, and returns, so the "too early" message below can never name
+  // a floor that is itself illegal. Reachable because nothing caps week numbers
+  // or `payingFinalizationHours` — a schedule long enough closes the window
+  // entirely, and the honest answer is that the schedule is the problem rather
+  // than the date.
+  if (floor > ceiling) {
+    out.push(
+      `this league's schedule settles ${days(floor - ceiling)} days beyond the latest ` +
+        `permitted refund unlock (${ceiling}), so no legal value exists — shorten the ` +
+        `regular season, the playoff weeks, or payingFinalizationHours`,
+    );
+    return;
+  }
+
+  if (refundUnlockAt < floor) {
+    const short = days(floor - refundUnlockAt);
+    out.push(
+      `pot.refundUnlockAt is ${short} day${short === 1 ? "" : "s"} too early: the timelock ` +
+        `refund is unconditional once it opens, so a date before the last prize has settled ` +
+        `lets a losing member withdraw and keep playing for a pot they no longer stand behind. ` +
+        `The earliest permitted value is ${floor}.`,
+    );
+    return;
+  }
+
+  if (refundUnlockAt > ceiling) {
+    const over = days(refundUnlockAt - ceiling);
+    out.push(
+      `pot.refundUnlockAt is ${over} day${over === 1 ? "" : "s"} too late: the timelock ` +
+        `refund is the only way tokens leave the vault — there is no settlement instruction ` +
+        `yet, no setter and no authority — so a date long past the season freezes every ` +
+        `member's buy-in with nothing able to release it. ` +
+        `The latest permitted value is ${ceiling}.`,
+    );
+  }
 }
 
 function validatePot(rules: LeagueRules, out: string[]): void {

--- a/packages/escrow/src/idl.ts
+++ b/packages/escrow/src/idl.ts
@@ -702,6 +702,11 @@ export const ESCROW_IDL: EscrowIdl = {
       "code": 6022,
       "name": "MathOverflow",
       "msg": "Arithmetic overflow"
+    },
+    {
+      "code": 6023,
+      "name": "RefundUnlockTooFar",
+      "msg": "Refund unlock time is too far in the future"
     }
   ],
   "types": [

--- a/packages/escrow/src/types.ts
+++ b/packages/escrow/src/types.ts
@@ -688,6 +688,11 @@ export type RostrEscrow = {
       "code": 6022,
       "name": "mathOverflow",
       "msg": "Arithmetic overflow"
+    },
+    {
+      "code": 6023,
+      "name": "refundUnlockTooFar",
+      "msg": "Refund unlock time is too far in the future"
     }
   ],
   "types": [

--- a/programs/rostr-escrow/src/lib.rs
+++ b/programs/rostr-escrow/src/lib.rs
@@ -110,6 +110,15 @@ pub const MAX_FEE_BPS: u16 = 500;
 /// Smallest league that can meaningfully play.
 pub const MIN_TEAMS: u8 = 2;
 
+/// Furthest into the future a refund unlock may be set, measured from the moment
+/// the league account is created. Two years.
+///
+/// A backstop rather than the real bound — see the comment at its use in
+/// `initialize_league`. It is the smallest horizon that cannot falsely reject a
+/// league the off-chain validator would permit, which is the property that
+/// matters here, because a refusal at this point cannot be retried.
+pub const MAX_REFUND_UNLOCK_HORIZON_SECONDS: i64 = 730 * 24 * 60 * 60;
+
 #[program]
 pub mod rostr_escrow {
     use super::*;
@@ -187,6 +196,40 @@ pub mod rostr_escrow {
         require!(
             args.refund_unlock_at > now,
             EscrowError::RefundUnlockNotInFuture
+        );
+
+        // And a ceiling, because a date decades out is not a longer timelock —
+        // it is a permanent freeze. `refund_stake` is the only instruction that
+        // moves tokens out of the vault, there is no settlement instruction yet,
+        // and there is no setter or authority that could release them sooner.
+        //
+        // This cannot be the league's own settlement date. The program has no
+        // schedule — `rules_hash` is 32 opaque bytes to it — and any schedule
+        // passed in as an argument would be chosen by the same caller as the
+        // date, so the check would compare an attacker's input against their own
+        // input and read as a guarantee while being none. The clock is the only
+        // input here that the caller does not supply.
+        //
+        // `now` at initialisation is a sound lower bound on the first possible
+        // deposit, since `deposit` has no time condition and this account must
+        // exist before one can happen — so this bounds how long any stake can be
+        // locked without the program knowing anything about a season.
+        //
+        // **Deliberately loose, and do not tighten it.** The precise bound lives
+        // off-chain in `validatePot`, where the season is known. A false refusal
+        // here is unrecoverable: the args come from a rule set that is already
+        // frozen, so the league cannot be retried with a corrected value, and
+        // the PDA derives from its UUID — it could only be recreated under a new
+        // id. `MAX_DRAFT_LEAD_MS` in the create route keeps the off-chain
+        // maximum at draft + 365d with a draft at most 300d out, so 665 days is
+        // the most a legitimate league can ask for and this leaves 65 days spare.
+        //
+        // `saturating_add` rather than `+`: overflow here is unreachable in
+        // practice, and a panic is a worse answer to a hostile argument than a
+        // comparison that simply fails. With saturation `i64::MAX` still fails.
+        require!(
+            args.refund_unlock_at <= now.saturating_add(MAX_REFUND_UNLOCK_HORIZON_SECONDS),
+            EscrowError::RefundUnlockTooFar
         );
 
         let league = &mut ctx.accounts.league;
@@ -679,4 +722,13 @@ pub enum EscrowError {
     LeagueHasNoPot,
     #[msg("Arithmetic overflow")]
     MathOverflow,
+    // Appended last on purpose. Error codes are positional, so inserting a
+    // variant renumbers every one below it and silently changes what a deployed
+    // client reports for unrelated failures.
+    //
+    // `//` and not `///`: doc comments on error variants are compiled into the
+    // IDL, which `idl:check` compares byte for byte, and this machine has no
+    // Rust toolchain to regenerate it with.
+    #[msg("Refund unlock time is too far in the future")]
+    RefundUnlockTooFar,
 }

--- a/programs/rostr-escrow/tests/anchor.test.ts
+++ b/programs/rostr-escrow/tests/anchor.test.ts
@@ -29,7 +29,7 @@ import {
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
 } from "@rostr/core";
-import { createPotMint, getProgram, getProvider } from "./helpers";
+import { createPotMint, getProgram, getProvider, refundUnlockFor } from "./helpers";
 
 /**
  * Create → anchor → join, across both halves at once.
@@ -59,7 +59,7 @@ const DRAFT = {
   type: "SNAKE",
   mode: "SLOW",
   pickSeconds: 14_400,
-  scheduledAt: 1_756_400_000,
+  scheduledAt: Math.floor(Date.now() / 1000) + 30 * 24 * 3600,
 } as const;
 
 beforeAll(async () => {
@@ -91,7 +91,7 @@ async function createPotLeague(name: string) {
       // program that had quietly become a fixed price.
       buyInBaseUnits: "23500000",
       payout: NFL_DEFAULT_PAYOUT,
-      refundUnlockAt: Math.floor(Date.now() / 1000) + 365 * 24 * 3600,
+      refundUnlockAt: refundUnlockFor(DRAFT.scheduledAt),
       feeBps: NFL_DEFAULT_FEE_BPS,
       feeRecipient: anchor.web3.Keypair.generate().publicKey.toBase58(),
     },
@@ -275,7 +275,10 @@ describe("create -> anchor -> join", () => {
       rulesHash: hexToBytes(league.rulesHash), // the honest hash
       mint,
       buyInBaseUnits: "50000000", // rules say 23500000
-      refundUnlockAt: "9223372036854775807", // funds frozen forever
+      // Was i64::MAX ("funds frozen forever") until the program grew a ceiling.
+      // A year past what the rules say still diverges, which is what this test
+      // is for, and is a value initialize_league will now actually accept.
+      refundUnlockAt: String(refundUnlockFor(DRAFT.scheduledAt) + 365 * 24 * 3600),
       payoutBps: payoutArray(pot.payout),
       feeBps: pot.feeBps,
       feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),
@@ -291,10 +294,11 @@ describe("create -> anchor -> join", () => {
     expect(verdict.ok).toBe(true);
 
     if (verdict.ok) {
-      // Decoding i64::MAX must not throw. Reading it as a JS number did, on
-      // this input specifically, which turned the worst case into a 500.
-      expect(verdict.league.refundUnlockAt).toBe("9223372036854775807");
-
+      // The i64::MAX decoding guard that used to live here is gone with the
+      // hostile value: the program refuses that input now, so no account can
+      // hold it and the path is unreachable end to end. It is still covered as
+      // a unit in packages/escrow/src/verify.test.ts, which feeds the string
+      // straight to anchorTermMismatches and needs no validator.
       const mismatches = anchorTermMismatches(verdict.league, expectedTermsFromRules(rules));
       expect(mismatches.some((m) => /buyIn/.test(m))).toBe(true);
       expect(mismatches.some((m) => /refundUnlockAt/.test(m))).toBe(true);

--- a/programs/rostr-escrow/tests/divergence.test.ts
+++ b/programs/rostr-escrow/tests/divergence.test.ts
@@ -27,7 +27,13 @@ import {
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
 } from "@rostr/core";
-import { createPotMint, getProgram, getProvider, membershipPda } from "./helpers";
+import {
+  createPotMint,
+  getProgram,
+  getProvider,
+  membershipPda,
+  refundUnlockFor,
+} from "./helpers";
 
 /**
  * Proof that issue #26 is fixed: the on-chain join now has a real caller.
@@ -49,7 +55,7 @@ const DRAFT = {
   type: "SNAKE",
   mode: "SLOW",
   pickSeconds: 14_400,
-  scheduledAt: 1_756_400_000,
+  scheduledAt: Math.floor(Date.now() / 1000) + 30 * 24 * 3600,
 } as const;
 
 beforeAll(async () => {
@@ -69,7 +75,7 @@ async function createPotLeague(name: string) {
       tokenMint: mint.toBase58(),
       buyInBaseUnits: "23500000",
       payout: NFL_DEFAULT_PAYOUT,
-      refundUnlockAt: Math.floor(Date.now() / 1000) + 365 * 24 * 3600,
+      refundUnlockAt: refundUnlockFor(DRAFT.scheduledAt),
       feeBps: NFL_DEFAULT_FEE_BPS,
       feeRecipient: anchor.web3.Keypair.generate().publicKey.toBase58(),
     },

--- a/programs/rostr-escrow/tests/escrow.test.ts
+++ b/programs/rostr-escrow/tests/escrow.test.ts
@@ -237,6 +237,37 @@ describe("initialize_league", () => {
     );
   });
 
+  it("rejects i64::MAX, which used to be accepted", async () => {
+    // The freeze this ceiling exists for, and the exact value `anchor.test.ts`
+    // used to send and expect to succeed. `refund_stake` is the only way tokens
+    // leave the vault and there is no setter, so a date 292 billion years out is
+    // not a long timelock — it is a permanent one.
+    //
+    // Also the `saturating_add` guard: `now + MAX_REFUND_UNLOCK_HORIZON_SECONDS`
+    // must fail this comparison rather than overflow-panic on a hostile input.
+    await expectError(
+      initialize(validArgs({ refundUnlockAt: new anchor.BN("9223372036854775807") })),
+      "RefundUnlockTooFar",
+    );
+  });
+
+  it("rejects a refund unlock past the two-year horizon, and accepts one inside it", async () => {
+    // The pair proves it is a horizon rather than a special case for i64::MAX.
+    //
+    // Margins in days, never hours: a local validator can run over an hour
+    // behind wall clock (see CLAUDE.md), which has already broken seven timelock
+    // tests once. A boundary written as ±1h would be flaky for reasons that have
+    // nothing to do with this check.
+    const now = Math.floor(Date.now() / 1000);
+
+    await expectError(
+      initialize(validArgs({ refundUnlockAt: new anchor.BN(now + 800 * 24 * 3600) })),
+      "RefundUnlockTooFar",
+    );
+
+    await initialize(validArgs({ refundUnlockAt: new anchor.BN(now + 700 * 24 * 3600) }));
+  });
+
   it("rejects a mint that is not six decimals", async () => {
     // Nine decimals is SOL's convention. Accepting it would make the $50 cap
     // mean 0.05 SOL instead — the same constant, a different amount of money.

--- a/programs/rostr-escrow/tests/helpers.ts
+++ b/programs/rostr-escrow/tests/helpers.ts
@@ -8,6 +8,11 @@ import {
   mintTo,
 } from "@solana/spl-token";
 import { expect } from "vitest";
+import {
+  earliestRefundUnlock,
+  NFL_DEFAULT_SCHEDULE,
+  NFL_DEFAULT_SETTLEMENT,
+} from "@rostr/core";
 
 /**
  * Shared setup for the program tests.
@@ -193,3 +198,27 @@ export const expectError = async (promise: Promise<unknown>, code: string): Prom
     `expected AnchorError ${code}`,
   );
 };
+
+/**
+ * A refund unlock that is legal for a league drafting at `draftScheduledAt`.
+ *
+ * `validateLeagueRules` now bounds this field on both sides, so a fixture cannot
+ * pick a date freely. It must sit at or above `earliestRefundUnlock` and at or
+ * below `latestRefundUnlock`, and the window is 90 days wide — so this takes the
+ * floor and adds a day.
+ *
+ * **Derived from the draft, never from `Date.now()` independently.** These
+ * fixtures used to pin `scheduledAt` to a fixed August 2025 timestamp while
+ * computing the refund date from the wall clock, which meant the gap between
+ * them widened every day and the pair was going to fall out of the legal window
+ * on its own — with or without the ceiling that exposed it. A fixed date beside
+ * a live clock is the same shape the create form was fixed for.
+ */
+export const refundUnlockFor = (draftScheduledAt: number): number =>
+  earliestRefundUnlock({
+    draftScheduledAt,
+    regularSeasonWeeks: NFL_DEFAULT_SCHEDULE.regularSeasonWeeks,
+    playoffWeeks: NFL_DEFAULT_SCHEDULE.playoffWeeks,
+    payingFinalizationHours: NFL_DEFAULT_SETTLEMENT.payingFinalizationHours,
+  }) +
+  24 * 3600;

--- a/programs/rostr-escrow/tests/stake.test.ts
+++ b/programs/rostr-escrow/tests/stake.test.ts
@@ -20,6 +20,7 @@ import {
   fundedMember,
   getProvider,
   getProgram,
+  refundUnlockFor,
   tokenBalance,
   vaultPda,
 } from "./helpers";
@@ -92,7 +93,7 @@ const DRAFT = {
   type: "SNAKE",
   mode: "SLOW",
   pickSeconds: 14_400,
-  scheduledAt: 1_756_400_000,
+  scheduledAt: Math.floor(Date.now() / 1000) + 30 * 24 * 3600,
 } as const;
 
 const BUY_IN = 23_500_000;
@@ -105,11 +106,15 @@ beforeAll(async () => {
   await seedSport(db, NFL);
 });
 
-async function createPotLeague(name: string, refundUnlockAt: number) {
+async function createPotLeague(
+  name: string,
+  refundUnlockAt: number,
+  scheduledAt: number = DRAFT.scheduledAt,
+) {
   const commissioner = await createUser(db, `${name}@example.com`, "Commish");
   const rules = buildNflPprRules({
     seasonYear: 2026,
-    draft: DRAFT,
+    draft: { ...DRAFT, scheduledAt },
     pot: {
       tokenMint: mint.toBase58(),
       buyInBaseUnits: String(BUY_IN),
@@ -155,7 +160,7 @@ describe("deposit and refund are wired (issue #27)", () => {
     // verify helpers.
     const { league, rules } = await createPotLeague(
       "stake",
-      Math.floor(Date.now() / 1000) + 365 * 24 * 3600,
+      refundUnlockFor(DRAFT.scheduledAt),
     );
     const sig = await anchorLeague(league.id, league.rulesHash, rules);
     const verdict = await verifyLeagueAnchor(program, league.id, league.rulesHash);
@@ -212,7 +217,7 @@ describe("deposit and refund are wired (issue #27)", () => {
   it("deposit is refused for a member who never joined on-chain", async () => {
     const { league, rules } = await createPotLeague(
       "nojoin",
-      Math.floor(Date.now() / 1000) + 365 * 24 * 3600,
+      refundUnlockFor(DRAFT.scheduledAt),
     );
     const sig = await anchorLeague(league.id, league.rulesHash, rules);
     await recordChainAnchor(db, league.id, {
@@ -248,9 +253,14 @@ describe("deposit and refund are wired (issue #27)", () => {
  */
 describe("a completed refund verifies as a refund", () => {
   it("reports ok once the stake is actually back out", async () => {
+    // A draft in the past, so a three-second unlock is inside the legal window
+    // rather than hundreds of days below the floor. The validator does not
+    // require a future draft — that check lives in the create route, because it
+    // is clock-dependent and re-validating stored rules must stay deterministic.
     const { league, rules } = await createPotLeague(
       "refundverify",
       Math.floor(Date.now() / 1000) + 3,
+      Math.floor(Date.now() / 1000) - 220 * 24 * 3600,
     );
     const sig = await anchorLeague(league.id, league.rulesHash, rules);
     await recordChainAnchor(db, league.id, {


### PR DESCRIPTION
Finding #1 from the rule-set audit (#67). Three agents independently confirmed the bug, each designed a fix, and then argued to a consensus that none of them proposed on their own.

> **Stacked on #65** (the refund *floor*), because the ceiling composes with it. Retarget when that merges.

`pot.refundUnlockAt` had a floor and no ceiling, in either half. A commissioner could freeze a league whose refund opens in 2100 — and it **anchors cleanly**, because `expectedTermsFromRules` derives the expected terms from the same signed document, so `anchorTermMismatches` compares the hostile value against itself and agrees. `refund_stake` is the only instruction that moves tokens out of the vault and there is no settlement instruction, so that is every member's buy-in locked for decades.

**It was also asserted as correct behaviour by a test I added with the floor** — *"accepts a refund unlock later than the floor"*, ten years out, under the comment *"Ten years out is legal, if strange."* Rewritten here rather than added to.

## The ceiling is the smaller of two bounds, and it needs both

```ts
min(floor + 90 days, draft.scheduledAt + 365 days)
```

**90 days above the floor** is the ordinary allowance. The floor already carries 60 days of grace past a deliberately conservative settlement estimate, so this is discretion on top of slack.

**The draft-anchored cap is what makes that number mean anything.** The floor is derived from inputs that nothing bounds above:

| inflated input | floor-relative ceiling | draft-anchored |
|---|---|---|
| `playoffWeeks: [15,16,900]` | **2043-05-03** | 2027-08-22 |
| `payingFinalizationHours: 200_000` | **2048-12-18** | 2027-08-22 |

`validateSchedule` bounds week numbers only by `> 0` and ascending; `validateSettlement` bounds `payingFinalizationHours` only from below. A ceiling built only on the floor stretches to fit whatever the commissioner invents — it moves the hole rather than closing it. `draft.scheduledAt` is the one term in the floor's formula the other levers cannot inflate.

Where the two bounds cross, no legal value exists, and that gets its **own message naming the schedule rather than the date** — otherwise the "too early" branch would name a floor that is itself illegal. It fires at a last week of 43+, against a real NFL calendar topping out at 22.

**The asymmetry that sized the floor runs the other way here**, which is why this can be tight where `MIN_REFUND_GRACE_SECONDS` had to be generous. Too early is theft. Too tight is a 400 at creation, before anything is frozen and before any money exists.

## On-chain, because an off-chain bound binds nobody who calls the program directly

The program **cannot** compute this league's ceiling. It has no schedule, and any schedule passed as an argument would be chosen by the same caller as the date — the check would compare an attacker's input against their own and read as a guarantee while being none.

The clock is the only input the caller does not supply, and `now` at initialisation is a sound lower bound on the first possible deposit, since `deposit` has no time condition and the account must exist first. So `now + 730 days`, **deliberately loose**: a false rejection there is unrecoverable, because the args come from an already-frozen rule set and the PDA derives from the league's UUID.

## `MAX_DRAFT_LEAD_MS` is what keeps that composition sound

The route bounded only *"in the future"*, so an unbounded draft carried the ceiling with it — a draft in 2100 puts the whole legal refund window in 2100, a date inside it validates clean, and members stake today against a hatch that opens in seventy years.

With the draft capped at 300 days:

```
latest legal draft       2027-06-08
worst legal refund date  2028-06-07
program horizon          2028-08-11   ← 65 days of margin
```

So the program can never falsely reject a league the validator allowed.

## Not optional: three program test files were already a time bomb

`anchor.test.ts`, `divergence.test.ts` and `stake.test.ts` pinned `DRAFT.scheduledAt` to a fixed August 2025 timestamp while computing `refundUnlockAt` from `Date.now()`. The gap widened daily, and **`stake.test.ts` would have started failing around 2026-08-28 with or without this change.** They now derive the refund date from the draft through a shared helper, and the draft follows the clock — the same shape the create form was fixed for.

`anchor.test.ts` also sent `i64::MAX` and *required* `initialize_league` to accept it, so the terms check had something to catch. It now sends a value inside the horizon that still diverges. The `i64::MAX` decoding guard it carried becomes unreachable once no account can hold that value; it stays covered as a unit in `verify.test.ts`, and the comment says so rather than letting the coverage look deleted.

## One more thing the design review turned up

A non-number reaching `validateRefundUnlock` now returns early. `"abc" <= 0` is `false`, so a string passes `validatePot`'s only gate, and `earliestRefundUnlock` then **concatenates rather than adds** — a string `scheduledAt` yields a floor of `1.7e30`. Pre-existing with the floor; one garbage comparison was survivable, two that can disagree are not.

## Verification

`pnpm test` **1139 passing**, typecheck, lint, format and `next build` clean.

The four new validation tests were **mutation-checked**: stub the ceiling and unsatisfiable branches and exactly those four fail.

**The golden hash does not move** — no field was added to `LeagueRules`, and the fixture clears the new ceiling by 84 days.

**IDL:** `RefundUnlockTooFar` appended last at code 6023, so nothing renumbers. Rationale in `//` not `///`, since doc comments on error variants compile into the IDL. `idl.ts` and `types.ts` hand-edited in their own casing conventions (PascalCase and camelCase respectively) — both are in `.prettierignore` and were not reformatted.

**`anchor test` not run locally** (no Rust toolchain); CI runs it on this PR, including two new program tests: `i64::MAX` is refused, and the horizon accepts `now + 700d` while refusing `now + 800d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
