### PR TITLE
fix(web,escrow): close mainnet deposits until the program can pay them out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,18 @@ moment it does.
   only when a fee is actually charged: fee-free leagues legitimately carry an empty one.
 
   `expectedTermsFromRules` and `anchorTermMismatches` live in `@rostr/escrow`, not in the
-  route, because `apps/web` has no test project — a mapping inline in a route is verified
-  only by being run in production, and both defects found in review were in the mapping
-  rather than the comparison.
+  route, because **`apps/web` cannot test React** — a mapping inline in a component is
+  verified only by being run in production, and both defects found in review were in the
+  mapping rather than the comparison.
+
+  **Corrected 2026-08-12: `apps/web` does have a test project**, and this sentence used to
+  say it did not. The root `vitest.config.ts` collects `apps/web/src/**/*.test.ts` (so
+  `pnpm test` runs them) and `vitest.web.config.ts` runs them alone as `pnpm test:web`.
+  Five files live there today. What is still true is the narrower claim: both configs are
+  node-environment and the glob is `.ts`, with no jsdom and no testing-library, so a
+  **component** cannot be rendered in a test. Server-side helpers under
+  `apps/web/src/lib/` are testable and should be tested — `lib/cluster.test.ts` and
+  `lib/pot.test.ts` are the pattern, using `vi.stubEnv` and needing no database.
 
   Verified end to end against a real validator, not reasoned about — see
   `programs/rostr-escrow/tests/anchor.test.ts` below.
@@ -308,12 +317,18 @@ still needs Rust and a decision before Aug 22:
    derives it from posted scores. That makes D6 depend on G4–G8 (dual-source oracle, scores
    on-chain), which the build plan schedules for Dec–Jan. Do not start D6 expecting an
    afternoon.
-3. **Pot leagues can now technically take money, and the reason not to is a decision
-   rather than a missing part.** Anchor → join → deposit → timelock refund all work end to
-   end and are exercised against a validator on every CI run (#62, #63). What is still
-   absent is the _payout_ (#28, D6), so money can go in and come back out through the
-   unconditional refund, but it cannot be distributed. Nothing in the code stops a pot
-   league opening; this is item 1 plus an owner call.
+3. **Pot leagues must not take money on mainnet** until D6 can pay it back out — and that
+   is now enforced rather than remembered. Anchor → join → deposit → timelock refund all
+   work end to end and are exercised against a validator on every CI run (#62, #63), so
+   the structural barrier is gone: money can go in and come back out through the
+   unconditional refund, but it cannot be _distributed_. What closes the gap is
+   `potDepositGate`, which shuts the stake button on mainnet until the committed IDL
+   carries a settlement instruction. See "Deposit and refund" below.
+
+   The missing piece is the payout (#28, D6). PR #31 offered one and was closed on
+   2026-08-14 — see the review above; the short version is that it declared a winner,
+   which `RULES.md` §7 forbids, and its authority field was never actually enforced.
+
 4. **Settlement**, which is where the season ends up. `championship()` now derives all
    five prize-holders from the scores; nothing pays them out yet, and that is D6 — see
    above for why it is not an afternoon.
@@ -1145,11 +1160,39 @@ what people read is its own kind of serious.
 beats validating a supplied address: a caller with no way to _name_ a wallet has no way to
 name somebody else's.
 
-**The whole path is inert until on-chain join ships, structurally.** The program's
-`deposit` requires a `Membership` account and only `join_league` creates one, so
-`verifyOnChainDeposit` answers `NOT_JOINED` for everyone until the app invokes it. That is
-a property of the program, not a flag somebody has to remember to unset — which is the
-right way for "pot leagues cannot take money yet" to be true.
+**That path was inert until on-chain join shipped, and it is not any more.** The
+guarantee used to be structural: `deposit` requires a `Membership` account, only
+`join_league` creates one, and the app did not invoke `join_league` — so
+`verifyOnChainDeposit` answered `NOT_JOINED` for everyone and nobody had to remember
+anything. `JoinPanel` now sends `join_league`, and the property went with it. The
+paragraph that used to sit here outlived what it described, which is the exact defect
+class this file warns about two sections up.
+
+**What replaces it is `potDepositGate`** (`packages/escrow/src/settlement.ts`), read
+through `depositsOpen()` in `apps/web/src/lib/pot.ts`:
+
+```
+open  =  settlementShipped(ESCROW_IDL)  ||  cluster !== "mainnet-beta"
+```
+
+The committed IDL is what answers "can this program pay a pot out". It is in the tree,
+`pnpm idl:check` fails in the Anchor job when it drifts from the Rust, and a tripwire test
+pins the five instruction names — so the commit that ships D6 opens the gate **in the same
+commit**, and is forced to visit the file that decides it. No date, no environment
+variable, nothing to unset.
+
+Two things it is not. It is a **client-side** rule: `deposit` is permissionless on-chain,
+so a member who has joined can build the instruction themselves and nothing in TypeScript
+stops them. It is weaker than what it replaces, and the comment there says so rather than
+reprising the sentence it retired. And it is **not** applied in the deposit route — see
+that file for why refusing to record a deposit the chain has already accepted produces
+amnesia rather than an emptier vault.
+
+**Off mainnet the gate is open**, deliberately: the funding path has to be exercisable end
+to end, which is what Aug 22's "fundable" asks for and what `stake.test.ts` already proves
+against a real validator. What closes is a **mainnet** buy-in during the window where the
+only exit is the timelock — and the create form's default `refundUnlockAt` is
+**2027-03-01**, so that window is about seven months long.
 
 **The original program test only exercised `NOT_JOINED`** — the one refund path that was
 already correct — which is how an inverted verifier shipped green. `membership.test.ts`

--- a/apps/web/src/app/api/leagues/[id]/deposit/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/deposit/route.ts
@@ -11,6 +11,7 @@ import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 import { assertRpcCluster, ClusterConfigError } from "@/lib/cluster";
 import { EscrowConfigError, readOnlyEscrow } from "@/lib/escrow";
+import { depositsOpen } from "@/lib/pot";
 
 /**
  * Recording that a member has staked into a league on-chain.
@@ -29,13 +30,35 @@ import { EscrowConfigError, readOnlyEscrow } from "@/lib/escrow";
  * **The wallet is derived from this user's own membership row**, never taken
  * from the request. See `memberWallet`.
  *
- * ## This route is inert until on-chain join ships, structurally
+ * ## This route was inert until on-chain join shipped. It is not any more
  *
- * The program's `deposit` requires a `Membership` account, which only
- * `join_league` creates. Until the app invokes that, `verifyOnChainDeposit`
- * answers `NOT_JOINED` for everyone and nothing can be recorded here. That is a
- * property of the program rather than a flag somebody has to remember to unset,
- * which is the right way for "pot leagues cannot take money yet" to be true.
+ * It used to say, here, that the path was inert **structurally**: `deposit`
+ * needs a `Membership` account, only `join_league` creates one, and the app did
+ * not invoke `join_league` — so `verifyOnChainDeposit` answered `NOT_JOINED` for
+ * everyone and nothing could be recorded. That was true, and it stopped being
+ * true when `JoinPanel` began sending `join_league`. The sentence outlived the
+ * property it described.
+ *
+ * What replaces it is `potDepositGate` (`@rostr/escrow`), read through
+ * `depositsOpen()`, and it is applied where a deposit is **invited** — the stake
+ * button — not here.
+ *
+ * ## Why this route does not refuse when that gate is closed
+ *
+ * Deliberate, and the opposite of the obvious move.
+ *
+ * By the time anything reaches this handler the tokens have already moved: the
+ * browser builds `deposit`, signs it, and sends it to the chain itself, and only
+ * then reports it. Refusing to record does not empty a vault. It produces a
+ * member whose money is in escrow and a database that has never heard of it —
+ * so nobody can tell them when their timelock opens, and the record disagrees
+ * with the chain, which is its own kind of serious in a project whose whole
+ * claim is that the two agree.
+ *
+ * Recording a deposit we would rather not have taken is strictly better than not
+ * knowing about it. So this route's job is to record the truth and say what is
+ * true: `settlementPending` tells the member the program cannot pay out yet, and
+ * the refund unlock is the date that matters to them.
  */
 export async function POST(
   request: Request,
@@ -126,6 +149,12 @@ export async function POST(
       baseUnits: verdict.deposited.toString(),
       cluster,
       signature,
+      // Recorded, and said out loud: this stake is in a vault the program has no
+      // instruction to pay out, so the timelock refund is the only way it moves
+      // until D6 ships. A member who got here past a closed gate is owed that
+      // sentence rather than a bare success.
+      settlementPending: !depositsOpen(),
+      refundUnlockAt: stored.rules.pot.refundUnlockAt,
     });
   } catch (error) {
     if (error instanceof EscrowConfigError || error instanceof ClusterConfigError) {

--- a/apps/web/src/app/leagues/[id]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/page.tsx
@@ -12,6 +12,7 @@ import { AnchorPanel } from "@/components/AnchorPanel";
 import { DepositPanel } from "@/components/DepositPanel";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
+import { depositsOpen } from "@/lib/pot";
 
 export default async function LeaguePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -163,11 +164,22 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
         </p>
       )}
 
-      {stored.rules.pot && (
+      {/*
+        Members only — `memberWallet` is the same derivation `/api/leagues/[id]/
+        deposit` enforces server-side, so the screen and the server give one
+        answer. A stranger was previously shown a Stake button on a league they
+        had not joined.
+
+        Deliberately **not** conditioned on `depositsOpen()`. The panel holds the
+        only refund control in the app, and a member who has already staked must
+        be able to reach it whether or not new deposits are open. The gate is
+        passed down and applied to the stake button alone.
+      */}
+      {stored.rules.pot && myWallet !== null && (
         <DepositPanel
           leagueId={league.id}
           tokenMint={stored.rules.pot.tokenMint}
-          hasPot={stored.rules.pot !== null}
+          depositsOpen={depositsOpen()}
           refundUnlockAt={stored.rules.pot.refundUnlockAt}
         />
       )}

--- a/apps/web/src/components/DepositPanel.tsx
+++ b/apps/web/src/components/DepositPanel.tsx
@@ -23,14 +23,22 @@ import { AnchorProvider, type Wallet } from "@coral-xyz/anchor";
 export function DepositPanel({
   leagueId,
   tokenMint,
-  hasPot,
+  depositsOpen,
   refundUnlockAt,
 }: {
   leagueId: string;
   /** The pot token mint (USDC). Required for a deposit. */
   tokenMint: string | null;
-  /** Whether this league has a pot to stake into. */
-  hasPot: boolean;
+  /**
+   * Whether this deployment should invite a buy-in — `depositsOpen()` in
+   * `lib/pot.ts`, resolved on the server.
+   *
+   * **It gates the stake button and nothing else.** Refund is deliberately
+   * untouched: a member who has already staked must be able to get their money
+   * out whatever this says, and hiding the panel to hide the stake control
+   * would take the only refund UI in the app with it.
+   */
+  depositsOpen: boolean;
   /** Unix seconds after which a refund is permitted. */
   refundUnlockAt: number | null;
 }) {
@@ -41,7 +49,10 @@ export function DepositPanel({
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<"deposit" | "refund" | null>(null);
 
-  if (!hasPot || !tokenMint) {
+  // Only `tokenMint`. This early return sits above **both** buttons, so every
+  // condition added here hides the refund control too. `depositsOpen` therefore
+  // does not belong in it — see the stake button below.
+  if (!tokenMint) {
     return (
       <section className="rounded border border-white/10 p-6">
         <p className="text-sm text-white/60">
@@ -159,18 +170,32 @@ export function DepositPanel({
         <WalletMultiButton />
       ) : (
         <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={() => void stake()}
-            disabled={busy !== null || done === "deposit"}
-            className="rounded bg-[--color-turf] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
-          >
-            {busy === "deposit"
-              ? "Waiting for the chain…"
-              : done === "deposit"
-                ? "Staked"
-                : "Stake buy-in"}
-          </button>
+          {/*
+            No button at all when deposits are closed, rather than a disabled
+            one. A disabled button reads as "try again in a moment", and the
+            honest answer is "not until the program can pay it back out" — which
+            is a different sentence and a different wait.
+          */}
+          {depositsOpen ? (
+            <button
+              type="button"
+              onClick={() => void stake()}
+              disabled={busy !== null || done === "deposit"}
+              className="rounded bg-[--color-turf] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+            >
+              {busy === "deposit"
+                ? "Waiting for the chain…"
+                : done === "deposit"
+                  ? "Staked"
+                  : "Stake buy-in"}
+            </button>
+          ) : (
+            <p className="text-sm text-white/60">
+              Staking is not open yet. The escrow program has no payout instruction, so a buy-in
+              taken now could only come back out through the timelock refund — and this app will
+              not take money for prizes it cannot award.
+            </p>
+          )}
 
           <button
             type="button"

--- a/apps/web/src/lib/pot.test.ts
+++ b/apps/web/src/lib/pot.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { depositsOpen } from "./pot.js";
+
+/**
+ * The mainnet deposit gate, bound to this deployment's declared cluster.
+ *
+ * The rule is tested in `packages/escrow/src/settlement.test.ts`. What is tested
+ * here is the binding — and in particular that a deployment which cannot say
+ * which chain it is on answers "closed" rather than throwing, because this runs
+ * on a page that strangers are meant to be able to read.
+ */
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("depositsOpen", () => {
+  it("is closed on mainnet while the program has no settlement instruction", () => {
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet-beta");
+    expect(depositsOpen()).toBe(false);
+  });
+
+  it.each(["devnet", "testnet", "localnet"])("is open on %s", (cluster) => {
+    vi.stubEnv("SOLANA_CLUSTER", cluster);
+    expect(depositsOpen()).toBe(true);
+  });
+
+  it("is closed, and does not throw, when the cluster is unset in production", () => {
+    // The assertion that matters most. `declaredCluster()` throws here, and
+    // this is called from the league page — which is deliberately readable by
+    // people who are not members. If the throw escaped, one missing environment
+    // variable would 500 the entrance to every league rather than closing a
+    // button nobody should be pressing yet.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SOLANA_CLUSTER", "");
+    expect(() => depositsOpen()).not.toThrow();
+    expect(depositsOpen()).toBe(false);
+  });
+
+  it("is closed, and does not throw, when the cluster names nothing", () => {
+    vi.stubEnv("SOLANA_CLUSTER", "mainnet");
+    expect(() => depositsOpen()).not.toThrow();
+    expect(depositsOpen()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/pot.ts
+++ b/apps/web/src/lib/pot.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { potDepositGate } from "@rostr/escrow";
+import { ClusterConfigError, declaredCluster } from "./cluster";
+
+/**
+ * Whether this deployment should invite a pot deposit.
+ *
+ * The rule itself is `potDepositGate` in `@rostr/escrow`, where it is tested and
+ * where the native app can reach it too. This is the thin server-side binding:
+ * which cluster we declare ourselves to be on.
+ *
+ * **Fails closed, and the catch is load-bearing.** `declaredCluster()` throws in
+ * production when `SOLANA_CLUSTER` is unset, and this is called from
+ * `/leagues/[id]` — one of the two pages deliberately left readable by people
+ * who are not members, because `RULES.md` requires the full rule set to be shown
+ * before anyone joins. Letting the throw escape would turn a missing environment
+ * variable into a 500 on the league entrance for everyone, private and public
+ * alike. A deployment that cannot say which chain it is on is exactly the one
+ * that must not invite a buy-in, so answering "closed" is both the safe reading
+ * and the honest one.
+ */
+export function depositsOpen(): boolean {
+  try {
+    return potDepositGate(declaredCluster()).open;
+  } catch (error) {
+    if (error instanceof ClusterConfigError) return false;
+    throw error;
+  }
+}

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -37,6 +37,14 @@ export {
   type RulesLikeTerms,
 } from "./verify.js";
 export {
+  SETTLEMENT_PREFIXES,
+  instructionNames,
+  potDepositGate,
+  settlementShipped,
+  type DepositGate,
+  type IdlShape,
+} from "./settlement.js";
+export {
   PRIZE_ORDER,
   depositIx,
   escrowProgram,

--- a/packages/escrow/src/settlement.test.ts
+++ b/packages/escrow/src/settlement.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { ESCROW_IDL } from "./idl.js";
+import { instructionNames, potDepositGate, settlementShipped } from "./settlement.js";
+
+/**
+ * The instructions the program has today.
+ *
+ * Pinned deliberately. See the tripwire test at the bottom of this file for why
+ * this list is the thing that opens the mainnet deposit gate.
+ */
+const TODAY = [
+  "deposit",
+  "initialize_free_league",
+  "initialize_league",
+  "join_league",
+  "refund_stake",
+];
+
+const settled = { instructions: [...TODAY, "settle_league"].map((name) => ({ name })) };
+
+describe("settlementShipped", () => {
+  it("is false for the program as it stands", () => {
+    expect(settlementShipped(ESCROW_IDL)).toBe(false);
+  });
+
+  it("is true once an instruction that pays a pot out exists", () => {
+    expect(settlementShipped(settled)).toBe(true);
+  });
+
+  it("does not mistake refund_stake for settlement", () => {
+    // The trap this whole gate exists for: a refund returns your own stake, it
+    // does not pay a champion. A prefix list that matched "refund" would read
+    // the escape hatch as the payout and open the gate on a program that still
+    // cannot award a prize.
+    expect(settlementShipped({ instructions: [{ name: "refund_stake" }] })).toBe(false);
+  });
+});
+
+describe("potDepositGate", () => {
+  it("closes mainnet while the program cannot pay a pot out", () => {
+    expect(potDepositGate("mainnet-beta", ESCROW_IDL)).toEqual({
+      open: false,
+      reason: "SETTLEMENT_NOT_SHIPPED",
+    });
+  });
+
+  it("leaves every other cluster open", () => {
+    // Not a loophole. The funding path has to be exercisable end to end — that
+    // is the Aug 22 milestone — and no real money is at risk off mainnet.
+    for (const cluster of ["devnet", "testnet", "localnet"] as const) {
+      expect(potDepositGate(cluster, ESCROW_IDL)).toEqual({ open: true });
+    }
+  });
+
+  it("opens mainnet on the program's interface, not on a date or a variable", () => {
+    expect(potDepositGate("mainnet-beta", settled)).toEqual({ open: true });
+  });
+});
+
+describe("the tripwire", () => {
+  it("pins the program's instruction list", () => {
+    // This test exists to fail, once, on the commit that ships settlement.
+    //
+    // `potDepositGate` opens when it recognises a settlement instruction by
+    // name prefix, and those prefixes are a guess. A wrong guess fails in the
+    // dangerous direction — the gate stays shut and nobody notices, or worse,
+    // somebody deletes the gate rather than teaching it the new name.
+    //
+    // So pin the list. When D6 lands, `pnpm idl:sync` moves this and the
+    // failure lands here, in the file that decides whether mainnet can take a
+    // buy-in, with instructions attached.
+    //
+    // If you are reading this because the test just failed: check that
+    // `SETTLEMENT_PREFIXES` in `settlement.ts` matches whatever the new
+    // instruction is called, confirm `potDepositGate("mainnet-beta")` is now
+    // open, then add the name below.
+    expect(instructionNames(ESCROW_IDL).sort()).toEqual(TODAY);
+  });
+
+  it("keeps the gate shut on an IDL whose shape has moved", () => {
+    // A regenerated IDL that no longer looks like this should read as "no
+    // settlement here" rather than throwing — this runs behind a page a
+    // stranger can load, and the safe answer is the closed one.
+    expect(settlementShipped({ instructions: [null, 42, {}, { name: 7 }] })).toBe(false);
+    expect(potDepositGate("mainnet-beta", { instructions: [null] })).toEqual({
+      open: false,
+      reason: "SETTLEMENT_NOT_SHIPPED",
+    });
+  });
+});

--- a/packages/escrow/src/settlement.ts
+++ b/packages/escrow/src/settlement.ts
@@ -1,0 +1,104 @@
+/**
+ * Whether the program can pay a pot out, and therefore whether this app should
+ * invite a buy-in.
+ *
+ * ## Why this exists
+ *
+ * "Pot leagues cannot take money yet" used to be true **structurally**: the
+ * program's `deposit` requires a `Membership` account, only `join_league`
+ * creates one, and the app did not invoke `join_league`. So no client could
+ * deposit, because the account a deposit needs did not exist. Nobody had to
+ * remember anything.
+ *
+ * On-chain join has since shipped, and that property is gone with it. What
+ * replaces it has to be something nobody can forget to set, because the thing it
+ * guards is a member's money.
+ *
+ * ## The rule
+ *
+ * A mainnet deposit is open only once the program has an instruction that can
+ * pay it back out. Until then the sole exit from a vault is `refund_stake` after
+ * the timelock, so a buy-in is a payment for prizes nobody can award.
+ *
+ * The **committed IDL** is what answers that. It is the program's interface, it
+ * is in the tree, and `pnpm idl:check` fails in the Anchor job when it drifts
+ * from the Rust. So the day settlement ships, `pnpm idl:sync` regenerates this
+ * file's input and the gate opens **in the same commit** — not on a date, not on
+ * an environment variable somebody has to unset.
+ *
+ * ## What this is not
+ *
+ * This is a client-side rule and it must not be mistaken for the structural
+ * guarantee it replaces. `deposit` is permissionless on-chain (`lib.rs`): any
+ * member who has joined can build the instruction and send it themselves, and
+ * nothing in TypeScript can stop them. This decides what **our** clients invite,
+ * which is the strongest form available without changing Rust — and Rust is
+ * deliberately not on the table, because `refund_stake` having exactly three
+ * conditions is what makes the escape hatch trustworthy.
+ */
+
+import { ESCROW_IDL } from "./idl.js";
+import type { Cluster } from "./cluster.js";
+
+/**
+ * Instruction-name prefixes that would mean "this program can pay a pot out".
+ *
+ * A guess about what D6 will be called, and it does not have to be right: the
+ * tripwire in `settlement.test.ts` pins the current instruction list, so the
+ * commit that adds settlement is forced to open this file whatever it names its
+ * instruction.
+ */
+export const SETTLEMENT_PREFIXES = ["settle", "payout", "distribute"] as const;
+
+/**
+ * The IDL, seen as loosely as possible.
+ *
+ * `EscrowIdl` types `instructions` as `readonly unknown[]`, so this narrows each
+ * element at runtime instead of casting. That is the right direction anyway: a
+ * regenerated IDL whose shape has moved should read as "no settlement here" and
+ * keep the gate shut, not throw on a page a stranger can load.
+ */
+export interface IdlShape {
+  readonly instructions: readonly unknown[];
+}
+
+/** The instruction names an IDL declares, ignoring anything malformed. */
+export function instructionNames(idl: IdlShape = ESCROW_IDL): string[] {
+  return idl.instructions
+    .map((instruction) =>
+      typeof instruction === "object" &&
+      instruction !== null &&
+      "name" in instruction &&
+      typeof instruction.name === "string"
+        ? instruction.name
+        : null,
+    )
+    .filter((name): name is string => name !== null);
+}
+
+/** Does this IDL describe a program that can move a pot to its winners? */
+export function settlementShipped(idl: IdlShape = ESCROW_IDL): boolean {
+  return instructionNames(idl).some((name) =>
+    SETTLEMENT_PREFIXES.some((prefix) => name.startsWith(prefix)),
+  );
+}
+
+export type DepositGate =
+  { readonly open: true } | { readonly open: false; readonly reason: "SETTLEMENT_NOT_SHIPPED" };
+
+/**
+ * Whether this deployment should invite a pot deposit.
+ *
+ * Open everywhere except mainnet while settlement is missing. Devnet, testnet
+ * and localnet stay open on purpose: the funding path has to be exercisable end
+ * to end — that is the Aug 22 milestone, and it is what `stake.test.ts` proves
+ * against a real validator — and no real money is at risk on those chains.
+ *
+ * Closed on mainnet, where a stake would be real and the only way back out is a
+ * timelock the league's own creator sets months away.
+ */
+export function potDepositGate(cluster: Cluster, idl: IdlShape = ESCROW_IDL): DepositGate {
+  if (settlementShipped(idl)) return { open: true };
+  if (cluster !== "mainnet-beta") return { open: true };
+  return { open: false, reason: "SETTLEMENT_NOT_SHIPPED" };
+}


### PR DESCRIPTION
Fixes item 1 of #80. Confirmed and designed by three agents under separate mandates (designer / adversary / blast-radius); every load-bearing claim re-verified by hand.

## The defect

`CLAUDE.md` states the property the whole "settlement doesn't exist yet" position rests on:

> **The whole path is inert until on-chain join ships, structurally.** The program's `deposit` requires a `Membership` account and only `join_league` creates one… **That is a property of the program, not a flag somebody has to remember to unset.**

On-chain join shipped (`JoinPanel.tsx:298-305`), so that property is gone. `apps/web/src/app/leagues/[id]/page.tsx:166` renders the stake control on `stored.rules.pot` alone — no check on membership, anchor state, league state or sign-in — and `programs/rostr-escrow/src/lib.rs` has exactly five instructions, none of them settlement.

**Severity comes from the timelock.** `CreateLeagueForm.tsx:72` sets `DEFAULT_REFUND_UNLOCK = "2027-03-01T00:00"`. A deposit taken today cannot come back before March 2027 by any mechanism, and the thing that would release it sooner (D6) depends on G4–G8, scheduled Dec–Jan. That is ~7 months of locked capital in an unaudited program, for prizes the program cannot award.

## The fix

```
open  =  settlementShipped(ESCROW_IDL)  ||  cluster !== "mainnet-beta"
```

The **committed IDL** answers "can this program pay a pot out". It is in the tree, and `pnpm idl:check` fails in the Anchor job when it drifts from the Rust — so the commit that ships D6 opens the gate *in the same commit*. A tripwire test pins the five current instruction names, so that commit is forced to visit the file that decides.

No date, no environment variable, nothing to unset. `CLAUDE.md` asks for structure over a flag, and this is the strongest form available without changing Rust — which is deliberately off the table, because `refund_stake` having exactly three conditions is what makes the escape hatch trustworthy.

**Off mainnet the gate is open.** The funding path has to be exercisable end to end — that is Aug 22's "fundable", and `stake.test.ts` already proves it against a real validator. What closes is a mainnet buy-in during the window where the only exit is a timelock.

## Three things this deliberately does not do

**It does not hide the panel.** `DepositPanel` holds the only refund control in the app — `refundStakeIx` has exactly three callers repo-wide, one of which is this component and two of which are program tests. Its early return sits *above both buttons*, so gating the render, or adding one word to that return, would take a member's money and then remove the way out. The gate is passed down and applied to the stake button alone. That was the single largest risk in this fix and all three agents flagged it independently.

**It does not refuse in the deposit route.** By the time that handler runs the tokens have already moved: the browser builds `deposit`, signs it, sends it to the chain, and only then reports. Refusing to record does not empty a vault — it produces a member whose money is in escrow and a database that has never heard of it, so nobody can tell them when their timelock opens. Recording a deposit we would rather not have taken is strictly better than not knowing about it. The route now returns `settlementPending` and the unlock date.

**It does not touch the program.** `deposit` stays permissionless; a member who has joined can still build the instruction by hand. This decides what *our* clients invite, and the comment says so rather than reprising the structural claim it retired.

## Also fixed, same defect

- The page showed a stake button to **signed-out strangers** on leagues they had not joined. Now gated on `myWallet !== null` — the same `memberWallet` derivation `/deposit` already enforces server-side, so the screen and the server give one answer.
- `hasPot` was dead: always `true`, because it was evaluated inside `{stored.rules.pot && …}`.

## Documentation corrected

By this repo's own convention, a comment asserting a guarantee the code does not provide is a defect in its own right. Three were:

- **`deposit/route.ts:32-38`** — the false "inert… structurally" claim, sitting in the file that takes the money. Highest priority.
- **`CLAUDE.md`** — the same claim as the source of truth, plus "Pot leagues still cannot take money in the app" (the *cannot* was false; the *must not* survives and is now enforced).
- **`CLAUDE.md`, "`apps/web` has no test project"** — false. The root `vitest.config.ts` collects `apps/web/src/**/*.test.ts` and `vitest.web.config.ts` runs them as `pnpm test:web`; five test files live there. The true statement is the narrower **"cannot test React"** — both configs are node-environment, the glob is `.ts`, and there is no jsdom. This matters here: it is why the gate predicate is testable but the component is not.

## Verification

- **13 new tests.** `packages/escrow/src/settlement.test.ts` (the rule, plus the tripwire, plus a malformed-IDL case that must fail closed) and `apps/web/src/lib/pot.test.ts` (the binding).
- The assertion that matters most: **`SOLANA_CLUSTER` unset in production returns closed and does not throw.** `declaredCluster()` throws there, and this runs on `/leagues/[id]` — one of the two pages deliberately readable by non-members, because `RULES.md` requires the rule set to be shown before joining. An escaping throw would 500 the entrance to every league.
- **Mutation-checked**: forcing the gate open fails three tests across both packages.
- 1134 tests, typecheck, lint — all green. No Rust changed, so `anchor test` is untouched.

## One question for the owner, not blocking this PR

`CLAUDE.md`'s deadline table says leagues must be **"fundable"** by Aug 22. This PR reads that as *fundable on devnet* — the software path works end to end — with mainnet funding waiting for D6, which is what `CLAUDE.md:253` separately requires. Both texts are satisfied and nothing about the settled "mainnet with the pot live for 2026" changes: pot leagues stay creatable, anchorable and joinable, and the gate reopens automatically when settlement lands.

**If the intent is instead that leagues take real mainnet buy-ins from August**, this contradicts that plan and the gate is one boolean to open — but that should be a line in `DECISIONS.md` recording that real money was taken knowing the only exit was a 2027 timelock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
