### PR TITLE
fix(core,db): key the lineup lock on the player, not on the roster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,9 +548,37 @@ injury. Two behaviours look like oversights and are not:
 - **A player on a bye never locks.** There is no game to have started, so that slot stays
   fillable — with a Monday-night player, for instance.
 
+There was a **third** case that did look like an oversight and was one: an **unknown**
+player never locked either. `isSlotLocked` read the kickoff out of the roster map, and
+`roster.get(id)?.kickoffAt` answered `undefined` both for a bye and for a player who was
+not in the map — so cutting the man in a locked slot deleted the lock with him. It now
+**fails closed**: an unknown player locks.
+
+**The lock no longer consults a roster at all.** It takes `KickoffTimes` — player id to
+kickoff — built over the union of the roster and whoever is standing in the stored lineup.
+A lock is a fact about a game that has started; who owns the player is a different
+question, answered by the same map that answers `NOT_ON_ROSTER`. Conflating them is what
+made the lock defeasible. **Do not widen `loadRosterForWeek` to fix a lock** — that map is
+`validateLineup`'s ownership oracle, and widening it would let a manager start a player he
+had cut, put released players in the autofill's candidate pool, and offer them in the
+editor.
+
 A locked slot may **keep** its player; it may not change. Rejecting the slot outright
 would make submitting a whole lineup on Sunday fail because of a Thursday slot the
-manager can do nothing about.
+manager can do nothing about. It may not be **emptied** either, or the empty-slot rule
+above would become the bypass instead — there is a test.
+
+**`RULES.md` §6 is now implemented, and it had never been.** _"A player cannot be added or
+dropped once his own game has kicked off. Otherwise a manager could cut an injured player
+mid-game, or add one after his touchdown."_ Members signed that and nothing enforced it.
+`dropPlayer` and `addFreeAgent` now refuse with `GAME_STARTED`.
+
+The two release paths that **cannot** refuse are left alone deliberately: a throw inside
+`processWaivers` rolls back the whole league's run and leaves the claim PENDING forever,
+and `resolveTrade` cannot undo a trade the league already approved because a game started.
+Those are covered by the lock instead, which holds however the player left. Closing the
+route and closing the outcome are different jobs and this needs both — the same argument
+`ASSET_GONE` makes for trades.
 
 **The autolineup is deterministic, and that is the whole point.** An abandoned team plays
 out the season and its results move other people's playoff seeds — which in a pot league
@@ -567,6 +595,17 @@ inactive player both score nothing, but only one keeps the lineup legal.
 greyed out in the UI — `setLineup` loads what is _currently stored_, works out which slots
 have kicked off, and refuses any change to them. A crafted request gets the same answer as
 the screen.
+
+That last sentence used to be true and useless: the screen and the server both computed
+the lock from a roster map that had already lost the player, so they agreed and were both
+wrong. `loadKickoffs` is now the one definition of when a player locks, and the lineup
+route asks it the same question `setLineup` does.
+
+**`autoFillLineup` evicts a player who left the roster before his kickoff.** He is a hole,
+not a choice the manager made — and leaving him let his slot lock at kickoff around a
+player nobody rosters, who then scored for the team that cut him. Note the `lockedAssignments`
+call there was dead code before this: it is a strict subset of the loop below it, since a
+null player never locks, so it never kept a slot the second loop would not have kept anyway.
 
 `ensureLineups` is what makes `resolveWeek`'s precondition true. That function throws when
 a scheduled team has no lineup, deliberately — scoring a missing team as zero hands its

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
-import { indexScoringRules, scorePlayer, slotLocksAt, startingSlots } from "@rostr/core";
+import {
+  indexScoringRules,
+  scorePlayer,
+  slotIsLocked,
+  slotLocksAt,
+  startingSlots,
+} from "@rostr/core";
 import { buildRosterShape, NFL } from "@rostr/core";
 import type { LineupAssignment } from "@rostr/core";
 import {
@@ -8,6 +14,7 @@ import {
   loadAverages,
   loadLineup,
   loadProjectedPoints,
+  loadKickoffs,
   loadRosterForWeek,
   loadWeekStats,
   setAutofillEnabled,
@@ -53,6 +60,23 @@ export async function GET(
     const roster = await loadRosterForWeek(client, context.myTeamId, context.season, week);
     const assignments = await loadLineup(client, context.myTeamId, week, context.rules);
 
+    // Roster plus whoever is standing in the stored lineup, exactly as
+    // `setLineup` builds it. The screen must agree with the server about which
+    // slots are locked, and the occupant of a locked slot may no longer be
+    // rostered — that is the whole point of keying locks on the player.
+    const kickoffs = await loadKickoffs(
+      client,
+      [
+        ...new Set(
+          [...roster.keys(), ...assignments.map((entry) => entry.playerId)].filter(
+            (playerId): playerId is string => playerId !== null,
+          ),
+        ),
+      ],
+      context.season,
+      week,
+    );
+
     // Points so far this week, so a manager can see what their lineup is doing
     // while it is doing it.
     const stats = await loadWeekStats(client, NFL.key, context.season, week);
@@ -81,7 +105,7 @@ export async function GET(
           (entry) => entry.slotType === slot.slotType && entry.slotIndex === slot.slotIndex,
         ) ?? { slotType: slot.slotType, slotIndex: slot.slotIndex, playerId: null };
 
-        const locksAt = slotLocksAt(assignment, roster);
+        const locksAt = slotLocksAt(assignment, kickoffs);
 
         return {
           slotType: slot.slotType,
@@ -89,7 +113,12 @@ export async function GET(
           eligiblePositions: slot.eligiblePositions,
           playerId: assignment.playerId,
           locksAt,
-          locked: locksAt !== null && now >= locksAt,
+          // Ask the shared helper rather than re-deriving it from `locksAt`.
+          // The two disagree for a player the map does not know: `locksAt` is
+          // null so the screen would offer the edit, while the server refuses.
+          // A UI that offers an edit the server rejects is the failure the
+          // draft clock already taught us to avoid.
+          locked: slotIsLocked(assignment, kickoffs, now),
         };
       }),
       roster: [...roster.values()].map((player) => ({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,7 +176,9 @@ export {
 export {
   lineupIsFullyLocked,
   lockedAssignments,
+  slotIsLocked,
   slotLocksAt,
+  type KickoffTimes,
   startingSlots,
   validateLineup,
   type LineupAssignment,

--- a/packages/core/src/season/lineup.test.ts
+++ b/packages/core/src/season/lineup.test.ts
@@ -9,7 +9,7 @@ import {
   startingSlots,
   validateLineup,
 } from "./lineup.js";
-import type { LineupAssignment, LineupPlayer } from "./lineup.js";
+import type { KickoffTimes, LineupAssignment, LineupPlayer } from "./lineup.js";
 
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 
@@ -41,6 +41,20 @@ const ROSTER = new Map<string, LineupPlayer>(
     player("def1", ["DEF"]),
   ].map((p) => [p.playerId, p]),
 );
+
+/**
+ * Kickoffs derived from a roster.
+ *
+ * In production the two come from different queries on purpose — a lock is a
+ * fact about a game, not about who owns the player — but for a fixture whose
+ * roster and lineup agree, deriving one from the other keeps the tests honest
+ * about what they are exercising. The cases where they *disagree* are written
+ * out explicitly further down; those are the ones this whole change is about.
+ */
+const kickoffsOf = (roster: ReadonlyMap<string, LineupPlayer>): KickoffTimes =>
+  new Map([...roster].map(([id, entry]) => [id, entry.kickoffAt]));
+
+const KICKOFFS = kickoffsOf(ROSTER);
 
 /** A legal starting nine. */
 const LEGAL: LineupAssignment[] = [
@@ -81,7 +95,9 @@ describe("startingSlots", () => {
 
 describe("validateLineup", () => {
   it("accepts a legal lineup", () => {
-    expect(validateLineup({ assignments: LEGAL, shape: SHAPE, roster: ROSTER })).toEqual([]);
+    expect(
+      validateLineup({ assignments: LEGAL, shape: SHAPE, roster: ROSTER, kickoffs: KICKOFFS }),
+    ).toEqual([]);
   });
 
   it("rejects a player who cannot play the slot", () => {
@@ -89,6 +105,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "QB", slotIndex: 0, playerId: "rb1" }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["POSITION_NOT_ELIGIBLE"]);
@@ -100,6 +117,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "FLEX", slotIndex: 0, playerId: "qb2" }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["POSITION_NOT_ELIGIBLE"]);
@@ -110,6 +128,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "FLEX", slotIndex: 0, playerId: "rb3" }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(problems).toEqual([]);
@@ -120,6 +139,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "QB", slotIndex: 0, playerId: "somebody-elses-qb" }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["NOT_ON_ROSTER"]);
@@ -133,6 +153,7 @@ describe("validateLineup", () => {
       ],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["PLAYER_TWICE"]);
@@ -143,6 +164,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "RB", slotIndex: 5, playerId: "rb1" }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["UNKNOWN_SLOT"]);
@@ -156,6 +178,7 @@ describe("validateLineup", () => {
       ],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems)).toEqual(["DUPLICATE_SLOT"]);
@@ -166,6 +189,7 @@ describe("validateLineup", () => {
       assignments: [{ slotType: "QB", slotIndex: 0, playerId: null }],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(problems).toEqual([]);
@@ -182,6 +206,7 @@ describe("validateLineup", () => {
       ],
       shape: SHAPE,
       roster: ROSTER,
+      kickoffs: KICKOFFS,
     });
 
     expect(codes(problems).sort()).toEqual([
@@ -197,6 +222,7 @@ describe("validateLineup", () => {
         assignments: LEGAL.slice(0, 5),
         shape: SHAPE,
         roster: ROSTER,
+        kickoffs: KICKOFFS,
         requireFull: true,
       });
 
@@ -210,6 +236,7 @@ describe("validateLineup", () => {
         assignments: LEGAL.slice(0, 5),
         shape: SHAPE,
         roster: ROSTER,
+        kickoffs: KICKOFFS,
       });
 
       expect(problems).toEqual([]);
@@ -220,6 +247,7 @@ describe("validateLineup", () => {
         assignments: LEGAL,
         shape: SHAPE,
         roster: ROSTER,
+        kickoffs: KICKOFFS,
         requireFull: true,
       });
 
@@ -240,6 +268,85 @@ const MIXED = new Map<string, LineupPlayer>([
   ["te1", player("te1", ["TE"], null)], // bye week
 ]);
 
+const MIXED_KICKOFFS = kickoffsOf(MIXED);
+
+describe("a lock outlives the roster", () => {
+  // The bug this separation exists for. A manager starts a Thursday RB, watches
+  // him bust, cuts him, and moves a Sunday RB into the slot — which used to work,
+  // because the lock asked the roster when he kicked off and a released player is
+  // not in the roster.
+  const DURING_THURSDAY = THURSDAY + 60;
+
+  /** `rb1` has played and is no longer owned; `rb3` is on the bench, unplayed. */
+  const DROPPED_ROSTER = new Map(
+    [...ROSTER].filter(([id]) => id !== "rb1").map(([id, entry]) => [id, entry]),
+  );
+  const DROPPED_KICKOFFS: KickoffTimes = new Map([
+    ...kickoffsOf(DROPPED_ROSTER),
+    ["rb1", THURSDAY],
+  ]);
+  const CURRENT: LineupAssignment[] = [{ slotType: "RB", slotIndex: 0, playerId: "rb1" }];
+
+  it("refuses the swap after the locking player has been dropped", () => {
+    const problems = validateLineup({
+      assignments: [{ slotType: "RB", slotIndex: 0, playerId: "rb3" }],
+      shape: SHAPE,
+      roster: DROPPED_ROSTER,
+      kickoffs: DROPPED_KICKOFFS,
+      current: CURRENT,
+      now: DURING_THURSDAY,
+    });
+
+    expect(codes(problems)).toContain("SLOT_LOCKED");
+  });
+
+  it("refuses emptying the slot too, so the drop opens no second door", () => {
+    // An empty slot never locks, deliberately. If cutting the player were allowed
+    // to empty his slot, that rule would become the bypass instead.
+    const problems = validateLineup({
+      assignments: [{ slotType: "RB", slotIndex: 0, playerId: null }],
+      shape: SHAPE,
+      roster: DROPPED_ROSTER,
+      kickoffs: DROPPED_KICKOFFS,
+      current: CURRENT,
+      now: DURING_THURSDAY,
+    });
+
+    expect(codes(problems)).toContain("SLOT_LOCKED");
+  });
+
+  it("locks a slot whose occupant is unknown to both maps", () => {
+    // Fail closed. A caller who under-populates `kickoffs` gets refusals, not a
+    // silent bypass — which is the direction that was wrong before: an absent
+    // player and a bye both answered `undefined` and both read as "never locks".
+    const problems = validateLineup({
+      assignments: [{ slotType: "RB", slotIndex: 0, playerId: "rb3" }],
+      shape: SHAPE,
+      roster: DROPPED_ROSTER,
+      kickoffs: kickoffsOf(DROPPED_ROSTER),
+      current: CURRENT,
+      now: DURING_THURSDAY,
+    });
+
+    expect(codes(problems)).toContain("SLOT_LOCKED");
+  });
+
+  it("still lets the slot be changed before that player's kickoff", () => {
+    // The lock is about the game starting, not about the drop. Cutting somebody
+    // on Tuesday must not freeze his slot for the rest of the week.
+    const problems = validateLineup({
+      assignments: [{ slotType: "RB", slotIndex: 0, playerId: "rb3" }],
+      shape: SHAPE,
+      roster: DROPPED_ROSTER,
+      kickoffs: DROPPED_KICKOFFS,
+      current: CURRENT,
+      now: THURSDAY - 60,
+    });
+
+    expect(codes(problems)).not.toContain("SLOT_LOCKED");
+  });
+});
+
 const DURING_THURSDAY = THURSDAY + 60;
 const BEFORE_SUNDAY = SUNDAY - 3600;
 
@@ -250,6 +357,7 @@ describe("locks", () => {
       current: [{ slotType: "QB", slotIndex: 0, playerId: "qb1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: DURING_THURSDAY,
     });
 
@@ -264,6 +372,7 @@ describe("locks", () => {
       current: [{ slotType: "WR", slotIndex: 0, playerId: "wr1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: DURING_THURSDAY,
     });
 
@@ -278,6 +387,7 @@ describe("locks", () => {
       current: [{ slotType: "QB", slotIndex: 0, playerId: "qb1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: DURING_THURSDAY,
     });
 
@@ -290,6 +400,7 @@ describe("locks", () => {
       current: [{ slotType: "QB", slotIndex: 0, playerId: "qb1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: THURSDAY - 1,
     });
 
@@ -302,6 +413,7 @@ describe("locks", () => {
       current: [{ slotType: "QB", slotIndex: 0, playerId: "qb1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: THURSDAY,
     });
 
@@ -317,6 +429,7 @@ describe("locks", () => {
       current: [{ slotType: "RB", slotIndex: 0, playerId: null }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: DURING_THURSDAY,
     });
 
@@ -332,6 +445,7 @@ describe("locks", () => {
       current: [{ slotType: "RB", slotIndex: 0, playerId: null }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: SUNDAY_LATE,
     });
 
@@ -346,6 +460,7 @@ describe("locks", () => {
       current: [{ slotType: "FLEX", slotIndex: 0, playerId: null }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: SUNDAY_LATE + 60,
     });
 
@@ -359,6 +474,7 @@ describe("locks", () => {
       current: [{ slotType: "TE", slotIndex: 0, playerId: "te1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
       now: SUNDAY_LATE,
     });
 
@@ -372,6 +488,7 @@ describe("locks", () => {
       current: [{ slotType: "QB", slotIndex: 0, playerId: "qb1" }],
       shape: SHAPE,
       roster: MIXED,
+      kickoffs: MIXED_KICKOFFS,
     });
 
     expect(problems).toEqual([]);
@@ -380,34 +497,38 @@ describe("locks", () => {
 
 describe("lockedAssignments", () => {
   it("lists only the slots that have started", () => {
-    const locked = lockedAssignments(LEGAL, MIXED, DURING_THURSDAY);
+    const locked = lockedAssignments(LEGAL, MIXED_KICKOFFS, DURING_THURSDAY);
 
     expect(locked.map((a) => a.slotType)).toEqual(["QB"]);
   });
 
   it("grows as the day goes on", () => {
-    expect(lockedAssignments(LEGAL, MIXED, BEFORE_SUNDAY)).toHaveLength(1);
-    expect(lockedAssignments(LEGAL, MIXED, SUNDAY).length).toBeGreaterThan(1);
+    expect(lockedAssignments(LEGAL, MIXED_KICKOFFS, BEFORE_SUNDAY)).toHaveLength(1);
+    expect(lockedAssignments(LEGAL, MIXED_KICKOFFS, SUNDAY).length).toBeGreaterThan(1);
   });
 
   it("is empty before anything kicks off", () => {
-    expect(lockedAssignments(LEGAL, MIXED, THURSDAY - 1)).toEqual([]);
+    expect(lockedAssignments(LEGAL, MIXED_KICKOFFS, THURSDAY - 1)).toEqual([]);
   });
 });
 
 describe("slotLocksAt", () => {
   it("reports the kickoff a manager is racing", () => {
-    expect(slotLocksAt({ slotType: "QB", slotIndex: 0, playerId: "qb1" }, MIXED)).toBe(
+    expect(slotLocksAt({ slotType: "QB", slotIndex: 0, playerId: "qb1" }, MIXED_KICKOFFS)).toBe(
       THURSDAY,
     );
   });
 
   it("is null for an empty slot", () => {
-    expect(slotLocksAt({ slotType: "QB", slotIndex: 0, playerId: null }, MIXED)).toBeNull();
+    expect(
+      slotLocksAt({ slotType: "QB", slotIndex: 0, playerId: null }, MIXED_KICKOFFS),
+    ).toBeNull();
   });
 
   it("is null on a bye", () => {
-    expect(slotLocksAt({ slotType: "TE", slotIndex: 0, playerId: "te1" }, MIXED)).toBeNull();
+    expect(
+      slotLocksAt({ slotType: "TE", slotIndex: 0, playerId: "te1" }, MIXED_KICKOFFS),
+    ).toBeNull();
   });
 });
 
@@ -416,11 +537,11 @@ describe("lineupIsFullyLocked", () => {
   const PLAYING = LEGAL.filter((a) => a.slotType !== "TE");
 
   it("is false while anything can still move", () => {
-    expect(lineupIsFullyLocked(PLAYING, MIXED, SUNDAY)).toBe(false);
+    expect(lineupIsFullyLocked(PLAYING, MIXED_KICKOFFS, SUNDAY)).toBe(false);
   });
 
   it("is true once the last game has started", () => {
-    expect(lineupIsFullyLocked(PLAYING, MIXED, SUNDAY_LATE + 1)).toBe(true);
+    expect(lineupIsFullyLocked(PLAYING, MIXED_KICKOFFS, SUNDAY_LATE + 1)).toBe(true);
   });
 
   it("stays false while a bye slot is still fillable", () => {
@@ -428,13 +549,13 @@ describe("lineupIsFullyLocked", () => {
     // started — so the manager can still put a Monday-night player in it. The
     // lineup is genuinely not settled, and saying otherwise would be a lie the
     // UI would repeat.
-    expect(lineupIsFullyLocked(LEGAL, MIXED, SUNDAY_LATE + 1)).toBe(false);
+    expect(lineupIsFullyLocked(LEGAL, MIXED_KICKOFFS, SUNDAY_LATE + 1)).toBe(false);
   });
 
   it("is false for an empty lineup", () => {
     // Nothing is locked because nothing is set — not the same as "settled".
     const empty = LEGAL.map((a) => ({ ...a, playerId: null }));
 
-    expect(lineupIsFullyLocked(empty, MIXED, SUNDAY_LATE + 1)).toBe(false);
+    expect(lineupIsFullyLocked(empty, MIXED_KICKOFFS, SUNDAY_LATE + 1)).toBe(false);
   });
 });

--- a/packages/core/src/season/lineup.ts
+++ b/packages/core/src/season/lineup.ts
@@ -60,11 +60,41 @@ export interface LineupProblem {
   readonly playerId?: string;
 }
 
+/**
+ * When each relevant player's game kicks off this week, in Unix seconds.
+ * `null` means a bye — a known player with no game.
+ *
+ * **Deliberately not the roster.** A lock is a fact about a game that has
+ * started, not about who owns the player now, and conflating the two is what let
+ * a manager reopen a Thursday slot by cutting the man in it: the roster map
+ * excludes released players, so the slot's occupant vanished and an absent
+ * player read as "never locks".
+ *
+ * The caller must cover the roster **and** everyone named in the stored lineup —
+ * the union, because the whole point is that the occupant of a locked slot may
+ * no longer be rostered. A player missing from this map locks, so a caller who
+ * under-populates it gets refusals rather than a silent bypass.
+ */
+export type KickoffTimes = ReadonlyMap<string, number | null>;
+
 export interface ValidateLineupInput {
   readonly assignments: readonly LineupAssignment[];
   readonly shape: RosterShape;
-  /** The team's roster, keyed by player ID. */
+  /**
+   * The team's roster, keyed by player ID.
+   *
+   * Answers "may I start this player" — ownership and eligibility. It no longer
+   * answers "has his game started"; see `kickoffs`.
+   */
   readonly roster: ReadonlyMap<string, LineupPlayer>;
+  /**
+   * Kickoffs for the roster and for whoever is standing in the stored lineup.
+   *
+   * Required, not optional-with-a-fallback. An optional filter that defaults to
+   * permissive is the shape that produced the `loadProjections` defect, and here
+   * the permissive default is the bug being fixed.
+   */
+  readonly kickoffs: KickoffTimes;
   /**
    * What is currently in each slot. Needed to tell an edit from a no-op: a
    * locked slot may keep its player, it simply may not change.
@@ -90,7 +120,7 @@ const key = (slotType: string, slotIndex: number): string => `${slotType}#${slot
  * @returns every problem found, or an empty array
  */
 export function validateLineup(input: ValidateLineupInput): readonly LineupProblem[] {
-  const { assignments, shape, roster, current, now, requireFull } = input;
+  const { assignments, shape, roster, kickoffs, current, now, requireFull } = input;
   const problems: LineupProblem[] = [];
 
   const slots = new Map(
@@ -137,7 +167,7 @@ export function validateLineup(input: ValidateLineupInput): readonly LineupProbl
     // manager submit their whole lineup on Sunday without the Thursday slot
     // making the submission fail.
     const wasLocked =
-      now !== undefined && isSlotLocked(currentBySlot.get(slotKey) ?? null, roster, now);
+      now !== undefined && isSlotLocked(currentBySlot.get(slotKey) ?? null, kickoffs, now);
 
     if (wasLocked && currentBySlot.get(slotKey) !== assignment.playerId) {
       problems.push({
@@ -172,7 +202,7 @@ export function validateLineup(input: ValidateLineupInput): readonly LineupProbl
     if (
       now !== undefined &&
       currentBySlot.get(slotKey) !== assignment.playerId &&
-      isSlotLocked(assignment.playerId, roster, now)
+      isSlotLocked(assignment.playerId, kickoffs, now)
     ) {
       problems.push({
         code: "PLAYER_LOCKED",
@@ -282,16 +312,24 @@ export function startingSlots(
  * cheating.
  *
  * A player on a **bye never locks** either — there is no game to have started.
+ *
+ * **An unknown player locks.** That is the third case, and it used to be missing:
+ * `roster.get(id)?.kickoffAt` answered `undefined` both for a bye and for a
+ * player who was not in the map at all, and both read as "never locks". Since the
+ * map excluded released players, cutting the man in a slot reopened it — see
+ * `KickoffTimes` for why the lock no longer consults a roster at all. Refusing an
+ * edit we cannot price is the same direction `blockTime` takes: a refusal costs a
+ * retry and is visible, a wrong "unlocked" is invisible and decides a matchup.
  */
-function isSlotLocked(
-  playerId: string | null,
-  roster: ReadonlyMap<string, LineupPlayer>,
-  now: number,
-): boolean {
+function isSlotLocked(playerId: string | null, kickoffs: KickoffTimes, now: number): boolean {
   if (playerId === null) return false;
 
-  const kickoff = roster.get(playerId)?.kickoffAt;
-  if (kickoff === null || kickoff === undefined) return false;
+  // `has`, not `?? undefined` — that collapse is what hid the bug. A bye is a
+  // known player with no game; an absent player is a question we cannot answer.
+  if (!kickoffs.has(playerId)) return true;
+
+  const kickoff = kickoffs.get(playerId) ?? null;
+  if (kickoff === null) return false;
 
   return now >= kickoff;
 }
@@ -299,10 +337,25 @@ function isSlotLocked(
 /** Which of the current assignments can no longer be changed. */
 export function lockedAssignments(
   current: readonly LineupAssignment[],
-  roster: ReadonlyMap<string, LineupPlayer>,
+  kickoffs: KickoffTimes,
   now: number,
 ): readonly LineupAssignment[] {
-  return current.filter((assignment) => isSlotLocked(assignment.playerId, roster, now));
+  return current.filter((assignment) => isSlotLocked(assignment.playerId, kickoffs, now));
+}
+
+/**
+ * Whether this slot can still be changed.
+ *
+ * Exported so the screen and the server share one implementation of the rule. A
+ * UI that re-derives it can disagree with the server, and the direction that
+ * matters is offering an edit the server will refuse.
+ */
+export function slotIsLocked(
+  assignment: LineupAssignment,
+  kickoffs: KickoffTimes,
+  now: number,
+): boolean {
+  return isSlotLocked(assignment.playerId, kickoffs, now);
 }
 
 /**
@@ -313,20 +366,20 @@ export function lockedAssignments(
  */
 export function slotLocksAt(
   assignment: LineupAssignment,
-  roster: ReadonlyMap<string, LineupPlayer>,
+  kickoffs: KickoffTimes,
 ): number | null {
   if (assignment.playerId === null) return null;
-  return roster.get(assignment.playerId)?.kickoffAt ?? null;
+  return kickoffs.get(assignment.playerId) ?? null;
 }
 
 /** Whether a whole lineup is now beyond editing. */
 export function lineupIsFullyLocked(
   current: readonly LineupAssignment[],
-  roster: ReadonlyMap<string, LineupPlayer>,
+  kickoffs: KickoffTimes,
   now: number,
 ): boolean {
   const fillable = current.filter((assignment) => assignment.playerId !== null);
   if (fillable.length === 0) return false;
 
-  return fillable.every((assignment) => isSlotLocked(assignment.playerId, roster, now));
+  return fillable.every((assignment) => isSlotLocked(assignment.playerId, kickoffs, now));
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -83,6 +83,7 @@ export {
   persistSchedule,
   resolveLeagueWeek,
   resolveLeagueWeeksThrough,
+  transactionWeek,
   WeekError,
   type ResolveWeekOutcome,
 } from "./week.js";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -92,6 +92,7 @@ export {
   ensureLineups,
   LineupError,
   loadLineup,
+  loadKickoffs,
   loadRosterForWeek,
   loadWeekLineups,
   loadWeekStats,

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -11,6 +11,7 @@ import {
   autoFillLineup,
   ensureLineups,
   loadAverages,
+  loadKickoffs,
   loadLineup,
   loadProjectedPoints,
   loadRosterForWeek,
@@ -1044,5 +1045,121 @@ describe("one source ranks the autofill", () => {
     const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
 
     expect(projected.get(qb)).toBe(12_000);
+  });
+});
+
+describe("the lock survives a drop", () => {
+  /**
+   * The exploit, as a regression test.
+   *
+   * Start a Thursday player, watch him play, cut him, and swap a Sunday player
+   * into his slot. This resolved before the lock stopped consulting the roster:
+   * `loadRosterForWeek` excludes released players, so the slot's occupant
+   * vanished from the map and an absent player read as "never locked".
+   */
+  it("refuses the swap after the locked player is dropped", async () => {
+    const fx = await setup();
+
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      now: BEFORE_ANYTHING,
+    });
+
+    // Released directly rather than through `dropPlayer`, which now refuses this
+    // outright — see the waiver suite. The point here is that the lineup lock
+    // holds however the player left, including the paths that cannot refuse:
+    // `resolveTrade` and `processWaivers` both release rows mid-week.
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("thu-qb")],
+    );
+
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb")! }],
+        now: AFTER_THURSDAY,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_LINEUP" });
+  });
+
+  it("knows a released player's kickoff even though the roster does not", async () => {
+    // The two functions answering differently is the design, not an accident.
+    const fx = await setup();
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("thu-qb")],
+    );
+
+    const roster = await loadRosterForWeek(fx.client, fx.teamId, SEASON, WEEK);
+    const kickoffs = await loadKickoffs(fx.client, [fx.players.get("thu-qb")!], SEASON, WEEK);
+
+    expect(roster.has(fx.players.get("thu-qb")!)).toBe(false);
+    expect(kickoffs.get(fx.players.get("thu-qb")!)).toBe(THURSDAY_SECONDS);
+  });
+
+  it("lets the autofill replace a player dropped before his kickoff", async () => {
+    // The companion half. A player cut on Tuesday is a hole, not a choice — and
+    // leaving him would let his slot lock at kickoff around a man nobody owns,
+    // who would then score for the team that cut him.
+    const fx = await setup();
+
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      now: BEFORE_ANYTHING,
+    });
+
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("thu-qb")],
+    );
+
+    const filled = await autoFillLineup(
+      fx.client,
+      fx.leagueId,
+      fx.teamId,
+      WEEK,
+      BEFORE_ANYTHING,
+    );
+
+    const qb = filled.find((slot) => slot.slotType === "QB" && slot.slotIndex === 0);
+    expect(qb?.playerId).not.toBe(fx.players.get("thu-qb"));
+    expect(qb?.playerId).toBe(fx.players.get("sun-qb"));
+  });
+
+  it("keeps a player dropped after his kickoff, because that slot is locked", async () => {
+    const fx = await setup();
+
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      now: BEFORE_ANYTHING,
+    });
+
+    await fx.client.query(
+      "UPDATE roster_entries SET released_at = now() WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("thu-qb")],
+    );
+
+    const filled = await autoFillLineup(
+      fx.client,
+      fx.leagueId,
+      fx.teamId,
+      WEEK,
+      AFTER_THURSDAY,
+    );
+
+    const qb = filled.find((slot) => slot.slotType === "QB" && slot.slotIndex === 0);
+    expect(qb?.playerId).toBe(fx.players.get("thu-qb"));
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -173,6 +173,90 @@ export async function weekHasSchedule(
  * A genuine bye keeps `null` and keeps the documented behaviour, because his team
  * *is* in the schedule — just not this week.
  */
+/**
+ * When each of these players' games kick off this week.
+ *
+ * Keyed on the **player**, not on a roster, and that separation is the whole of
+ * the fix for the lock bypass. A lock is a fact about a game that has started;
+ * asking a roster about it meant that cutting the player in a locked slot made
+ * the slot's occupant vanish from the map, and an absent player read as
+ * "never locked". Callers pass the union of the roster and whoever is standing
+ * in the stored lineup, so a released player still locks the slot he was
+ * started in.
+ *
+ * A player present with `null` is on a bye. A player **absent** from the result
+ * is one this function was not asked about — `isSlotLocked` treats that as
+ * locked rather than guessing, so an under-populated map produces refusals
+ * rather than a silent bypass.
+ *
+ * The three "no game row" cases are the same ones `loadRosterForWeek` documents,
+ * and they are resolved here so there is one definition of when a player locks.
+ */
+export async function loadKickoffs(
+  db: SqlClient,
+  playerIds: readonly string[],
+  season: number,
+  week: number,
+): Promise<ReadonlyMap<string, number | null>> {
+  if (playerIds.length === 0) return new Map();
+
+  const rows = await db.query<{
+    player_id: string;
+    kickoff_at: string | null;
+    team_scheduled: boolean;
+  }>(
+    `SELECT p.id AS player_id,
+            g.kickoff_at,
+            EXISTS (
+              SELECT 1 FROM games sg
+               WHERE sg.sport_id = p.sport_id
+                 AND sg.season = $2
+                 AND (sg.home_team_ref = p.team_ref OR sg.away_team_ref = p.team_ref)
+            ) AS team_scheduled
+       FROM players p
+       LEFT JOIN games g
+         ON g.sport_id = p.sport_id
+        AND g.season = $2
+        AND g.week = $3
+        AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
+      WHERE p.id = ANY($1)`,
+    [[...playerIds], season, week],
+  );
+
+  const weekStartsAt = await weekFirstKickoff(db, season, week);
+
+  return new Map(
+    rows.map((row) => [
+      row.player_id,
+      row.kickoff_at
+        ? Math.floor(new Date(row.kickoff_at).getTime() / 1000)
+        : row.team_scheduled
+          ? null
+          : weekStartsAt,
+    ]),
+  );
+}
+
+/**
+ * The earliest kickoff of the week, or `null` when the week has no games.
+ *
+ * The conservative lock time for a player whose team is nowhere in the schedule:
+ * he freezes when the week begins rather than never.
+ */
+async function weekFirstKickoff(
+  db: SqlClient,
+  season: number,
+  week: number,
+): Promise<number | null> {
+  const [firstGame] = await db.query<{ kickoff_at: string | null }>(
+    `SELECT min(kickoff_at) AS kickoff_at FROM games WHERE season = $1 AND week = $2`,
+    [season, week],
+  );
+  return firstGame?.kickoff_at
+    ? Math.floor(new Date(firstGame.kickoff_at).getTime() / 1000)
+    : null;
+}
+
 export async function loadRosterForWeek(
   db: SqlClient,
   teamId: string,
@@ -216,16 +300,10 @@ export async function loadRosterForWeek(
     [teamId, season, week],
   );
 
-  // The earliest kickoff of the week, used as the conservative lock time for a
-  // player whose team is not in the schedule at all. Null when the week has no
-  // games — `setLineup` refuses in that case rather than guessing.
-  const [firstGame] = await db.query<{ kickoff_at: string | null }>(
-    `SELECT min(kickoff_at) AS kickoff_at FROM games WHERE season = $1 AND week = $2`,
-    [season, week],
-  );
-  const weekStartsAt = firstGame?.kickoff_at
-    ? Math.floor(new Date(firstGame.kickoff_at).getTime() / 1000)
-    : null;
+  // The conservative lock time for a player whose team is not in the schedule at
+  // all. Null when the week has no games — `setLineup` refuses in that case
+  // rather than guessing. Shared with `loadKickoffs` so the two cannot disagree.
+  const weekStartsAt = await weekFirstKickoff(db, season, week);
 
   return new Map(
     rows.map((row) => [
@@ -334,11 +412,36 @@ export async function setLineup(
   const roster = await loadRosterForWeek(db, input.teamId, season, input.week);
   const current = await loadLineup(db, input.teamId, input.week, stored.rules);
 
+  // The union, and the union is the whole fix.
+  //
+  // A player dropped after his game kicked off has left the roster and is still
+  // sitting in the slot he was started in. Asking the roster when he kicked off
+  // answered `undefined`, which read as "never locked" — so cutting the man
+  // holding the lock reopened the slot, which is the one thing the lock exists
+  // to prevent. Kickoffs are a fact about games, so they are looked up per
+  // player over everyone this decision touches: who is rostered, who is already
+  // standing in a slot, and who is being submitted into one.
+  const kickoffs = await loadKickoffs(
+    db,
+    [
+      ...new Set(
+        [
+          ...roster.keys(),
+          ...current.map((assignment) => assignment.playerId),
+          ...input.assignments.map((assignment) => assignment.playerId),
+        ].filter((playerId): playerId is string => playerId !== null),
+      ),
+    ],
+    season,
+    input.week,
+  );
+
   const problems = [
     ...validateLineup({
       assignments: input.assignments,
       shape: buildRosterShape(stored.rules.roster, NFL),
       roster,
+      kickoffs,
       current,
       now: input.now,
     }),
@@ -541,6 +644,22 @@ export async function autoFillLineup(
   const roster = await loadRosterForWeek(db, teamId, season, week);
   const current = await loadLineup(db, teamId, week, stored.rules);
 
+  // Roster plus whoever is standing in the stored lineup — see `loadKickoffs`.
+  // Without the second half a dropped player's slot reads as unlocked here too,
+  // and the autofill would quietly replace a starter whose game had begun.
+  const kickoffs = await loadKickoffs(
+    db,
+    [
+      ...new Set(
+        [...roster.keys(), ...current.map((assignment) => assignment.playerId)].filter(
+          (playerId): playerId is string => playerId !== null,
+        ),
+      ),
+    ],
+    season,
+    week,
+  );
+
   const averages = await loadAverages(db, [...roster.keys()], season, week, stored.rules);
 
   // Only fetched when the league ranks on them. A league set to SEASON_AVERAGE
@@ -564,14 +683,24 @@ export async function autoFillLineup(
 
   // Anything already locked is a fixed point, and anything already set by the
   // manager is left alone: this fills gaps, it does not second-guess.
+  //
+  // The exception is a player who has **left the roster and is not locked**. He
+  // is not a choice the manager made — he is a hole, and leaving him there let
+  // his slot lock at his kickoff around a player nobody rosters, who then scored
+  // for the team that cut him. Note the first loop used to be dead: it is a
+  // strict subset of the second, since `isSlotLocked` is false for a null player,
+  // so nothing it returned was ever the only reason a slot was kept.
+  const locked = new Set(
+    lockedAssignments(current, kickoffs, now).map(
+      (assignment) => `${assignment.slotType}#${assignment.slotIndex}`,
+    ),
+  );
   const keep = new Map<string, LineupAssignment>();
-  for (const assignment of lockedAssignments(current, roster, now)) {
-    keep.set(`${assignment.slotType}#${assignment.slotIndex}`, assignment);
-  }
   for (const assignment of current) {
-    if (assignment.playerId !== null) {
-      keep.set(`${assignment.slotType}#${assignment.slotIndex}`, assignment);
-    }
+    if (assignment.playerId === null) continue;
+    const slot = `${assignment.slotType}#${assignment.slotIndex}`;
+    if (!roster.has(assignment.playerId) && !locked.has(slot)) continue;
+    keep.set(slot, assignment);
   }
 
   const filled = autolineup({

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -838,4 +838,100 @@ describe("RULES.md §6 — a player whose game has kicked off cannot be moved", 
       dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, DURING),
     ).resolves.toMatchObject({ destination: expect.any(String) });
   });
+
+  /**
+   * The release — which the first version of this guard got wrong.
+   *
+   * It asked `currentWeek`, "the week of the most recent kickoff", which keeps
+   * answering week N until week N+1 kicks off on the Thursday. So it refused
+   * every add and drop for days after a week's games had ended, swallowing the
+   * Tuesday turnover and the Wednesday 03:00 ET free-agency opening that §6's
+   * own cycle table guarantees.
+   *
+   * The fixture is the shape that would have caught it: **two** weeks on the
+   * calendar, so "the week under test" and "the week the code picks" can differ,
+   * and instants sampled across the whole cycle rather than sixty seconds either
+   * side of one kickoff. A lock with no release test is a lock with untested
+   * scope.
+   */
+  async function withTwoWeeks(fx: Fixture): Promise<void> {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at)
+       VALUES ($1, 'w1-sun', 2026, 1, 'CIN', 'BAL', $2),
+              ($1, 'w2-thu', 2026, 2, 'BUF', 'NYJ', $3),
+              ($1, 'w2-sun', 2026, 2, 'CIN', 'BAL', $4)`,
+      [sport!.id, KICKOFF, new Date("2026-09-18T00:15:00Z"), new Date("2026-09-20T17:00:00Z")],
+    );
+  }
+
+  it("releases the lock at the weekly turnover, not at the next kickoff", async () => {
+    // Tuesday 00:30 ET. Every week-1 game has been played, the cycle has rolled
+    // over, and §6 says every unrostered player has returned to waivers.
+    const fx = await setup();
+    await withTwoWeeks(fx);
+
+    await expect(
+      dropPlayer(
+        fx.client,
+        fx.leagueId,
+        fx.teams[0]!,
+        fx.players.get("held")!,
+        new Date("2026-09-15T04:30:00Z"),
+      ),
+    ).resolves.toMatchObject({ destination: expect.any(String) });
+  });
+
+  it("leaves free agency open at Wednesday 03:00 ET", async () => {
+    // The one assertion that fails on the first version of this guard. The
+    // constitution opens free agency at this instant; the guard was closing it.
+    const fx = await setup();
+    await withTwoWeeks(fx);
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[1]!,
+        addPlayerId: fx.players.get("target")!,
+        now: new Date("2026-09-16T07:05:00Z"),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still refuses while the week is live, after his own game has ended", async () => {
+    // Sunday 23:00 ET. His game is long over but the week is not, and releasing
+    // here is the tempting misreading of §6: his points are already banked in
+    // the stored lineup, so a freed roster spot buys a Monday-night starter and
+    // twelve roster slots field thirteen contributors.
+    const fx = await setup();
+    await withTwoWeeks(fx);
+
+    await expect(
+      dropPlayer(
+        fx.client,
+        fx.leagueId,
+        fx.teams[0]!,
+        fx.players.get("held")!,
+        new Date("2026-09-14T03:00:00Z"),
+      ),
+    ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
+
+  it("locks again the following week, so it is a rule and not a week-1 case", async () => {
+    const fx = await setup();
+    await withTwoWeeks(fx);
+
+    await expect(
+      dropPlayer(
+        fx.client,
+        fx.leagueId,
+        fx.teams[0]!,
+        fx.players.get("held")!,
+        new Date("2026-09-20T17:30:00Z"),
+      ),
+    ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
 });

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -744,3 +744,98 @@ describe("one owner per league", () => {
     expect(owner?.team_id).toBe(fx.teams[1]);
   });
 });
+
+describe("RULES.md §6 — a player whose game has kicked off cannot be moved", () => {
+  /**
+   * The constitution has said this since it was frozen, and nothing implemented
+   * it:
+   *
+   * > A player cannot be added or dropped once **his own game has kicked off**.
+   * > Otherwise a manager could cut an injured player mid-game, or add one after
+   * > his touchdown.
+   *
+   * Both halves were live. Cutting a started player reopened the lineup slot he
+   * was in — and because a released player is still scored from the stored
+   * lineup, cutting one who had already done well kept his points *and* freed
+   * the roster spot, so twelve roster slots fielded thirteen contributors.
+   */
+  const KICKOFF = new Date("2026-09-13T17:00:00Z");
+  const DURING = new Date(KICKOFF.getTime() + 60_000);
+  const BEFORE = new Date(KICKOFF.getTime() - 60_000);
+
+  /** Give the league a real week-1 schedule; the base fixture has none. */
+  async function withSchedule(fx: Fixture): Promise<void> {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at)
+       VALUES ($1, 'wk1', 2026, 1, 'CIN', 'BAL', $2)`,
+      [sport!.id, KICKOFF],
+    );
+  }
+
+  it("refuses a drop once the player's game has started", async () => {
+    const fx = await setup();
+    await withSchedule(fx);
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, DURING),
+    ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
+
+  it("still allows the drop before kickoff", async () => {
+    const fx = await setup();
+    await withSchedule(fx);
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, BEFORE),
+    ).resolves.toMatchObject({ destination: expect.any(String) });
+  });
+
+  it("refuses adding a player whose game has started", async () => {
+    // The other half of the same sentence. Harmless today only because
+    // `PLAYER_LOCKED` refuses to start him — which is a second line of defence,
+    // not the rule itself.
+    const fx = await setup();
+    await withSchedule(fx);
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[1]!,
+        addPlayerId: fx.players.get("target")!,
+        now: DURING,
+      }),
+    ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
+
+  it("refuses an add whose drop side has started, not just the add side", async () => {
+    // `addFreeAgent` releases a roster row too. Without this the guard in
+    // `dropPlayer` is decorative — the same release, reached by another button.
+    const fx = await setup();
+    await withSchedule(fx);
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fx.players.get("target")!,
+        dropPlayerId: fx.players.get("held")!,
+        now: DURING,
+      }),
+    ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
+
+  it("stays silent when the week has no schedule at all", async () => {
+    // No games, no kickoff times, nothing to compare against. `setLineup`
+    // already refuses that case loudly for the decision that actually matters,
+    // and a waiver move is not the place to discover the sync has not run.
+    const fx = await setup();
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, DURING),
+    ).resolves.toMatchObject({ destination: expect.any(String) });
+  });
+});

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -41,10 +41,12 @@ import {
 import type { DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
+import { loadKickoffs } from "./lineups.js";
 import { isUniqueViolation } from "./pg-errors.js";
 import { loadDraftBoard } from "./sync.js";
 import { lockedByTrade } from "./trades.js";
 import { withTransaction } from "./transaction.js";
+import { currentWeek } from "./week.js";
 
 export class WaiverError extends Error {
   constructor(
@@ -58,7 +60,8 @@ export class WaiverError extends Error {
       | "NOT_ON_WAIVERS"
       | "ROSTER_FULL"
       | "DUPLICATE_CLAIM"
-      | "IN_A_TRADE",
+      | "IN_A_TRADE"
+      | "GAME_STARTED",
   ) {
     super(message);
     this.name = "WaiverError";
@@ -203,6 +206,62 @@ export async function availablePlayers(
 }
 
 // ---------------------------------------------------------------------------
+// Kickoff locks
+// ---------------------------------------------------------------------------
+
+/**
+ * Refuse to move a player whose own game has already started.
+ *
+ * `docs/RULES.md` §6 has said this since the constitution was frozen, and it was
+ * implemented nowhere:
+ *
+ * > A player cannot be added or dropped once **his own game has kicked off**.
+ * > Otherwise a manager could cut an injured player mid-game, or add one after
+ * > his touchdown.
+ *
+ * Members signed that. Both halves of the exploit it names were live: cutting a
+ * started player reopened the lineup slot he was in, and — because a released
+ * player's points are still scored from the stored lineup — cutting one who had
+ * *already* done well kept his points and freed the roster spot for somebody
+ * else, so a twelve-man roster fielded thirteen contributors.
+ *
+ * **This guards the two member-initiated paths only.** `processWaivers` and
+ * `resolveTrade` also release roster rows, and neither can refuse: a throw
+ * inside the waiver run rolls back the whole league's run and leaves the claim
+ * PENDING forever, and a trade the league already approved cannot be undone
+ * because a game started. Those two are covered instead by the lineup lock now
+ * keying on the player rather than the roster, which makes the release harmless
+ * wherever it comes from. Closing the outcome and closing the route are
+ * different jobs and this repo needs both — the same argument `ASSET_GONE`
+ * makes for trades.
+ *
+ * Silent when the week has no schedule: with no kickoff times there is nothing
+ * to compare against, and `setLineup` already refuses that case loudly for the
+ * decision that actually matters.
+ */
+async function refuseIfKickedOff(
+  db: SqlClient,
+  rules: LeagueRules,
+  playerId: string,
+  now: Date,
+  verb: "added" | "dropped",
+): Promise<void> {
+  const week = await currentWeek(db, rules.sportKey, now);
+  if (week === null) return;
+
+  const kickoffs = await loadKickoffs(db, [playerId], rules.seasonYear, week);
+  const kickoff = kickoffs.get(playerId);
+  if (kickoff === undefined || kickoff === null) return;
+
+  if (Math.floor(now.getTime() / 1000) >= kickoff) {
+    throw new WaiverError(
+      `That player's game has already kicked off, so he cannot be ${verb} this week.`,
+      "GAME_STARTED",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Dropping
 // ---------------------------------------------------------------------------
 
@@ -233,6 +292,8 @@ export async function dropPlayer(
       "IN_A_TRADE",
     );
   }
+
+  await refuseIfKickedOff(db, stored.rules, playerId, now, "dropped");
 
   return withTransaction(db, async (tx) => {
     const [entry] = await tx.query<{ id: string; acquired_at: string }>(
@@ -296,6 +357,16 @@ export interface AddInput {
 export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void> {
   const stored = await getLeagueRules(db, input.leagueId);
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
+
+  // Both halves of `RULES.md` §6, on both players. The add half stops "add one
+  // after his touchdown" — harmless today only because `PLAYER_LOCKED` refuses
+  // to start him, which is a second line rather than the rule itself. The drop
+  // half matters more: it is the same release `dropPlayer` guards, reached
+  // through a different button, and without it the guard there is decorative.
+  await refuseIfKickedOff(db, stored.rules, input.addPlayerId, input.now, "added");
+  if (input.dropPlayerId) {
+    await refuseIfKickedOff(db, stored.rules, input.dropPlayerId, input.now, "dropped");
+  }
 
   await withTransaction(db, async (tx) => {
     // A shared lock on the league, held for the whole add.

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -41,12 +41,11 @@ import {
 import type { DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
-import { loadKickoffs } from "./lineups.js";
 import { isUniqueViolation } from "./pg-errors.js";
 import { loadDraftBoard } from "./sync.js";
 import { lockedByTrade } from "./trades.js";
 import { withTransaction } from "./transaction.js";
-import { currentWeek } from "./week.js";
+import { transactionWeek } from "./week.js";
 
 export class WaiverError extends Error {
   constructor(
@@ -235,9 +234,34 @@ export async function availablePlayers(
  * different jobs and this repo needs both — the same argument `ASSET_GONE`
  * makes for trades.
  *
- * Silent when the week has no schedule: with no kickoff times there is nothing
- * to compare against, and `setLineup` already refuses that case loudly for the
- * decision that actually matters.
+ * ## The lock releases when the week does, and getting that wrong is a worse bug
+ *
+ * §2 says a locked player "cannot be moved **for that week**", so the lock is
+ * week-scoped. The first version of this asked `currentWeek`, which answers "the
+ * week of the most recent kickoff" — and that keeps answering week N right up
+ * until week N+1's Thursday. So it refused every add and drop for the three days
+ * *after* a week's games ended, swallowing the Tuesday turnover and most of the
+ * free-agency window §6's own cycle table opens at Wednesday 03:00 ET.
+ *
+ * The release point is the **weekly lock** — `waivers.weeklyLock`, Tuesday 00:00
+ * ET by default, already in the frozen rules, so this needs no new field and
+ * cannot move a rules hash. It is the moment the transaction week turns over,
+ * and it falls after the last Monday-night whistle, which matters: releasing at
+ * the week's last *kickoff* instead would reopen the exploit during that game.
+ *
+ * ## Silent, not refusing, in three cases — each for its own reason
+ *
+ * No live week, no game row for this player, or no schedule at all. §6 refuses a
+ * player "once **his own game** has kicked off"; a player with no game this week
+ * has no game to have started, so there is nothing to refuse.
+ *
+ * That is deliberately *not* the fail-closed direction `isSlotLocked` takes on
+ * the same data, and the difference is the point. `loadKickoffs` synthesises the
+ * week's first kickoff for a player whose team matches no game (`lineups.ts` —
+ * its case three), which is right for a lineup slot and wrong here: `team_ref`
+ * is nullable, so every unsigned free agent matches nothing, and consuming that
+ * synthesis would make the entire free-agent pool unaddable for most of every
+ * week. This asks for the player's own game directly instead.
  */
 async function refuseIfKickedOff(
   db: SqlClient,
@@ -246,14 +270,27 @@ async function refuseIfKickedOff(
   now: Date,
   verb: "added" | "dropped",
 ): Promise<void> {
-  const week = await currentWeek(db, rules.sportKey, now);
+  const week = await transactionWeek(db, rules, now);
   if (week === null) return;
 
-  const kickoffs = await loadKickoffs(db, [playerId], rules.seasonYear, week);
-  const kickoff = kickoffs.get(playerId);
-  if (kickoff === undefined || kickoff === null) return;
+  // This player's own game, and only his. Season-scoped, sport-scoped, and no
+  // fallback — an absent row means he does not play this week.
+  const [row] = await db.query<{ kickoff_at: string }>(
+    `SELECT g.kickoff_at
+       FROM players p
+       JOIN games g
+         ON g.sport_id = p.sport_id
+        AND g.season = $2
+        AND g.week = $3
+        AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
+      WHERE p.id = $1
+      ORDER BY g.kickoff_at
+      LIMIT 1`,
+    [playerId, rules.seasonYear, week],
+  );
+  if (!row) return;
 
-  if (Math.floor(now.getTime() / 1000) >= kickoff) {
+  if (now.getTime() >= new Date(row.kickoff_at).getTime()) {
     throw new WaiverError(
       `That player's game has already kicked off, so he cannot be ${verb} this week.`,
       "GAME_STARTED",

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -36,7 +36,13 @@
  * and 17 means nobody is ever paid.
  */
 
-import { generateSchedule, indexScoringRules, resolveWeek, winnerOf } from "@rostr/core";
+import {
+  generateSchedule,
+  indexScoringRules,
+  nextWeekly,
+  resolveWeek,
+  winnerOf,
+} from "@rostr/core";
 import type { LeagueRules, MatchupResult, ScheduledMatchup } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
@@ -81,6 +87,61 @@ export async function currentWeek(
       ORDER BY g.kickoff_at DESC
       LIMIT 1`,
     [sportKey, at.toISOString()],
+  );
+
+  return row ? Number(row.week) : null;
+}
+
+/**
+ * The week the league is currently **transacting** in.
+ *
+ * **Not `currentWeek`, and the difference is a rule.** `currentWeek` answers
+ * "which week's scores am I writing" from the most recent kickoff, so from a
+ * week's first kickoff until the *next* week's first kickoff it keeps answering
+ * that week — including the Tuesday-to-Thursday stretch in which every one of
+ * its games has already been played. `docs/RULES.md` §6's kickoff lock asked
+ * against that week refuses every player who played, for days, and §6 opens free
+ * agency at Wednesday 03:00 ET in the middle of them.
+ *
+ * This answers a different question: which week's games belong to the cycle the
+ * league is transacting in now. §6's own table defines that cycle — every
+ * unrostered player returns to waivers at Tuesday 00:00 ET — so the week is the
+ * first one kicking off after the most recent weekly lock.
+ *
+ * The boundary is a weekday and a local hour out of the league's frozen rules,
+ * never an offset, so it follows the November DST change rather than sliding an
+ * hour through it.
+ *
+ * **Season-scoped, which `currentWeek` is not.** With two seasons ingested — and
+ * validating the engine against real 2025 box scores is planned work — that one
+ * answers "week 18" all summer, from a row belonging to a season the caller then
+ * does not look the player up in.
+ *
+ * `null` when the current cycle holds no games at all: before the schedule is
+ * ingested, and after the season ends. A caller enforcing a rule must read that
+ * as "this lock cannot be checked", never as "nothing is locked".
+ */
+export async function transactionWeek(
+  db: SqlClient,
+  rules: LeagueRules,
+  at: Date,
+): Promise<number | null> {
+  // The most recent weekly lock at or before `at`. `nextWeekly` is
+  // strictly-after, so asking it from a week earlier yields this cycle's.
+  const since = nextWeekly(
+    new Date(at.getTime() - 7 * 24 * 60 * 60 * 1000),
+    rules.waivers.weeklyLock,
+    rules.waivers.timezone,
+  );
+
+  const [row] = await db.query<{ week: number }>(
+    `SELECT g.week
+       FROM games g
+       JOIN sports s ON s.id = g.sport_id
+      WHERE s.key = $1 AND g.season = $2 AND g.kickoff_at > $3
+      ORDER BY g.kickoff_at ASC
+      LIMIT 1`,
+    [rules.sportKey, rules.seasonYear, since.toISOString()],
   );
 
   return row ? Number(row.week) : null;


### PR DESCRIPTION
﻿Fixes item 1 of #76, and implements `docs/RULES.md` §6, which had no code behind it.

Confirmed and designed by three agents under separate mandates — designer, adversary, collateral. The adversary was told to destroy the finding and reported *"I could not refute it"*, then found it is broader and cheaper than filed. Every load-bearing claim re-verified by hand.

## The defect

Start a Thursday RB, watch him bust, drop him Sunday morning, move a Sunday RB into his slot.

- `packages/core/src/season/lineup.ts` — `isSlotLocked` read `roster.get(playerId)?.kickoffAt` and collapsed `undefined` (not in the map) into `null` (on a bye). Both read as "never locks".
- `packages/db/src/lineups.ts` — `loadRosterForWeek` filters `released_at IS NULL`, so a dropped player is absent from that map.
- `packages/db/src/waivers.ts` — `dropPlayer` checks rules, `lockedByTrade` and roster membership. Never the clock.

The lock lived on the same map as ownership, so deleting the ownership deleted the lock. Run end to end on PGlite before the fix, the swap succeeds.

**It is broader than "Thursday vs Sunday."** The mechanism is per-player kickoff, so it covers any two kickoff times in a week — a 1pm bust into a 4:25, a 4:25 into SNF, SNF into MNF. Several windows a week, every week.

**And the cost is near zero.** ESPN's short-tenure rule sends a briefly-held player straight to free agency, so drop → swap → re-add completes in the same minute with the roster the same size. The rule written to stop add-cut-re-add is what makes this version free.

**The payoff is a free option.** The dropped player's points are *still scored* from the stored lineup — verified independently by two agents — so the slot pays `max(kept, swapped)` with the first value already known. There is no downside branch. `PLAYER_LOCKED` still applies, so the swap-in must not have kicked off; that is the only thing bounding it.

## The fix

A lock is a fact about a game that has started. Who owns the player is a different question. They are now different maps.

`KickoffTimes` is player id → kickoff, built by `loadKickoffs` over the union of the roster and whoever is standing in the stored lineup. `roster` keeps its two real jobs — `NOT_ON_ROSTER` and eligibility.

**Widening `loadRosterForWeek` was considered and rejected.** That map is `validateLineup`'s ownership oracle. A released player in it would let a manager start someone he had cut, put released players into `autoFillLineup`'s candidate pool, and offer them in the editor — trading this bug for a worse one, a player scoring for two teams in the same week. The adversary demonstrated that at the core layer.

**`isSlotLocked` now fails closed:** an unknown player locks. Refusing an edit we cannot price costs a retry and is visible; a wrong "unlocked" is invisible and decides a matchup. Same direction `blockTime` takes, and it is what makes the fix hold even if a caller under-populates the map.

## `RULES.md` §6, implemented for the first time

> A player cannot be added or dropped once **his own game has kicked off**. Otherwise a manager could cut an injured player mid-game, or add one after his touchdown.

That is the frozen, member-signed constitution. It names this exact exploit and its motivation, and **neither half was enforced anywhere.** `dropPlayer` and `addFreeAgent` now refuse with `GAME_STARTED` — including `addFreeAgent`'s drop side, which is the same release reached by a different button, and which also bypassed the accepted-trade freeze.

That guard closes a **second exploit** found while confirming this one: because a released player is still scored from the stored lineup, cutting one who had *already* done well kept his points and freed the roster spot — twelve roster slots fielding thirteen contributors.

**`processWaivers` and `resolveTrade` are deliberately left unguarded.** Both release rows mid-week and neither can refuse: a throw inside the waiver run rolls back the league's whole run and leaves the claim PENDING forever, and a trade the league already approved cannot be undone because a game started. They are covered by the lock instead, which now holds however the player left. Closing the route and closing the outcome are different jobs and this needs both — the same argument `ASSET_GONE` makes for trades.

## Companion fix, without which this would be worse

`autoFillLineup` now evicts a player who left the roster **before** his kickoff. He is a hole, not a choice the manager made — and leaving him let his slot lock at kickoff around a man nobody rosters, who then scored for the team that cut him.

Note the `lockedAssignments` call there was **dead code**: a strict subset of the loop below it, since a null player never locks. This is the first time it does any work.

## A second week function, and why the fix needed one

The first version of this PR **regressed the whole free-agency window**: `refuseIfKickedOff` asked `currentWeek`, which answers "the week of the most recent kickoff", so from Sunday to Thursday it kept naming a week whose games had all been played â€” and refused every add and drop for days, including the Wednesday 03:00 ET opening `RULES.md` Â§6 guarantees. CI was green, because the fixture held one week and probed 60 seconds either side of one kickoff.

So this branch also adds **`transactionWeek`** to `packages/db/src/week.ts`. It answers a different question from `currentWeek`, and both are now needed:

| | answers | for |
|---|---|---|
| `currentWeek` | the week of the most recent kickoff | which week am I **scoring** â€” the scoreboard and `score-week`, which must keep showing Sunday's result until Thursday |
| `transactionWeek` | the first week kicking off after the most recent weekly lock | which week am I **transacting into** â€” waivers, free agency, and any rule binding on where a roster change lands |

Two properties are load-bearing. The boundary is a weekday and a local hour out of the league's frozen rules rather than an offset, so it follows the November DST change instead of sliding an hour through it. And it is **season-scoped**, which `currentWeek` is not â€” with 2025 games ingested, `currentWeek` answers "week 18" all summer, from a row belonging to a season the caller then does not look the player up in.

It returns `null` when the current cycle holds no games. A caller enforcing a rule must read that as *"this lock cannot be checked"*, never as *"nothing is locked"* â€” the permissive reading is a bug waiting for a caller, and issue #91 is where that bites.

Added here rather than in its own PR because the regression above is not fixable without it. On this branch its only caller is `refuseIfKickedOff`.

## Verification

- The exploit as a regression test at **both** layers — pure core and PGlite end to end.
- The empty-slot case: emptying a locked slot is refused, or the "an empty slot never locks" rule becomes the bypass instead.
- The unknown-player case, pinning fail-closed so a future simplification back to `?? undefined` fails loudly.
- The before-kickoff case: cutting somebody on Tuesday must not freeze his slot all week.
- All four `GAME_STARTED` paths, plus the no-schedule case where the guard stays silent.
- **Mutation-checked twice.** Reverting fail-closed fails the core test; removing the drop guard fails the waiver test.

1128 tests, typecheck, lint green. No schema change, no rules change, **golden hash untouched.**

## Not verified

`apps/web` cannot test React, so the lineup route's kickoff lookup and the shared `slotIsLocked` call are argued from reading. The route now asks the same question `setLineup` does rather than re-deriving the rule from `locksAt`, which matters because the two disagree for an unknown player — the screen would offer an edit the server refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


