### PR TITLE
fix(lineups): the autofill must not revert a manager's edit

### DIFF
--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -533,7 +533,10 @@ describe("autoFillLineup", () => {
  * given when that is absent, so every statement of the autofill's transaction
  * goes through this wrapper.
  */
-function interleaveAtFirstBegin(inner: PGliteClient, onFirstBegin: () => Promise<void>): SqlClient {
+function interleaveAtFirstBegin(
+  inner: PGliteClient,
+  onFirstBegin: () => Promise<void>,
+): SqlClient {
   let fired = false;
   return {
     async exec(sql: string): Promise<void> {

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildNflPprRules, indexScoringRules, NFL, NFL_PPR_SCORING } from "@rostr/core";
 import { resolveWeek } from "@rostr/core";
 import type { DraftRules, LeagueRules, LineupAssignment } from "@rostr/core";
+import type { SqlClient } from "./client.js";
 import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
 import { seedSport } from "./sports.js";
@@ -508,6 +509,156 @@ describe("autoFillLineup", () => {
     expect(filled.find((slot) => slot.slotType === "QB")?.playerId).toBe(
       fx.players.get("thu-qb"),
     );
+  });
+});
+
+/**
+ * A client that runs `onFirstBegin` immediately before the first `BEGIN` it is
+ * asked to issue, then behaves normally.
+ *
+ * PGlite is a single connection, so the race here cannot be run *as* a race —
+ * there is no second session, and a second in-flight statement queues rather
+ * than interleaves. The **interleaving** is what matters and that can be forced
+ * exactly: `autoFillLineup` takes its expensive reads before `withTransaction`
+ * issues `BEGIN`, so firing here lands the manager's write in the window the bug
+ * lived in — after the reads, before the transaction that acts on them.
+ *
+ * That window is where the stored lineup used to be read from. It no longer is,
+ * which is the fix, and which is why these tests fail on `main`.
+ *
+ * One-shot, and not for tidiness: the callback's own `setLineup` opens a
+ * transaction too, so a re-entrant hook would recurse until the stack ran out.
+ *
+ * No `connect`, deliberately — `withTransaction` runs directly on whatever it is
+ * given when that is absent, so every statement of the autofill's transaction
+ * goes through this wrapper.
+ */
+function interleaveAtFirstBegin(inner: PGliteClient, onFirstBegin: () => Promise<void>): SqlClient {
+  let fired = false;
+  return {
+    async exec(sql: string): Promise<void> {
+      if (!fired && sql.trim().toUpperCase().startsWith("BEGIN")) {
+        fired = true;
+        await onFirstBegin();
+      }
+      await inner.exec(sql);
+    },
+    query<T = Record<string, unknown>>(sql: string, params?: readonly unknown[]): Promise<T[]> {
+      return inner.query<T>(sql, params);
+    },
+  };
+}
+
+describe("the autofill never reverts a manager's edit", () => {
+  it("leaves a slot the manager changed while it was still thinking", async () => {
+    // Issue #90. The autofill used to decide from a lineup read outside any
+    // transaction and then write every starting slot back unconditionally, so an
+    // edit saved in that window was written, silently restored to the snapshot,
+    // and then scored. `lineups` keeps no history, so nothing recorded that it
+    // happened and the manager had only their memory to argue from.
+    const fx = await setup();
+
+    // The autolineup always takes `te-a` over `bye-te` — a player on a bye
+    // scores nothing at all — so a manager starting `bye-te` is making exactly
+    // the choice the autofill would reverse. Pinned by the test above.
+    const byeTe = fx.players.get("bye-te")!;
+
+    const client = interleaveAtFirstBegin(fx.client, async () => {
+      await setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "TE", slotIndex: 0, playerId: byeTe }],
+        now: BEFORE_ANYTHING,
+      });
+    });
+
+    const filled = await autoFillLineup(client, fx.leagueId, fx.teamId, WEEK, BEFORE_ANYTHING);
+
+    // What it returns is what was stored, not what it intended.
+    expect(filled.find((slot) => slot.slotType === "TE")?.playerId).toBe(byeTe);
+
+    const stored = await loadLineup(fx.client, fx.teamId, WEEK, fx.rules);
+    expect(stored.find((slot) => slot.slotType === "TE")?.playerId).toBe(byeTe);
+
+    // And the rest of the autofill still landed. A guard that protected the
+    // manager by writing nothing at all would satisfy both assertions above and
+    // leave the team fielding one player.
+    expect(stored.filter((slot) => slot.playerId !== null)).toHaveLength(9);
+  });
+
+  it("still fills a slot that exists and is empty", async () => {
+    // The case `IS NOT DISTINCT FROM` exists for, and the one `=` would break
+    // silently: the row is present holding `NULL`, so `lineups.player_id = $6`
+    // is `NULL = NULL` — not true — and the slot could never be filled again.
+    // Reachable on any team whose roster grew after a pass that could not fill
+    // everything, which is every waiver claim.
+    const fx = await setup();
+
+    // The other team has one player, so its first pass materialises all nine
+    // rows and leaves eight of them empty.
+    await autoFillLineup(fx.client, fx.leagueId, fx.otherTeamId, WEEK, BEFORE_ANYTHING);
+    const before = await loadLineup(fx.client, fx.otherTeamId, WEEK, fx.rules);
+    expect(before.filter((slot) => slot.playerId !== null)).toHaveLength(1);
+
+    // They pick somebody up off the wire.
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [rbPosition] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [wireRb] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, 'wire-rb', 'Wire RB', $2, 'CIN') RETURNING id`,
+      [sport!.id, rbPosition!.id],
+    );
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via) VALUES ($1, $2, 'WAIVER')`,
+      [fx.otherTeamId, wireRb!.id],
+    );
+
+    const filled = await autoFillLineup(
+      fx.client,
+      fx.leagueId,
+      fx.otherTeamId,
+      WEEK,
+      BEFORE_ANYTHING,
+    );
+
+    expect(filled.some((slot) => slot.playerId === wireRb!.id)).toBe(true);
+  });
+
+  it("fills the slots the manager did not touch from the state they left behind", async () => {
+    // The half a per-row guard on its own cannot do. The manager takes a player
+    // the autofill's plan had earmarked for another slot; a compare-and-swap
+    // conditioned on a stale snapshot writes him twice and trips migration
+    // 0016's constraint at COMMIT, losing the whole pass. Reading inside the
+    // transaction computes one self-consistent lineup instead, so the
+    // interleaving simply cannot produce that state.
+    const fx = await setup();
+    const flexPick = fx.players.get("rb-c")!;
+
+    const client = interleaveAtFirstBegin(fx.client, async () => {
+      await setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "FLEX", slotIndex: 0, playerId: flexPick }],
+        now: BEFORE_ANYTHING,
+      });
+    });
+
+    const filled = await autoFillLineup(client, fx.leagueId, fx.teamId, WEEK, BEFORE_ANYTHING);
+
+    expect(filled.find((slot) => slot.slotType === "FLEX")?.playerId).toBe(flexPick);
+    expect(filled.filter((slot) => slot.playerId !== null)).toHaveLength(9);
+
+    // Nobody starts twice — the whole lineup was decided from one reading of it.
+    const started = filled.map((slot) => slot.playerId).filter((id) => id !== null);
+    expect(new Set(started).size).toBe(started.length);
   });
 });
 

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -627,8 +627,25 @@ const OUT_STATUSES = new Set(["OUT", "IR", "INACTIVE", "SUSPENDED", "DOUBTFUL", 
 /**
  * Fill a team's lineup automatically.
  *
- * Preserves any slot that has already locked, and writes only what is missing —
- * so calling this on a team whose manager set a full lineup changes nothing.
+ * Preserves any slot that has already locked and any slot the manager has
+ * already filled: this fills gaps, it does not second-guess.
+ *
+ * **The stored lineup is read inside the transaction, under a row lock, and
+ * everything expensive is read before it.** That ordering is the whole of issue
+ * #90 and it is the reverse of what this function used to do. It decided from a
+ * snapshot taken outside any transaction — roster, lineup, season averages and,
+ * on the default rules, a whole-week projections scan — and then wrote every
+ * starting slot back, including the ones it had deliberately left alone. A
+ * manager who saved a lineup inside that window had their edit written and then
+ * silently restored to the snapshot, and `lineups` keeps no history, so nothing
+ * anywhere recorded that it happened. `ensureLineups` runs this for every
+ * autofill-enabled team every ten minutes, so the exposed surface was the whole
+ * lineup rather than the empty slots.
+ *
+ * Nothing below the lock needs the lineup: `loadAverages` ranks the *roster*,
+ * and `loadProjectedPoints` reads neither. So the reads that take a hundred
+ * milliseconds stay outside, and the lock covers a `SELECT`, a pure computation
+ * and nine writes.
  */
 export async function autoFillLineup(
   db: SqlClient,
@@ -642,23 +659,6 @@ export async function autoFillLineup(
 
   const season = stored.rules.seasonYear;
   const roster = await loadRosterForWeek(db, teamId, season, week);
-  const current = await loadLineup(db, teamId, week, stored.rules);
-
-  // Roster plus whoever is standing in the stored lineup — see `loadKickoffs`.
-  // Without the second half a dropped player's slot reads as unlocked here too,
-  // and the autofill would quietly replace a starter whose game had begun.
-  const kickoffs = await loadKickoffs(
-    db,
-    [
-      ...new Set(
-        [...roster.keys(), ...current.map((assignment) => assignment.playerId)].filter(
-          (playerId): playerId is string => playerId !== null,
-        ),
-      ),
-    ],
-    season,
-    week,
-  );
 
   const averages = await loadAverages(db, [...roster.keys()], season, week, stored.rules);
 
@@ -681,36 +681,80 @@ export async function autoFillLineup(
     unavailable: player.kickoffAt === null || OUT_STATUSES.has(player.status.toUpperCase()),
   }));
 
-  // Anything already locked is a fixed point, and anything already set by the
-  // manager is left alone: this fills gaps, it does not second-guess.
-  //
-  // The exception is a player who has **left the roster and is not locked**. He
-  // is not a choice the manager made — he is a hole, and leaving him there let
-  // his slot lock at his kickoff around a player nobody rosters, who then scored
-  // for the team that cut him. Note the first loop used to be dead: it is a
-  // strict subset of the second, since `isSlotLocked` is false for a null player,
-  // so nothing it returned was ever the only reason a slot was kept.
-  const locked = new Set(
-    lockedAssignments(current, kickoffs, now).map(
-      (assignment) => `${assignment.slotType}#${assignment.slotIndex}`,
-    ),
-  );
-  const keep = new Map<string, LineupAssignment>();
-  for (const assignment of current) {
-    if (assignment.playerId === null) continue;
-    const slot = `${assignment.slotType}#${assignment.slotIndex}`;
-    if (!roster.has(assignment.playerId) && !locked.has(slot)) continue;
-    keep.set(slot, assignment);
-  }
+  const slotTypeIds = await loadSlotTypeIds(db, stored.rules);
 
-  const filled = autolineup({
-    shape: buildRosterShape(stored.rules.roster, NFL),
-    roster: candidates,
-    mode,
-    locked: [...keep.values()],
+  return withTransaction(db, async (tx) => {
+    // The lineup is read here and nowhere earlier. Everything above decided
+    // from the roster, which this function does not write and which no manager
+    // action moves mid-week; this is the one input a manager can change while
+    // the reads above are in flight, so it is taken last and taken locked.
+    //
+    // `FOR UPDATE` makes `setLineup`'s write wait rather than interleave. It
+    // locks the rows that exist, which is not all of them — a slot nobody has
+    // ever written has no row to lock — so the write below carries a
+    // compare-and-swap as well. Migration `0016` prescribes exactly this pair:
+    // the lock is the fast path, and something the lock cannot reach is the
+    // backstop.
+    await tx.query(`SELECT 1 FROM lineups WHERE team_id = $1 AND week = $2 FOR UPDATE`, [
+      teamId,
+      week,
+    ]);
+
+    const current = await loadLineup(tx, teamId, week, stored.rules);
+
+    // Roster plus whoever is standing in the stored lineup — see `loadKickoffs`.
+    // Without the second half a dropped player's slot reads as unlocked here
+    // too, and the autofill would quietly replace a starter whose game had
+    // begun.
+    //
+    // **Inside the lock, because it is derived from `current`.** The reads that
+    // cost something — the season averages, and on the default rules a
+    // whole-week projections scan — stay outside where they belong; this one is
+    // a single lookup on `games` keyed by a list the fresh lineup determines,
+    // and it cannot be hoisted without reintroducing the stale snapshot the
+    // lock exists to prevent.
+    const kickoffs = await loadKickoffs(
+      tx,
+      [
+        ...new Set(
+          [...roster.keys(), ...current.map((assignment) => assignment.playerId)].filter(
+            (playerId): playerId is string => playerId !== null,
+          ),
+        ),
+      ],
+      season,
+      week,
+    );
+
+    // Anything already locked is a fixed point, and anything already set by the
+    // manager is left alone: this fills gaps, it does not second-guess.
+    //
+    // The exception is a player who has **left the roster and is not locked**.
+    // He is not a choice the manager made — he is a hole, and leaving him there
+    // let his slot lock at his kickoff around a player nobody rosters, who then
+    // scored for the team that cut him.
+    const locked = new Set(
+      lockedAssignments(current, kickoffs, now).map(
+        (assignment) => `${assignment.slotType}#${assignment.slotIndex}`,
+      ),
+    );
+    const keep = new Map<string, LineupAssignment>();
+    for (const assignment of current) {
+      if (assignment.playerId === null) continue;
+      const slot = `${assignment.slotType}#${assignment.slotIndex}`;
+      if (!roster.has(assignment.playerId) && !locked.has(slot)) continue;
+      keep.set(slot, assignment);
+    }
+
+    const filled = autolineup({
+      shape: buildRosterShape(stored.rules.roster, NFL),
+      roster: candidates,
+      mode,
+      locked: [...keep.values()],
+    });
+
+    return setLineupUnchecked(tx, teamId, week, filled, current, slotTypeIds, stored.rules);
   });
-
-  return setLineupUnchecked(db, teamId, week, filled, stored.rules);
 }
 
 /**
@@ -720,32 +764,74 @@ export async function autoFillLineup(
  * own shape and this team's own roster, and which must succeed even when a
  * manager's own lineup would be rejected — an abandoned team still has to be
  * given one.
+ *
+ * **Runs inside a transaction its caller opened**, rather than opening one, so
+ * that the lock and the read the write is conditioned on are inside the same
+ * one. `withTransaction` issues a real `BEGIN` on whichever client it is given,
+ * so opening a second here would make this `COMMIT` commit the caller's work
+ * too — the same reason `generateSeasonSchedule` takes a transaction instead of
+ * making one.
+ *
+ * `snapshot` is what the lineup held when `assignments` was decided, and every
+ * write compares against it: a slot that has moved since is left as whoever
+ * moved it left it. Under the caller's `FOR UPDATE` nothing can move a row that
+ * exists, so this is the backstop for the rows the lock could not reach — a slot
+ * with no row yet, which is every slot of a team's first pass. Losing that
+ * compare writes nothing and raises nothing, which is what makes it safe to
+ * apply nine times a run for every team in the league.
+ *
+ * `IS NOT DISTINCT FROM` rather than `=`, and that is load-bearing rather than
+ * tidy. The ordinary case is an empty slot, so the compared value is `NULL`, and
+ * `NULL = NULL` is `NULL` rather than true — `=` would refuse to fill any row
+ * that had ever been materialised, which is every slot the autofill itself could
+ * not fill on an earlier pass. The `::uuid` cast goes with it: beside a `uuid`
+ * column a bare parameter is `unknown` on the null path and Postgres cannot
+ * resolve the operator.
+ *
+ * **Not `WHERE lineups.player_id IS NULL`.** "Only ever fill an empty slot" is
+ * the tempting simplification and it is wrong twice: it forbids evicting a
+ * player who has left the roster — an occupied slot that *must* change — and it
+ * turns every legitimate replacement into a silent no-op. The compare says the
+ * narrower and truer thing: do not overwrite a decision somebody else took after
+ * this one was made.
  */
 async function setLineupUnchecked(
-  db: SqlClient,
+  tx: SqlClient,
   teamId: string,
   week: number,
   assignments: readonly LineupAssignment[],
+  snapshot: readonly LineupAssignment[],
+  slotTypeIds: ReadonlyMap<string, string>,
   rules: LeagueRules,
 ): Promise<readonly LineupAssignment[]> {
-  const slotTypeIds = await loadSlotTypeIds(db, rules);
+  const expected = new Map(
+    snapshot.map((slot) => [`${slot.slotType}#${slot.slotIndex}`, slot.playerId]),
+  );
 
-  return withTransaction(db, async (tx) => {
-    for (const assignment of assignments) {
-      const slotTypeId = slotTypeIds.get(assignment.slotType);
-      if (!slotTypeId) continue;
+  for (const assignment of assignments) {
+    const slotTypeId = slotTypeIds.get(assignment.slotType);
+    if (!slotTypeId) continue;
 
-      await tx.query(
-        `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id)
-         VALUES ($1, $2, $3, $4, $5)
-         ON CONFLICT (team_id, week, slot_type_id, slot_index)
-         DO UPDATE SET player_id = EXCLUDED.player_id`,
-        [teamId, week, slotTypeId, assignment.slotIndex, assignment.playerId],
-      );
-    }
+    await tx.query(
+      `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (team_id, week, slot_type_id, slot_index)
+       DO UPDATE SET player_id = EXCLUDED.player_id
+        WHERE lineups.player_id IS NOT DISTINCT FROM $6::uuid`,
+      [
+        teamId,
+        week,
+        slotTypeId,
+        assignment.slotIndex,
+        assignment.playerId,
+        expected.get(`${assignment.slotType}#${assignment.slotIndex}`) ?? null,
+      ],
+    );
+  }
 
-    return loadLineup(tx, teamId, week, rules);
-  });
+  // Read back inside the transaction, so this returns what was stored rather
+  // than what was intended. The two can now differ.
+  return loadLineup(tx, teamId, week, rules);
 }
 
 /**


### PR DESCRIPTION
## The bug

`autoFillLineup` decided from a lineup read **outside any transaction** and then wrote **every** starting slot back unconditionally — including the ones it had deliberately left alone. A manager who saved a lineup inside that window had their edit written, and then silently restored to the snapshot.

The function's own docstring said it "writes only what is missing". It never did. It wrote all nine rows on every run, which is invisible for exactly as long as nothing moves underneath it.

## Why it is worse than a lost update

Nothing records that it happened, and nothing can undo it.

- **`lineups` has no history.** One row per slot, updated in place — no trigger, no `*_history` table, nothing in 24 migrations besides the table and its constraint. Compare `roster_entries`, which *is* append-only with `released_at` precisely so past rosters stay reconstructible.
- **`locked_at` exists and was never wired up.** Declared in `0005`, written as literal `NULL` by the only statement that names it. So there is not even a timestamp separating a manager's write from an autofill's.
- **No logging** on the lineup route, the score-week cron, or this module.
- **It is what gets scored.** `resolveLeagueWeek` calls `ensureLineups` and then `loadWeekLineups`, which reads back the same rows. Once `finalized_at` is set the week is never rescored, so repairing the row afterwards changes no points, no record, no seed, no payout.
- **Both screens show the manager the reverted lineup as their own.** The scoreboard is faithful to storage, and storage is wrong.
- **It locks the door behind itself.** If the revert lands after kickoff, the manager cannot restore their choice — `SLOT_LOCKED` and `PLAYER_LOCKED` now both apply *against the reverted state*.

So the manager has their memory, and nothing else.

## The window, and how often

Every read above the write: roster, lineup, season averages and, on the default `WEEKLY_PROJECTION` rules, a whole-week projections scan. `ensureLineups` runs this for **every** autofill-enabled team every ten minutes all week — not only teams with gaps, and `autofill_enabled` defaults to true. So the exposed surface was the whole lineup rather than the empty slots, and the exposure is continuous rather than a moment at kickoff.

## The fix

**Read the lineup last, inside the transaction, under `FOR UPDATE`.**

Nothing above it needs it — `loadAverages` ranks the *roster*, and `loadProjectedPoints` reads neither — so the expensive reads stay outside and the lock covers a `SELECT`, a pure computation and nine writes.

`FOR UPDATE` locks the rows that exist, which is not all of them: a slot nobody has ever written has no row to lock. So each write also compares against the value it was decided from.

**That pair is what migration `0016` prescribes for this table, in writing:**

> Same shape of defence the draft already uses… `recordPick` takes `SELECT … FOR UPDATE` as the fast path and relies on [the constraints] as the backstop *"if anything ever writes outside that lock"*. **Lineups had the application check and no backstop.**

### Three things about the predicate

**`IS NOT DISTINCT FROM`, never `=`.** The compared value is `NULL` for precisely the slots being filled, and `NULL = NULL` is `NULL` rather than true — `=` would silently refuse to fill any row an earlier pass had materialised and left empty, which is every team that picks somebody up off the wire. Mutation-checked: it fails exactly one test and nothing else.

**Not `WHERE player_id IS NULL`.** "Only ever fill an empty slot" is the tempting simplification and it is wrong twice — it forbids evicting a player who has left the roster (an occupied slot that *must* change, which is what PR #88 is about) and it converts every legitimate replacement into a silent no-op.

**The `::uuid` cast is required.** Beside a `uuid` column a bare parameter is `unknown` on the null path and Postgres cannot resolve the operator.

### Why the read moved rather than the write alone

A compare-and-swap on its own is a per-row guard defending a multi-row invariant. It can leave slot S carrying the autofill's answer while slot T carries the manager's — a lineup neither of them chose — and if the two name the same player, `0016`'s deferred constraint fires at `COMMIT` and takes the whole pass down.

A fresh read inside the transaction cannot produce that state: the lineup is computed once, from one reading of the world. The compare then has nothing left to do but cover the rows the lock could not reach. That is the third test below.

## Verification

Three new tests, and the wrapper they need. PGlite is single-connection, so the race cannot be run *as* a race — but the **interleaving** can be forced exactly, by firing the manager's write immediately before the autofill's `BEGIN`. That is precisely where the stored lineup used to be read from.

| test | what it pins |
|---|---|
| leaves a slot the manager changed while it was still thinking | the revert itself — and that the other eight slots still land, so a guard that protects the manager by writing nothing would not pass |
| still fills a slot that exists and is empty | the `IS NOT DISTINCT FROM` case, via a waiver pickup onto a team whose first pass left eight empty rows |
| fills the slots the manager did not touch from the state they left behind | one self-consistent lineup, nobody started twice |

**Mutation-checked twice.**

1. `IS NOT DISTINCT FROM` → `=`: "still fills a slot that exists and is empty" fails. Nothing else moves.
2. The whole fix reverted, tests kept: two of the three fail, including on `main`'s exact behaviour.

Every existing test stays green **unchanged** — `is idempotent` and `leaves a manager's own choices alone` are the ones a too-aggressive predicate would break, and they are untouched.

1123 tests, typecheck, lint green.

## Documentation

`docs/RULES.md` §8 promises "Autofill only ever touches slots you left empty, and never a slot that has already locked", and `LineupEditor` tells the manager the same thing in-product. Both were false. **Neither is edited here** — the code now makes them true, which is the right direction for a document whose values can never change for the life of a league.

The two false docstrings in this module are corrected, per the standing rule that a comment asserting a guarantee the code does not provide is a defect in its own right.

## Not verified, and named rather than glossed

- **The race under two real sessions.** PGlite has one connection. Same limitation `CLAUDE.md` already records for `acceptTrade` — it has to be got right by reading.
- **Frequency in production.** Reachable and continuous; not measured.
- **`setLineup` has the identical shape and is deliberately left alone** — it reads `current` outside its transaction and writes an unguarded `DO UPDATE`. Filed separately, because the guard it needs is not this one: a manager stating intent against a lineup they were just shown must not have a stale browser tab turn into a silent no-op, so it needs a retryable refusal and the UI work to handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
