### PR TITLE
fix(web,escrow,core): derive the pot token from the cluster, not the caller

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,3 +173,22 @@ NEXT_PUBLIC_SOLANA_RPC_URL=
 #
 # Unset, devnet — the fallback that fails visibly rather than expensively.
 NEXT_PUBLIC_SOLANA_CLUSTER=devnet
+
+# The pot token on a LOCAL validator, and only there.
+#
+# Pot leagues are denominated in USDC, whose address differs per cluster, so the
+# mint is a constant (`POT_MINTS` in packages/escrow/src/cluster.ts) rather than
+# something a league creator sends — the same reasoning as FEE_RECIPIENT above.
+# A caller-supplied mint is a mint the caller can pick for its freeze authority,
+# and a frozen vault cannot be refunded.
+#
+# A local validator has no USDC, so there is nothing to pin: set this to a mint
+# you created to exercise the pot flow end to end. Both variables must name the
+# same mint, for the same reason the two cluster variables must agree — the
+# browser previews the rules hash and the server freezes it.
+#
+# **Ignored on every public cluster.** Declaring mainnet and setting this does
+# not widen mainnet; the value is simply not read. Unset, pot leagues are
+# unavailable locally and everything else still works.
+POT_MINT_LOCALNET=
+NEXT_PUBLIC_POT_MINT_LOCALNET=

--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -10,7 +10,9 @@ import {
 } from "@rostr/core";
 import type { PotRules } from "@rostr/core";
 import { createDraftRecord, createLeague, LeagueValidationError, seedSport } from "@rostr/db";
+import { potMintFor } from "@rostr/escrow";
 import { db } from "@/lib/db";
+import { declaredCluster } from "@/lib/cluster";
 import { currentUser } from "@/lib/session";
 
 /**
@@ -60,7 +62,12 @@ interface CreateBody {
   draftAt?: number;
   tradeDeadlineWeek?: number;
   pot?: {
-    tokenMint: string;
+    /**
+     * Deliberately absent: the token. It comes from `POT_MINTS` on the server,
+     * for the same reason `feeRecipient` does — see where it is derived below.
+     * Declaring it here and ignoring it would invite someone to start reading
+     * it again.
+     */
     buyInBaseUnits: string;
     refundUnlockAt: number;
     /** Which prize shape. Anything else, including absent, is the split. */
@@ -139,6 +146,36 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  // **And the token, for the same reason, which was the one that got missed.**
+  // The fee recipient decides where 1% goes; the mint decides what the money
+  // *is*, and it used to arrive in the request body and go into the frozen
+  // rules unread — `validateLeagueRules` asked only that the string was not
+  // empty. A crafted POST could denominate a league in any six-decimal token,
+  // including one the caller minted and holds the freeze authority for, which
+  // would let them freeze the vault and hold every stake to ransom.
+  //
+  // Deriving it here removes the only write an attacker had into the signed
+  // document, and everything downstream is already checked against that
+  // document: the anchor route refuses a chain account whose terms differ, and
+  // the deposit path builds the member's token account from the *signed* mint,
+  // so the program's own `member_token_account.mint == league.token_mint`
+  // rejects anything else. The gap was never the checking, it was that the
+  // thing being checked against came from the caller.
+  //
+  // A cluster with no mint refuses rather than falling back — no mint is a
+  // reason not to take money, not a reason to accept whatever was offered.
+  const potMint = potMintFor(declaredCluster(), process.env.POT_MINT_LOCALNET);
+  if (body.pot && !potMint) {
+    return NextResponse.json(
+      {
+        error:
+          `Pot leagues are unavailable on ${declaredCluster()}: no pot token is ` +
+          `configured for this cluster`,
+      },
+      { status: 503 },
+    );
+  }
+
   // An unrecognised shape is refused rather than quietly treated as the split.
   // The whole creation promise is that the previewed hash is the frozen hash, so
   // a client sending a shape this server does not know about must fail loudly —
@@ -157,7 +194,8 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const pot: PotRules | null = body.pot
     ? {
-        tokenMint: body.pot.tokenMint,
+        // `potMint` is non-null here: the guard above returned 503 otherwise.
+        tokenMint: potMint!,
         buyInBaseUnits: body.pot.buyInBaseUnits,
         // The commissioner picks the shape of the prize at creation, and it is
         // frozen with everything else. Both presets are decidable in a league of

--- a/apps/web/src/components/CreateLeagueForm.tsx
+++ b/apps/web/src/components/CreateLeagueForm.tsx
@@ -15,6 +15,7 @@ import {
   NFL_WINNER_TAKE_ALL_PAYOUT,
 } from "@rostr/core";
 import type { LeagueRules, PotRules } from "@rostr/core";
+import { parseCluster, potMintFor } from "@rostr/escrow";
 import { RulesView } from "@/components/RulesView";
 
 /**
@@ -45,8 +46,30 @@ const SLOW_CLOCKS = [
   { label: "24 hours", seconds: 86_400 },
 ];
 
-/** USDC on mainnet. The only token offered for now — one pot, one token. */
-const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+/**
+ * The pot token for the cluster this build targets.
+ *
+ * **This was hardcoded to mainnet USDC, which was a live break and not only a
+ * hardening gap.** The deployment targets devnet, where that mint account does
+ * not exist, so `initialize_league` — which takes the mint as a real account —
+ * would have failed at account resolution the first time anyone anchored a pot
+ * league there. It never surfaced because the program has not been deployed to
+ * devnet yet.
+ *
+ * It must be the same value the server derives, because the whole creation
+ * promise is that the previewed hash is the frozen hash. Both read `POT_MINTS`;
+ * a build pointed at one cluster and a server at another would disagree, and
+ * the preview would be a hash of terms nobody stored. `NEXT_PUBLIC_*` is
+ * inlined at build time, so this is a property of the deployment, exactly as
+ * `NEXT_PUBLIC_FEE_RECIPIENT` is.
+ *
+ * `null` where the cluster has no pot token, which disables the pot section
+ * rather than previewing a league the server would refuse to create.
+ */
+const POT_MINT = potMintFor(
+  parseCluster(process.env["NEXT_PUBLIC_SOLANA_CLUSTER"]) ?? "devnet",
+  process.env["NEXT_PUBLIC_POT_MINT_LOCALNET"],
+);
 
 /**
  * Must match `FEE_RECIPIENT` on the server — see the comment where it is used.
@@ -153,13 +176,13 @@ export function CreateLeagueForm() {
   }
 
   const pot: PotRules | null = useMemo(() => {
-    if (!withPot) return null;
+    if (!withPot || !POT_MINT) return null;
 
     const amount = Number.parseFloat(buyIn);
     if (!Number.isFinite(amount) || amount <= 0) return null;
 
     return {
-      tokenMint: USDC_MINT,
+      tokenMint: POT_MINT,
       // USDC has six decimals. A decimal string, because this is a u64 on chain
       // and JavaScript numbers stop being exact well before a u64 does.
       buyInBaseUnits: String(Math.round(amount * 1_000_000)),
@@ -216,7 +239,11 @@ export function CreateLeagueForm() {
           tradeDeadlineWeek,
           pot: pot
             ? {
-                tokenMint: pot.tokenMint,
+                // No `tokenMint`. The server derives it from the cluster, for
+                // the same reason it derives the fee recipient — a mint the
+                // caller chose is a mint the caller can pick for its freeze
+                // authority. The preview above uses the identical constant, so
+                // the hash shown is still the hash stored.
                 buyInBaseUnits: pot.buyInBaseUnits,
                 refundUnlockAt: pot.refundUnlockAt,
                 payout: payoutShape,
@@ -355,12 +382,26 @@ export function CreateLeagueForm() {
             <input
               type="checkbox"
               checked={withPot}
+              disabled={!POT_MINT}
               onChange={(e) => setWithPot(e.target.checked)}
             />
-            <span>Play for a pot</span>
+            <span className={POT_MINT ? undefined : "text-white/40"}>Play for a pot</span>
           </label>
 
-          {withPot ? (
+          {/*
+            Offered only where there is a token to denominate it in. The server
+            refuses a pot league on such a cluster, so an enabled checkbox here
+            would be a form that submits and fails — and the honest failure is
+            the one shown before anything is typed.
+          */}
+          {!POT_MINT && (
+            <p className="text-xs text-white/40">
+              Pot leagues are unavailable on this network — no pot token is configured for it.
+              Everything else works.
+            </p>
+          )}
+
+          {withPot && POT_MINT ? (
             <div className="space-y-3">
               <p className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
                 The escrow contract holding this money has <strong>not been audited</strong>. Do

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -442,11 +442,21 @@ Optional per league. When enabled:
   A wider choice needs either a per-token cap or a price oracle; neither is worth building
   before the escrow has been reviewed.
 - Funds lock in escrow until the championship resolves.
-- **The buy-in is between $5 and $50 per member** while the escrow contract is young. Both
-  bounds are enforced by the program, not the interface, so they bind every caller. A
+- **The buy-in is between $5 and $50 per member** while the escrow contract is young. A
   league stakes any amount in that range — $5, $10, $25, $47, $50 — the ceiling is a limit,
   not a price. At twelve members the most a single league can lose to a bug in new code is
   therefore $600.
+
+  **Two things enforce that, and it is worth being exact about which does what**, because
+  the dollar figure above depends on both. The _bounds_ are enforced by the program rather
+  than the interface, so they bind every caller. The _token_ is set by this service, per
+  network, and is not something a league creator supplies — which is what makes a bound
+  expressed in base units mean a bound expressed in dollars. A cap of fifty on a token
+  nobody chose deliberately is a cap of fifty of something, and the $600 above would not
+  follow from it. The program checks the token has six decimals; it does not yet check
+  which token it is, so a caller who bypasses this service entirely can still create a
+  league denominated in another six-decimal token. Nobody can join or stake in such a
+  league through rostr, and pinning the mint in the program is planned before mainnet.
 
   The floor is there because a pot has fixed costs a stake does not scale with: every
   deposit and refund is a transaction, the vault and each membership cost rent, and

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -297,22 +297,61 @@ The fee is **1%, taken once at settlement** — decided 2026-08-07, documented i
 address it pays to. That address is the Squads **vault**; see the multisig entry above,
 which is where the decision actually lives.
 
-### ⬜ Pin the USDC mint before mainnet
+### ⬜ Pin the USDC mint in the program before mainnet
 
-**Blocks:** nothing on localnet. It is the last gap between the $50 cap and the $50 it is
-supposed to mean.
-**Needed by:** **before any mainnet deployment**.
+**Blocks:** nothing. The service half shipped, and it is what closes the reachable
+attack — this entry is now defence-in-depth rather than the fix.
+**Needed by:** **before any mainnet deployment**, and specifically before the upgrade
+authority is burned, because after that the constant can never be corrected.
 
 The program requires pot tokens to have **six decimals**, which is what makes
 `MAX_BUY_IN_BASE_UNITS = 50_000_000` mean fifty dollars rather than fifty million of
-something. That is as tight as this can be without a price oracle, and it is **not a proof
-of value**: nothing stops a six-decimal token worth far more than a dollar, which would
-blow through the cap while satisfying every check.
+something. That is as tight as a program can be without a price oracle, and it is **not a
+proof of value**: nothing stops a six-decimal token worth far more, or far less, than a
+dollar.
 
-Pinning USDC's mint address closes it — one constant in `lib.rs`. The reason it is not
-done already is that localnet tests cannot mint at a fixed mainnet address, so it needs
-either a cluster-conditional constant or an allowlist, and either one wants a moment's
-thought rather than being bolted on at deploy time.
+**What already shipped.** The mint used to arrive in the create request body and go into
+the frozen rules unread, so a crafted POST could denominate a league in any six-decimal
+token — including one the caller minted and held the **freeze authority** for. That is the
+part that had teeth: a frozen vault makes `refund_stake` fail, and `refund_stake` is the
+instruction the whole safety case rests on. The service now derives the mint from
+`POT_MINTS` per cluster, the way it already derived the fee recipient, which removes the
+only write an attacker had into the signed document. Verified live on 2026-08-13:
+
+| cluster      | mint                                           | decimals |
+| ------------ | ---------------------------------------------- | -------- |
+| mainnet-beta | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` | 6        |
+| devnet       | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` | 6        |
+
+**What that does not cover, and why the on-chain pin still matters.** The derivation binds
+only while this service is the only way leagues are created. `join_league` and `deposit`
+are permissionless, so a socially-directed victim depositing into a raw PDA is defended by
+the program alone; and the detection layer is one `if` in the anchor route, which a
+refactor could weaken. The program's own comment already says it: an off-chain check
+"produces good error messages", and the on-chain one "is what actually binds, because it is
+the only one an attacker cannot skip by calling the program directly."
+
+**Why it was not done in the same change.** Localnet cannot mint at a fixed mainnet
+address, so it needs a build-time constant with a test-only escape — Anchor programs cannot
+ask which chain they are running on, so there is no runtime alternative. That costs **61 of
+72 test cases** in `programs/rostr-escrow/tests/`, which all obtain their mint from one
+helper. Real work, and not work to do in a hurry.
+
+**Get the polarity right.** Put mainnet in the _default_ build and the test mints behind
+the feature flag. A build that forgot its flag then refuses every league on devnet —
+loud, immediate, one redeploy. The opposite ships a mainnet program that accepts any
+six-decimal token and looks perfectly healthy until someone's pot is denominated in a token
+its creator prints.
+
+**And pinning USDC does not remove the freeze risk — it renames it.** Both USDC mints carry
+a live freeze authority (mainnet's is Circle's, `7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar`,
+confirmed on-chain). So `require!(mint.freeze_authority.is_none())` and pinning USDC are
+mutually exclusive: shipping both makes league creation impossible. The trade is a
+regulated issuer who freezes on legal order in place of an anonymous commissioner who can
+freeze a mint they made this morning — much better, and not nothing. `docs/RULES.md`,
+`lib.rs`'s `refund_stake` and the deposit screen all currently promise a refund that
+"can never be stuck"; that sentence needs the exception written into it, in the signed rule
+set rather than a banner, the same way the unaudited-escrow warning is.
 
 ---
 

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -347,6 +347,32 @@ describe("validateLeagueRules", () => {
     expect(validateLeagueRules(bad, NFL)).toContainEqual(expect.stringContaining("90 seconds"));
   });
 
+  it.each([
+    ["empty", ""],
+    ["truncated", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt"],
+    ["not base58", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1O"],
+    ["a sentence", "USDC please"],
+    ["too long", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1vEPjFW"],
+  ])("rejects a token mint that is %s", (_label, mint) => {
+    // Only emptiness was checked before, which let a mistyped or truncated
+    // address be canonically encoded, hashed, signed and frozen — and a frozen
+    // rules document cannot be corrected. This cannot say the mint is the one
+    // anybody wanted; it can refuse the shapes that are silent and permanent.
+    const bad = mutate((d) => {
+      (d.pot as { tokenMint: string }).tokenMint = mint;
+    });
+    expect(validateLeagueRules(bad, NFL)).toContainEqual(
+      expect.stringContaining("valid token mint address"),
+    );
+  });
+
+  it("accepts a well-formed mint", () => {
+    // The control: the check must not reject the address every fixture uses.
+    expect(validateLeagueRules(FIXTURE, NFL)).not.toContainEqual(
+      expect.stringContaining("token mint"),
+    );
+  });
+
   it("rejects a buy-in below the minimum", () => {
     const bad = mutate((d) => {
       (d.pot as { buyInBaseUnits: string }).buyInBaseUnits = "4999999";

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -9,6 +9,7 @@
  * sees everything wrong at once.
  */
 
+import bs58 from "bs58";
 import type { SportDef } from "../sports/types.js";
 import { slotTypesByKey, statKeysByKey } from "../sports/types.js";
 import {
@@ -540,6 +541,23 @@ function validateRefundUnlock(rules: LeagueRules, refundUnlockAt: number, out: s
   }
 }
 
+/**
+ * Whether a string is a well-formed Solana address.
+ *
+ * Base58 decoding to exactly 32 bytes, which is all a chain-free package can
+ * honestly check: it does not prove the account exists, holds a mint, or is the
+ * one anybody wanted. It does refuse the failures that are silent and permanent
+ * — a truncated paste, a checksum-less typo, an address in the wrong encoding.
+ * `bs58.decode` throws on an invalid alphabet rather than returning a flag.
+ */
+function isPublicKeyLike(value: string): boolean {
+  try {
+    return bs58.decode(value).length === 32;
+  } catch {
+    return false;
+  }
+}
+
 function validatePot(rules: LeagueRules, out: string[]): void {
   const pot = rules.pot;
   if (pot === null) return;
@@ -564,7 +582,15 @@ function validatePot(rules: LeagueRules, out: string[]): void {
       );
     }
   }
-  if (pot.tokenMint.length === 0) out.push("pot requires a token mint");
+  // Shape only, deliberately. *Which* mint is a per-cluster question and this
+  // package is chain-free — it depends on no web3 library and knows nothing
+  // about clusters, which is what lets the same encoder produce the same hash
+  // everywhere. The server picks the mint from `POT_MINTS`; this checks that
+  // whatever ends up in the frozen document is at least a public key, because
+  // "is not the empty string" was the entire test and it let a typo, a
+  // truncation, or a sentence be hashed into a league's rules for good.
+  if (!isPublicKeyLike(pot.tokenMint)) out.push("pot requires a valid token mint address");
+
   if (pot.refundUnlockAt <= 0) {
     out.push("pot requires a refund unlock time");
   } else {

--- a/packages/escrow/src/cluster.test.ts
+++ b/packages/escrow/src/cluster.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { PublicKey } from "@solana/web3.js";
 import type { Connection } from "@solana/web3.js";
 import {
   clusterFromGenesisHash,
   clusterMismatch,
   GENESIS_HASHES,
   parseCluster,
+  POT_MINTS,
+  potMintFor,
   resolveCluster,
   type Cluster,
 } from "./cluster.js";
@@ -118,5 +121,65 @@ describe("clusterMismatch", () => {
     // The reason it is dangerous here specifically is that the address is the
     // same on both chains, so every screen keeps rendering normally.
     expect(clusterMismatch("mainnet-beta", "devnet")).toMatch(/same address on every cluster/);
+  });
+});
+
+/**
+ * The mint decides what the money *is*, which is why it is a constant here and
+ * not a field in the create request. It used to be the latter: the API copied
+ * `pot.tokenMint` out of the request body into the rules document it then froze
+ * and hashed, while the fee recipient thirty lines above it was deliberately
+ * read from server config. A caller could therefore denominate a league in a
+ * token they minted and held the freeze authority for, and a frozen vault
+ * fails `refund_stake` — the one instruction the escrow's safety case rests on.
+ */
+describe("potMintFor", () => {
+  it("answers the real USDC mint on each public cluster", () => {
+    // Verified against live RPC on 2026-08-13, both reporting six decimals
+    // under the legacy SPL token program — which is what the program requires,
+    // since it rejects Token-2022 mints outright.
+    expect(potMintFor("mainnet-beta")).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    expect(potMintFor("devnet")).toBe("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+  });
+
+  it("gives mainnet and devnet different answers", () => {
+    // The bug this replaces was one hardcoded mainnet address used everywhere,
+    // which on devnet names an account that does not exist — so `create_league`
+    // would have failed at account resolution rather than doing anything
+    // dangerous. Pinning both is what makes the constant usable at all.
+    expect(potMintFor("mainnet-beta")).not.toBe(potMintFor("devnet"));
+  });
+
+  it("has no answer for a cluster with no pot token", () => {
+    // Testnet has no USDC worth naming and localnet has no fixed mint at all.
+    // `null` rather than a fallback: the caller refuses to create a pot league,
+    // which is the only safe reading of "there is no token here".
+    expect(potMintFor("testnet")).toBeNull();
+    expect(potMintFor("localnet")).toBeNull();
+  });
+
+  it("takes an override on localnet, where there is nothing to protect", () => {
+    const local = "So11111111111111111111111111111111111111112";
+    expect(potMintFor("localnet", local)).toBe(local);
+  });
+
+  it("ignores the override on every public cluster", () => {
+    // The escape hatch must not become the hole. Declaring mainnet and passing
+    // a local mint does not widen mainnet — the argument is simply not read,
+    // so a misconfigured environment cannot promote a worthless token into a
+    // real pot.
+    const attacker = "So11111111111111111111111111111111111111112";
+    expect(potMintFor("mainnet-beta", attacker)).toBe(POT_MINTS["mainnet-beta"]);
+    expect(potMintFor("devnet", attacker)).toBe(POT_MINTS.devnet);
+    expect(potMintFor("testnet", attacker)).toBeNull();
+  });
+
+  it("names mints the program would accept", () => {
+    // Base58, 32 bytes. A truncated or mistyped constant here is frozen into
+    // every league created under it, so the shape is worth pinning even though
+    // the value cannot be checked without a node.
+    for (const mint of Object.values(POT_MINTS)) {
+      expect(new PublicKey(mint).toBase58()).toBe(mint);
+    }
   });
 });

--- a/packages/escrow/src/cluster.ts
+++ b/packages/escrow/src/cluster.ts
@@ -46,6 +46,61 @@ export const GENESIS_HASHES: Readonly<Record<Exclude<Cluster, "localnet">, strin
 };
 
 /**
+ * The token a pot is denominated in, per cluster.
+ *
+ * **Verified against the live chains on 2026-08-13**, not recalled — the same
+ * standard as {@link GENESIS_HASHES}, and for a sharper reason. A recalled
+ * address that is one character wrong is not a typo here, it is a different
+ * token, and the value is frozen into every league created under it:
+ *
+ * ```
+ * curl -s -X POST -H 'Content-Type: application/json' \
+ *   -d '{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",{"encoding":"jsonParsed"}]}' \
+ *   https://api.mainnet-beta.solana.com
+ * ```
+ *
+ * Both answered `"decimals": 6` and `"program": "spl-token"`, which is what the
+ * program requires: `POT_MINT_DECIMALS` in `lib.rs`, and legacy SPL rather than
+ * Token-2022, whose mints the program rejects outright.
+ *
+ * **Why this is a constant and not a choice.** The buy-in cap is expressed in
+ * base units, so "fifty" only means fifty dollars if the token is worth a
+ * dollar. `docs/RULES.md` §7 tells members the $5–$50 bounds "bind every
+ * caller" and reasons from that to what a league can lose — a sentence that
+ * holds only if something decides the token. Nothing did: the mint arrived in
+ * the create request body and was written into the signed rules unread, while
+ * the fee recipient beside it was deliberately taken from server config
+ * because "a client-supplied recipient would let them redirect ours". The mint
+ * decides what the money *is*, which is the larger question of the two.
+ *
+ * **Testnet and localnet are deliberately absent**, and they are absent for
+ * different reasons. Testnet has no USDC worth naming. Localnet has no fixed
+ * mint at all — a fresh ledger per run, so the anchor tests create their own —
+ * which is the same reason {@link GENESIS_HASHES} skips it. Both answer `null`
+ * from {@link potMintFor}, and a caller with no mint refuses to create a pot
+ * league rather than falling back to whatever it was handed.
+ */
+export const POT_MINTS: Readonly<Partial<Record<Cluster, string>>> = {
+  "mainnet-beta": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  devnet: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+};
+
+/**
+ * The mint a pot must use on this cluster, or `null` where there is no answer.
+ *
+ * `localnetOverride` exists so a local validator can still exercise the pot
+ * flow end to end, and it is **ignored on every public cluster** — passing one
+ * while declaring mainnet does not widen mainnet, it is simply not read. That
+ * asymmetry is the point: the escape hatch cannot become the hole. A local
+ * chain has no shared identity and no real money on it, which is the same
+ * reasoning that lets an unrecognised genesis hash read as `"localnet"`.
+ */
+export function potMintFor(cluster: Cluster, localnetOverride?: string): string | null {
+  if (cluster === "localnet") return localnetOverride || null;
+  return POT_MINTS[cluster] ?? null;
+}
+
+/**
  * The cluster a genesis hash identifies, or `"localnet"` for anything else.
  *
  * Answering `"localnet"` rather than `null` for an unknown hash is the fail-safe

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -9,9 +9,11 @@
 export { ESCROW_IDL, type EscrowIdl } from "./idl.js";
 export {
   GENESIS_HASHES,
+  POT_MINTS,
   clusterFromGenesisHash,
   clusterMismatch,
   parseCluster,
+  potMintFor,
   resolveCluster,
   type Cluster,
 } from "./cluster.js";


### PR DESCRIPTION
## The defect, in one file

`apps/web/src/app/api/leagues/route.ts` refuses `feeBps` and `feeRecipient` from the request body, under a comment saying exactly why:

> The fee and its recipient come from server configuration, never from the request… a client-supplied recipient would let them redirect ours.

Thirty lines later, in the same function, it copied `body.pot.tokenMint` straight into the rules document it then froze, canonically encoded and hashed. `validateLeagueRules` asked only that the string was non-empty — not that it parsed as a public key.

So the field deciding **where 1% goes** was server-derived, and the field deciding **what the money is** came from the caller.

## What is actually exploitable — and what isn't

**Not the worthless-token story.** There is no swap, oracle, price or second asset anywhere in the program. The token that enters the vault is the only token anyone can get back, so a creator denominating a league in a coin they minted extracts nothing — joiners would have to already hold it, which is a token scam that needs no escrow.

**The freeze authority is the real one**, and the creator picks it along with the mint. Proven on a local validator:

```
[2] staked; vault holds 10000000
[3] vault frozen by the mint's freeze authority
[4] refund_stake rejected: custom program error: 0x11  "Account is frozen"
[5] after thaw the identical refund succeeds — the freeze was the whole lock
[6] targeted victim refund rejected                    (0x11)
[7] the bystander refunded normally — the griefing is selective
```

Step [5] is the control: after `thawAccount` the byte-identical transaction succeeds. Ransom rather than theft — the attacker holds the thaw key but cannot move the pot, since the vault's authority is the league PDA.

It defeats the strongest claim in the codebase, at `lib.rs:339-351`: *"This is the instruction that makes the rest safe to ship… whatever else in this program is broken, unfinished, or never written."* A mint-level power sits outside the program, so no condition inside it can hold that promise.

The existing suite structurally cannot see this — `createPotMint` passes `null` for the freeze authority.

Also confirmed while here: **Token-2022 is excluded.** `Account<'info, Mint>` rejects it with `AccountOwnedByWrongProgram` (3007), so the transfer-fee and transfer-hook class is unreachable. The comment at `lib.rs:18-25` is accurate.

## The fix

`POT_MINTS` per cluster in `packages/escrow/src/cluster.ts`, beside `GENESIS_HASHES` and following its idiom exactly — including the verification note. Both addresses were checked against live RPC on 2026-08-13, six decimals under legacy SPL, **not recalled**: a draft of this used a remembered devnet address that turned out not to be a valid pubkey at all, which is the argument for the house rule.

| cluster | mint | decimals |
| --- | --- | --- |
| mainnet-beta | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` | 6 |
| devnet | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` | 6 |

Deriving it removes the attacker's only write into the signed document, and everything downstream already checks against that document — the anchor route refuses a chain account whose terms differ (`TERMS_MISMATCH`, which gates the only production writer of `chain_anchored_at`, which `joinLeague` requires), and the deposit path builds the member's token account from the *signed* mint so the program's own `member_token_account.mint == league.token_mint` rejects anything else. **The gap was never the checking — it was that the thing being checked against came from the caller.**

Because the ransom path needs a commissioner-held freeze authority, and that needs a hostile mint, this closes the freeze attack too.

## A live break, not only hardening

`CreateLeagueForm.tsx` hardcoded **mainnet** USDC while the deployment targets devnet, where that account does not exist. `initialize_league` takes the mint as a real account, so the first devnet anchor of a pot league would have failed at account resolution. It has not surfaced only because the program is still local-validator-only.

Client and server now read the same constant, which matters: the creation promise is that the previewed hash is the frozen hash, so a form previewing one mint against a server freezing another would hash terms nobody stored.

## `RULES.md` §7 was making a promise the program cannot keep

> **The buy-in is between \$5 and \$50 per member**… Both bounds are enforced by the program, not the interface, so they bind every caller… the most a single league can lose to a bug in new code is therefore \$600.

The bounds are in **base units**. The dollar reading needs something to decide the token, and nothing did. §7 now says which half enforces what, and states plainly that a caller bypassing this service can still create a league in another six-decimal token — one nobody can join or stake in through rostr.

## Scope

- **Core keeps a shape check only** — base58, 32 bytes. Which mint is a per-cluster question and `@rostr/core` is deliberately chain-free (no web3 dependency); a cluster-aware allowlist there would need a `cluster` parameter threaded through every caller, and would break the three cross-layer anchor tests that legitimately name a localnet mint.
- **The on-chain pin is deferred**, and `SETUP-REQUIRED.md` now records it as defence-in-depth rather than the fix, with the reasoning: a program cannot ask which chain it is on (no sysvar carries a chain identity), so it needs a build-time constant with a test-only escape, costing **61 of 72 test cases** in `programs/`. The entry also records the polarity to use — mainnet in the *default* build, test mints behind the flag, so a forgotten flag fails loudly on devnet instead of silently accepting any token on mainnet.
- **Pinning USDC does not remove the freeze risk — it reassigns it.** Both USDC mints carry a live freeze authority (mainnet's is Circle's, confirmed on-chain), so `require!(freeze_authority.is_none())` and pinning USDC are mutually exclusive. That trade is now written down rather than left to be discovered.
- **No `programs/` changes here.** Two `lib.rs` comments are false — the claim that `RULES.md` §7 "permits any SPL token" (§7 has required six decimals since it was written) and the unconditional-refund guarantee above. Both are comment-only and each triggers the full Anchor build, so they land together in a follow-up rather than across two CI cycles.

## Verification

- **11 new tests.** Reverting the shape check fails 4 of 5 malformed-mint cases while the well-formed control still passes.
- `potMintFor` covers the override being honoured on localnet and **ignored on every public cluster** — the escape hatch must not become the hole.
- Full fast suite **1132 passed, 2 skipped**; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)