### PR TITLE
fix(core,db,web): bind the trade deadline on the week a trade executes in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -872,11 +872,29 @@ unaccepted for days slides past the first check. A window closing past the deadl
 **expires** the trade, rosters untouched. That is what `EXPIRED` in the `trade_state` enum
 is for; it was unused before.
 
+**Both checks derive that week themselves, from `transactionWeek`, and share one
+comparison.** They used to be two independent implementations of one rule — `proposeTrade`
+took a `week` field computed by the route, and `resolveDueTrades` asked `currentWeek` — and
+both were wrong the same way. `currentWeek` names the week of the most recent kickoff, so
+from a week's last game until the next week's first it keeps answering a week whose games
+are over: a trade resolving on the Tuesday or Wednesday after week 11 executed into week
+12's rosters while being checked against week 11. `pastTradeDeadline` in `@rostr/core` is
+now the only place the comparison happens.
+
+**An execution week of `null` is past every deadline.** `transactionWeek` cannot name one
+when the season's games are exhausted, and reading that as "not past the deadline" would
+open the trade window permanently the moment a season ended — the January free-for-all the
+deadline exists to prevent. The strict direction costs a league with no schedule ingested
+its trade window, and such a league cannot set a lineup either, so it is not operational.
+
 **`currentWeek()` in `week.ts` exists so no route takes a week from the client.** A
 deadline checked against a client-supplied week is not a deadline — anyone could trade in
 January by posting `week: 1`. Routes that legitimately display an arbitrary week (a past
-lineup) still accept one; routes enforcing a rule must not. `score-week` had this query
-inline and now shares it.
+lineup) still accept one; routes enforcing a rule must not — and a rule-enforcing caller
+wants `transactionWeek` rather than this one. `score-week` still carries its own copy of
+the same SQL (`apps/web/src/app/api/cron/score-week/route.ts:46-54`) rather than importing
+it; that is tolerable, because it wants exactly the lagging semantics, but it is a copy and
+not a shared call.
 
 **A veto is scoped to the trade's own league, at three layers.** `vetoTrade` refuses an
 outside voter (`NOT_IN_LEAGUE`); the tally in `loadTrade` counts only rows from teams that

--- a/apps/web/src/app/api/leagues/[id]/trades/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/trades/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
-import { NFL } from "@rostr/core";
+import { pastTradeDeadline } from "@rostr/core";
+import type { LeagueRules } from "@rostr/core";
 import {
   acceptTrade,
-  currentWeek,
   declineTrade,
   listTrades,
   lockedByTrade,
   proposeTrade,
   TradeError,
+  transactionWeek,
   vetoTrade,
   withdrawTrade,
 } from "@rostr/db";
@@ -34,19 +35,23 @@ const STATUS: Record<string, number> = {
 };
 
 /**
- * The week a trade proposed now would soonest execute in.
+ * Whether a proposal made now would already be past the league's deadline.
  *
- * **Server-derived, never taken from the request.** A deadline checked against a
- * client-supplied week is not a deadline: anyone could trade in January by
- * posting `week: 1`. And it is the *execution* week rather than today's, because
- * a trade accepted on the deadline still has a veto window to sit through, and a
- * trade that landed after the deadline is exactly what the deadline prevents.
+ * **For the screen only. The rule is enforced in `proposeTrade`**, which derives
+ * the execution week itself rather than being handed one — a deadline checked
+ * against a number worked out somewhere else is not a deadline, and this route
+ * used to be that somewhere else. Both now go through `transactionWeek` and
+ * `pastTradeDeadline`, so the banner cannot disagree with the refusal.
  *
- * Zero before the season's first kickoff, which no deadline is ever below.
+ * The reason this is a boolean rather than a week is that there is no week to
+ * report in the cases that matter: once the season's games are exhausted the
+ * schedule cannot name an execution week at all, and the old `?? 0` fallback
+ * reported that as week zero — which the screen rendered as "trading is open",
+ * in January, permanently.
  */
-async function executionWeek(now: Date, vetoWindowHours: number): Promise<number> {
-  const lands = new Date(now.getTime() + vetoWindowHours * 3600 * 1000);
-  return (await currentWeek(db(), NFL.key, lands)) ?? 0;
+async function tradingClosed(now: Date, rules: LeagueRules): Promise<boolean> {
+  const lands = new Date(now.getTime() + rules.trades.vetoWindowHours * 3600 * 1000);
+  return pastTradeDeadline(await transactionWeek(db(), rules, lands), rules.trades);
 }
 
 /**
@@ -95,7 +100,7 @@ export async function GET(
       enabled: context.rules.trades.enabled,
       deadlineWeek: context.rules.trades.deadlineWeek,
       vetoWindowHours: context.rules.trades.vetoWindowHours,
-      week: await executionWeek(now, context.rules.trades.vetoWindowHours),
+      tradingClosed: await tradingClosed(now, context.rules),
       teams: teams.map((team) => ({
         teamId: team.id,
         name: team.name,
@@ -177,7 +182,6 @@ export async function POST(
         receiverTeamId: body.receiverTeamId,
         proposerGives: body.proposerGives,
         receiverGives: body.receiverGives,
-        week: await executionWeek(now, context.rules.trades.vetoWindowHours),
         now,
       });
 

--- a/apps/web/src/components/TradeBlock.tsx
+++ b/apps/web/src/components/TradeBlock.tsx
@@ -53,7 +53,15 @@ interface TradesResponse {
   enabled: boolean;
   deadlineWeek: number;
   vetoWindowHours: number;
-  week: number;
+  /**
+   * Whether a proposal made now would already land past the deadline.
+   *
+   * Decided by the server, not by comparing a week here. There is no week to
+   * compare once the season's games are exhausted, and the field this replaced
+   * reported that case as week zero — which rendered as "trading is open", in
+   * January, permanently.
+   */
+  tradingClosed: boolean;
   teams: TradeTeam[];
   trades: Trade[];
 }
@@ -109,7 +117,7 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
 
   const mine = data.teams.find((team) => team.teamId === data.myTeamId);
   const partner = data.teams.find((team) => team.teamId === withTeam);
-  const pastDeadline = data.week > data.deadlineWeek;
+  const pastDeadline = data.tradingClosed;
 
   function toggle(set: Set<string>, id: string): Set<string> {
     const next = new Set(set);
@@ -172,8 +180,9 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
 
       {data.enabled && pastDeadline && (
         <p className="rounded border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200/80">
-          The trade deadline was the end of week {data.deadlineWeek}. Nothing new can be
-          proposed.
+          The trade deadline is the end of week {data.deadlineWeek}, and an accepted trade waits{" "}
+          {data.vetoWindowHours} hours before it executes — so anything proposed now would land
+          after it. Nothing new can be proposed.
         </p>
       )}
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -225,6 +225,7 @@ export {
 
 export {
   isVetoed,
+  pastTradeDeadline,
   tradeBlockedBecause,
   vetoWindowEndsAt,
   vetoWindowHasClosed,

--- a/packages/core/src/trades/veto.ts
+++ b/packages/core/src/trades/veto.ts
@@ -80,6 +80,33 @@ export function vetoWindowHasClosed(
 export type TradeBlock = "TRADES_DISABLED" | "PAST_DEADLINE" | "SAME_TEAM" | "NOTHING_OFFERED";
 
 /**
+ * Whether a trade landing in `executionWeek` is past the league's deadline.
+ *
+ * **One definition, because the rule is enforced twice.** `docs/RULES.md` §6
+ * requires both a proposal check — against the earliest week the trade could
+ * land in — and a resolution check, since a trade left unaccepted for days
+ * slides past the first. Two comparisons written separately are two chances to
+ * write it differently, and the deadline exists to stop an eliminated team
+ * handing its roster to a contender.
+ *
+ * **`null` is past every deadline, and that direction is deliberate.** The
+ * caller supplies the week a trade would execute in, derived from the schedule;
+ * `null` means it could not be determined — the season's games are exhausted,
+ * or no schedule is ingested for the league's season at all. Reading that as
+ * "not past the deadline" would open the trade window permanently the moment a
+ * season ended, which is precisely the January free-for-all the deadline exists
+ * to prevent. A rule that cannot be checked is not a rule that does not apply.
+ *
+ * The cost of the strict direction is that a league whose schedule has never
+ * been ingested cannot trade. That league cannot set a lineup either — every
+ * lock derives from `games.kickoff_at`, and `setLineup` already refuses without
+ * a schedule — so it is not operational in the first place.
+ */
+export function pastTradeDeadline(executionWeek: number | null, rules: TradeRules): boolean {
+  return executionWeek === null || executionWeek > rules.deadlineWeek;
+}
+
+/**
  * Whether a trade may be proposed at all.
  *
  * The deadline is checked against the week the trade would *execute*, not the
@@ -87,17 +114,20 @@ export type TradeBlock = "TRADES_DISABLED" | "PAST_DEADLINE" | "SAME_TEAM" | "NO
  * window to run, and a trade that executed after the deadline would be exactly
  * what the deadline exists to prevent: an eliminated team handing its roster to
  * a contender.
+ *
+ * `week` is that execution week, or `null` when the schedule cannot answer —
+ * see `pastTradeDeadline` for why that refuses rather than permits.
  */
 export function tradeBlockedBecause(input: {
   readonly rules: TradeRules;
-  readonly week: number;
+  readonly week: number | null;
   readonly proposerTeamId: string;
   readonly receiverTeamId: string;
   readonly proposerGives: readonly string[];
   readonly receiverGives: readonly string[];
 }): TradeBlock | null {
   if (!input.rules.enabled) return "TRADES_DISABLED";
-  if (input.week > input.rules.deadlineWeek) return "PAST_DEADLINE";
+  if (pastTradeDeadline(input.week, input.rules)) return "PAST_DEADLINE";
   if (input.proposerTeamId === input.receiverTeamId) return "SAME_TEAM";
 
   // A trade where one side gives nothing is a gift, and a gift is how an

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -35,9 +35,50 @@ const DRAFT: DraftRules = {
 };
 
 const HOUR = 3600 * 1000;
+const DAY = 24 * HOUR;
 const MONDAY = new Date("2026-10-12T18:00:00Z");
 /** Past the 48-hour veto window, so an accepted trade is due to resolve. */
 const AFTER_WINDOW = new Date(MONDAY.getTime() + 49 * HOUR);
+
+/**
+ * The real 2026 season, so a week number means something.
+ *
+ * Week 1's Thursday is 10 September 2026, the opener following Labor Day, which
+ * puts week 11 on 19-23 November and matches the trade deadline in `CLAUDE.md`'s
+ * calendar. `MONDAY` above is week 5's Monday night on the same schedule.
+ *
+ * **Three kickoffs a week, and every week, because fewer of either cannot see
+ * the bug this fixture exists for.** The deadline used to be checked with
+ * `currentWeek`, which disagrees with `transactionWeek` only while the calendar
+ * holds a week whose games are finished *and* a following week whose games have
+ * not started. A single-week fixture makes that state unrepresentable, which is
+ * why the two deadline tests this replaces both passed under the bug.
+ *
+ * Kickoffs step a uniform seven days in UTC, so from November they read an hour
+ * earlier in local time than the NFL plays. Deliberate and harmless: the rules
+ * turn on which side of Tuesday 00:00 **Eastern** a game falls, and an hour does
+ * not move any of these across it. That boundary is computed by `nextWeekly`
+ * from the league's frozen rules, which is code under test rather than fixture.
+ */
+const WEEK1_THURSDAY = new Date("2026-09-11T00:15:00Z");
+/** Thursday night, Sunday afternoon, Monday night, as offsets from the Thursday. */
+const SLOTS = [0, 2 * DAY + 16 * HOUR + 45 * 60 * 1000, 4 * DAY];
+
+/**
+ * The week-11/12 boundary, which is where the default deadline lives.
+ *
+ * Week 11's last game kicks off Monday evening; the league starts transacting in
+ * week 12 at Tuesday 00:00 ET, hours later; week 12's first game is not until
+ * the Thursday. So for three days "the week whose games were played" and "the
+ * week a roster change lands in" are different numbers, and every assertion
+ * below turns on which one the deadline is measured against.
+ */
+const WEEK11_FRIDAY = new Date("2026-11-20T18:00:00Z");
+const WEEK11_SUNDAY = new Date("2026-11-22T18:00:00Z");
+/** Monday 23:00 ET, after week 11's last kickoff and before the Tuesday lock. */
+const BEFORE_WEEK12_LOCK = new Date("2026-11-24T04:00:00Z");
+/** Tuesday 01:00 ET, an hour past it and still three days from any week-12 game. */
+const AFTER_WEEK12_LOCK = new Date("2026-11-24T06:00:00Z");
 
 interface Fixture {
   client: PGliteClient;
@@ -114,34 +155,48 @@ async function setup(overrides?: Partial<LeagueRules>): Promise<Fixture> {
     [teams[0], spare!.id, new Date(MONDAY.getTime() - 30 * 24 * HOUR)],
   );
 
+  await seedSchedule(db, sport!.id);
+
   return { client: db, leagueId: league.id, rules, teams, players };
 }
 
 /**
- * Put a kickoff on the calendar, so `currentWeek` has something to answer with.
- * The week is read from the schedule rather than guessed from the date.
+ * The whole 2026 regular season, on the calendar above.
+ *
+ * Seeded for **every** fixture rather than per test. The deadline is derived
+ * from the schedule, so a league with no games is one in which the rule cannot
+ * be evaluated at all — and it now refuses when it cannot be evaluated. Tests
+ * about vetoes and freezes are not trying to say anything about that; they need
+ * a league that is simply in season.
  */
-async function kickoff(fx: Fixture, week: number, at: Date): Promise<void> {
-  const [sport] = await fx.client.query<{ id: string }>(
-    "SELECT id FROM sports WHERE key = $1",
-    [NFL.key],
-  );
-  await fx.client.query(
+async function seedSchedule(client: PGliteClient, sportId: string): Promise<void> {
+  const rows: string[] = [];
+  const values: unknown[] = [sportId];
+
+  for (let week = 1; week <= 18; week++) {
+    for (const [slot, offset] of SLOTS.entries()) {
+      const at = new Date(WEEK1_THURSDAY.getTime() + (week - 1) * 7 * DAY + offset);
+      values.push(`w${week}g${slot}`, week, at.toISOString());
+      const i = values.length;
+      rows.push(`($1, $${i - 2}, 2026, $${i - 1}, 'CIN', 'CLE', $${i})`);
+    }
+  }
+
+  await client.query(
     `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at)
-     VALUES ($1, $2, 2026, $3, 'CIN', 'CLE', $4)`,
-    [sport!.id, `w${week}`, week, at.toISOString()],
+     VALUES ${rows.join(", ")}`,
+    values,
   );
 }
 
 /** The straightforward one-for-one: team 1's player for team 2's. */
-async function propose(fx: Fixture, week = 5, now = MONDAY): Promise<string> {
+async function propose(fx: Fixture, now = MONDAY): Promise<string> {
   const { tradeId } = await proposeTrade(fx.client, {
     leagueId: fx.leagueId,
     proposerTeamId: fx.teams[0]!,
     receiverTeamId: fx.teams[1]!,
     proposerGives: [fx.players.get("p1")!],
     receiverGives: [fx.players.get("p2")!],
-    week,
     now,
   });
   return tradeId;
@@ -181,7 +236,6 @@ describe("proposing", () => {
         proposerGives: [fx.players.get("p3")!],
         receiverTeamId: fx.teams[1]!,
         receiverGives: [fx.players.get("p2")!],
-        week: 5,
         now: MONDAY,
       }),
     ).rejects.toMatchObject({ code: "NOT_YOUR_PLAYER" });
@@ -197,31 +251,43 @@ describe("proposing", () => {
         proposerGives: [fx.players.get("p1")!],
         receiverTeamId: fx.teams[1]!,
         receiverGives: [fx.players.get("p3")!],
-        week: 5,
         now: MONDAY,
       }),
     ).rejects.toMatchObject({ code: "NOT_YOUR_PLAYER" });
   });
 
-  it("refuses after the deadline", async () => {
+  it("refuses one that would land after the deadline", async () => {
+    // The proposal check bounds the *earliest* week a trade could execute in, so
+    // it asks about `now` plus the veto window rather than about now. Proposed
+    // during week 11's Sunday games, a 48-hour window closes on the Tuesday, by
+    // which time the league is transacting in week 12.
     const fx = await setup();
 
-    await expect(propose(fx, fx.rules.trades.deadlineWeek + 1)).rejects.toMatchObject({
+    await expect(propose(fx, WEEK11_SUNDAY)).rejects.toMatchObject({
       code: "PAST_DEADLINE",
     });
   });
 
-  it("allows one in the deadline week itself", async () => {
+  it("allows one whose window still closes inside the deadline week", async () => {
+    // Two days earlier the same 48 hours close on week 11's Sunday. Nothing
+    // about the deadline week itself is refused — only landing past it.
     const fx = await setup();
-    await expect(propose(fx, fx.rules.trades.deadlineWeek)).resolves.toBeTypeOf("string");
+
+    await expect(propose(fx, WEEK11_FRIDAY)).resolves.toBeTypeOf("string");
   });
 
-  it("honours a commissioner-set deadline", async () => {
+  it("honours a commissioner-set deadline, across the DST change", async () => {
+    // Deadline 8 rather than the default 11, which also moves the boundary to
+    // the other side of 1 November. The week-8 lock is 04:00 UTC and the week-9
+    // lock is 05:00 UTC, because both are Tuesday 00:00 *Eastern* — a fixed
+    // offset would put one of these two assertions on the wrong side of it.
     const base = buildNflPprRules({ seasonYear: 2026, draft: DRAFT });
     const fx = await setup({ trades: { ...base.trades, deadlineWeek: 8 } });
 
-    await expect(propose(fx, 9)).rejects.toMatchObject({ code: "PAST_DEADLINE" });
-    await expect(propose(fx, 8)).resolves.toBeTypeOf("string");
+    await expect(propose(fx, new Date("2026-11-01T12:00:00Z"))).rejects.toMatchObject({
+      code: "PAST_DEADLINE",
+    });
+    await expect(propose(fx, new Date("2026-10-28T12:00:00Z"))).resolves.toBeTypeOf("string");
   });
 
   it("refuses when the league disabled trading", async () => {
@@ -254,7 +320,6 @@ describe("proposing", () => {
         proposerGives: [fx.players.get("p1")!],
         receiverTeamId: fx.teams[1]!,
         receiverGives: [fx.players.get("p4")!],
-        week: 5,
         now: MONDAY,
       }),
     ).rejects.toBeInstanceOf(TradeError);
@@ -375,7 +440,6 @@ describe("the freeze between acceptance and execution", () => {
         proposerGives: [fx.players.get("p1")!],
         receiverTeamId: fx.teams[2]!,
         receiverGives: [fx.players.get("p3")!],
-        week: 5,
         now: MONDAY,
       }),
     ).rejects.toMatchObject({ code: "PLAYER_IN_ANOTHER_TRADE" });
@@ -405,7 +469,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[1]!,
       proposerGives: [p1],
       receiverGives: [fx.players.get("p2")!],
-      week: 5,
       now: MONDAY,
     });
     const b = await proposeTrade(fx.client, {
@@ -414,7 +477,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[2]!,
       proposerGives: [p1],
       receiverGives: [fx.players.get("p3")!],
-      week: 5,
       now: MONDAY,
     });
 
@@ -456,7 +518,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[1]!,
       proposerGives: [p1],
       receiverGives: [fx.players.get("p2")!],
-      week: 5,
       now: MONDAY,
     });
     await acceptTrade(fx.client, trade.tradeId, fx.teams[1]!, MONDAY);
@@ -500,7 +561,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[1]!,
       proposerGives: [p1],
       receiverGives: [fx.players.get("p2")!],
-      week: 5,
       now: MONDAY,
     });
     const healthy = await proposeTrade(fx.client, {
@@ -509,7 +569,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[3]!,
       proposerGives: [p3],
       receiverGives: [fx.players.get("p4")!],
-      week: 5,
       now: MONDAY,
     });
 
@@ -537,7 +596,6 @@ describe("no double-spend across trades", () => {
       receiverTeamId: fx.teams[1]!,
       proposerGives: [p1],
       receiverGives: [fx.players.get("p2")!],
-      week: 5,
       now: MONDAY,
     });
 
@@ -901,17 +959,17 @@ describe("resolution", () => {
     expect(owners[0]?.team_id).toBe(fx.teams[1]);
   });
 
-  it("expires a trade whose window closed after the deadline", async () => {
-    // The deadline binds on the week a trade *executes*. Checking only at
-    // proposal bounds the earliest week it might land in — a trade proposed on
-    // the deadline and accepted days later slides past it, and this is where
-    // that is caught.
+  it("expires a trade whose window closes in the gap after the deadline week", async () => {
+    // **The bug this fixture exists for.** Week 11's games are all played, week
+    // 12's have not started, and the league has been transacting in week 12
+    // since Tuesday 00:00 ET. `currentWeek` still answers 11 here, because it
+    // names the most recent kickoff — so the deadline used to read as unpassed,
+    // and the swap landed in week 12's rosters days past a date members signed.
     const fx = await setup();
-    const tradeId = await propose(fx, fx.rules.trades.deadlineWeek);
-    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await kickoff(fx, fx.rules.trades.deadlineWeek + 1, new Date(MONDAY.getTime() + 40 * HOUR));
+    const tradeId = await propose(fx, WEEK11_FRIDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WEEK12_LOCK);
 
     expect(resolution?.outcome).toBe("EXPIRED");
 
@@ -922,15 +980,38 @@ describe("resolution", () => {
     expect(row?.team_id).toBe(fx.teams[0]);
   });
 
-  it("executes when the closing week is still inside the deadline", async () => {
+  it("executes one whose window closes before that week turns over", async () => {
+    // Two hours earlier and the answer flips. The rule turns on the Tuesday lock
+    // rather than on week 12's Thursday kickoff, so this pins where the boundary
+    // is and not merely that one exists.
     const fx = await setup();
-    const tradeId = await propose(fx, fx.rules.trades.deadlineWeek);
-    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await kickoff(fx, fx.rules.trades.deadlineWeek, new Date(MONDAY.getTime() - HOUR));
+    const tradeId = await propose(fx, WEEK11_FRIDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, BEFORE_WEEK12_LOCK);
 
     expect(resolution?.outcome).toBe("EXECUTED");
+  });
+
+  it("expires rather than executing once the season's games are exhausted", async () => {
+    // The regression the obvious version of this fix introduces, and the reason
+    // a null execution week refuses. After the season's last Tuesday lock the
+    // schedule cannot name a week at all, and the shape this replaced —
+    // `week !== null && week > deadlineWeek` — read that as "not past the
+    // deadline". A trade left accepted would then execute in January, which is
+    // the exact free-for-all the deadline exists to prevent. A rule that cannot
+    // be checked is not a rule that has lapsed.
+    const fx = await setup();
+    const tradeId = await propose(fx, WEEK11_FRIDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
+
+    const [resolution] = await resolveDueTrades(
+      fx.client,
+      fx.leagueId,
+      new Date("2027-01-20T12:00:00Z"),
+    );
+
+    expect(resolution?.outcome).toBe("EXPIRED");
   });
 
   it("executes an uneven trade", async () => {
@@ -944,7 +1025,6 @@ describe("resolution", () => {
       proposerGives: [fx.players.get("p1")!, fx.players.get("spare")!],
       receiverTeamId: fx.teams[1]!,
       receiverGives: [fx.players.get("p2")!],
-      week: 5,
       now: MONDAY,
     });
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
@@ -998,7 +1078,6 @@ describe("finding work", () => {
       proposerGives: [fx.players.get("p3")!],
       receiverTeamId: fx.teams[3]!,
       receiverGives: [fx.players.get("p4")!],
-      week: 5,
       now: MONDAY,
     });
     await acceptTrade(fx.client, second, fx.teams[3]!, MONDAY);
@@ -1020,7 +1099,6 @@ describe("listing", () => {
       proposerGives: [fx.players.get("p3")!],
       receiverTeamId: fx.teams[3]!,
       receiverGives: [fx.players.get("p4")!],
-      week: 5,
       now: MONDAY,
     });
     await declineTrade(fx.client, gone, fx.teams[3]!, MONDAY);

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -26,6 +26,7 @@
 
 import {
   isVetoed,
+  pastTradeDeadline,
   tradeBlockedBecause,
   vetoWindowEndsAt,
   vetoWindowHasClosed,
@@ -35,7 +36,7 @@ import type { LeagueRules } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { withTransaction } from "./transaction.js";
-import { currentWeek } from "./week.js";
+import { transactionWeek } from "./week.js";
 
 export class TradeError extends Error {
   constructor(
@@ -224,9 +225,32 @@ export interface ProposeTradeInput {
   readonly receiverTeamId: string;
   readonly proposerGives: readonly string[];
   readonly receiverGives: readonly string[];
-  /** The current week, checked against the league's frozen deadline. */
-  readonly week: number;
   readonly now: Date;
+}
+
+/**
+ * The week a trade decided at `at` would execute in.
+ *
+ * **`transactionWeek`, never `currentWeek`.** `currentWeek` answers "the week of
+ * the most recent kickoff", so from a week's last game until the next week's
+ * first it keeps naming a week whose games have all been played — and a trade
+ * landing in that stretch executes into the *following* week's rosters. Asking
+ * it about a deadline let a trade land roughly three days past a date members
+ * signed, which is exactly what `docs/RULES.md` §6 says the deadline prevents.
+ *
+ * It is also season-scoped, which `currentWeek` is not: with a prior season's
+ * games ingested, `currentWeek` answers "week 18" all summer and would refuse
+ * every proposal in the preseason.
+ *
+ * `null` when the schedule cannot answer. `pastTradeDeadline` decides what that
+ * means, in one place, for both callers.
+ */
+async function executionWeek(
+  db: SqlClient,
+  rules: LeagueRules,
+  at: Date,
+): Promise<number | null> {
+  return transactionWeek(db, rules, at);
 }
 
 export async function proposeTrade(
@@ -236,9 +260,20 @@ export async function proposeTrade(
   const stored = await getLeagueRules(db, input.leagueId);
   if (!stored) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
 
+  // Derived here, never taken from the caller. This used to be a `week` field on
+  // the input, supplied by the route — so the rule depended on a number computed
+  // outside the package that enforces it, and the route computed it wrongly.
+  // A deadline checked against a week somebody else worked out is not a deadline.
+  //
+  // The earliest a proposal can land is when its veto window closes, which is
+  // the check `RULES.md` §6 requires at proposal time.
+  const lands = new Date(
+    input.now.getTime() + stored.rules.trades.vetoWindowHours * 3600 * 1000,
+  );
+
   const blocked = tradeBlockedBecause({
     rules: stored.rules.trades,
-    week: input.week,
+    week: await executionWeek(db, stored.rules, lands),
     proposerTeamId: input.proposerTeamId,
     receiverTeamId: input.receiverTeamId,
     proposerGives: input.proposerGives,
@@ -567,8 +602,14 @@ export async function resolveDueTrades(
   // proposal check can only bound the earliest week it might land in, and a
   // trade left unaccepted for days slides past that. This is where it actually
   // holds, and it is the reason `EXPIRED` exists in the state enum.
-  const week = await currentWeek(db, stored.rules.sportKey, now);
-  const pastDeadline = week !== null && week > stored.rules.trades.deadlineWeek;
+  //
+  // Same derivation as the proposal check, same rule applied to it. The two used
+  // to be independent: this one asked `currentWeek` and the route asked it
+  // separately, so one rule had two implementations and both were wrong.
+  const pastDeadline = pastTradeDeadline(
+    await executionWeek(db, stored.rules, now),
+    stored.rules.trades,
+  );
 
   const out: TradeResolution[] = [];
 

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -69,8 +69,15 @@ export class WeekError extends Error {
  * **This exists so no route has to take a week from the client.** A deadline
  * checked against a client-supplied week is not a deadline — anyone could
  * trade in January by posting `week: 1`. Callers that legitimately display an
- * arbitrary week (a lineup for a past week, say) can still accept one; callers
- * enforcing a rule must use this.
+ * arbitrary week (a lineup for a past week, say) can still accept one.
+ *
+ * **But a caller enforcing a rule wants `transactionWeek`, not this.** This
+ * answers "which week am I scoring" and so keeps naming a week whose games have
+ * all been played, right up until the next week kicks off — which is the correct
+ * lag for the scoreboard and a three-day hole in any rule that binds on where a
+ * roster change lands. It is also not season-scoped: with a prior season's games
+ * ingested it answers "week 18" all summer. Both defects have been shipped and
+ * fixed once each, in the waiver lock and in the trade deadline.
  *
  * Returns `null` before the season's first kickoff, when there is no week yet.
  */


### PR DESCRIPTION
Closes #91. **Stacked on #88**, which adds `transactionWeek`.

## The bug

`resolveDueTrades` asked `currentWeek` — "the week of the most recent kickoff" — so from a week's last game until the next week's first, it keeps naming a week whose games have all been played. A trade whose veto window closed on the Tuesday or Wednesday after week 11 **executed into week 12's rosters while being checked against week 11**.

The comment directly above that line already stated the rule correctly:

> The deadline binds on the week a trade *executes*, which is this one

It was not that one. `docs/RULES.md` §6 says the same thing, and gives the reason: the deadline stops "an eliminated team handing its roster to a contender", which is exactly what those days permit.

**The window is ~2.8 days**, measured — from §6's Tuesday 00:00 ET boundary to week 12's first kickoff. (Issue #91 said 3.5; that was my error. In 2026 it is nearer 2.5, because week 12 is Thanksgiving and opens at 12:30 ET.)

`currentWeek` is also **not season-scoped**, so once a prior season's games are ingested it answers "week 18" all summer — verified on PGlite, `currentWeek(NFL, 2026-08-13) = 18` — which would refuse every proposal in the preseason. Latent today, planned work by Sep 9, and unconditional every offseason from January 2027.

## One derivation, one comparison

The rule was enforced at two sites by **two independent implementations**: `proposeTrade` took a `week` field computed by the web route, and `resolveDueTrades` asked `currentWeek` itself. Both were wrong the same way, and fixing one would have left the other — the shape this repo has already been bitten by.

`proposeTrade` now derives its own execution week. A deadline checked against a number worked out somewhere else is not a deadline, and the route was that somewhere else. Both sites go through `transactionWeek` and a single `pastTradeDeadline` in `@rostr/core`.

`acceptTrade` is still deliberately unguarded — `docs/DECISIONS.md` records that rejection, and this does not reopen it.

## A null execution week is past every deadline

**This is the part the issue got wrong, and it is the one that would have shipped a new bug.**

`transactionWeek` cannot name a week once the season's games are exhausted. The shape this replaces — `week !== null && week > deadline` — reads that as *"not past the deadline"*. So the obvious version of this fix would let a trade left accepted **execute in January**, which is precisely the free-for-all `currentWeek`'s own docstring cites as the reason it exists. `leaguesWithDueTrades` filters on nothing but state and deadline, so a settled league is still swept hourly.

`transactionWeek`'s docstring, added in #88, already forbids this: *"A caller enforcing a rule must read that as 'this lock cannot be checked', never as 'nothing is locked'."* This would have been the first caller to violate it.

The cost of the strict direction is that a league whose schedule was never ingested cannot trade. That league cannot set a lineup either — every lock derives from `games.kickoff_at` and `setLineup` already refuses without a schedule — so it is not operational in the first place.

## What managers will notice

The effective proposal cutoff moves **about 60 hours earlier**: from Tuesday of week 12 to Saturday night of week 11. That is the faithful reading of §6 — a proposal is refused if the earliest week it could land in is already past — but it is a real change to when the window shuts, not only a bug fix, so the banner now says why rather than asserting the deadline "was" a week that has not ended.

The trades screen and the scoreboard will now print different week numbers from Tuesday to Thursday each week. Both are right for their own job: the scoreboard must lag, the trade page must lead. Do not unify them.

## The fixture is the fix

**Both existing deadline tests passed under the bug**, and one passed *vacuously* — it returned `null`, `null` was permissive, and it asserted nothing about the deadline at all. You could have broken `transactionWeek` any way you liked and both stayed green.

The two week functions can only disagree when the calendar holds a finished week **and** an unstarted one, so a single-week fixture makes the bug unrepresentable. Every fixture now seeds the real 2026 season — three kickoffs a week, all 18 weeks — and the deadline tests drive time rather than passing a week in.

| test | pins |
|---|---|
| refuses one that would land after the deadline | the proposal check asks about `now + veto window`, not `now` |
| allows one whose window still closes inside the deadline week | the negative — nothing about the deadline week itself is refused |
| honours a commissioner-set deadline, across the DST change | the boundary is Tuesday 00:00 **Eastern**; a fixed offset puts one assertion on the wrong side |
| expires a trade whose window closes in the gap | **the bug** |
| executes one whose window closes before that week turns over | the boundary is the Tuesday lock, not week 12's kickoff |
| expires once the season's games are exhausted | the null regression above |

**Mutation-checked twice.** Reverting to `currentWeek` fails exactly the three tests that pin the rule and no negatives. Making `null` permissive fails exactly the offseason test.

1138 tests, typecheck, lint green. No schema change, no rules change, **golden hash untouched.**

## Comments corrected

Per the standing rule that a comment asserting a guarantee the code does not provide is a defect in its own right:

- `currentWeek`'s docstring said "callers enforcing a rule must use this". It now says the opposite, and why — both of its defects have been shipped and fixed once each, in the waiver lock and here.
- `ProposeTradeInput.week` was documented as "the current week". The field is gone.
- `CLAUDE.md` claimed `score-week` "had this query inline and now shares it". **It does not** — `apps/web/src/app/api/cron/score-week/route.ts:46-54` still carries a byte-identical copy. Corrected in the handoff rather than in the code: `score-week` legitimately wants the lagging, season-unfiltered answer, and changing the scoring cron inside a trades PR would be the wrong fix.

## Not verified

- **The season-filter half is fixed for trades only.** `matchup/route.ts` and `score-week`'s inline copy still read the unfiltered query. Both want the lagging semantics, so neither is wrong in the way trades was — but neither is season-scoped either. Filed separately rather than bundled.
- **No test kills a mutation that deletes `AND g.season = $2` from `transactionWeek`.** Because it looks *forward*, a prior season's rows are excluded by chronology regardless of the filter; the filter only bites once a *later* season is ingested, where the answer is null anyway. Saying so rather than writing a test that pretends otherwise. The filter's justification is in its own docstring, and it is exercised where it belongs, in waivers.
- **`RULES.md` claims validation refuses a deadline below week 8; `validate.ts` only refuses below 1.** Real, verified, and out of scope — it is about the deadline's permitted *value*, not its timing. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
