### PR TITLE
fix(season): say what LOWEST_TEAM_ID sorts, and pin it

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -328,7 +328,38 @@ league that can never accept a deposit.
 ### The final tiebreaker is deterministic
 
 Every major platform ends its tiebreaker chain with a coin flip. Fine for bragging
-rights; unacceptable when the contract has to settle. The chain ends on lowest team ID.
+rights; unacceptable when the contract has to settle. The chain ends on lowest team ID —
+`teams.id`, the random UUID, sorted ascending.
+
+**Rejected: join order.** The obvious reading of "team ID" is a 1..N number, and
+`teams.slot` is exactly that. Ranking on it is worse than the arbitrariness it removes.
+`slot` is `count(*) + 1` at join, so the lowest belongs to whoever joined first — in
+practice the commissioner, who holds the league URL before anyone else has seen it. That
+makes the last word on every unresolved tie, and the 1000 bps regular-season prize hanging
+off seed 1, a standing property of having created the league. It is the same special power
+the rest of this system is built to delete, arriving through a column nobody thinks of as
+a permission.
+
+**Rejected: a key derived from the draft-order seed.** Attractive because the seed is
+already unpredictable and already published, so the tiebreak would be unguessable at
+formation and checkable afterwards. It closes nothing: a v4 UUID is equally unchooseable
+and equally checkable, and the seed becomes public at the draw either way. It costs a
+league-identity parameter threaded through a pure function that deliberately has none, a
+fallback for the pre-draw state it was meant to replace, and — since the value would no
+longer be a team id — either a rename that moves the golden hash and breaks every anchored
+league, or a name that lies about what the code does. That last is the defect this decision
+exists to correct, so paying for it with a fresh instance of it is not a trade.
+
+**Arbitrary is the requirement, not a concession.** Four real criteria have already found
+the teams indistinguishable. What is left is not a question about football, and inventing a
+measurement to answer it would be worse than admitting that. The bar is that it terminates,
+that anyone holding the standings can reproduce it, and that no participant can steer it.
+
+Note what this branch actually does in practice. Deciding money needs exact equality on win
+percentage, points for, head-to-head and points against — order 10⁻⁸ per league-season. But
+with no games played every team is equal on all four, so it orders the **entire league on
+every pre-season standings view**. The visible behaviour is common and the paying behaviour
+is vanishingly rare, which is why this is documented carefully and not engineered heavily.
 
 ---
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -297,10 +297,18 @@ Applied in order for seeding:
 2. **Points For**
 3. Head-to-head record — _skipped unless the tied teams played an equal number of times_
 4. Points Against
-5. Lowest team ID
+5. Lowest team ID — your team's unique identifier, the same one §4's draft-order
+   recipe shuffles. It is assigned at random when you join. It is **not** the order
+   people joined in.
 
 Step 5 is deterministic on purpose. No coin flips: the contract must be able to settle
 without randomness when money is at stake.
+
+It is also arbitrary on purpose. By the time it is consulted, the four criteria above
+have said the teams are indistinguishable, so there is nothing left to measure — only a
+tie to break in a way nobody can steer and anybody can check. Seniority was rejected for
+that reason: ranking on join order would give whoever created the league the last word on
+every tie it reaches, for as long as the league exists.
 
 **Championship tie:** if both finalists score exactly equal totals in Week 17, the
 higher seed wins.

--- a/packages/core/src/season/season.test.ts
+++ b/packages/core/src/season/season.test.ts
@@ -391,6 +391,25 @@ describe("computeStandings", () => {
     expect(standings.map((row) => row.seed)).toEqual([1, 2, 3, 4]);
   });
 
+  it("breaks the last tie on the team id, never on the order teams joined", () => {
+    // The pin against "making the code match the comment". Callers select
+    // `ORDER BY slot`, so the array arrives in join order — and the backstop
+    // must ignore that and sort the ids. `0005_teams_and_play.sql:11-13` claims
+    // the opposite; migration `0025` is the correction, and this is the test
+    // that makes acting on the wrong one fail loudly rather than quietly
+    // reseeding every league in favour of whoever joined first.
+    const joinOrder = [
+      "ffffffff-0000-4000-8000-000000000001", // joined first, highest id
+      "88888888-0000-4000-8000-000000000002",
+      "00000000-0000-4000-8000-000000000003", // joined last, lowest id
+    ];
+
+    const standings = computeStandings(joinOrder, [], DEFAULT_TIEBREAKERS);
+
+    expect(standings.map((row) => row.teamId)).toEqual([...joinOrder].reverse());
+    expect(standings[0]?.teamId).toBe("00000000-0000-4000-8000-000000000003");
+  });
+
   it("does not depend on the order teams were passed in", () => {
     // A seed that moved with database row order would be indefensible.
     const results = [

--- a/packages/core/src/season/standings.ts
+++ b/packages/core/src/season/standings.ts
@@ -216,9 +216,10 @@ function scoresFor(
     case "HEAD_TO_HEAD":
       return headToHeadScores(group, results);
     case "LOWEST_TEAM_ID":
-      // The deterministic backstop. Not fair in any meaningful sense — it is
-      // simply guaranteed to terminate, which matters more than fairness once
-      // every real criterion has come up equal.
+      // The deterministic backstop, handled by `orderGroup` rather than scored
+      // here — see the branch there for which id it sorts and why. Not fair in
+      // any meaningful sense; it is simply guaranteed to terminate, which
+      // matters more than fairness once every real criterion has come up equal.
       return null;
   }
 }
@@ -257,6 +258,33 @@ function orderGroup(
   for (let i = 0; i < tiebreakers.length; i++) {
     const tiebreaker = tiebreakers[i]!;
 
+    // Sorts the team's **id** — a random UUID (`teams.id`) — ascending. Not the
+    // join slot, whatever `0005_teams_and_play.sql:11-13` says; that sentence is
+    // wrong and migration `0025` is the correction. It cannot be edited, because
+    // migrations are forward-only and the runner refuses an applied file whose
+    // checksum moved.
+    //
+    // Sorting on the join slot was considered and rejected. `slot` is
+    // `count(*) + 1` at join, so the lowest belongs to whoever joined first —
+    // in practice the commissioner, who holds the league URL before anyone
+    // else. That would give one participant the last word on every unresolved
+    // tie, and the 1000 bps regular-season prize that hangs off seed 1, by
+    // construction and every season. This repo removes powers like that rather
+    // than granting them.
+    //
+    // A UUID is arbitrary, and that is the point rather than a shortcoming: by
+    // the time this runs, four real criteria have said the teams are
+    // indistinguishable, so there is nothing left to be fair about. What is
+    // required is that it be total, deterministic, reproducible by anyone
+    // holding the published standings, and impossible for a participant to
+    // steer. Nobody supplies their own id, and there is no leave-league path,
+    // so nobody gets a second draw.
+    //
+    // The one residual, recorded because it is real rather than because it is
+    // worth code: a commissioner could create and discard unjoined leagues
+    // until their own UUID comes up low. Each attempt costs a fresh on-chain
+    // anchor, and it buys a branch that decides money on the order of once in
+    // a hundred million league-seasons.
     if (tiebreaker === "LOWEST_TEAM_ID") {
       return [...group]
         .sort((a, b) => a.teamId.localeCompare(b.teamId))

--- a/packages/db/migrations/0025_team_id_is_the_tiebreaker.sql
+++ b/packages/db/migrations/0025_team_id_is_the_tiebreaker.sql
@@ -1,0 +1,36 @@
+-- Correct migration 0005's account of the LOWEST_TEAM_ID tiebreaker.
+--
+-- `0005_teams_and_play.sql:11-13` says, of `teams.slot`:
+--
+--   1..N within the league, assigned at join. This is the "team id" the
+--   LOWEST_TEAM_ID tiebreaker refers to: a UUID has no meaningful order, and
+--   the final tiebreaker must be deterministic when money is at stake.
+--
+-- That is wrong. `LOWEST_TEAM_ID` sorts `teams.id` — the random UUID — in
+-- `packages/core/src/season/standings.ts`. It has never read `slot`.
+--
+-- Migrations are forward-only and the runner refuses to start when an applied
+-- file's checksum moves, so the sentence in 0005 cannot be edited and stays in
+-- the tree forever. This migration is the correction, and it is written into
+-- the database itself so a reader inspecting the schema is told the truth by
+-- the schema rather than by whichever comment they happened to find first.
+--
+-- The code was not changed to match the comment, and that was a decision
+-- rather than an oversight. `slot` is `count(*) + 1` at join, so the lowest
+-- slot belongs to whoever joined first — in practice the commissioner, who
+-- holds the league URL before anybody else can. Ranking on it would hand the
+-- final tiebreaker, and with it the 1000 bps regular-season prize, to one
+-- participant by construction, every season. A UUID is arbitrary, which is the
+-- point: four real criteria have already come up equal by the time anything
+-- reads it, so there is nothing left to be fair about — only to be neutral,
+-- deterministic, and reproducible by anyone holding the published standings.
+
+COMMENT ON COLUMN teams.id IS
+  'Random v4 UUID. This is what the LOWEST_TEAM_ID tiebreaker sorts, ascending. '
+  'Never client-supplied, and there is no leave-league path, so a member cannot '
+  're-roll it. Corrects the claim in migration 0005.';
+
+COMMENT ON COLUMN teams.slot IS
+  'Join order, 1..N. Two uses: the domain of the seeded draft-order shuffle, and '
+  'a stable ORDER BY. It is NOT the LOWEST_TEAM_ID tiebreaker input — that sorts '
+  'teams.id. Migration 0005 says otherwise and is wrong.';

--- a/packages/db/src/playoffs.test.ts
+++ b/packages/db/src/playoffs.test.ts
@@ -660,3 +660,92 @@ describe("the third-place game is played whether or not it pays", () => {
     expect(state.playoffs?.bracket.thirdPlaceGame).not.toBeNull();
   });
 });
+
+describe("the LOWEST_TEAM_ID backstop, where the query meets the sort", () => {
+  /**
+   * A team with a chosen id.
+   *
+   * `addTestTeam` lets Postgres draw the UUID, which is right everywhere else
+   * and useless here: this test exists to make join order and id order
+   * *disagree*, and a random draw agrees with slot order half the time. Every
+   * other column is written exactly as `addTestTeam` writes it, including the
+   * `max(slot) + 1` that makes slot the real join order.
+   */
+  async function addTeamWithId(
+    client: PGliteClient,
+    leagueId: string,
+    name: string,
+    teamId: string,
+  ): Promise<void> {
+    const [user] = await client.query<{ id: string }>(
+      `INSERT INTO users (email, display_name) VALUES ($1, $2) RETURNING id`,
+      [`${name.toLowerCase().replace(/\W+/g, "-")}-${leagueId.slice(0, 8)}@example.test`, name],
+    );
+
+    await client.query(
+      `INSERT INTO teams (league_id, owner_id, is_bot, name, slot, id)
+       VALUES ($1, $2, false, $3,
+               COALESCE((SELECT max(slot) FROM teams WHERE league_id = $1), 0) + 1, $4)`,
+      [leagueId, user!.id, name, teamId],
+    );
+  }
+
+  it("seeds the regular-season prize on the id, not on who joined first", async () => {
+    // The money assertion. `regularSeasonWinner` is seed 1, which is the
+    // REGULAR_SEASON prize — 1000 bps of the pot. Two teams are made exactly
+    // equal on all four real criteria, so the seed between them is decided by
+    // the backstop alone.
+    //
+    // If anyone ever "fixes" this to match `0005_teams_and_play.sql:11-13` and
+    // sorts the join slot, this test fails — and it fails on the one assertion
+    // that says a participant would have won a prize for having joined first.
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+
+    const commissioner = await createUser(db, "backstop@example.com", "Commish");
+    const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT });
+    const league = await createLeague(db, NFL, {
+      name: "Backstop League",
+      commissionerId: commissioner.id,
+      rules,
+    });
+
+    // Ids descending as teams join, so id order is the exact reverse of slot
+    // order and the two orderings cannot accidentally agree.
+    const ids = [
+      "88888888-0000-4000-8000-000000000000",
+      "77777777-0000-4000-8000-000000000000",
+      "66666666-0000-4000-8000-000000000000",
+      "55555555-0000-4000-8000-000000000000",
+      "44444444-0000-4000-8000-000000000000",
+      "33333333-0000-4000-8000-000000000000",
+      "22222222-0000-4000-8000-000000000000",
+      "11111111-0000-4000-8000-000000000000",
+    ];
+    for (const [index, id] of ids.entries()) {
+      await addTeamWithId(db, league.id, `Team ${index + 1}`, id);
+    }
+
+    // Pairs 0 and 1 produce identical winners: same record, same points for,
+    // same points against, and they never met — so head-to-head returns null
+    // for that group rather than deciding it. Four criteria, all equal.
+    const points = [200_000, 100_000, 200_000, 100_000, 180_000, 80_000, 170_000, 70_000];
+    for (let i = 0; i + 1 < ids.length; i += 2) {
+      await db.query(
+        `INSERT INTO matchups
+           (league_id, week, phase, home_team_id, away_team_id,
+            home_milli_points, away_milli_points, finalized_at)
+         VALUES ($1, 1, 'REGULAR', $2, $3, $4, $5, $6)`,
+        [league.id, ids[i], ids[i + 1], points[i], points[i + 1], FINAL.toISOString()],
+      );
+    }
+    await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
+    const state = await playoffState(db, league.id);
+
+    // Team 3 joined third and Team 1 joined first. Team 3 holds the lower id, so
+    // Team 3 takes seed 1 — and with it the regular-season prize.
+    expect(state.regularSeasonWinner).toBe(ids[2]);
+    expect(state.regularSeasonWinner).not.toBe(ids[0]);
+  });
+});

--- a/packages/db/src/playoffs.ts
+++ b/packages/db/src/playoffs.ts
@@ -135,6 +135,10 @@ async function seedOrder(
   rules: LeagueRules,
   finalizedOnly = false,
 ) {
+  // `ORDER BY slot` is for stable row order and nothing else. `computeStandings`
+  // does not depend on the order it is given, and the `LOWEST_TEAM_ID` backstop
+  // sorts `id`, not `slot` — see the branch in `standings.ts`, and migration
+  // `0025` for why `0005` says otherwise.
   const teams = await db.query<{ id: string }>(
     "SELECT id FROM teams WHERE league_id = $1 ORDER BY slot",
     [leagueId],


### PR DESCRIPTION
Finding #2 of the pre-mainnet rule-set audit.

## The defect

`packages/db/migrations/0005_teams_and_play.sql:11-13` says, of `teams.slot`:

> 1..N within the league, assigned at join. This is the "team id" the
> `LOWEST_TEAM_ID` tiebreaker refers to: a UUID has no meaningful order, and the
> final tiebreaker must be deterministic when money is at stake.

That is wrong. `LOWEST_TEAM_ID` sorts `teams.id` — the random UUID — at
`packages/core/src/season/standings.ts:260`. It has never read `slot`.

It matters because this is the **last** link in the chain: `computeStandings`
throws if the chain runs out, so nothing follows it. Seed 1 is
`regularSeasonWinner` (`packages/db/src/playoffs.ts:114`), which `championship()`
pays at **1000 bps**.

## Why the comment was fixed and not the code

The obvious repair is worse than the bug.

`slot` is `count(*) + 1` at join (`packages/db/src/membership.ts:216`), so the
lowest belongs to whoever joined first — in practice the commissioner, who holds
the league URL before anyone else has seen it. Ranking on it would make the last
word on every unresolved tie, and the prize hanging off seed 1, a standing
property of having created the league. That is the special power the rest of this
system is built to delete, arriving through a column nobody reads as a
permission.

A key derived from the draft-order seed was also weighed and rejected. It closes
nothing a v4 UUID does not already close — both are unchooseable at formation and
both are checkable afterwards — and it costs a league-identity parameter threaded
through a pure function that deliberately has none, plus a fallback for the
pre-draw state it was meant to replace. Worse, the value would no longer be a team
id, so it needs either a rename that **moves the golden hash and breaks every
anchored league**, or a name that lies about what the code does. The second is the
defect this PR exists to correct.

Arbitrary is the requirement, not a concession. By the time this branch runs, four
real criteria have found the teams indistinguishable, so there is nothing left to
measure. The bar is that it terminates, that anyone holding the published
standings can reproduce it, and that no participant can steer it. Nobody supplies
their own id and there is no leave-league path, so nobody gets a second draw.

## How often it fires

Deciding money needs exact equality on win percentage, points for, head-to-head
and points against — order **10⁻⁸ per league-season**, on 20-milli-point scoring
quanta.

But with no games played every team is equal on all four, so it orders the
**entire league on every pre-season standings view**, labelling rows "on team ID"
before a ball is thrown. The visible behaviour is universal and the paying
behaviour is vanishingly rare, which is why this is documented carefully and not
engineered heavily.

## The changes

- **`packages/db/migrations/0025_team_id_is_the_tiebreaker.sql`** — new, because
  migrations are forward-only and the runner refuses an applied file whose
  checksum moved (`migrate.ts:242-260`). The wrong sentence stays in `0005`
  forever, so the correction is written as `COMMENT ON COLUMN` on both `teams.id`
  and `teams.slot` — the schema tells a reader the truth rather than leaving it to
  whichever comment they find first.
- **`standings.ts`** — the branch now states which id it sorts, and records both
  rejected alternatives at the point someone would act on them.
- **`playoffs.ts`** — one line noting the `ORDER BY slot` is for stable rows only.
  That inference is exactly what the `0005` comment invited.
- **`docs/RULES.md`** — step 5 now defines the term. Members sign this.
- **`docs/DECISIONS.md`** — both rejected options, so this is not re-litigated.

## Verification

- `packages/core/src/season/season.test.ts` — ids whose order is the exact
  reverse of join order, which is how every caller supplies them.
- `packages/db/src/playoffs.test.ts` — where the query meets the sort. Two teams
  made exactly equal on all four criteria, asserted on `regularSeasonWinner`. If
  anyone "fixes" this to match `0005`, it fails on the assertion that says a
  participant won money for joining first.
- **Mutation-checked**: deleting the sort fails both new tests and nothing else.
- 1122 tests, typecheck, lint — all green. Migration `0025` applies in every
  PGlite test database.

No logic changed. No `Tiebreaker` union change, no schema version bump, **the
golden hash does not move.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
