### PR TITLE
fix(stats,db): recognise the status the provider actually sends, and wire the schedule sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,10 @@ See [`docs/BUILD-PLAN.md`](docs/BUILD-PLAN.md) for the full commit-by-commit pla
   and the `MatchupResult`s the standings consume. This was the missing join: the scoring
   engine and the standings table were both finished and had no way to reach each other.
 
-- B6–B8: Tank01 adapter, box scores, live sync (`packages/stats/`, `packages/db/sync.ts`)
+- B6–B7: Tank01 adapter and the box-score **translator** (`packages/stats/`). **B8 is
+  partial**: players, byes, rankings, projections and now the schedule sync; there is
+  still **no box-score producer**, so `stat_lines` is empty and `getBoxScore` has no
+  caller. See issue #75 — "live sync" was listed as done here and was not.
 
 - B16: the draft persisted (`packages/db/src/draft.ts`, migration `0009`)
 
@@ -119,9 +122,29 @@ See [`docs/BUILD-PLAN.md`](docs/BUILD-PLAN.md) for the full commit-by-commit pla
 - **The on-chain anchor recorded** (migration `0014`) — transaction and cluster, write-once
   by trigger. `recordChainAnchor` / `getChainState` in `packages/db/src/leagues.ts`.
 
-**Both hard deadlines are now covered in code.** Aug 22 is create → join → draft; Sep 9 is
-set a lineup → score the week → standings. What they need is deployment and the
-credentials in `SETUP-REQUIRED.md`, not more code.
+**Aug 22 is covered in code — create → join → draft. Sep 9 is not, and this paragraph
+used to say it was.**
+
+The sentence here read "Both hard deadlines are now covered in code… what they need is
+deployment and the credentials in `SETUP-REQUIRED.md`, not more code." That was false, and
+it is the most expensive kind of false: it is the sentence that stops someone looking.
+
+What was missing (issue #75): **nothing wrote `stat_lines` and nothing called `syncGames`.**
+`getBoxScore` had no caller outside its own interface and a test stub. So on a real
+deployment `games` was empty, `weekHasSchedule` was false, and **no manager could set a
+lineup at all** — `setLineup` refuses with `SCHEDULE_MISSING`. `currentWeek` was null, so
+`/api/cron/score-week` returned `{week: null, leagues: []}` and had been a no-op every ten
+minutes since it shipped. And with `games` hand-populated but no stat lines, every week
+would have finalised **0–0, permanently**, because a finalised week is never rescored.
+
+`docs/LIVE-SCORING.md` describes six automation jobs in the present tense and only one of
+them exists. Reading a plan as a description is how the claim above got written.
+
+**Now:** `syncGames` is wired into `pnpm db:sync` and the schedule is real. **Still
+outstanding:** `syncBoxScores` does not exist, so `stat_lines` is still empty and every
+player still scores zero. Sep 9 is not covered until that lands, and the adapter defects in
+issue #81 — which are latent only because nothing calls `getBoxScore` — become live the
+moment it does.
 
 - **Anchoring wired into the app** — `POST /api/leagues/[id]/anchor`, `AnchorPanel.tsx`,
   and `readOnlyEscrow()` in `apps/web/src/lib/escrow.ts`. The commissioner signs from

--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -18,10 +18,20 @@ import { seedSport } from "./sports.js";
 import {
   loadDraftBoard,
   syncByeWeeks,
+  syncGames,
   syncPlayers,
   syncProjections,
   syncRankings,
 } from "./sync.js";
+
+/**
+ * NFL regular-season weeks.
+ *
+ * Not read from a league's rules on purpose — this syncs the *sport's* schedule,
+ * which every league in the database shares, and a league's own
+ * `regularSeasonWeeks` is how much of it that league plays.
+ */
+const REGULAR_SEASON_WEEKS = 18;
 
 function connectionString(): string {
   const url = process.env["DATABASE_URL"];
@@ -119,6 +129,26 @@ async function main(): Promise<void> {
             console.log(`    ... and ${rankings.unmatched.length - 15} more`);
           }
         }
+
+        // The schedule, and it was missing from this list entirely.
+        //
+        // Without `games` rows nothing works: `weekHasSchedule` is false so
+        // `setLineup` refuses every lineup with `SCHEDULE_MISSING`, `currentWeek`
+        // is null so the scoring cron returns `{week: null, leagues: []}` and
+        // does nothing, and `finalizationHold` answers "no games are scheduled"
+        // so no week can ever finalise. `syncGames` was written, exported and
+        // tested, and never called — the one command an operator runs did not
+        // include it.
+        //
+        // Every week up front, not just the current one. The NFL schedule is
+        // published in May, and a manager setting a Week 1 lineup the day before
+        // kickoff needs those rows to already exist.
+        let games = 0;
+        for (let week = 1; week <= REGULAR_SEASON_WEEKS; week++) {
+          const result = await syncGames(client, provider, NFL.key, season, week);
+          games += result.inserted + result.updated;
+        }
+        console.log(`games      ${games} scheduled across ${REGULAR_SEASON_WEEKS} weeks`);
 
         const projections = await syncProjections(client, provider, NFL.key, season);
         console.log(

--- a/packages/stats/src/tank01/adapter.test.ts
+++ b/packages/stats/src/tank01/adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { Tank01Client } from "./client.js";
 import { DST_REF_PREFIX, Tank01Provider } from "./adapter.js";
+import rawBoxScore from "./__fixtures__/box-score.json" with { type: "json" };
 
 /**
  * Player records shaped exactly as `getNFLPlayerList` returns them, including
@@ -191,11 +192,24 @@ describe("listGames", () => {
   });
 
   it("maps game statuses we act on", async () => {
+    // `Completed` is the only wording in this list that came from a real Tank01
+    // response — `__fixtures__/box-score.json` carries it. Every other entry was
+    // written from documentation, which is why this test passed for months while
+    // the one string we had evidence for fell through to SCHEDULED. An
+    // unrecognised status there means `syncGames` writes a finished game as
+    // unstarted, and every week in the season finalises down the postponement
+    // fallback.
     const statuses = [
+      ["Completed", "FINAL"],
       ["Final", "FINAL"],
+      ["Final/OT", "FINAL"],
       ["Live - In Progress", "IN_PROGRESS"],
+      ["In Progress", "IN_PROGRESS"],
+      ["Halftime", "IN_PROGRESS"],
       ["Postponed", "POSTPONED"],
+      ["Canceled", "CANCELLED"],
       ["Scheduled", "SCHEDULED"],
+      ["Not Started", "SCHEDULED"],
     ] as const;
 
     for (const [raw, expected] of statuses) {
@@ -214,5 +228,34 @@ describe("listGames", () => {
       const [game] = await subject.listGames(2025, 1);
       expect(game?.status, `${raw} should map to ${expected}`).toBe(expected);
     }
+  });
+
+  it("maps the status the captured response actually carries", async () => {
+    // The list above is still a list of strings somebody typed. This one reads
+    // the wording out of the only real Tank01 response in the repo, so it cannot
+    // drift from the provider the way a hand-written fixture can — which is
+    // exactly how the mapping came to be wrong about `Completed` while a green
+    // test asserted `Final`.
+    const observed = (rawBoxScore as { gameStatus?: string }).gameStatus;
+
+    expect(observed, "the fixture should carry a gameStatus to assert against").toBeTruthy();
+
+    const subject = provider({
+      getNFLGamesForWeek: [
+        {
+          gameID: "g",
+          gameWeek: "Week 1",
+          home: "A",
+          away: "B",
+          gameTime_epoch: "1757031600.0",
+          gameStatus: observed,
+        },
+      ],
+    });
+
+    const [game] = await subject.listGames(2025, 1);
+    expect(game?.status, `the captured ${JSON.stringify(observed)} must read as finished`).toBe(
+      "FINAL",
+    );
   });
 });

--- a/packages/stats/src/tank01/adapter.ts
+++ b/packages/stats/src/tank01/adapter.ts
@@ -100,23 +100,51 @@ interface RawGame {
   gameStatus?: string;
 }
 
-/** Tank01's game status wording to ours. */
+/**
+ * Tank01's game status wording to ours.
+ *
+ * **`"Completed"` is the one form we have actually observed**, and it was
+ * missing. `__fixtures__/box-score.json` is the only real Tank01 response in the
+ * repo and it carries `gameStatus: "Completed"` with `gameStatusCode: "2"`; every
+ * other branch below was written from documentation. The unit test that appears
+ * to cover this feeds `"Final"` — a string invented in the test, not captured —
+ * so it passed while the mapping was wrong for the only evidence available.
+ *
+ * That miss is not cosmetic. An unrecognised status falls to `SCHEDULED`, so
+ * `syncGames` writes every finished game as unstarted with a null `final_at`,
+ * `finalizationHold` counts `finished = 0`, and every week in the season
+ * finalises down `RULES.md` §10's postponement fallback — the path reserved for
+ * a game that was never played. It is the fourth time a field guessed from
+ * documentation has been wrong here.
+ *
+ * So: match on a prefix rather than an exact string, because the observed
+ * vocabulary is inconsistent (`"Completed"`, and `docs/TANK01.md` records
+ * `"Final/OT"` elsewhere), and treat an unrecognised value as `SCHEDULED` **but
+ * say so** — a silent default is what hid this.
+ */
 function mapGameStatus(status: string | undefined): ProviderGame["status"] {
-  switch ((status ?? "").toLowerCase()) {
-    case "final":
-    case "final/ot":
-      return "FINAL";
-    case "in progress":
-    case "live - in progress":
-      return "IN_PROGRESS";
-    case "postponed":
-      return "POSTPONED";
-    case "cancelled":
-    case "canceled":
-      return "CANCELLED";
-    default:
-      return "SCHEDULED";
+  const raw = (status ?? "").trim().toLowerCase();
+
+  if (raw.startsWith("final") || raw.startsWith("completed")) return "FINAL";
+  if (raw.startsWith("in progress") || raw.startsWith("live")) return "IN_PROGRESS";
+  if (raw.startsWith("halftime")) return "IN_PROGRESS";
+  if (raw.startsWith("postponed")) return "POSTPONED";
+  if (raw.startsWith("cancel") || raw.startsWith("canceled")) return "CANCELLED";
+  if (raw === "" || raw.startsWith("scheduled") || raw.startsWith("not started")) {
+    return "SCHEDULED";
   }
+
+  // Loud, because the silent version of this cost a season's finalisation. It
+  // still answers `SCHEDULED` — refusing outright would take a whole sync down
+  // over one unfamiliar word — but an operator gets told rather than the wrong
+  // answer being written 16 times a week without comment.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[tank01] unrecognised gameStatus ${JSON.stringify(status)} — treating it as ` +
+      `SCHEDULED. If this is a finished game, finalisation will fall back to the ` +
+      `postponement path. Record the verbatim string in docs/TANK01.md and add it here.`,
+  );
+  return "SCHEDULED";
 }
 
 export class Tank01Provider implements StatsProvider {


### PR DESCRIPTION
The first half of #75. Confirmed and designed by three agents under separate mandates; the adversary found the status bug, which was not in the issue at all.

**The box-score producer is deliberately not in this PR** — see "What is not here".

## 1. `mapGameStatus` did not recognise `"Completed"`

`packages/stats/src/tank01/__fixtures__/box-score.json` is the **only real Tank01 response in this repo**, and it carries:

```
gameStatus:     "Completed"
gameStatusCode: "2"
```

`mapGameStatus` knew `final`, `final/ot`, `in progress`, `live - in progress`, `postponed`, `cancelled`, `canceled` — and defaulted everything else to `SCHEDULED`.

The test that appears to cover this (`adapter.test.ts`) feeds `"Final"`, a string **written inside the test** rather than captured. So it passed while the mapping was wrong about the one value we have evidence for.

`CLAUDE.md` warns that field names guessed from documentation *"have been wrong three times already."* This is the fourth, and it was behind a green test.

### Why it would have been expensive

An unrecognised status means `syncGames` writes every finished game as unstarted with a null `final_at`. Then:

- `finalizationHold` counts `finished = 0`, so inside the window every week holds on "16 of 16 games are still in progress";
- past the window **every week of the season** finalises down `RULES.md` §10's postponement fallback — the path reserved for a game that was never played, and the one `CLAUDE.md` says is worth waking someone for;
- `matchup.ts` never reports `FINAL`, so every finished player shows as in-progress forever.

### The fix

Prefix matching, because the observed vocabulary is inconsistent, and an unrecognised value still answers `SCHEDULED` **but warns**. A silent default is what hid this; throwing would take a whole sync down over one unfamiliar word.

The new test reads the wording **out of the captured fixture** rather than restating it, so it cannot drift from the provider the way a hand-written case can. That is the shape that would have caught the original.

## 2. `syncGames` had no caller

Written, exported, tested — and `pnpm db:sync`, the one command an operator runs, did not include it. Its own CLI help does not even list `sync`.

So `games` is empty on any real deployment, and four separate gates fail:

| Gate | Behaviour with `games` empty |
|---|---|
| `weekHasSchedule` → `setLineup` | **Nobody can set a lineup at all** — `SCHEDULE_MISSING` |
| `currentWeek` → `/api/cron/score-week` | Returns `{week: null, leagues: []}`. **A no-op every ten minutes since it shipped** |
| `finalizationHold` | "no games are scheduled for this week yet" — no week finalises, no bracket advances, `championship()` never derivable |
| `matchup.ts` | Reports `BYE` for every rostered player |

All 18 weeks are synced, not just the current one: the NFL schedule is published in May, and a manager setting a Week 1 lineup the day before kickoff needs those rows to already exist.

## What is not here, and why

**`syncBoxScores`.** It is the larger half, and it makes every adapter defect in **#81** live — they are latent *only* because `getBoxScore` has no caller.

The one that decides the split is `adapter.ts` throwing on **any** warning. One kicker whose `Kicking.fgMade` disagrees with the field goals parsed from his scoring plays discards **all ~50 stat lines for all 93 players in that game**. Composed with clock-based finalisation that is not "retry later" — it is a permanent zero for sixteen real starters, with no signal anywhere, because the game *is* `FINAL` so the `finalizedWithUnfinishedGames` fallback does not even fire.

So the producer ships with those fixes, in its own PR. **This half is safe standing alone**: a schedule with no stat lines is the state we are already in, minus the two defects above.

Design work for that PR is done and recorded — revision-only-on-change evaluated in SQL, an explicit retraction pass with `def_pts_allowed` excluded by key (retracting it writes `0`, and `0` is a shutout — the top tier of the sport's only TIERED rule), `season`/`week` taken from the `games` row because `getBoxScore` returns `season: 0, week: 0`, per-game failure isolation, and one box-score fetch **on transition to FINAL** rather than polling — which is what `docs/TANK01.md` already prescribes and what keeps the call budget inside the tier.

## Documentation corrected

`CLAUDE.md` claimed *"Both hard deadlines are now covered in code… what they need is deployment and the credentials in `SETUP-REQUIRED.md`, **not more code**."* That is the most expensive kind of false statement — the one that stops someone looking. It now says what is actually true, names what is still missing, and records that `docs/LIVE-SCORING.md` describes six automation jobs in the present tense of which one exists. Reading a plan as a description is how the claim got written.

The "B6–B8 … live sync" line listed the missing producer as done; it now says B8 is partial.

## Verification

1121 tests, typecheck, lint green. **Mutation-checked:** dropping the `completed` case fails two tests, including the one that reads the fixture.

## Not verified

No Tank01 API key on this machine. Whether `getNFLGamesForWeek` uses the same status vocabulary as `getNFLBoxScore` is **UNVERIFIED** — `docs/TANK01.md` records only `gameID` and `gameTime_epoch` for that endpoint. Prefix matching plus the warning is the hedge: a form we have not seen is reported rather than silently mis-filed. One call from the main PC settles it, and the verbatim string belongs in `docs/TANK01.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
