### PR TITLE
fix(db,web): make the scoring write refuse an already-finalised matchup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,6 +622,31 @@ and, _within_ that window, only when every game is `FINAL`. A finalised week is 
 rescored — in a paying week it has already decided money, and a silently changed result
 afterwards is exactly what the window exists to prevent.
 
+**And that is enforced on the write, not by the check above it** (issue #76). `ALREADY_FINAL`
+reads `count(*)` in its own autocommit statement and the `UPDATE` runs four round trips later
+— `ensureLineups` alone opens a transaction of its own — so two overlapping runs both read
+zero and the slower one wrote its older stat snapshot over the settled row. Nothing recorded
+it: `finalized_at = CASE … ELSE finalized_at END` kept the timestamp, and the sweep's
+`NOT EXISTS` selection means the guard that failed to prevent the write is the same guard
+that prevents the repair. There is no winner column, so the overwrite flips `winnerOf` and
+everything seeded from it.
+
+`AND finalized_at IS NULL` on the `UPDATE` is what closes it, and it has to be _in the
+statement_: at READ COMMITTED the loser blocks on the row lock, wakes when the winner
+commits, and re-evaluates that WHERE against the committed row. Which is also why there is
+no `FOR UPDATE` here — serialising the two runs would only queue the loser up to write its
+stale numbers in turn. The lock decides who writes first; it cannot make a decision taken
+before the lock true afterwards.
+
+**Refused everything throws; refused _some_ reports.** A run that matched no rows raises
+`ALREADY_FINAL`, and the rollback discards nothing because nothing was written. A week can
+also hold a settled row beside an open one, and there the run legitimately writes the open
+one — throwing would roll back a real write that nothing would ever retry. That case says so
+in `matchupsAlreadyFinal`, and `matchups` counts rows written rather than results scored.
+The count is only knowable because the statement ends in `RETURNING id`: `PostgresClient.query`
+returns `rows` and discards `rowCount`, so a refused write was not merely ignored, it was
+unobservable.
+
 The window comes from the rules: 48 hours normally, **168 for weeks 14 and 17**, because
 official NFL stat corrections arrive for up to seven days.
 

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -154,6 +154,7 @@ export async function GET(request: Request): Promise<NextResponse> {
           ...(o.finalizedWithUnfinishedGames
             ? { finalizedWithUnfinishedGames: o.finalizedWithUnfinishedGames }
             : {}),
+          ...(o.matchupsAlreadyFinal ? { matchupsAlreadyFinal: o.matchupsAlreadyFinal } : {}),
         })),
         ...(sweep.failures.length > 0 ? { failedWeeks: sweep.failures } : {}),
         ...(sweep.deferred.length > 0 ? { deferredWeeks: sweep.deferred } : {}),

--- a/apps/web/src/lib/cron.ts
+++ b/apps/web/src/lib/cron.ts
@@ -14,11 +14,20 @@ import { NextResponse } from "next/server";
  * Not much, and that is worth saying plainly rather than letting the word
  * "secret" imply otherwise. These endpoints only do what the clock already
  * permits: `catchUpExpiredPicks` is deterministic and stamped at the missed
- * deadline, scoring is idempotent and rewrites the same numbers, and
+ * deadline, scoring rewrites an unfinalised week and is refused a finalised one
+ * by `AND finalized_at IS NULL` on the write in `resolveLeagueWeek`, and
  * `finalizationHold` decides finalisation independently of who asked. An
  * unauthorised call cannot produce a wrong pick, a wrong score, or an early
  * settlement. **The guard is about database load**, and about not handing
  * anonymous callers a lever on every league at once.
+ *
+ * That middle clause used to read "scoring is idempotent and rewrites the same
+ * numbers", which was the whole justification for the guard being deliberately
+ * weak and was not true. An extra caller overlapping the scheduled sweep raced
+ * it: both passed the `ALREADY_FINAL` check, and the slower one wrote its older
+ * stat snapshot over the settled result. Naming the enforcement point rather
+ * than asserting idempotence is the difference — the property now holds because
+ * a specific predicate refuses the write, which is checkable against `week.ts`.
  *
  * ## Why it refuses when the secret is missing in production
  *

--- a/packages/db/src/week.rescore-race.test.ts
+++ b/packages/db/src/week.rescore-race.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Issue #76 part 2 — a finalised week must not be silently rescored.
+ *
+ * ## The defect these pin
+ *
+ * `resolveLeagueWeek` checks "is this week already final?" with a bare `SELECT
+ * count(*)` **outside any transaction**, and then writes inside a *later*
+ * transaction. Between the two sit `ensureLineups` (which opens a transaction of
+ * its own), `loadWeekLineups`, `loadWeekStats` and `finalizationHold` — four
+ * round trips. That check is a check-then-act with a wide window.
+ *
+ * The write used to carry no `finalized_at` predicate, so nothing held the
+ * window closed. Two overlapping runs both read `count = 0` and both wrote; the
+ * slower one's stat snapshot was older, and `finalized_at = CASE WHEN $5 THEN $6
+ * ELSE finalized_at END` meant the row kept its original timestamp — so nothing
+ * stored recorded that it had happened, and nothing revisits a finalised week to
+ * find out. The write now carries `AND finalized_at IS NULL`, which is what
+ * actually keeps a settled week settled.
+ *
+ * ## How the interleaving is produced, and what that does and does not prove
+ *
+ * The fast test project runs PGlite, which is a **single connection**. It cannot
+ * run two real transactions at once, and `FOR UPDATE` holds nothing in it — the
+ * repo says as much in `migrations/README.md`. So this does not prove anything
+ * by racing.
+ *
+ * Instead it produces the interleaving deterministically. `PausingClient` wraps
+ * the real client and suspends the slow run at the exact instruction boundary a
+ * race would suspend it: after its guard read and its stat read, immediately
+ * before its write transaction's `BEGIN`. The fast run then completes on the
+ * unwrapped client, and the slow run is released.
+ *
+ * **Read this before trusting the results.** Because the slow run is suspended
+ * *before* its `BEGIN`, the two write transactions never overlap in time: the
+ * fast run commits, then the slow run starts and takes a fresh READ COMMITTED
+ * snapshot that sees the committed `finalized_at`. The predicate is evaluated by
+ * ordinary visibility rules. **That is not EvalPlanQual** — EPQ is the narrower
+ * case where the two `UPDATE`s overlap, the loser blocks on the row lock, and
+ * Postgres re-evaluates its `WHERE` against the winner's newly committed version
+ * on wake-up. That case cannot be produced on one connection at all: pausing
+ * after `BEGIN` would not create contention, it would nest two transactions and
+ * let the fast run's `COMMIT` commit the slow run's work. Any test in this suite
+ * claiming to cover EPQ would be lying.
+ *
+ * So these cover the interleaving that was actually reproduced — which is also
+ * the wide one, since the read-to-write window is four round trips while the
+ * write transaction is a single statement. The EPQ residual is closed by the
+ * same predicate, by argument rather than by this file.
+ *
+ * What none of this proves: that two Vercel invocations do in fact overlap in
+ * production. That is an argument about the schedule (`apps/web/vercel.json`
+ * runs `score-week` every 10 minutes) and about the absence of any lock, not
+ * something a single-connection test can observe. The predicate is worth having
+ * regardless — `docs/RULES.md` §7 already says a correction arriving after a
+ * paying week has finalised does not reopen it.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNflPprRules, generateSchedule, NFL } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import type { SqlClient } from "./client.js";
+import { createLeague } from "./leagues.js";
+import { createUser } from "./identity.js";
+import { seedSport } from "./sports.js";
+import { setLineup } from "./lineups.js";
+import { addTestTeam, createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import { loadScheduledWeek, persistSchedule, resolveLeagueWeek, winnerOf } from "./week.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: 1_756_400_000,
+};
+
+const SEASON = 2026;
+const WEEK = 1;
+
+const KICKOFF = new Date("2026-09-13T17:00:00Z");
+/** Inside the 48h standings window — `finalizationHold` says "wait". */
+const INSIDE_WINDOW = new Date(KICKOFF.getTime() + 47 * 3600 * 1000);
+/** Past it — the week may finalise. */
+const AFTER_STANDARD = new Date(KICKOFF.getTime() + 49 * 3600 * 1000);
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/**
+ * A client that suspends its caller immediately before the write transaction.
+ *
+ * The gate is armed by `finalizationHold`'s query (the `FILTER (WHERE g.status =
+ * 'FINAL')` aggregate) and fires on the next `BEGIN`, which is
+ * `withTransaction`'s. Arming on the hold query rather than on the first `BEGIN`
+ * matters: `ensureLineups` opens a transaction of its own when a team is missing
+ * a lineup, and pausing there would be a different — and less interesting —
+ * interleaving.
+ *
+ * No `connect`, so `withTransaction` runs the callback directly on it, exactly
+ * as it does for PGlite.
+ */
+class PausingClient implements SqlClient {
+  private armed = false;
+  private fired = false;
+  readonly reached = deferred();
+  readonly release = deferred();
+  /**
+   * How many rows each `UPDATE matchups` actually touched.
+   *
+   * Readable only because the statement now ends in `RETURNING id`.
+   * `PostgresClient.query` returns `result.rows` and discards `rowCount`, so
+   * before that this number was not merely ignored — it was unobtainable, which
+   * is why a refused write could not have been reported even in principle.
+   */
+  readonly rowsWritten: number[] = [];
+
+  constructor(
+    private readonly inner: SqlClient,
+    private readonly pause = true,
+  ) {
+    if (!pause) {
+      this.reached.resolve();
+      this.release.resolve();
+    }
+  }
+
+  async exec(sql: string): Promise<void> {
+    if (
+      this.pause &&
+      this.armed &&
+      !this.fired &&
+      sql.trim().toUpperCase().startsWith("BEGIN")
+    ) {
+      this.fired = true;
+      this.reached.resolve();
+      await this.release.promise;
+    }
+    return this.inner.exec(sql);
+  }
+
+  async query<T = Record<string, unknown>>(
+    sql: string,
+    params: readonly unknown[] = [],
+  ): Promise<T[]> {
+    if (sql.includes("g.status = 'FINAL'")) this.armed = true;
+
+    const rows = await this.inner.query<T>(sql, params);
+    if (sql.includes("UPDATE matchups")) this.rowsWritten.push(rows.length);
+    return rows;
+  }
+}
+
+interface Fixture {
+  client: PGliteClient;
+  leagueId: string;
+  rules: LeagueRules;
+  teamIds: string[];
+  players: Map<string, string>;
+  statKeys: Map<string, string>;
+}
+
+/** The same fixture `week.test.ts` uses, trimmed to what this needs. */
+async function setup(teamCount = 4): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const commissioner = await createUser(db, "commish@example.com", "Commish");
+  const rules = buildNflPprRules({ seasonYear: SEASON, draft: DRAFT }) as LeagueRules;
+  const league = await createLeague(db, NFL, {
+    name: "Race League",
+    commissionerId: commissioner.id,
+    rules,
+  });
+
+  const teamIds: string[] = [];
+  for (let i = 0; i < teamCount; i++) {
+    teamIds.push((await addTestTeam(db, league.id, `Bot ${i + 1}`)).teamId);
+  }
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const positions = new Map(
+    (
+      await db.query<{ id: string; key: string }>(
+        "SELECT id, key FROM positions WHERE sport_id = $1",
+        [sport!.id],
+      )
+    ).map((row) => [row.key, row.id]),
+  );
+  const statKeys = new Map(
+    (
+      await db.query<{ id: string; key: string }>(
+        "SELECT id, key FROM stat_keys WHERE sport_id = $1",
+        [sport!.id],
+      )
+    ).map((row) => [row.key, row.id]),
+  );
+
+  await db.query(
+    `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status)
+     VALUES ($1, 'g1', $2, $3, 'CIN', 'BAL', $4, 'SCHEDULED')`,
+    [sport!.id, SEASON, WEEK, KICKOFF],
+  );
+
+  const players = new Map<string, string>();
+  for (const [index, teamId] of teamIds.entries()) {
+    const handle = `qb-${index}`;
+    const [row] = await db.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, positions.get("QB")!],
+    );
+    players.set(handle, row!.id);
+
+    await db.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via) VALUES ($1, $2, 'DRAFT')`,
+      [teamId, row!.id],
+    );
+
+    await setLineup(db, {
+      leagueId: league.id,
+      teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: row!.id }],
+      now: Math.floor(KICKOFF.getTime() / 1000) - 3600,
+    });
+  }
+
+  return { client: db, leagueId: league.id, rules, teamIds, players, statKeys };
+}
+
+async function score(
+  fx: Fixture,
+  handle: string,
+  passYards: number,
+  revision = 0,
+): Promise<void> {
+  await fx.client.query(
+    `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, source, revision)
+     VALUES ($1, $2, $3, $4, $5, 'tank01', $6)`,
+    [fx.players.get(handle), SEASON, WEEK, fx.statKeys.get("pass_yd"), passYards, revision],
+  );
+}
+
+const finishGames = (fx: Fixture) =>
+  fx.client.query("UPDATE games SET status = 'FINAL' WHERE season = $1 AND week = $2", [
+    SEASON,
+    WEEK,
+  ]);
+
+const schedule = (fx: Fixture) =>
+  persistSchedule(fx.client, fx.leagueId, generateSchedule(fx.teamIds, 14, "seed"));
+
+interface StoredRow {
+  home_team_id: string;
+  away_team_id: string | null;
+  home_milli_points: number | null;
+  away_milli_points: number | null;
+  finalized_at: string | null;
+}
+
+/** The stored row for the matchup team 0 plays in. */
+async function storedRow(fx: Fixture): Promise<StoredRow> {
+  const [row] = await fx.client.query<StoredRow>(
+    `SELECT home_team_id, away_team_id, home_milli_points, away_milli_points, finalized_at
+       FROM matchups
+      WHERE league_id = $1 AND week = $2
+        AND (home_team_id = $3 OR away_team_id = $3)`,
+    [fx.leagueId, WEEK, fx.teamIds[0]],
+  );
+  return row!;
+}
+
+const storedWinner = (row: StoredRow): string | null =>
+  winnerOf({
+    week: WEEK,
+    homeTeamId: row.home_team_id,
+    awayTeamId: row.away_team_id,
+    homeMilliPoints: Number(row.home_milli_points ?? 0),
+    awayMilliPoints: Number(row.away_milli_points ?? 0),
+  });
+
+/**
+ * Set up team 0's matchup so the stale snapshot and the corrected one disagree
+ * about the *winner*, not merely about a total. Returns the opponent's index.
+ */
+async function armWinnerFlip(fx: Fixture): Promise<{ opponentIndex: number }> {
+  const scheduled = await loadScheduledWeek(fx.client, fx.leagueId, WEEK);
+  const mine = scheduled.find(
+    (m) => m.homeTeamId === fx.teamIds[0] || m.awayTeamId === fx.teamIds[0],
+  )!;
+  const opponentId = mine.homeTeamId === fx.teamIds[0] ? mine.awayTeamId! : mine.homeTeamId;
+  const opponentIndex = fx.teamIds.indexOf(opponentId);
+  expect(opponentIndex).toBeGreaterThan(0);
+
+  // Revision 0 — the snapshot the slow run will read: team 0 has 4 points, the
+  // opponent 8. The opponent is winning.
+  await score(fx, "qb-0", 100);
+  await score(fx, `qb-${opponentIndex}`, 200);
+
+  return { opponentIndex };
+}
+
+describe("a finalised week survives a run that overlapped its finalisation", () => {
+  it("CONTROL: the pre-check still refuses a serialised second run", async () => {
+    // Nothing was ever wrong with the guard when the two runs do not overlap,
+    // and the predicate does not replace it — it is still the cheap fast path
+    // that avoids scoring a week nobody will write. Repeated here so the tests
+    // below are visibly about the interleaving.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await armWinnerFlip(fx);
+
+    await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    await expect(
+      resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD),
+    ).rejects.toMatchObject({ code: "ALREADY_FINAL" });
+  });
+
+  it("refuses the losing write and leaves the settled result byte-identical", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    const { opponentIndex } = await armWinnerFlip(fx);
+
+    // --- the slow run starts, reads its guard (count = 0) and its stats, and is
+    // suspended immediately before its write transaction.
+    const gated = new PausingClient(fx.client);
+    const slow = resolveLeagueWeek(gated, fx.leagueId, WEEK, AFTER_STANDARD);
+    await gated.reached.promise;
+
+    // --- while it is suspended, an NFL stat correction lands. Team 0's
+    // quarterback is upgraded from 100 to 500 passing yards: 4 points to 20, so
+    // team 0 now wins a matchup it was losing.
+    await score(fx, "qb-0", 500, 1);
+
+    // --- the fast run (the 10-minute cron, or the manual `?week=` call — the
+    // same code path) reads the guard, sees count = 0 because the slow run has
+    // written nothing yet, scores the correction, and finalises.
+    const fast = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    expect(fast.finalized).toBe(true);
+
+    const settled = await storedRow(fx);
+    expect(settled.finalized_at).not.toBeNull();
+    expect(storedWinner(settled)).toBe(fx.teamIds[0]);
+
+    // --- the slow run wakes and tries to write its pre-correction snapshot over
+    // the finalised row.
+    gated.release.resolve();
+    await expect(slow).rejects.toMatchObject({ code: "ALREADY_FINAL" });
+
+    // Both of the week's matchups were final, so both writes matched nothing.
+    expect(gated.rowsWritten).toEqual([0, 0]);
+
+    // The row is exactly what the fast run settled — not merely "still final".
+    // The failure this replaces kept `finalized_at` and changed only the points,
+    // so asserting the timestamp alone would have passed against the bug.
+    expect(await storedRow(fx)).toEqual(settled);
+    expect(storedWinner(await storedRow(fx))).toBe(fx.teamIds[0]);
+    expect(storedWinner(await storedRow(fx))).not.toBe(fx.teamIds[opponentIndex]);
+  });
+
+  it("refuses it even when the losing run believes it is not finalising anything", async () => {
+    // The worse shape, and the one a `finalized_at`-only guard would miss. The
+    // slow run is a request that started inside the correction window — the
+    // route takes `now = new Date()` at its own start, so two invocations do not
+    // share one — therefore its `finalizationHold` says "wait" and `finalized`
+    // is false. Its UPDATE used to take the `ELSE finalized_at` branch: points
+    // replaced, timestamp preserved byte for byte, the row afterwards
+    // indistinguishable from one finalised once and never touched. And it
+    // reported `finalized: false, holdReason: "waiting until…"` while doing it.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    const { opponentIndex } = await armWinnerFlip(fx);
+
+    const gated = new PausingClient(fx.client);
+    const slow = resolveLeagueWeek(gated, fx.leagueId, WEEK, INSIDE_WINDOW);
+    await gated.reached.promise;
+
+    await score(fx, "qb-0", 500, 1);
+
+    const fast = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+    expect(fast.finalized).toBe(true);
+
+    const settled = await storedRow(fx);
+    expect(settled.finalized_at).not.toBeNull();
+
+    gated.release.resolve();
+    await expect(slow).rejects.toMatchObject({ code: "ALREADY_FINAL" });
+
+    // The predicate gates the whole statement, so the points are protected even
+    // though this run would never have touched `finalized_at`.
+    expect(await storedRow(fx)).toEqual(settled);
+    expect(storedWinner(await storedRow(fx))).toBe(fx.teamIds[0]);
+    expect(storedWinner(await storedRow(fx))).not.toBe(fx.teamIds[opponentIndex]);
+  });
+
+  it("CONTROL: an ordinary run writes every row and reports nothing refused", async () => {
+    // The predicate must not be a fix that also stops the normal path working.
+    // No prior finalisation, no pausing.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    const { opponentIndex } = await armWinnerFlip(fx);
+
+    const watched = new PausingClient(fx.client, false);
+    const outcome = await resolveLeagueWeek(watched, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    // One row per matchup — the clause narrows nothing on an unfinalised week.
+    expect(watched.rowsWritten).toEqual([1, 1]);
+    expect(outcome.matchups).toBe(2);
+    expect(outcome.matchupsAlreadyFinal).toBeUndefined();
+
+    const row = await storedRow(fx);
+    expect(row.finalized_at).not.toBeNull();
+    // No correction landed in this test, so the pre-correction snapshot stands
+    // and the opponent's 8 points beat team 0's 4. That is the *correct* result
+    // here, and asserting team 0 — as the race tests do, after their correction
+    // — would be asserting the bug.
+    expect(storedWinner(row)).toBe(fx.teamIds[opponentIndex]);
+  });
+
+  it("keeps a legitimate write when only some of the week is final, and says so", async () => {
+    // The reason a blanket throw would be wrong. A week can hold a settled row
+    // beside an open one, and rolling the run back to punish the settled row
+    // would destroy a real write to the open one — for which nothing would ever
+    // try again, since the sweep skips a week holding any finalised row.
+    //
+    // The mixed state is constructed rather than raced: one of the week's two
+    // rows is finalised directly while the slow run is suspended. That is the
+    // only way to put a row in the loser's result set that the winner never
+    // settled, because any real `resolveLeagueWeek` winner finalises every row
+    // of the week at once.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await armWinnerFlip(fx);
+
+    const gated = new PausingClient(fx.client);
+    const slow = resolveLeagueWeek(gated, fx.leagueId, WEEK, AFTER_STANDARD);
+    await gated.reached.promise;
+
+    // Exactly one of the week's rows becomes final — the one team 0 is *not* in,
+    // so the row asserted on afterwards is the one still open.
+    const [locked] = await fx.client.query<{ id: string }>(
+      `UPDATE matchups SET home_milli_points = 1, away_milli_points = 2, finalized_at = $3
+        WHERE league_id = $1 AND week = $2
+          AND home_team_id <> $4 AND away_team_id IS DISTINCT FROM $4
+        RETURNING id`,
+      [fx.leagueId, WEEK, AFTER_STANDARD.toISOString(), fx.teamIds[0]],
+    );
+    expect(locked).toBeDefined();
+
+    gated.release.resolve();
+    const outcome = await slow;
+
+    const open = await storedRow(fx);
+    const [stillLocked] = await fx.client.query<StoredRow>(
+      `SELECT home_team_id, away_team_id, home_milli_points, away_milli_points, finalized_at
+         FROM matchups WHERE id = $1`,
+      [locked!.id],
+    );
+
+    // One skipped, one written — the input that must not throw.
+    expect([...gated.rowsWritten].sort()).toEqual([0, 1]);
+
+    // The finalised row is untouched...
+    expect(Number(stillLocked!.home_milli_points)).toBe(1);
+    expect(Number(stillLocked!.away_milli_points)).toBe(2);
+
+    // ...the open row carries its real write...
+    expect(open.home_milli_points).not.toBeNull();
+    expect(Number(open.home_milli_points) + Number(open.away_milli_points)).toBe(12_000);
+
+    // ...and the outcome describes what actually happened rather than what was
+    // scored. Reporting `matchups: 2` here would assert a write the settled row
+    // never received.
+    expect(outcome.matchups).toBe(1);
+    expect(outcome.matchupsAlreadyFinal).toBe(1);
+  });
+});

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -23,7 +23,12 @@
  *
  * So `resolveLeagueWeek` updates points every time it runs and sets
  * `finalized_at` only once the wait has elapsed. A finalised week is never
- * rescored.
+ * rescored — and that is enforced by `AND finalized_at IS NULL` on the write
+ * itself, not by the `ALREADY_FINAL` check above it. The check reads in its own
+ * statement and the write happens four round trips later, so two overlapping
+ * runs both passed it and the slower one overwrote a settled result. Making the
+ * write conditional is what closes that, because it is the write that has to
+ * refuse.
  *
  * ## The wait is bounded, because a game may never be played
  *
@@ -193,6 +198,13 @@ export async function loadScheduledWeek(
 
 export interface ResolveWeekOutcome {
   readonly week: number;
+  /**
+   * How many matchups this run actually wrote — not how many it scored.
+   *
+   * The two differ only when a row was refused for being already final, which
+   * `matchupsAlreadyFinal` then reports. Counting the scored results instead
+   * would assert writes that a refused row never received.
+   */
   readonly matchups: number;
   readonly finalized: boolean;
   /** Why it was not finalised, when it was not. */
@@ -208,6 +220,19 @@ export interface ResolveWeekOutcome {
    * because a finalised week is never rescored.
    */
   readonly finalizedWithUnfinishedGames?: string;
+  /**
+   * How many matchups this run declined to write because they were already
+   * final, when it wrote at least one other.
+   *
+   * Present only when it happened, like `holdReason`. A run that was refused
+   * everything throws `ALREADY_FINAL` instead — this field is the partial case,
+   * where a week holds both a settled row and an open one and only the open one
+   * moved. Reporting it matters for the same reason
+   * `finalizedWithUnfinishedGames` does: without it the outcome describes writes
+   * that did not happen, and an operator reads `matchups: 7` as seven rows
+   * updated.
+   */
+  readonly matchupsAlreadyFinal?: number;
   readonly results: readonly MatchupResult[];
 }
 
@@ -262,16 +287,39 @@ export async function resolveLeagueWeek(
   const decision = await finalizationHold(db, stored.rules, week, now);
   const finalized = decision.hold === null;
 
+  // `AND finalized_at IS NULL` is what actually keeps a settled week settled.
+  // The check above is a fast path, not the guarantee: it reads in its own
+  // autocommit statement, and by the time this transaction opens, four round
+  // trips have passed — `ensureLineups` alone opens a transaction of its own.
+  // Two runs overlapping in that gap both read zero, and the slower one used to
+  // write its older stat snapshot straight over the finalised row, flipping who
+  // won a week nothing would ever revisit.
+  //
+  // Moving the check inside the transaction would not have been enough. At READ
+  // COMMITTED the loser blocks on the row lock, wakes when the winner commits,
+  // and re-evaluates *this* WHERE against the committed row — so the predicate
+  // has to be in the statement for the re-check to see it. That is also why no
+  // `FOR UPDATE` is needed: serialising the two runs would only queue the loser
+  // up to write its stale numbers in turn. The lock decides who writes first; it
+  // cannot make a decision taken before the lock true afterwards.
+  let written = 0;
+  let alreadyFinal = 0;
+
   await withTransaction(db, async (tx) => {
     for (const result of results) {
-      await tx.query(
+      // `RETURNING id` because `PostgresClient.query` hands back `rows` and
+      // drops `rowCount` — without it, a refused write is not merely ignored,
+      // it is unobservable.
+      const touched = await tx.query<{ id: string }>(
         `UPDATE matchups
             SET home_milli_points = $3,
                 away_milli_points = $4,
                 finalized_at = CASE WHEN $5::boolean THEN $6 ELSE finalized_at END
           WHERE league_id = $1 AND week = $2
             AND home_team_id = $7
-            AND away_team_id IS NOT DISTINCT FROM $8`,
+            AND away_team_id IS NOT DISTINCT FROM $8
+            AND finalized_at IS NULL
+        RETURNING id`,
         [
           leagueId,
           week,
@@ -283,15 +331,31 @@ export async function resolveLeagueWeek(
           result.awayTeamId,
         ],
       );
+
+      if (touched.length === 0) alreadyFinal++;
+      else written++;
+    }
+
+    // Refused everything: another run settled this week while this one was
+    // scoring, and the answer is the same one the fast path gives. Throwing
+    // here costs nothing — the rollback has no writes to discard — and it keeps
+    // the raced path and the serialised path reporting one fact.
+    //
+    // Refused *some* is a different fact and must not throw. A week can hold a
+    // settled row beside an open one, and rolling back would destroy the
+    // legitimate write to the open one. That case reports itself instead.
+    if (written === 0 && results.length > 0) {
+      throw new WeekError(`Week ${week} is already final`, "ALREADY_FINAL");
     }
   });
 
   return {
     week,
-    matchups: results.length,
+    matchups: written,
     finalized,
     ...(decision.hold === null ? {} : { holdReason: decision.hold }),
     ...(decision.fallback ? { finalizedWithUnfinishedGames: decision.fallback } : {}),
+    ...(alreadyFinal > 0 ? { matchupsAlreadyFinal: alreadyFinal } : {}),
     results,
   };
 }


### PR DESCRIPTION
Closes part 2 of #76. Part 1 (the lineup lock bypass) is #85.

## The bug

`resolveLeagueWeek` checks "is this week already final?" with a bare `SELECT count(*)` in its own autocommit statement, then writes **four round trips later** — `ensureLineups` (which opens a transaction of its own), `loadWeekLineups`, `loadWeekStats`, `finalizationHold` — inside a transaction whose `UPDATE` carried **no `finalized_at` predicate**. That is a check-then-act with a wide window and nothing holding it closed: no row lock, no advisory lock, no predicate.

Two overlapping runs both read `count = 0`. The slower one writes its older stat snapshot over the row the faster one just settled.

**Reproduced.** `PausingClient` suspends the slow run at the exact boundary a race would — after its guard read and its stat read, immediately before its write transaction's `BEGIN`:

```
finalised by the fast run : home=20000 away=8000 winner=team-0
after the slow run wrote  : home=4000  away=8000 winner=team-2
finalized_at still set    : true
```

**The winner flips.** There is no winner column anywhere — [`winnerOf`](packages/core/src/season/results.ts) compares the two stored totals — so a one-milli-point overwrite changes who won, and standings, seeding, `bracketFor` (which reads `finalizedOnly`) and the prize split all move with it.

**The worse shape** is a slow run that started *inside* the correction window. Its `finalizationHold` says "wait", so `finalized` is false and the `UPDATE` takes the `ELSE finalized_at` branch: points replaced, timestamp preserved byte for byte, the row afterwards indistinguishable from one finalised once and never touched. That run's operator JSON reports `finalized: false, holdReason: "waiting until…"` **while it is overwriting a settled result**.

**And nothing repairs it.** `resolveLeagueWeeksThrough`'s `NOT EXISTS` selection excludes any week holding a finalised row, and the pre-check refuses it — so the guard that failed to prevent the write is the same guard that prevents the repair. The wrong number is permanent.

## The fix

`AND finalized_at IS NULL` on the `UPDATE`, and it has to be **in the statement** rather than in a check above it. At READ COMMITTED the loser blocks on the row lock, wakes when the winner commits, and re-evaluates *that* `WHERE` against the committed row — so the predicate is what turns the write into a compare-and-swap.

**No `FOR UPDATE`, deliberately.** Serialising the two runs would only queue the loser up to write its stale numbers in turn. The points were computed from a snapshot read four round trips earlier; the lock decides who writes first, it cannot make a decision taken before the lock true afterwards. Once something re-checks `finalized_at`, the lock is redundant.

**`RETURNING id` is the other half, and it is not optional.** `PostgresClient.query` returns `result.rows` and discards `rowCount`, and the statement had no `RETURNING` — so a refused write was not merely ignored, it was *unobservable*. Without this the predicate would trade silent data corruption for a silent lie: a run reporting `finalized: true` for a week it never wrote.

Refused/kept split:

- **Refused everything** → throw `ALREADY_FINAL`. Same answer the pre-check gives, and the rollback discards nothing because nothing was written.
- **Refused some** → no throw. A week can hold a settled row beside an open one; the run legitimately writes the open one and reports `matchupsAlreadyFinal`. Throwing would roll back a real write that nothing would ever retry, since the sweep skips any week holding a finalised row. This follows the repo's existing call on the same shape — *"Losing that race is a no-op, not a throw"*.

`matchups` now counts rows written rather than results scored, so the outcome stops asserting writes a refused row never received.

## A comment that was load-bearing and false

`cron.ts` said *"scoring is idempotent and rewrites the same numbers"* and concluded *"an unauthorised call cannot produce … a wrong score"*. That was the stated justification for the cron guard being deliberately weak, and the PoC disproves it. Deleting the premise would leave the conclusion unsupported, so it now names the enforcement point instead — the property holds because a specific predicate refuses the write, which is checkable against `week.ts`.

## Verification

- **5 tests.** Without the predicate, 3 fail. Without the zero-row throw, 2 fail. **Both controls pass either way** — a serialised second run is still refused by the pre-check, and an ordinary run still writes every row (`[1, 1]`) and reports nothing refused.
- Full fast suite **1125 passed, 2 skipped**; typecheck, lint, format clean.
- `week.test.ts` unchanged and still green, including its existing "never rescores a finalised week".

## Scope notes

- **The invariant is enforced in one `WHERE` clause in one function, not in the schema.** `matchups.finalized_at` is the only write-once, money-deciding value with no constraint behind it, while `league_rules_immutable`, `leagues_rules_hash_immutable`, `drafts_order_immutable`, `teams_draft_position_immutable` and `leagues_chain_anchor_immutable` all exist. A `BEFORE UPDATE` trigger is worth adding as a backstop — but it is unreachable on every path this predicate covers (the `WHERE` filters the row out before the trigger fires), so it would ship as dead code here. **Follow-up PR.**
- **Frequency is unmeasured.** Overlap is reachable by construction — `vercel.json` schedules the sweep every 10 minutes, the manual `?week=&secret=` path is a URL in a browser bar, and there is no lock anywhere in the scoring path — but nobody has observed two invocations actually overlapping in production. The clause is free and `RULES.md` §7 already mandates the behaviour regardless.
- **A `phase` predicate was considered and rejected**, not deferred: `validate.ts` refuses any playoff week `<= regularSeasonWeeks`, so REGULAR and PLAYOFF rows cannot share a week in a league that passed validation, and the `WHERE` is unambiguous for any league that exists.
- **Orphan playoff fixtures are closed by this.** `advancePlayoffs` is insert-only and never reconciles a fixture whose round has been restated; with finalised results now immutable, `bracketFor`'s input set is append-only and `buildBracket`'s output monotone. The property holds *because of* this clause and would return the moment anyone adds a post-finalisation write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)