### PR TITLE
fix(db,web): a waiver claim must wait for its player to clear

### DIFF
--- a/apps/web/src/app/api/cron/waivers/route.ts
+++ b/apps/web/src/app/api/cron/waivers/route.ts
@@ -25,6 +25,8 @@ export async function GET(request: Request): Promise<NextResponse> {
     leagueId: string;
     awarded?: number;
     failed?: number;
+    /** Claims whose player has not cleared waivers yet. Left PENDING on purpose. */
+    deferred?: number;
     cleared?: number;
     error?: string;
   }[] = [];
@@ -36,6 +38,10 @@ export async function GET(request: Request): Promise<NextResponse> {
         leagueId,
         awarded: outcome.awarded,
         failed: outcome.failed,
+        // Reported rather than collapsed into a zero-everything run. A league
+        // waiting on a player to clear and a league with nothing to do are
+        // different states, and only this tells them apart.
+        deferred: outcome.deferred,
         cleared: outcome.cleared,
       });
     } catch (error) {

--- a/apps/web/src/app/leagues/[id]/players/page.tsx
+++ b/apps/web/src/app/leagues/[id]/players/page.tsx
@@ -34,7 +34,8 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
         </a>
         <h1 className="text-2xl font-semibold tracking-tight">Players</h1>
         <p className="text-sm text-white/50">
-          Next waiver run {nextRun.toLocaleString()} — claims are resolved then, by priority.
+          Next waiver run {nextRun.toLocaleString()}. A claim is resolved by priority at the run
+          its player clears at, which is not always the next one.
         </p>
       </header>
 

--- a/apps/web/src/components/PlayerMarket.tsx
+++ b/apps/web/src/components/PlayerMarket.tsx
@@ -8,7 +8,8 @@ import useSWR from "swr";
  *
  * The same button says "Add" or "Claim" depending on where the player stands,
  * because those are genuinely different things: an add is immediate and first
- * come first served, a claim waits for Wednesday and is decided by priority.
+ * come first served, a claim waits for the run that player clears at and is
+ * decided by priority.
  * Showing one control that quietly does either would hide the only distinction
  * that matters here.
  *
@@ -112,7 +113,10 @@ export function PlayerMarket({ leagueId }: { leagueId: string }) {
       if (!response.ok) throw new Error(payload.error ?? "That did not work");
 
       if (payload.claimed) {
-        setNote("Claim submitted. It resolves at the next waiver run, by priority.");
+        // Not "the next waiver run" — a player who has not served his waiver
+        // period is not awarded at the next run, he waits for the run he clears
+        // at. The screen already shows that time beside his name.
+        setNote("Claim submitted. It resolves by priority, at the run he clears at.");
       } else if (payload.added) {
         setNote("Added.");
       } else if (payload.dropped) {

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -512,6 +512,272 @@ describe("processing", () => {
   });
 });
 
+/**
+ * RULES.md §6, "Waiver period": *"A player clears at the first processing run at
+ * least a full day after landing on waivers — so someone dropped on Tuesday
+ * evening does not clear the next morning, which would leave the rest of the
+ * league no real chance to claim him."*
+ *
+ * He did. `processWaivers` selected every PENDING claim with no reference to the
+ * wire, so a claim was awarded at the run 168 hours before its player's own
+ * `clears_at` — at an instant when `availabilityOf` still answered ON_WAIVERS
+ * for the same player.
+ *
+ * **The instants below are the real week-2 2026 calendar, and they are literals
+ * on purpose.** Every existing processing test drops at one instant and runs
+ * eleven hours the safe side of `clears_at`, so none of them can see this bug in
+ * either direction — a no-op fix, an inverted comparison, or a filter on the
+ * wrong column all ship green against them. Computing an expectation with
+ * `waiverClearsAt` would inherit the same blindness.
+ */
+describe("RULES.md §6 — a claim waits for its player to clear", () => {
+  /** Wed 16 Sep 2026, 03:00 EDT. The week-2 processing instant. */
+  const RUN = new Date("2026-09-16T07:00:00.000Z");
+  /** Wed 23 Sep 2026, 03:00 EDT. */
+  const NEXT_RUN = new Date("2026-09-23T07:00:00.000Z");
+  /**
+   * Tue 15 Sep 2026, 22:00 EDT — inside the band.
+   *
+   * Any drop after Tuesday 03:00 ET rounds its clear up to the *following*
+   * Wednesday, because a one-day waiver period against a weekly run rounds up by
+   * a whole week. The run below is five hours away; the clear is seven days.
+   */
+  const LATE_DROP = new Date("2026-09-16T02:00:00.000Z");
+
+  it("defers a claim whose player has not served his waiver period", async () => {
+    const fx = await setup();
+    const held = fx.players.get("held")!;
+
+    const drop = await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, held, LATE_DROP);
+    expect(drop.destination).toBe("WAIVERS");
+    expect(drop.clearsAt?.toISOString()).toBe("2026-09-23T07:00:00.000Z");
+
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: held,
+      now: new Date(LATE_DROP.getTime() + 30 * 60 * 1000),
+    });
+
+    const before = await loadWaiverPriority(fx.client, fx.leagueId);
+    const outcome = await processWaivers(fx.client, fx.leagueId, RUN);
+
+    // Deferred, and that is a third thing: not awarded, and emphatically not
+    // failed. A manager told their claim failed would go and look for the player.
+    expect(outcome.awarded).toBe(0);
+    expect(outcome.failed).toBe(0);
+    expect(outcome.deferred).toBe(1);
+
+    const [claim] = await fx.client.query<{ state: string; processed_at: string | null }>(
+      "SELECT state, processed_at FROM waiver_claims WHERE league_id = $1",
+      [fx.leagueId],
+    );
+    expect(claim?.state).toBe("PENDING");
+    expect(claim?.processed_at).toBeNull();
+
+    // The wire row survives, so the player is still on waivers and the run that
+    // was supposed to decide him has not spent anything.
+    const [wire] = await fx.client.query<{ clears_at: string }>(
+      "SELECT clears_at FROM waiver_wire WHERE league_id = $1 AND player_id = $2",
+      [fx.leagueId, held],
+    );
+    expect(new Date(wire!.clears_at).toISOString()).toBe("2026-09-23T07:00:00.000Z");
+
+    // Priority is not spent on a claim that has not resolved.
+    expect(await loadWaiverPriority(fx.client, fx.leagueId)).toEqual(before);
+
+    // And nobody holds him.
+    const rostered = await fx.client.query(
+      "SELECT 1 FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+      [held],
+    );
+    expect(rostered).toHaveLength(0);
+
+    // ---- the same claim, at the run it was actually waiting for ------------
+    //
+    // Deliberately the same database and the same test. Two separate tests
+    // cannot tell "deferred" from "lost" — only running on and seeing it land
+    // proves the claim survived.
+    const later = await processWaivers(fx.client, fx.leagueId, NEXT_RUN);
+
+    expect(later.awarded).toBe(1);
+    expect(later.deferred).toBe(0);
+
+    const [winner] = await fx.client.query<{ team_id: string }>(
+      `SELECT team_id FROM roster_entries
+        WHERE player_id = $1 AND released_at IS NULL AND acquired_via = 'WAIVER'`,
+      [held],
+    );
+    expect(winner?.team_id).toBe(fx.teams[3]);
+  });
+
+  it("still awards an ordinary claim at the very run its player clears at", async () => {
+    // **The test that stops the fix being worse than the bug.** `clears_at` is a
+    // processing instant and this runs at processing instants, so for an
+    // ordinary drop the two are *equal* — the normal case, not a boundary. A
+    // `<` rather than `<=` would delay every waiver claim in every league by a
+    // week, and no other test in this file would notice.
+    const fx = await setup();
+    const held = fx.players.get("held")!;
+
+    const drop = await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, held, MONDAY);
+    expect(drop.clearsAt?.toISOString()).toBe(RUN.toISOString());
+
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: held,
+      now: new Date(MONDAY.getTime() + 30 * 60 * 1000),
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, RUN);
+
+    expect(outcome.awarded).toBe(1);
+    expect(outcome.deferred).toBe(0);
+  });
+
+  it("holds at one millisecond before the clear and awards at the clear", async () => {
+    const fx = await setup();
+    const held = fx.players.get("held")!;
+
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, held, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: held,
+      now: new Date(MONDAY.getTime() + 30 * 60 * 1000),
+    });
+
+    const early = await processWaivers(fx.client, fx.leagueId, new Date(RUN.getTime() - 1));
+    expect(early.awarded).toBe(0);
+    expect(early.deferred).toBe(1);
+
+    const onTime = await processWaivers(fx.client, fx.leagueId, RUN);
+    expect(onTime.awarded).toBe(1);
+  });
+
+  it("awards a claim whose wire row is already gone", async () => {
+    // A claim can outlive its wire row: the post-run sweep removes it once the
+    // clear passes, and so does a free-agent add. **No row means clear**, never
+    // blocked — reading it the other way (an inner join, which is the obvious
+    // way to write this filter) would strand such a claim PENDING forever, hourly.
+    const fx = await setup();
+    const held = fx.players.get("held")!;
+
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, held, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: held,
+      now: new Date(MONDAY.getTime() + 30 * 60 * 1000),
+    });
+
+    await fx.client.query("DELETE FROM waiver_wire WHERE league_id = $1", [fx.leagueId]);
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, RUN);
+    expect(outcome.awarded).toBe(1);
+  });
+
+  it("resolves a cleared claim without dragging an uncleared one along", async () => {
+    // Per claim, not per league. A guard that skipped the whole run while any
+    // claim was uncleared would pass every test above and reintroduce the
+    // "unrelated claims taken down with a stale one" bug this file already
+    // guards against elsewhere.
+    const fx = await setup();
+    const ready = fx.players.get("held")!;
+    const notReady = fx.players.get("other")!;
+
+    // Long enough on the roster that dropping him goes to waivers rather than
+    // straight to free agency.
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [fx.teams[0], notReady, new Date(MONDAY.getTime() - 7 * DAY).toISOString()],
+    );
+
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, ready, MONDAY);
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, notReady, LATE_DROP);
+
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: ready,
+      now: new Date(MONDAY.getTime() + 30 * 60 * 1000),
+    });
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[2]!,
+      addPlayerId: notReady,
+      now: new Date(LATE_DROP.getTime() + 30 * 60 * 1000),
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, RUN);
+
+    expect(outcome.awarded).toBe(1);
+    expect(outcome.deferred).toBe(1);
+
+    const [winner] = await fx.client.query<{ team_id: string }>(
+      `SELECT team_id FROM roster_entries
+        WHERE player_id = $1 AND released_at IS NULL AND acquired_via = 'WAIVER'`,
+      [ready],
+    );
+    expect(winner?.team_id).toBe(fx.teams[3]);
+
+    const [stillWaiting] = await fx.client.query<{ state: string }>(
+      "SELECT state FROM waiver_claims WHERE add_player_id = $1",
+      [notReady],
+    );
+    expect(stillWaiting?.state).toBe("PENDING");
+  });
+
+  it("does not re-freeze a player a pending claim merely names", async () => {
+    // The run used to call `placeDroppedPlayer` for every pending claim's drop
+    // player, whether or not the run had released him. So a player somebody else
+    // legitimately dropped was swept into free agency by the clear and then
+    // immediately re-frozen for another week by a stranger's unresolved claim.
+    //
+    // A deferred claim is re-read every hour for a week, so that fires on every
+    // tick — and since a fresh clear is always in the future, the victim could
+    // never clear at all.
+    const fx = await setup();
+    const held = fx.players.get("held")!;
+    const victim = fx.players.get("spare")!;
+
+    // Team 4 holds someone, and offers him as the drop side of a claim for a
+    // player who will not clear until next week. The claim will be deferred.
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [fx.teams[3], victim, new Date(MONDAY.getTime() - 7 * DAY).toISOString()],
+    );
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, held, LATE_DROP);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[3]!,
+      addPlayerId: held,
+      dropPlayerId: victim,
+      now: new Date(LATE_DROP.getTime() + 30 * 60 * 1000),
+    });
+
+    // Then they drop him for real, early enough that he clears at this run.
+    const drop = await dropPlayer(fx.client, fx.leagueId, fx.teams[3]!, victim, MONDAY);
+    expect(drop.clearsAt?.toISOString()).toBe(RUN.toISOString());
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, RUN);
+    expect(outcome.deferred).toBe(1);
+
+    // He served his week and became a free agent. Nothing about somebody else's
+    // outstanding claim may put him back on the wire.
+    expect(outcome.cleared).toBe(1);
+    const wire = await fx.client.query(
+      "SELECT 1 FROM waiver_wire WHERE league_id = $1 AND player_id = $2",
+      [fx.leagueId, victim],
+    );
+    expect(wire).toHaveLength(0);
+    expect(await availabilityOf(fx.client, fx.leagueId, victim, RUN)).toBe("FREE_AGENT");
+  });
+});
+
 describe("availablePlayers", () => {
   it("lists everyone unrostered", async () => {
     const fx = await setup();

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -8,7 +8,9 @@
  * ## Why a drop is not just a delete
  *
  * Dropping a player puts him somewhere. Held 24 hours or more, he goes to
- * **waivers** and is claimable only by blind claim until the next Wednesday run;
+ * **waivers** and is claimable only by blind claim until the run he clears at —
+ * the first processing run a full waiver period after he landed, which for a
+ * drop late in the cycle is the Wednesday *after* next, not the next one;
  * held less, he goes straight to **free agency**. That second rule is ESPN's and
  * it exists to stop a manager adding someone, cutting him hours later, and
  * re-adding him to dodge the queue.
@@ -119,7 +121,12 @@ export async function loadWaiverPriority(
  *
  * Three states, and the difference between the last two is the whole system: a
  * free agent is first come first served, a player on waivers is claimable only
- * by blind claim until the next processing run.
+ * by blind claim until the run at which he clears.
+ *
+ * The `<=` against `clears_at` below is the definition of "cleared", and
+ * `processWaivers` compares the same way against the same column. It did not,
+ * and the two disagreeing by a week is what let a claim be awarded while this
+ * function still answered `ON_WAIVERS` for the same player at the same instant.
  */
 export async function availabilityOf(
   db: SqlClient,
@@ -607,7 +614,14 @@ export async function cancelClaim(
   );
 }
 
-/** A team's own pending claims, in the order they will resolve. */
+/**
+ * A team's own pending claims, newest last.
+ *
+ * **Not the order they resolve in**, which it used to claim. Resolution is by
+ * waiver priority first, and a claim for a player who has not cleared yet waits
+ * for a later run than one filed after it — so submission order predicts neither
+ * the ordering nor the run.
+ */
 export async function pendingClaims(
   db: SqlClient,
   leagueId: string,
@@ -639,17 +653,35 @@ export interface WaiverRunOutcome {
   readonly leagueId: string;
   readonly awarded: number;
   readonly failed: number;
+  /**
+   * Claims left PENDING because their player has not cleared waivers yet.
+   *
+   * **Not collapsed into "nothing happened".** A run that defers three claims
+   * and a run with no work look identical from `awarded`/`failed`/`cleared`, and
+   * they are different facts — only the first explains to whoever is watching
+   * why a manager's claim is still outstanding. Same argument as
+   * `finalizedWithUnfinishedGames` on the week outcome.
+   *
+   * It is also the only trace this leaves. A wrongly-early award used to destroy
+   * its own evidence: the wire row carrying `clears_at` is deleted as part of
+   * awarding, and nothing else stores it.
+   */
+  readonly deferred: number;
   readonly priorityAfter: readonly string[];
   readonly cleared: number;
 }
 
 /**
- * Resolve every pending claim in a league.
+ * Resolve every pending claim whose player has cleared waivers.
  *
  * The decision belongs entirely to `resolveWaiverClaims`; this loads its inputs
  * and writes its outputs. Everything happens in one transaction, so a run either
  * lands whole or not at all — a half-applied waiver run would leave rosters that
  * no rule produced.
+ *
+ * **Not every pending claim, and the difference is a signed rule.** A claim
+ * filed against a player who has not served his waiver period stays PENDING and
+ * is resolved by a later run. It is deferred, never failed.
  *
  * **The inputs are read inside that transaction too.** They were not, and the gap
  * was the whole bug: every roster in the league was read on `db`, resolved
@@ -733,9 +765,42 @@ export async function processWaivers(
      */
     const alreadyHeld = new Set(rosterRows.map((row) => row.player_id));
 
+    /**
+     * Players whose waiver period has not elapsed yet.
+     *
+     * **The run must not award a player before he clears**, and until this
+     * existed it did. `waiverClearsAt` rounds a drop up to the first processing
+     * run at least `waiverPeriodDays` later, and the runs are weekly — so a drop
+     * in the 24 hours before a run rounds up by a whole week, while the run
+     * itself is hours away. `docs/RULES.md` §6 names that exact case: "someone
+     * dropped on Tuesday evening does not clear the next morning, which would
+     * leave the rest of the league no real chance to claim him." He did.
+     *
+     * **A missing row means clear, never blocked.** An absent wire row is what
+     * "free agent" *is* everywhere else in this module, and a claim can outlive
+     * its row — the sweep below removes it, and so does an add. An inner join
+     * here would leave those claims PENDING forever, retried hourly, which is
+     * the permanent wedge the filter above exists to prevent.
+     *
+     * **`<=`, matching `availabilityOf` and the sweep exactly.** `clears_at` is
+     * itself a processing instant and this runs at processing instants, so
+     * equality is the ordinary case rather than a boundary curiosity: a `<` here
+     * would defer every ordinary claim by a week, and would defer a claim in the
+     * same run that the sweep below frees his player to whoever is fastest.
+     */
+    const wireRows = await tx.query<{ player_id: string; clears_at: string }>(
+      "SELECT player_id, clears_at FROM waiver_wire WHERE league_id = $1",
+      [leagueId],
+    );
+    const clearsAt = new Map(wireRows.map((row) => [row.player_id, new Date(row.clears_at)]));
+    const notYetClear = (playerId: string): boolean => {
+      const clears = clearsAt.get(playerId);
+      return clears !== undefined && clears.getTime() > now.getTime();
+    };
+
     const resolution = resolveWaiverClaims({
       claims: claims
-        .filter((row) => !alreadyHeld.has(row.add_player_id))
+        .filter((row) => !alreadyHeld.has(row.add_player_id) && !notYetClear(row.add_player_id))
         .map((row): WaiverClaim => ({
           claimId: row.id,
           teamId: row.team_id,
@@ -751,9 +816,17 @@ export async function processWaivers(
     let awarded = 0;
     let failed = 0;
 
-    // Filtered out above, so they never reach `outcomes` — and a claim left
-    // PENDING is retried every hour forever, which is the wedge this is here to
-    // avoid. It really did fail, and for a reason worth telling the manager.
+    // **Two filters above, and only one of them is a failure.**
+    //
+    // A claim for a player somebody already holds can never succeed, so it is
+    // written FAILED here — leaving it PENDING would retry it hourly forever.
+    // A claim for a player who has not cleared yet is not failed, it is *early*:
+    // it stays PENDING deliberately and is resolved by the run after he clears.
+    //
+    // So this loop keys on `alreadyHeld` specifically. Do not "simplify" it to
+    // "anything missing from `resolution.outcomes` failed" — that would turn
+    // every deferral into a permanent rejection, silently, and the manager would
+    // be told their claim lost to a player nobody had.
     for (const row of claims) {
       if (!alreadyHeld.has(row.add_player_id)) continue;
 
@@ -763,6 +836,10 @@ export async function processWaivers(
       );
       failed++;
     }
+
+    // Players this run actually released, which is not the same as every player
+    // any pending claim happens to name. See the loop below the transaction.
+    const dropped: string[] = [];
 
     for (const outcome of resolution.outcomes) {
       const claim = claims.find((row) => row.id === outcome.claimId)!;
@@ -782,6 +859,7 @@ export async function processWaivers(
             WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
           [claim.team_id, claim.drop_player_id, now.toISOString()],
         );
+        dropped.push(claim.drop_player_id);
       }
 
       // No `try` around this one, unlike `addFreeAgent`. There, a unique
@@ -824,10 +902,22 @@ export async function processWaivers(
       ]);
     }
 
-    return { awarded, failed, claims, priorityAfter: resolution.priorityAfter };
+    // Everything the run neither awarded nor failed: still PENDING, waiting for
+    // its player to clear. Reported rather than inferred — a league with three
+    // deferred claims and a league with nothing to do are different facts, and
+    // only the first explains why a manager's claim is still outstanding.
+    const deferred = claims.length - awarded - failed;
+
+    return {
+      awarded,
+      failed,
+      deferred,
+      dropped,
+      priorityAfter: resolution.priorityAfter,
+    };
   });
 
-  const { awarded, failed, claims } = run;
+  const { awarded, failed, deferred, dropped } = run;
 
   // Players nobody claimed become free agents once their wire time passes.
   // Removing the row is what makes them free — absent means available.
@@ -840,16 +930,23 @@ export async function processWaivers(
 
   // Anyone dropped in the same run must not be swept up by that clear: he landed
   // after it, and his own wire time has not passed.
-  for (const claim of claims) {
-    if (claim.drop_player_id) {
-      await placeDroppedPlayer(db, leagueId, claim.drop_player_id, now, stored.rules);
-    }
+  //
+  // **Players this run released, not players some pending claim mentions.** It
+  // used to walk every pending claim, so a claim that failed — or, now that
+  // claims can be deferred, one that has simply not resolved yet — re-dated the
+  // wire row of a player it never touched. That is somebody else's player: a
+  // manager who legitimately dropped him watched his `clears_at` pushed a week
+  // further out by a stranger's losing claim, hourly, for as long as the claim
+  // sat there. Since `waiverClearsAt(now) > now` always, he could never clear.
+  for (const playerId of dropped) {
+    await placeDroppedPlayer(db, leagueId, playerId, now, stored.rules);
   }
 
   return {
     leagueId,
     awarded,
     failed,
+    deferred,
     priorityAfter: run.priorityAfter,
     cleared: cleared.length,
   };


### PR DESCRIPTION
Closes #79 (part 1). **Stacked on #88**, which also touches `waivers.ts`. Waivers go live **Sep 16 2026** — the first real run is this scenario.

## The bug

`processWaivers` selected every `PENDING` claim with no reference to the wire. So a claim was awarded **168 hours before its player's own `clears_at`**, at an instant when `availabilityOf` still answered `ON_WAIVERS` for the same player. The system contradicted itself: frozen on waivers to `addFreeAgent`, awardable to the waiver run.

`docs/RULES.md` §6 names the exact case:

> A player clears at the first processing run at least a full day after landing on waivers — **so someone dropped on Tuesday evening does not clear the next morning, which would leave the rest of the league no real chance to claim him.**

He did. This is the third §6 clause found unimplemented, after the kickoff lock.

**The cause is structural**, and worth stating because it is not an off-by-one: a **1-day** waiver period against a **weekly** processing moment means the real period is "one day, rounded up to the next weekly run". Any drop in the 24 hours before a run rounds up by a whole week, while the run itself is hours away. `waiverClearsAt` implements that correctly. The resolution path did not consult it at all.

Reproduced on PGlite, to the minute:

```
dropped at              Tue 15 Sep, 20:00 EDT
clears_at written       Wed 23 Sep, 03:00 EDT
claim submitted         Tue 15 Sep, 20:05 EDT   availabilityOf = ON_WAIVERS
run fires               Wed 16 Sep, 03:00 EDT   availabilityOf = ON_WAIVERS
                                                claim AWARDED, player rostered
skipped: 168 hours
```

The band is every drop in `(Tue 03:00 ET, Wed 03:00 ET)` — 24 hours a week, and it contains the single most common drop instant in fantasy football, right after Monday night. Reachable through `dropPlayer` and through the swap side of `addFreeAgent`.

**The window a league-mate actually gets ranges from 24 hours down to one minute** for a drop just before the run — while `PlayerMarket` shows them *"clears in 7d"* the whole time, because the display reads the one value the resolution ignored. The screen was never wrong; it was the witness.

## The fix

Claims for a player who has not cleared are **deferred**: left `PENDING`, resolved by the run after he clears. Not failed — a manager told their claim failed goes looking for the player.

Deferral is safe and was verified rather than assumed: `leaguesDueForWaivers` keys on the oldest pending claim's `created_at`, which never moves, so once due the league stays due, and the cron is hourly. Simulated across 216 hourly ticks; the award lands at exactly `clears_at`.

### Three load-bearing details, each mutation-checked

**`<=`, matching `availabilityOf` and the post-run sweep exactly.** For an ordinary drop, `clears_at` *equals* the run instant — equality is the normal case here, not a boundary curiosity, because `clears_at` is a processing instant and this runs at processing instants. A `<` would **delay every waiver claim in every league by a week**, and would defer a claim in the same run that the sweep frees his player to whoever is fastest. *Fails four tests.*

**A missing wire row means clear, never blocked.** A claim outlives its row — the sweep removes it, so does an add. The obvious reading of "filter the claim set on the wire" is an inner join, which would strand those claims `PENDING` forever, retried hourly. That is worse than the bug. *Fails one test.*

**The drop-side loop now walks players this run released**, not players any pending claim happens to name. It used to re-date the wire row of a third party: someone who legitimately dropped a player watched his `clears_at` pushed a further week out by a stranger's unresolved claim — and since a fresh clear is always in the future, he could never clear at all. Pre-existing, but deferral turns one occurrence into one an hour for a week. *Fails one test.*

## `deferred` on the outcome

A run holding three claims and a run with nothing to do were indistinguishable from `awarded`/`failed`/`cleared`. Reported rather than collapsed, on the same argument as `finalizedWithUnfinishedGames`.

It is also the **only trace this leaves**. Awarding deletes the wire row that carried `clears_at`, and nothing else stores it — so a wrongly-early award destroyed its own evidence. It is still reconstructible from `roster_entries.released_at` plus the frozen rules, because both wire writes are drop-driven, but nothing surfaces it and nobody would know to look. A history column is a migration and this has to land before Sep 16; filed separately.

## Verification

**The existing suite could not see this in either direction.** Every processing test drops at one instant and runs eleven hours the safe side of `clears_at`, so a no-op fix, an inverted comparison, or a filter on the wrong column would all ship green. The test at `waivers.test.ts:440` looks like coverage — its run instant *is* before `clears_at` — but it submits no claim, so it exercises the sweep, which was already right.

Six new tests on the real week-2 2026 calendar, with the instants written as literals so a moved constant fails loudly rather than quietly agreeing with itself:

| test | pins |
|---|---|
| defers a claim whose player has not served his waiver period | the bug — and that the claim is `PENDING` with `processed_at` null, the wire row intact, priority unspent, then **awarded at the next run on the same database** |
| still awards an ordinary claim at the very run its player clears at | the `<=`; the test that stops the fix being worse than the bug |
| holds at one millisecond before the clear and awards at the clear | the boundary from both sides |
| awards a claim whose wire row is already gone | no row ⇒ clear |
| resolves a cleared claim without dragging an uncleared one along | per claim, not per league |
| does not re-freeze a player a pending claim merely names | the drop-side loop |

The first is deliberately one test rather than two: only running on to the real clear on the same database distinguishes *deferred* from *lost*.

1143 tests, typecheck, lint green. No schema change, no rules change, **golden hash untouched.**

## Comments and copy corrected

The fix makes several statements false that were merely imprecise before, and user-facing copy is worse than a comment:

- `PlayerMarket`'s *"It resolves at the next waiver run"* → *"at the run he clears at"*. The screen already shows that time beside the player's name.
- The players page header, same correction.
- `processWaivers`' own header said *"Resolve every pending claim in a league"* — accurate before, false now.
- `pendingClaims` was documented as *"in the order they will resolve"*. It never was: resolution is by priority, and now a claim filed later can resolve sooner. Renamed to what it does.
- The module header and `availabilityOf` both said "until the next processing run", which is not when a player clears.

## Not fixed here, deliberately

- **A deferred claim makes the league due every hour until it resolves** — up to ~184 no-op runs, each taking `FOR UPDATE` on the league row and contending with `addFreeAgent`'s `FOR SHARE`. Correct but wasteful; `leaguesDueForWaivers` gates on `created_at` rather than on anything actionable. Filed separately rather than bundled, because tightening that gate is the kind of change that can strand claims if it is got wrong.
- **Part 2 of #79** (a team's own claims resolve in random-UUID order) stays open. It needs a new field on `WaiverClaim` in core and touches the pure resolver; mixing that with a timing fix makes both harder to review. Part 3 (`nextWeekly` and the spring-forward Sunday) is unreachable with the shipped rules — the transition is March 2027, two months after the last league settles.
- **`RULES.md` §6's Tuesday 00:00 ET weekly lock is implemented nowhere.** Filed separately; it is a larger §6 gap than this one.

## Not verified

The exploit path — dropping a player minutes before the run so nobody sees him move, then claiming him back — follows from the confirmed award behaviour but was not built and executed. The 24-hour short-tenure rule constrains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
