### PR TITLE
fix(db): re-assert "already final" at the write, not only before it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,6 +583,28 @@ and, _within_ that window, only when every game is `FINAL`. A finalised week is 
 rescored — in a paying week it has already decided money, and a silently changed result
 afterwards is exactly what the window exists to prevent.
 
+**Two guards enforce that, and naming them is the point.** The pre-check refuses an
+already-final week cheaply, with the `ALREADY_FINAL` code the cron reports. The `UPDATE`
+then carries `AND finalized_at IS NULL` and `RETURNING id`, because the pre-check reads on
+one connection and the write happens on another many round trips later — `ensureLineups`
+alone opens a transaction per team. Two overlapping runs both passed the check, and the
+loser wrote its older stat snapshot over the winner's finalised points; `CASE … ELSE
+finalized_at` then preserved the timestamp, so the rewrite left no trace.
+
+**`score-week` was the only one of the four crons with no serialisation.** `waivers` takes
+`FOR UPDATE` on the league, `trades` on the trade row, `draft-tick` on the draft row —
+and `waivers`' own comment says why: _"a slow run and a retry can overlap."_ A lock was
+rejected here because it would have to be held across `ensureLineups`, `loadWeekStats`
+and `finalizationHold`, and because a lock serialises without making a pre-lock decision
+true afterwards — the trap issue #22 records. The atomic predicate does both.
+
+**The empty `UPDATE` throws rather than skipping.** A silent no-op would be half a fix:
+the return value is built from the in-memory results, so a losing run would report
+`matchups: N, finalized: true` with a stale snapshot and the cron would publish it. The
+throw also makes the write all-or-nothing, matching the pre-check rather than quietly
+applying a second policy — which matters because a week can legitimately hold finalised
+consolation fixtures beside unfinalised playoff ones.
+
 The window comes from the rules: 48 hours normally, **168 for weeks 14 and 17**, because
 official NFL stat corrections arrive for up to seven days.
 

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -19,6 +19,20 @@ import { cronForbidden } from "@/lib/cron";
  * has elapsed, which inside that window also requires every game to be final. A
  * finalised week is skipped, not rescored.
  *
+ * **Safe to run *concurrently*, which is a different claim and was not true.**
+ * Unlike the other three crons, nothing here serialises two runs — `waivers`
+ * takes `FOR UPDATE` on the league, `trades` on the trade row, `draft-tick` on
+ * the draft row, and this had nothing. The sentence above was enforced by a
+ * check that read on one connection and wrote on another many round trips
+ * later, so two overlapped runs both passed it and the loser wrote its older
+ * stat snapshot over the winner's finalised points.
+ *
+ * It is now enforced by `finalized_at IS NULL` on the write itself, so the
+ * loser matches no rows and reports `ALREADY_FINAL` instead of publishing a
+ * restated week as the outcome. Overlap is not hypothetical: `?week=N` is
+ * accepted here precisely so an operator can hand-run a week that will not
+ * settle, which is the run most likely to collide with the sweep.
+ *
  * Past the window a week finalises whether or not every game reached `FINAL` —
  * `docs/RULES.md` §10, the postponed game — and says so in
  * `finalizedWithUnfinishedGames`. That field is the only signal that a week

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -7,6 +7,7 @@ import { seedSport } from "./sports.js";
 import { setLineup } from "./lineups.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
+import type { SqlClient } from "./client.js";
 import {
   finalizationHours,
   loadScheduledWeek,
@@ -737,5 +738,88 @@ describe("standings from resolved weeks", () => {
     await schedule(fx);
 
     expect(await loadWeekResults(fx.client, fx.leagueId, WEEK)).toEqual([]);
+  });
+});
+
+describe("a finalised week survives an overlapping run", () => {
+  /**
+   * The guard is a check-then-act across two connections.
+   *
+   * `resolveLeagueWeek` reads "is this week finalised" outside any transaction,
+   * then does `ensureLineups`, the lineup load, the stat load and the
+   * finalisation decision, and only then opens the transaction that writes. Two
+   * overlapped runs both pass the read; the loser then writes a stat snapshot
+   * taken *before* the winner's over a finalised row.
+   *
+   * **PGlite is single-connection, so the race itself cannot be reproduced
+   * here** — the same limitation the repo records for `acceptTrade`. What these
+   * tests do reproduce is the *ordering*: a client that finalises the week
+   * partway through the run, at exactly the point a competing run would have.
+   * That is the state the loser's write executes against, which is what the fix
+   * has to survive.
+   */
+  function finalisingMidRun(client: PGliteClient, leagueId: string, week: number): SqlClient {
+    let fired = false;
+    return {
+      exec: (sql) => client.exec(sql),
+      query: async <T = Record<string, unknown>>(
+        sql: string,
+        params?: readonly unknown[],
+      ): Promise<T[]> => {
+        // `ensureLineups` reads the team list first — the same instant a
+        // competing run would be finishing ahead of us.
+        if (!fired && sql.includes("autofill_enabled")) {
+          fired = true;
+          await client.query(
+            `UPDATE matchups
+                SET home_milli_points = 111000, away_milli_points = 222000,
+                    finalized_at = $3
+              WHERE league_id = $1 AND week = $2`,
+            [leagueId, week, new Date("2026-01-01T00:00:00Z").toISOString()],
+          );
+        }
+        return client.query<T>(sql, params);
+      },
+    };
+  }
+
+  it("refuses rather than writing a stale snapshot over it", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    const racing = finalisingMidRun(fx.client, fx.leagueId, WEEK);
+
+    await expect(
+      resolveLeagueWeek(racing, fx.leagueId, WEEK, AFTER_STANDARD),
+    ).rejects.toMatchObject({ code: "ALREADY_FINAL" });
+  });
+
+  it("leaves the winner's points and timestamp exactly as they were", async () => {
+    // The assertion that matters. Before the fix the losing run overwrote both,
+    // and `CASE ... ELSE finalized_at` hid it.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    const racing = finalisingMidRun(fx.client, fx.leagueId, WEEK);
+    await resolveLeagueWeek(racing, fx.leagueId, WEEK, AFTER_STANDARD).catch(() => undefined);
+
+    const rows = await fx.client.query<{
+      home_milli_points: number;
+      away_milli_points: number;
+      finalized_at: string;
+    }>(
+      `SELECT home_milli_points, away_milli_points, finalized_at
+         FROM matchups WHERE league_id = $1 AND week = $2`,
+      [fx.leagueId, WEEK],
+    );
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(Number(row.home_milli_points)).toBe(111000);
+      expect(Number(row.away_milli_points)).toBe(222000);
+      expect(new Date(row.finalized_at).toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    }
   });
 });

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -22,8 +22,16 @@
  * wait 48.
  *
  * So `resolveLeagueWeek` updates points every time it runs and sets
- * `finalized_at` only once the wait has elapsed. A finalised week is never
- * rescored.
+ * `finalized_at` only once the wait has elapsed.
+ *
+ * **A finalised week is never rescored, and two things enforce that** — say which,
+ * because this sentence was here on its own for a while and was not true. The
+ * pre-check refuses a week that is already final, cheaply and with a code the
+ * cron reports. The write then re-asserts it in its own `WHERE`, because the
+ * pre-check reads on one connection and the write happens on another many round
+ * trips later: two overlapping runs both pass the check, and without the
+ * predicate the loser wrote a stat snapshot taken before the winner's over a
+ * finalised row. Neither guard replaces the other — see the comments at each.
  *
  * ## The wait is bounded, because a game may never be played
  *
@@ -172,9 +180,22 @@ export async function resolveLeagueWeek(
     [leagueId, week],
   );
   if (Number(already?.count ?? 0) > 0) {
-    // A finalised week is not rescored. In a paying week it has already decided
-    // money, and a silently changed result afterwards is the exact thing the
-    // correction window exists to prevent.
+    // A fast path and a published error code — **not** the guarantee.
+    //
+    // The guarantee is `finalized_at IS NULL` on the UPDATE below. This reads on
+    // one connection and the write happens on another many round trips later —
+    // `ensureLineups` alone opens a transaction per team — so two overlapped
+    // runs both pass here. Same trap as issue #22: a decision taken before the
+    // write is not true at it.
+    //
+    // It stays for three reasons. It saves a whole scoring pass on a re-run of a
+    // settled week. `ALREADY_FINAL` is what the cron reports, and callers key on
+    // it. And — the one that stops it being redundant — it refuses a
+    // **part-finalised** week *whole*: a week can legitimately hold finalised
+    // consolation fixtures beside unfinalised playoff ones, and without this the
+    // loop would write the unfinalised rows, refuse the finalised ones, and roll
+    // back its own legitimate work. See the complementarity note on
+    // `resolveLeagueWeeksThrough`.
     throw new WeekError(`Week ${week} is already final`, "ALREADY_FINAL");
   }
 
@@ -196,14 +217,28 @@ export async function resolveLeagueWeek(
 
   await withTransaction(db, async (tx) => {
     for (const result of results) {
-      await tx.query(
+      // `AND finalized_at IS NULL` is the guarantee the pre-check cannot give.
+      //
+      // A single UPDATE is atomic with respect to its own predicate, and under
+      // READ COMMITTED a statement that blocks on a concurrent writer re-checks
+      // that predicate against the newly committed row. So the losing run of an
+      // overlap matches nothing, whichever order the two arrive in.
+      //
+      // It does not break the two cases that must still write. The live rewrite
+      // runs against rows whose `finalized_at` is null — this statement is the
+      // only writer of that column in the repo, and there is no default — and
+      // the finalising run matches on the *pre-update* row image, then sets it
+      // in the same statement.
+      const [written] = await tx.query<{ id: string }>(
         `UPDATE matchups
             SET home_milli_points = $3,
                 away_milli_points = $4,
                 finalized_at = CASE WHEN $5::boolean THEN $6 ELSE finalized_at END
           WHERE league_id = $1 AND week = $2
             AND home_team_id = $7
-            AND away_team_id IS NOT DISTINCT FROM $8`,
+            AND away_team_id IS NOT DISTINCT FROM $8
+            AND finalized_at IS NULL
+        RETURNING id`,
         [
           leagueId,
           week,
@@ -215,6 +250,23 @@ export async function resolveLeagueWeek(
           result.awayTeamId,
         ],
       );
+
+      // Nothing matched, so the week finalised while this run was working.
+      //
+      // Throwing rather than continuing, for two reasons. It rolls the
+      // transaction back, so a partly-rewritten week cannot exist — the same
+      // all-or-nothing policy the pre-check applies, rather than a second one
+      // that differs only in timing. And a silent skip would be half a fix:
+      // this function's return value is built from the in-memory `results`, so
+      // the run would report `matchups: N, finalized: true` with a stale
+      // snapshot and the cron would publish it as the week's outcome. That is
+      // the silent restatement being fixed, wearing a different hat.
+      //
+      // `ALREADY_FINAL` is deliberately the same code the pre-check throws: it
+      // is the same fact, learned later. Both callers already handle it.
+      if (!written) {
+        throw new WeekError(`Week ${week} is already final`, "ALREADY_FINAL");
+      }
     }
   });
 


### PR DESCRIPTION
Fixes item 2 of #76. Confirmed by three agents under separate mandates — designer, adversary, collateral. The adversary was told to destroy it; it confirmed the mechanism and **destroyed the severity**, which is reflected below.

## The defect

`resolveLeagueWeek`'s guard is a check-then-act across two connections. It reads "is this week finalised" on the bare client outside any transaction (`week.ts:169-179`), then runs `ensureLineups` (a transaction per team), the lineup load, the stat load and the finalisation decision — and only then opens the transaction that writes (`week.ts:197-219`), whose `WHERE` named `league_id`, `week` and the two team ids, and nothing about `finalized_at`.

Two overlapping runs both pass the check. The loser writes a stat snapshot taken **before** the winner's over a finalised row, and `CASE … ELSE finalized_at` preserves the timestamp, so the rewrite leaves no trace.

**It also defeats the one mechanism built to catch this.** `matchup.ts:189` reports `restatedMilliPoints` when a live recompute disagrees with the stored total, and the Scoreboard renders a banner saying a finalised week is never rescored. An overwrite puts the newer number *into* the stored total — so `live === authoritative`, the banner never fires, and the detector is silent about the one event it exists for.

**`score-week` was the only one of the four crons with no serialisation.** `waivers` takes `FOR UPDATE` on the league (`waivers.ts:578`), `trades` on the trade row (`trades.ts:388`), `draft-tick` on the draft row (`draft.ts:232`). `waivers`' own comment says why: *"a slow run and a retry can overlap."* Overlap here is not hypothetical either — `route.ts:39-42` accepts `?week=N` precisely so an operator can hand-run a week that will not settle, which is the run most likely to collide with the sweep.

## Severity today is nil, and that is deliberate to state

Nothing in production writes `stat_lines` — that is #75, confirmed independently: every `INSERT INTO stat_lines` is a test fixture, and `sync.ts` never writes that table. So every production matchup scores 0–0, the two racing runs compute identical numbers, and the loser writes zero over zero.

This is a **latent** defect that becomes real the moment a stat-ingest path lands. That is the argument for fixing it *before* #75, not because of anything it does today.

Two corrections to the issue text while I am here. `CASE … ELSE` only hides the rewrite when the loser's `finalized` is false; when both runs finalise, `finalized_at` is overwritten with the loser's `now`. And nothing anywhere reads the *value* of `finalized_at` — every consumer tests `IS NULL` / `!== null` — so the *fact* of finalisation is safe under the race. Only the points were ever at risk.

## The fix

`AND finalized_at IS NULL` on the write, plus `RETURNING id` and a throw when nothing matched.

**The predicate alone is not enough.** This function's return value is built from the in-memory `results`, so a losing run would still report `matchups: N, finalized: true` with a stale snapshot and the cron would publish it as the week's outcome — the same silent restatement wearing a different hat. `SqlClient` deliberately exposes no row count (`client.ts:13`), so `RETURNING id` is how the write becomes observable. Both `enterPlayoffs` and `resolveTrade` already use that shape.

**Throwing rather than skipping** keeps the write all-or-nothing, which matters because a week can legitimately hold finalised consolation fixtures beside unfinalised playoff ones (`week.ts:250-257`). A silent skip would apply a second, different policy to that week from the one the pre-check applies.

**The pre-check stays, and stops being redundant.** It saves a whole scoring pass on a re-run, it is the only producer of `ALREADY_FINAL` on the fast path, and — the reason it is now load-bearing — it refuses a part-finalised week *whole*. Without it that week reaches the loop, the finalised rows match nothing, the new throw fires, and the transaction rolls back its own legitimate writes to the unfinalised rows. Its comment now says which guard is which, because the failure mode is a future reader seeing two and deleting the one that matters.

## Alternatives weighed

**A lock**, which is the repo's own precedent elsewhere — rejected. To help it must be held from before the guard read to after the write, across `ensureLineups`, `loadWeekStats` and `finalizationHold`; `ensureLineups` opens its own transactions, which `week.ts:475-479` already documents as fatal to nesting. And a lock serialises without making a pre-lock decision true afterwards — the trap issue #22 records — so under a lock you would still want this re-check.

**Wrapping the whole function in one transaction** — rejected on two independent grounds: at READ COMMITTED it does not help without SERIALIZABLE plus a retry loop, and the nested `ensureLineups` transactions would make the inner `COMMIT` commit the outer work.

**An immutability trigger** — the right floor, and worth adding separately, but not as this fix. "Another run finalised first" is expected and benign; a trigger turns it into a raw Postgres exception with no error code, which `resolveLeagueWeeksThrough` would record as `error.message` and the cron would surface as an operator page on every overlap. It should land *after* this, never instead.

## Verification

Two tests reproduce the **ordering** by finalising the week partway through a run, at the point a competing run would — via a client wrapper that fires on `ensureLineups`' first query. They assert the run refuses with `ALREADY_FINAL` and that the winner's points and timestamp are byte-for-byte untouched.

**PGlite is single-connection, so the race itself is unreproducible.** That is stated in the test docstring rather than implied, the same caveat the repo records for `acceptTrade`.

**Mutation-checked:** removing the predicate fails both new tests. The four existing tests that cover the live rewrite and the finalising run stay green — those are the two cases a wrong predicate would have broken.

1122 tests, typecheck, lint green.

## Documentation corrected

The claim *"a finalised week is never rescored"* appeared in the module docstring, `CLAUDE.md`, and `score-week`'s route docstring as *"a finalised week is skipped, not rescored"* — a guarantee the code did not provide, in a repo that treats a false comment as a defect in its own right. Each now names what enforces it, in the style `CLAUDE.md` already uses for the draft order.

## Found while confirming, filed separately

The collateral agent swept for siblings of this shape and found several, one of which **outranks this bug and sits on this same call path**: `autoFillLineup` reads the stored lineup outside any transaction and then writes every slot with `ON CONFLICT … DO UPDATE`, so a manager's late edit between the read and the write is silently reverted — and that reverted lineup is what gets finalised. `writeEmptySlots`, twenty lines away, uses `DO NOTHING` with the comment *"a slot the manager set themselves must survive this untouched."* Filed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
