### PR TITLE
fix(stats): stop one bad line discarding a whole game, and credit blocked kicks correctly

### DIFF
--- a/packages/stats/src/provider.ts
+++ b/packages/stats/src/provider.ts
@@ -36,10 +36,27 @@ export interface ProviderGame {
 
 export interface ProviderBoxScore {
   readonly gameRef: string;
+  /**
+   * The season and week this box score belongs to.
+   *
+   * **A provider that is handed only a game reference cannot know these**, and
+   * `Tank01Provider.getBoxScore` returns `0` for both. A caller must take them
+   * from its own `games` row: writing these straight into `stat_lines` lands
+   * every row at season 0, week 0, where nothing ever reads it and every
+   * matchup scores zero with no error anywhere.
+   */
   readonly season: number;
   readonly week: number;
   /** Keyed by player external ref. */
   readonly players: ReadonlyMap<string, readonly StatLine[]>;
+  /**
+   * Things that did not reconcile, carried rather than thrown.
+   *
+   * A discrepancy in one player's line is not a reason to discard the other
+   * ninety — see `getBoxScore`. The caller is expected to record these against
+   * the game so a stat that quietly went missing is visible afterwards.
+   */
+  readonly warnings: readonly string[];
 }
 
 export interface ProviderInjury {

--- a/packages/stats/src/tank01/adapter.ts
+++ b/packages/stats/src/tank01/adapter.ts
@@ -197,11 +197,26 @@ export class Tank01Provider implements StatsProvider {
     const raw = await this.client.get<unknown>("getNFLBoxScore", { gameID: gameRef });
     const translated = translateBoxScore(raw);
 
-    if (translated.warnings.length > 0) {
-      // Surfaced rather than swallowed: a warning here means a stat did not
-      // reconcile, and silently scoring it anyway is how wrong totals ship.
+    // **Only `fatal` throws, and that split is the whole point.**
+    //
+    // This used to throw on any warning at all. One kicker whose `Kicking.fgMade`
+    // disagreed with the field goals parsed from his own scoring plays — two
+    // independently-updated parts of the same payload — discarded every stat line
+    // for all ~90 players in the game.
+    //
+    // Composed with clock-based finalisation that is not "retry later". The game
+    // is still `FINAL`, so `finalizationHold` counts it finished and the
+    // postponement fallback never fires; the week settles with sixteen real
+    // starters on zero, permanently, with no signal anywhere that anything was
+    // missing. A discrepancy about one kicker's 3-versus-4-point bucket is not a
+    // reason to throw away ninety players' verified stats.
+    //
+    // So `fatal` means "we could not read this response" and throws; `warnings`
+    // means "we read it and something did not add up" and is carried on the
+    // result for the caller to record.
+    if (translated.fatal.length > 0) {
       throw new ProviderError(
-        `Box score ${gameRef} did not reconcile:\n  ${translated.warnings.join("\n  ")}`,
+        `Box score ${gameRef} could not be read:\n  ${translated.fatal.join("\n  ")}`,
         this.name,
       );
     }
@@ -214,9 +229,13 @@ export class Tank01Provider implements StatsProvider {
 
     return {
       gameRef: translated.gameRef,
+      // The caller knows these; this method is handed a gameRef and does not.
+      // A producer that trusted them would write every row into a (0, 0)
+      // coordinate that nothing ever reads.
       season: 0,
       week: 0,
       players,
+      warnings: translated.warnings,
     };
   }
 

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -151,3 +151,112 @@ describe("no phantom stats", () => {
     }
   });
 });
+
+describe("a blocked kick is credited to whoever blocked it", () => {
+  /**
+   * Both play strings below are recorded verbatim in `docs/TANK01.md`, and they
+   * put different teams in `play.team` — which is the whole defect. The original
+   * code assumed `play.team` was always the *kicking* team and derived the
+   * blocker as "the other one", so a block returned for a score credited the two
+   * points to the team whose kick was blocked. Two defenses, usually two
+   * different rosters: a four-point swing, silently.
+   */
+  const dst = (home: string, away: string): Record<string, unknown> => ({
+    home: { teamAbv: home, ptsAllowed: "20" },
+    away: { teamAbv: away, ptsAllowed: "24" },
+  });
+
+  const blkOf = (lines: readonly StatLine[] | undefined): number =>
+    lines?.find((line) => line.statKey === "def_blk_kick")?.value ?? 0;
+
+  it("credits the returning team when the block is taken back for a score", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: dst("PHI", "DAL"),
+      scoringPlays: [
+        {
+          // PHI blocked it, recovered it and scored — so `team` is PHI.
+          score: "Blocked Kick Recovered by Jordan Davis (PHI) for a 61 Yd Touchown Return",
+          team: "PHI",
+        },
+      ],
+    });
+
+    expect(blkOf(translated.teamDefense.get("PHI"))).toBe(1);
+    expect(blkOf(translated.teamDefense.get("DAL"))).toBe(0);
+  });
+
+  it("still credits the opponent when the block is noted on the kicking team's own score", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: dst("PHI", "DAL"),
+      scoringPlays: [
+        // DAL scored the touchdown and their PAT was blocked, so `team` is DAL
+        // and the blocker is the opponent.
+        { score: "Blake Corum 1 Yd Rush (Joshua Karty PAT blocked)", team: "DAL" },
+      ],
+    });
+
+    expect(blkOf(translated.teamDefense.get("PHI"))).toBe(1);
+    expect(blkOf(translated.teamDefense.get("DAL"))).toBe(0);
+  });
+});
+
+describe("a defense that cannot be read says so", () => {
+  /**
+   * `translateTeamDefense` was the only translator not given the `warnings`
+   * array, so a missing or unparseable field vanished in silence. That matters
+   * most for `def_pts_allowed`: it is the only tiered rule in the sport, absent
+   * is not zero, and a unit that still emits a sack looks like it played and
+   * scored 2 rather than 12.
+   */
+  it("warns when points allowed is absent", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: { home: { teamAbv: "PHI", sacks: "2" }, away: { teamAbv: "DAL", ptsAllowed: "24" } },
+      scoringPlays: [],
+    });
+
+    expect(translated.warnings.join(" ")).toContain("def_pts_allowed");
+    expect(translated.warnings.join(" ")).toContain("PHI");
+  });
+
+  it("warns when points allowed is present but unreadable", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20-0" },
+        away: { teamAbv: "DAL", ptsAllowed: "24" },
+      },
+      scoringPlays: [],
+    });
+
+    expect(translated.warnings.join(" ")).toContain("PHI");
+  });
+});
+
+describe("a warning is not a reason to discard the game", () => {
+  it("keeps every other player when one line does not reconcile", () => {
+    // The clean fixture produces no warnings and no fatal, which is what makes
+    // the distinction observable rather than theoretical.
+    expect(box.warnings).toEqual([]);
+    expect(box.fatal).toEqual([]);
+    expect(box.players.size).toBeGreaterThan(50);
+  });
+
+  it("marks a response with no player stats as fatal", () => {
+    const translated = translateBoxScore({ gameID: "g", playerStats: {}, DST: {} });
+
+    expect(translated.fatal.join(" ")).toContain("playerStats");
+  });
+
+  it("marks a response with no game id as fatal", () => {
+    const translated = translateBoxScore({ playerStats: { a: { playerID: "1" } }, DST: {} });
+
+    expect(translated.fatal.join(" ")).toContain("gameID");
+  });
+});

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -60,8 +60,25 @@ export interface TranslatedBoxScore {
    *
    * Never silently absorbed: a translation that quietly drops a stat produces
    * wrong scores that look right.
+   *
+   * **A warning is not a reason to discard the game.** It used to be: the
+   * adapter threw on any warning at all, so one kicker whose `Kicking.fgMade`
+   * disagreed with the field goals parsed from his own scoring plays threw away
+   * every player in the game. Composed with clock-based finalisation that is not
+   * "retry later" — the game is still `FINAL`, so the postponement fallback does
+   * not fire, and the week settles with sixteen real starters on zero,
+   * permanently, with no signal anywhere.
    */
   readonly warnings: readonly string[];
+  /**
+   * Reasons this response cannot be used at all.
+   *
+   * The distinction is the point. `warnings` means "we read this and something
+   * did not add up" — drop the affected stat, keep the other ninety players.
+   * `fatal` means "we could not read this", which is the only case where
+   * discarding is right.
+   */
+  readonly fatal: readonly string[];
 }
 
 function accumulate(into: Map<string, number>, statKey: string, value: number): void {
@@ -180,10 +197,42 @@ function translatePlayer(
  * Blocked kicks are credited to the team that *blocked* one, which is the
  * opponent of the team whose kick it was.
  */
+/**
+ * Which team blocked the kick in this scoring play.
+ *
+ * `play.team` is the team that **scored** the play, and a blocked kick reaches
+ * the scoring list in two shapes that put different teams there:
+ *
+ *   - A block on somebody else's kick, noted in the trailing parenthetical of
+ *     *their* touchdown — `"Blake Corum 1 Yd Rush (Joshua Karty PAT blocked)"`.
+ *     `play.team` is the kicking team, so the blocker is the opponent.
+ *   - A block returned for a score — `"Blocked Kick Recovered by Jordan Davis
+ *     (PHI) … 61 Yd Touchown Return"`. Here `play.team` is the **blocking** team,
+ *     because they are the ones who scored.
+ *
+ * Both strings are recorded verbatim in `docs/TANK01.md`. The original code
+ * assumed the first shape always held and derived the blocker as "the other
+ * team", which credited the second shape's two points to the team whose kick was
+ * blocked — a four-point swing between two defenses, usually on two different
+ * rosters, with no warning.
+ */
+function blockingTeamOf(play: ScoringPlay, teamAbvs: readonly string[]): string | null {
+  const scoringTeam = play.team ?? "";
+  if (!scoringTeam) return null;
+
+  const text = play.score ?? "";
+  // A return or a recovery means the team on the play is the one that blocked it.
+  const scoredByTheBlocker = /\brecover(?:ed|y)\b/i.test(text) || /\breturn\b/i.test(text);
+
+  if (scoredByTheBlocker) return scoringTeam;
+  return teamAbvs.find((abv) => abv !== scoringTeam) ?? null;
+}
+
 function translateTeamDefense(
   raw: Record<string, unknown>,
   scoringPlays: readonly ScoringPlay[],
   teamAbvs: readonly string[],
+  warnings: string[],
 ): Map<string, StatLine[]> {
   const result = new Map<string, StatLine[]>();
 
@@ -198,7 +247,26 @@ function translateTeamDefense(
 
     for (const [field, statKey] of Object.entries(TANK01_DST_MAP)) {
       const parsed = parseStatValue(unit[field]);
-      if (parsed === null) continue;
+      if (parsed === null) {
+        // This translator used to be the only one with no `warnings` array, so a
+        // missing or unparseable field vanished in silence. That matters most
+        // for `def_pts_allowed`: it is the sport's only TIERED rule, absent is
+        // not zero, and a unit that still emits a sack looks like it played and
+        // scored 2 rather than 12. The rest are worth reporting too — a field
+        // the provider renamed should not read as a quiet zero.
+        if (unit[field] !== undefined) {
+          warnings.push(
+            `${teamAbv}: ${field} is ${JSON.stringify(unit[field])}, which is not a number — ` +
+              `${statKey} was dropped`,
+          );
+        } else if (statKey === "def_pts_allowed") {
+          warnings.push(
+            `${teamAbv}: the box score carries no ${field}, so ${statKey} was dropped — ` +
+              `this is the only tiered rule in the sport and absent is not zero`,
+          );
+        }
+        continue;
+      }
 
       // Points allowed is meaningful at zero; the rest are not worth emitting.
       if (parsed !== 0 || statKey === "def_pts_allowed") {
@@ -206,13 +274,9 @@ function translateTeamDefense(
       }
     }
 
-    // A blocked kick belongs to whoever blocked it — the other team.
     for (const play of scoringPlays) {
       if (!isBlockedKick(play.score ?? "")) continue;
-
-      const kickingTeam = play.team ?? "";
-      const blockingTeam = teamAbvs.find((abv) => abv !== kickingTeam);
-      if (blockingTeam === teamAbv) accumulate(totals, "def_blk_kick", 1);
+      if (blockingTeamOf(play, teamAbvs) === teamAbv) accumulate(totals, "def_blk_kick", 1);
     }
 
     result.set(teamAbv, toStatLines(totals));
@@ -242,7 +306,18 @@ export function translateBoxScore(raw: unknown): TranslatedBoxScore {
     String((dst["away"] as Record<string, unknown> | undefined)?.["teamAbv"] ?? ""),
   ].filter(Boolean);
 
-  const teamDefense = translateTeamDefense(dst, scoringPlays, teamAbvs);
+  const teamDefense = translateTeamDefense(dst, scoringPlays, teamAbvs, warnings);
 
-  return { gameRef, players, teamDefense, warnings };
+  // A response we cannot read at all is a different fact from one that read fine
+  // with a discrepancy in it, and only the first is a reason to throw the game
+  // away. See `fatal` on `TranslatedBoxScore`.
+  const fatal: string[] = [];
+  if (!gameRef) {
+    fatal.push("the response carries no gameID, so it cannot be attributed to a game");
+  }
+  if (Object.keys(playerStats).length === 0) {
+    fatal.push("the response carries no playerStats at all");
+  }
+
+  return { gameRef, players, teamDefense, warnings, fatal };
 }


### PR DESCRIPTION
Three defects in the box-score translator, from #81. All are **latent today** because `getBoxScore` has no caller — and all become live the moment the producer lands, which is why they ship first rather than riding along with it.

## 1. One warning discarded ~90 players

`getBoxScore` threw a `ProviderError` if `translateBoxScore` produced **any** warning.

The field-goal cross-check raises one whenever `Kicking.fgMade` disagrees with the field goals parsed from that kicker's own `scoringPlays` — two independently-updated parts of the same payload — and any play whose `playerIDs` does not include him is skipped entirely. So one malformed entry, on one kicker, discarded every stat line for every player in the game.

**Why that is not "retry later".** Composed with clock-based finalisation, the game is still `FINAL`, so `finalizationHold` counts it finished and the `finalizedWithUnfinishedGames` fallback **never fires**. The week settles with sixteen real starters on zero, permanently, with no signal anywhere that anything was missing. `RULES.md` §10's "affected players score 0" was written for a game that was never played; here it silently swallows a game that was played and read wrongly.

`TranslatedBoxScore` now separates the two facts:

- **`fatal`** — "we could not read this response" (no `gameID`, no `playerStats`). Still throws.
- **`warnings`** — "we read it and something did not add up". Carried on `ProviderBoxScore` for the caller to record against the game.

A discrepancy about one kicker's 3-versus-4-point bucket is not a reason to throw away ninety players' verified stats.

## 2. A defense that could not be read said nothing at all

`translateTeamDefense` was **the only translator not given the `warnings` array**, so a missing or unparseable field vanished in silence.

That matters most for `def_pts_allowed`: it is the only `TIERED` rule in the sport, absent is not zero, and the ladder runs from **+10 for a shutout to −4 for 35 allowed**. A unit that still emitted a sack looked like it played and scored 2 rather than 12 — a plausible, partial line that passed the reconciliation gate.

Both failure shapes now warn: the field absent, and the field present but unreadable (the `"20-0"` ratio form the provider uses elsewhere).

## 3. Blocked kicks were credited to the team whose kick was blocked

`play.team` is the team that **scored** the play, and a blocked kick reaches the scoring list in two shapes that put different teams there. Both are recorded verbatim in `docs/TANK01.md`:

```
"Blake Corum 1 Yd Rush (Joshua Karty PAT blocked)"              team = the kicker
"Blocked Kick Recovered by Jordan Davis (PHI) … 61 Yd Return"   team = the blocker
```

The code assumed the first shape always held and derived the blocker as "the other team" — so a block returned for a score credited its two points to the victim.

Two defenses, usually on two different rosters, so it is a **four-point relative swing** across two matchups. No warning. And **unrecoverable by re-ingest** once the week settles: the wrongly-credited team legitimately still holds the row, so nothing about a later fetch would remove it.

Rare, and that is the argument *for* fixing it now rather than against: rare means nobody will go looking, and if it lands after a week finalises that week is wrong forever.

## Also

`ProviderBoxScore.season` and `.week` now document that they are `0` and why. A provider handed only a game reference cannot know them, and a caller that writes them straight into `stat_lines` lands every row at season 0, week 0 — where nothing reads it and every matchup scores zero, with no error anywhere. That is a trap the types positively invite, so it is now called out at the type.

## Verification

Tests use the **verbatim strings from `docs/TANK01.md`** rather than invented ones — the same reason the fixture-driven tests in this file exist, and the reason the `"Completed"` status bug in #92 survived a green test for months.

The clean fixture still produces `warnings: []` and `fatal: []`, which is what makes the distinction observable rather than theoretical.

**Mutation-checked:** reverting the attribution fix fails the returned-block test.

1127 tests, typecheck, lint green.

## What is still outstanding from #81

Deliberately not here:

- **Two-point conversions matching on an exact full-name substring.** It fails *closed* — a non-match awards nothing, never credits the wrong player — and the fix depends on a provider fact this machine cannot check: whether Tank01 abbreviates names in the conversion slot specifically. Writing a normalised matcher now would mean guessing at provider behaviour to fix a bug whose existence is a guess. One `stats:verify` run from the main PC settles it (#93).
- **Non-scoring blocked kicks**, which are invisible because `def_blk_kick` is derived only from `scoringPlays`. That is a data floor, not a bug, and it should be recorded in `docs/TANK01.md` as one rather than invented — `docs/TANK01.md` currently overclaims it under "known gaps: none".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
