### PR TITLE
fix(db,web): a trade cannot cross a league boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -896,6 +896,27 @@ the same SQL (`apps/web/src/app/api/cron/score-week/route.ts:46-54`) rather than
 it; that is tolerable, because it wants exactly the lagging semantics, but it is a copy and
 not a shared call.
 
+**A trade never leaves the league it was proposed in, and until recently only the _veto_
+enforced that.** `proposeTrade` took the receiving team out of the request body and never
+joined it to the league; `acceptTrade` loaded a trade by id alone and read its `league_id`
+only to fetch rules. So a manager with a team in two leagues could propose in one naming
+the other, accept from the far side, and let the hourly cron execute it — moving a player
+between two closed pools.
+
+Nothing caught it downstream, and that is the part worth remembering: `0022`'s trigger
+derives `roster_entries.league_id` from the destination team, so the imported row lands
+correctly stamped and `roster_entries_one_owner_per_league` is satisfied. The result is
+indistinguishable from a legitimate acquisition. And because `resolveTrade` releases with a
+direct `UPDATE` rather than through `dropPlayer`, neither player touches `waiver_wire` — so
+the receiving league's blind claim queue and priority order are bypassed in both directions.
+
+Both teams are now bound at proposal, and every other entry point **derives** the league by
+joining rather than taking it as an argument — the shape `vetoTrade` has used since `0020`,
+and the reason it was the one entry point never exploitable. A `leagueId` parameter would
+close the same hole while creating an obligation each future caller has to honour.
+Migration `0026` makes the row unrepresentable, using the composite uniqueness `0020`
+already added and did not use.
+
 **A veto is scoped to the trade's own league, at three layers.** `vetoTrade` refuses an
 outside voter (`NOT_IN_LEAGUE`); the tally in `loadTrade` counts only rows from teams that
 are in the league, not bots, and not party to the trade — the _same three conditions as the

--- a/apps/web/src/app/api/leagues/[id]/trades/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/trades/route.ts
@@ -139,8 +139,17 @@ export async function GET(
 /**
  * Propose, accept, decline, withdraw, or veto.
  *
- * The acting team always comes from the session, never the body — a route that
- * took a team ID would let anyone accept anyone's trade.
+ * The **acting** team always comes from the session, never the body — a route
+ * that took a team ID would let anyone accept anyone's trade.
+ *
+ * **The objects it acts on do come from the body**, and that is the half this
+ * comment used to leave out. `receiverTeamId` and `tradeId` are both read off
+ * the wire, and authorising the actor says nothing about them: for a while a
+ * manager could name a team in a different league as the receiver, because
+ * nothing downstream joined it to the league in the URL. Both are now bound in
+ * `@rostr/db` rather than here — derived from the database on each call, so a
+ * second route could not get it wrong — and migration `0026` makes a trade whose
+ * teams are not in its league unrepresentable.
  */
 export async function POST(
   request: Request,

--- a/packages/db/migrations/0026_trades_scoped_to_league.sql
+++ b/packages/db/migrations/0026_trades_scoped_to_league.sql
@@ -1,0 +1,52 @@
+-- Trades belong to one league, and both sides of one belong to it too.
+--
+-- `proposeTrade` took the receiving team out of the request body and never
+-- joined it to the league it was proposing in, and `acceptTrade` loaded a trade
+-- by id alone and read its `league_id` only to fetch rules. So a manager holding
+-- a team in two leagues could propose in one naming the other, accept it from
+-- the far side, and let the hourly cron execute it — moving a player between two
+-- closed player pools.
+--
+-- The damage is not a corrupt row, which is what makes it worth a constraint.
+-- `roster_entries.league_id` is derived by 0022's trigger from the destination
+-- team, so the imported row lands correctly stamped and satisfies
+-- `roster_entries_one_owner_per_league`. It is indistinguishable from a
+-- legitimate acquisition. And because `resolveTrade` releases with a direct
+-- UPDATE rather than through `dropPlayer`, neither player touches
+-- `waiver_wire` — so the receiving league's blind claim queue and priority
+-- order are bypassed in both directions.
+--
+-- This is the same defect 0020 fixed for vetoes, in the same file, twenty lines
+-- from the fix. Its comment is worth repeating: "the read is scoped now and the
+-- write is refused, but neither repairs a row already written."
+--
+-- **Both prerequisites already exist.** 0020 added `teams_id_league_unique
+-- (id, league_id)` for the veto's composite key, and `trades.league_id` has been
+-- NOT NULL since 0005. So this needs no new column, no backfill and no trigger —
+-- only the two constraints 0020 built the uniqueness for and did not use.
+--
+-- No repair step, unlike 0020. There is no production data yet (0022 says so for
+-- the same reason), and a dirty row would make this ALTER fail loudly, which is
+-- the right direction: the alternative is a DELETE, and `trade_assets` and
+-- `trade_vetoes` both cascade from `trades`, so deleting an offending trade
+-- would silently take the assets and the votes with it. For an EXECUTED trade
+-- the roster moves survive the delete regardless, so it would destroy the only
+-- record of a change it cannot undo. A human should look at such a row.
+--
+-- Forward-only, like every migration here.
+
+ALTER TABLE trades
+  ADD CONSTRAINT trades_proposer_in_league
+  FOREIGN KEY (proposer_team_id, league_id) REFERENCES teams (id, league_id);
+
+ALTER TABLE trades
+  ADD CONSTRAINT trades_receiver_in_league
+  FOREIGN KEY (receiver_team_id, league_id) REFERENCES teams (id, league_id);
+
+-- Not closed here: `trade_assets.from_team_id` is a plain reference to
+-- `teams (id)` with no `league_id` column of its own, so an asset row naming a
+-- team in a third league stays representable. `resolveTrade` maps any
+-- non-proposer `from_team_id` to the proposer, so such a row would move a
+-- stranger's player. It is unreachable through `proposeTrade` now that both
+-- trade teams are pinned, and closing it properly needs a column, a backfill and
+-- a derive trigger — 0022's shape, not two ALTERs. Tracked separately.

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -189,6 +189,78 @@ async function seedSchedule(client: PGliteClient, sportId: string): Promise<void
   );
 }
 
+interface TwoLeagueFixture extends Fixture {
+  otherLeagueId: string;
+  otherTeams: string[];
+}
+
+/**
+ * The same league, plus a second one holding players of its own.
+ *
+ * A trade is a closed swap inside one league, and nothing in a single-league
+ * fixture can tell the difference between "scoped to the league being proposed
+ * in" and "scoped to whatever league the proposer happens to be in" — those are
+ * the same value until a second league exists.
+ *
+ * League B gets **new** player rows rather than reusing league A's. Reusing one
+ * would make the test pass on `roster_entries_one_owner_per_league` instead of
+ * on the fix, which is per-league and would fire for its own reasons.
+ *
+ * No second schedule: `games` are keyed by sport and season, so the one seeded
+ * above already answers for both leagues.
+ */
+async function setupWithSecondLeague(): Promise<TwoLeagueFixture> {
+  const fx = await setup();
+
+  const other = await createUser(fx.client, "outside@example.com", "Outside");
+  const otherLeague = await createLeague(fx.client, NFL, {
+    name: "Somewhere Else",
+    commissionerId: other.id,
+    rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+  });
+
+  const otherTeams: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    otherTeams.push((await addTestTeam(fx.client, otherLeague.id, `Other ${i + 1}`)).teamId);
+  }
+
+  const [sport] = await fx.client.query<{ id: string }>(
+    "SELECT id FROM sports WHERE key = $1",
+    [NFL.key],
+  );
+  const [position] = await fx.client.query<{ id: string }>(
+    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+    [sport!.id],
+  );
+
+  for (const [index, teamId] of otherTeams.entries()) {
+    const handle = `q${index + 1}`;
+    const [player] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, position!.id],
+    );
+    fx.players.set(handle, player!.id);
+
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [teamId, player!.id, new Date(MONDAY.getTime() - 30 * DAY).toISOString()],
+    );
+  }
+
+  return { ...fx, otherLeagueId: otherLeague.id, otherTeams };
+}
+
+/** Which team actively holds a player, anywhere. Null if nobody does. */
+async function ownerOf(fx: Fixture, playerId: string): Promise<string | null> {
+  const [row] = await fx.client.query<{ team_id: string }>(
+    "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+    [playerId],
+  );
+  return row?.team_id ?? null;
+}
+
 /** The straightforward one-for-one: team 1's player for team 2's. */
 async function propose(fx: Fixture, now = MONDAY): Promise<string> {
   const { tradeId } = await proposeTrade(fx.client, {
@@ -716,6 +788,113 @@ describe("vetoing", () => {
         [tradeId, outsider, otherLeague.id, MONDAY.toISOString()],
       ),
     ).rejects.toThrow(/trade_vetoes_trade_in_league/);
+  });
+
+  it("refuses a proposal naming a team in another league", async () => {
+    // Two closed player pools. A manager holding a team in each could propose in
+    // one naming the other, accept from the far side, and let the cron execute
+    // it — importing a player the receiving league's waiver queue never got to
+    // allocate, and exporting one who never reaches its wire at all, because
+    // `resolveTrade` releases with a direct UPDATE rather than through
+    // `dropPlayer`.
+    //
+    // The same defect `vetoTrade` was fixed for, twenty lines away in the same
+    // file, left standing on propose and accept.
+    const fx = await setupWithSecondLeague();
+
+    await expect(
+      proposeTrade(fx.client, {
+        leagueId: fx.leagueId,
+        proposerTeamId: fx.teams[0]!,
+        receiverTeamId: fx.otherTeams[0]!,
+        proposerGives: [fx.players.get("p1")!],
+        receiverGives: [fx.players.get("q1")!],
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_IN_LEAGUE" });
+
+    // **The property, not the code.** A refusal at the door proves nothing about
+    // where the players ended up, which is what actually matters — and a fix
+    // that closed propose while leaving the resolution path open would satisfy
+    // the assertion above.
+    expect(await listTrades(fx.client, fx.leagueId)).toHaveLength(0);
+    expect(await listTrades(fx.client, fx.otherLeagueId)).toHaveLength(0);
+
+    expect(await ownerOf(fx, fx.players.get("q1")!)).toBe(fx.otherTeams[0]);
+    expect(await ownerOf(fx, fx.players.get("p1")!)).toBe(fx.teams[0]);
+  });
+
+  it("says the team is not in this league rather than that it is a bot", async () => {
+    // Ordering. The bot check queries teams by id with no league predicate, so
+    // it answers correctly across leagues — which is the problem: reached first,
+    // it turns a refusal into an oracle. `BOT_CANNOT_TRADE` confirms the id
+    // names a real team, and that it is a bot, for an id the caller was never
+    // entitled to resolve. `NOT_IN_LEAGUE` reveals nothing.
+    //
+    // The mirror of this test is "refuses a trade involving a bot" above: a bot
+    // in *this* league must still say so. Either alone leaves the order free.
+    const fx = await setupWithSecondLeague();
+    await fx.client.query("UPDATE teams SET owner_id = NULL, is_bot = true WHERE id = $1", [
+      fx.otherTeams[0],
+    ]);
+
+    await expect(
+      proposeTrade(fx.client, {
+        leagueId: fx.leagueId,
+        proposerTeamId: fx.teams[0]!,
+        receiverTeamId: fx.otherTeams[0]!,
+        proposerGives: [fx.players.get("p1")!],
+        receiverGives: [fx.players.get("q1")!],
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_IN_LEAGUE" });
+  });
+
+  it("cannot even record a trade whose teams are not in its league", async () => {
+    // The guards in `proposeTrade` and `acceptTrade` close the doors. This
+    // asserts the stronger thing, as `0020` did for vetoes: after `0026` the row
+    // is unrepresentable, so a future caller — or a hand-written statement —
+    // cannot reintroduce it.
+    //
+    // It is also why there is no test here for `acceptTrade` refusing a
+    // cross-league trade: that state can no longer be constructed to accept.
+    // A test that cannot build its own precondition would pass against the fix,
+    // against the bug, and against no guard at all.
+    const fx = await setupWithSecondLeague();
+
+    await expect(
+      fx.client.query(
+        `INSERT INTO trades (league_id, proposer_team_id, receiver_team_id, state, proposed_at)
+         VALUES ($1, $2, $3, 'PROPOSED', $4)`,
+        [fx.leagueId, fx.teams[0], fx.otherTeams[0], MONDAY.toISOString()],
+      ),
+    ).rejects.toThrow(/trades_receiver_in_league/);
+
+    await expect(
+      fx.client.query(
+        `INSERT INTO trades (league_id, proposer_team_id, receiver_team_id, state, proposed_at)
+         VALUES ($1, $2, $3, 'PROPOSED', $4)`,
+        [fx.otherLeagueId, fx.teams[0], fx.otherTeams[0], MONDAY.toISOString()],
+      ),
+    ).rejects.toThrow(/trades_proposer_in_league/);
+  });
+
+  it("still executes an ordinary trade with another league present", async () => {
+    // The negative. Every other trade test runs in one league, so this is the
+    // only one that would catch a league predicate scoped against the wrong
+    // value — though not one scoped to the proposer's league rather than the
+    // league being proposed in, since here those are the same. That mutation is
+    // caught by "refuses a proposal naming a team in another league" and by
+    // nothing else.
+    const fx = await setupWithSecondLeague();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    expect(resolution?.outcome).toBe("EXECUTED");
+
+    expect(await ownerOf(fx, fx.players.get("p1")!)).toBe(fx.teams[1]);
+    expect(await ownerOf(fx, fx.players.get("q1")!)).toBe(fx.otherTeams[0]);
   });
 
   it("does not count a veto from a bot or from a team in the trade", async () => {

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -70,6 +70,8 @@ export type TradeState =
 
 export interface TradeSummary {
   readonly tradeId: string;
+  /** The league this trade belongs to. A trade never leaves it. */
+  readonly leagueId: string;
   readonly proposerTeamId: string;
   readonly receiverTeamId: string;
   readonly state: TradeState;
@@ -164,6 +166,7 @@ async function loadTrade(db: SqlClient, tradeId: string): Promise<TradeSummary> 
 
   return {
     tradeId: trade.id,
+    leagueId: trade.league_id,
     proposerTeamId: trade.proposer_team_id,
     receiverTeamId: trade.receiver_team_id,
     state: trade.state,
@@ -179,6 +182,35 @@ async function loadTrade(db: SqlClient, tradeId: string): Promise<TradeSummary> 
     vetoes: Number(votes?.n ?? 0),
     vetoesRequired: vetoesRequired(electorate, stored.rules.trades),
   };
+}
+
+/**
+ * Refuse a team acting on a trade that belongs to another league.
+ *
+ * **Derived, never supplied.** Both halves are read from the database in one
+ * query, so there is no league argument for a caller to get wrong — the shape
+ * `vetoTrade` has used since migration `0020`, and the reason it was the only
+ * one of the five entry points that was never exploitable. A `leagueId`
+ * parameter would have closed the same hole while creating an obligation every
+ * future caller has to honour, in a module whose rule is that the server does
+ * not take identifiers from the caller and trust them.
+ *
+ * `TRADE_NOT_FOUND` rather than `NOT_IN_LEAGUE`, deliberately: a trade in
+ * another league is one this team has no business knowing exists, and a distinct
+ * code would confirm the id names something real.
+ */
+async function requireSameLeague(
+  db: SqlClient,
+  tradeId: string,
+  actingTeamId: string,
+): Promise<void> {
+  const [row] = await db.query<{ id: string }>(
+    `SELECT t.id FROM teams t
+       JOIN trades tr ON tr.id = $2
+      WHERE t.id = $1 AND t.league_id = tr.league_id`,
+    [actingTeamId, tradeId],
+  );
+  if (!row) throw new TradeError("Trade not found", "TRADE_NOT_FOUND");
 }
 
 /** Every trade in a league, newest first. */
@@ -281,6 +313,38 @@ export async function proposeTrade(
   });
   if (blocked) throw new TradeError(explain(blocked, stored.rules), blocked);
 
+  // **Both teams must be in this league, and this is checked before anything
+  // else looks at them.**
+  //
+  // A trade is a closed swap inside one league. Nothing used to say so: the
+  // receiver arrived from the request body and was never joined to
+  // `input.leagueId`, so a manager holding a team in two leagues could name the
+  // other one and move a player between closed player pools — bypassing the
+  // receiving league's waiver queue in both directions, since `resolveTrade`
+  // releases with a direct `UPDATE` and never puts anyone on the wire.
+  //
+  // `vetoTrade` was fixed for exactly this and has been correct since migration
+  // `0020`; propose and accept were not revisited. This is that same join.
+  //
+  // **Order matters.** It has to come before the bot check below, which queries
+  // teams by id with no league predicate — so a receiver in another league gets
+  // `BOT_CANNOT_TRADE` rather than `NOT_IN_LEAGUE`, which answers "does this id
+  // name a bot somewhere" for an id the caller was never entitled to resolve.
+  // Two separate checks rather than one combined query, so a bot in this league
+  // still reports `BOT_CANNOT_TRADE`.
+  //
+  // The proposer is checked too, though today it always arrives as
+  // `context.myTeamId`, which the route derives with a league predicate of its
+  // own. That makes it safe by virtue of its one caller, which is the property
+  // this whole fix exists to stop relying on.
+  const inLeague = await db.query<{ id: string }>(
+    "SELECT id FROM teams WHERE id = ANY($1) AND league_id = $2",
+    [[input.proposerTeamId, input.receiverTeamId], input.leagueId],
+  );
+  if (inLeague.length !== 2) {
+    throw new TradeError("Both teams must be in this league", "NOT_IN_LEAGUE");
+  }
+
   // A bot has nobody to weigh an offer, so it cannot accept one. Letting a
   // manager propose to a bot would either strand the trade forever or require
   // the bot to judge it — and a bot that judges trades is a commissioner with
@@ -377,6 +441,8 @@ export async function acceptTrade(
   now: Date,
 ): Promise<TradeSummary> {
   const trade = await loadTrade(db, tradeId);
+  await requireSameLeague(db, tradeId, actingTeamId);
+
   if (trade.state !== "PROPOSED") {
     throw new TradeError(`This trade is ${trade.state.toLowerCase()}`, "WRONG_STATE");
   }
@@ -384,11 +450,7 @@ export async function acceptTrade(
     throw new TradeError("Only the team offered a trade can accept it", "NOT_YOUR_TRADE");
   }
 
-  const [row] = await db.query<{ league_id: string }>(
-    "SELECT league_id FROM trades WHERE id = $1",
-    [tradeId],
-  );
-  const stored = await getLeagueRules(db, row!.league_id);
+  const stored = await getLeagueRules(db, trade.leagueId);
   if (!stored) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
 
   const deadline = new Date(
@@ -433,7 +495,7 @@ export async function acceptTrade(
 
     // Pass two, with every lock now held, so a competing accept has either
     // already committed and is visible here, or is still blocked behind us.
-    const frozen = await lockedByTrade(tx, row!.league_id);
+    const frozen = await lockedByTrade(tx, trade.leagueId);
     for (const asset of assets) {
       if (frozen.has(asset.player_id)) {
         throw new TradeError(
@@ -452,7 +514,15 @@ export async function acceptTrade(
   });
 }
 
-/** Decline an offer. Only the team it was made to. */
+/**
+ * Decline an offer. Only the team it was made to.
+ *
+ * The league check below is symmetry rather than a hole being closed: the
+ * receiver-equality test underneath it means only a party to the trade gets
+ * this far, and a party in another league can only exist because `proposeTrade`
+ * let one through. Scoped anyway, because leaving one of five entry points
+ * deriving the league differently from the other four is how this recurs.
+ */
 export async function declineTrade(
   db: SqlClient,
   tradeId: string,
@@ -460,6 +530,8 @@ export async function declineTrade(
   now: Date,
 ): Promise<void> {
   const trade = await loadTrade(db, tradeId);
+  await requireSameLeague(db, tradeId, actingTeamId);
+
   if (trade.state !== "PROPOSED") {
     throw new TradeError(`This trade is ${trade.state.toLowerCase()}`, "WRONG_STATE");
   }
@@ -487,6 +559,8 @@ export async function withdrawTrade(
   now: Date,
 ): Promise<void> {
   const trade = await loadTrade(db, tradeId);
+  await requireSameLeague(db, tradeId, actingTeamId);
+
   if (trade.state !== "PROPOSED") {
     throw new TradeError(
       trade.state === "ACCEPTED"


### PR DESCRIPTION
Closes #77 (part 1). **Stacked on #103**, which changed `proposeTrade`'s signature.

## The bug

`proposeTrade` took the receiving team out of the request body and **never joined it to the league being proposed in**. `acceptTrade` loaded a trade by id alone and read its `league_id` only to fetch rules — never comparing it to the acting team's league.

So a manager holding a team in two leagues can propose in one naming the other, accept from the far side, and let the hourly cron execute it. Run end to end on PGlite:

```
PROPOSE (league A, receiver = my league-B team)  -> accepted
ACCEPT  (acting as the league-B team)            -> ACCEPTED
cron RESOLVE                                     -> EXECUTED

league A: teamA1 -> b1   (imported from league B)
league B: teamB1 -> a1   (exported from league A)
league A waiver_wire rows: 0
```

**This is the defect migration `0020` fixed for vetoes** — twenty lines away in the same file, with a comment explaining it — left standing on propose and accept.

## Why nothing downstream catches it

I expected the storage layer to save us. It does not, and this is the part worth reading:

- **`0022`'s trigger derives `roster_entries.league_id` from the destination team**, so the imported row lands correctly stamped and satisfies `roster_entries_one_owner_per_league`. There is no corrupt row. The result is indistinguishable from a legitimate acquisition.
- That index only fires if the player is *already* actively rostered in the destination league — which the attacker avoids by choosing someone unrostered. It is a backstop against duplication, and this is not duplication.
- **`resolveTrade` releases with a direct `UPDATE`, not through `dropPlayer`**, so neither player touches `waiver_wire`. That is correct and deliberate for an ordinary trade (a traded player must never surface on waivers), and it is exactly what the exploit abuses.

Verified consequences, all executed rather than reasoned about:

- **The waiver queue is bypassed in both directions.** A player who was `ON_WAIVERS` in the receiving league, with another manager's claim still `PENDING`, was imported straight onto the attacker's roster; the claim is still pending. The exported player becomes `FREE_AGENT` immediately, never entering the wire.
- **No roster ceiling.** A six-for-one import executed against a 14+2 shape. Nothing in `resolveTrade` counts slots.
- **The losing league gets no say.** The trade does not appear in its list and its managers get `NOT_IN_LEAGUE` if they try to veto. `lockedByTrade` is league-scoped, so the receiver's promised player is not even frozen.

## The fix

**Bind both teams at proposal**, and **derive** the league everywhere else.

`acceptTrade` / `declineTrade` / `withdrawTrade` do not take a league argument. They join, the way `vetoTrade` has since `0020` — both halves read from the database, so there is nothing a caller can pass wrongly. A `leagueId` parameter would have closed the same hole while creating an obligation every future caller has to honour, in a module whose rule is that the server does not take identifiers from the caller and trust them.

**The receiver check goes before the bot check**, and that ordering is load-bearing. The bot query looks teams up by id with no league predicate, so it answers correctly across leagues — reached first, it turns a refusal into an oracle: `BOT_CANNOT_TRADE` confirms that an id the caller was never entitled to resolve names a real team, and that the team is a bot. `NOT_IN_LEAGUE` reveals nothing. Two separate checks rather than one combined query, so a bot *in this league* still reports `BOT_CANNOT_TRADE`.

**`declineTrade` and `withdrawTrade` are scoped for symmetry, not because they were holes.** Both are gated on party equality, so only a party to the trade gets that far. Said so in the code, so the next reader does not assume all four were live.

## Migration 0026

Two composite FKs, and **both prerequisites already existed**: `0020` added `teams_id_league_unique (id, league_id)` for the veto's benefit, and `trades.league_id` has been `NOT NULL` since `0005`. No new column, no backfill, no trigger.

**No repair step, unlike `0020`.** There is no production data yet, and a dirty row makes the `ALTER` fail loudly — which is the right direction. The alternative is a `DELETE`, and `trade_assets` and `trade_vetoes` both cascade from `trades`, so deleting an offending trade would silently take the assets and the votes with it; for an `EXECUTED` trade the roster moves survive regardless, so it would destroy the only record of a change it cannot undo. A human should look at such a row.

## Verification

Four new tests, and they assert **where the players ended up in both leagues**, not error codes. A fix that closed propose and left the resolution path open would satisfy a `rejects.toMatchObject({ code })` assertion — the same lesson the veto tests already record in their own comments.

**Mutation-checked three times**, each failing exactly its own test and nothing else:

| mutation | fails |
|---|---|
| drop `AND league_id = $2` from the propose check | the cross-league propose, and the ordering test |
| move the league check after the bot query | the ordering test **only** — nothing else in the suite constrains it |
| remove the receiver FK from the migration | the unrepresentable-row test |

There is deliberately **no test of `acceptTrade` refusing a cross-league trade**: with the FKs in place that state cannot be constructed, so such a test would pass against the fix, against the bug, and against no guard at all. The guard stays as belt — a future caller or a psql session could still reach it — and the constraint is what is tested. Noted in the test file.

The negative (an ordinary same-league trade still works, with a second league present) is honest about its limits: it would pass under a fix scoped to the *proposer's* league rather than the league being proposed in, because in that fixture they are the same value. Only the cross-league test catches that.

1142 tests, typecheck, lint green. No rules change, **golden hash untouched.**

## Corrections to the issue text, all mine

- **The bot check is not itself exploitable.** It over-matches (a bot in any league is refused), so it is evidence of the missing binding rather than a usable hole.
- **A player cannot be traded out of free agency.** The ownership loop requires the receiving team to actually hold him, so the attacker must roster him in the other league first.
- **The bypassed queue is the *receiving* league's**, not the source league's. That is what the fixture had to be built around.
- **The trade is not invisible.** It appears in the proposing league's list and its managers can veto it inside the window — rendered with the receiver as `?`, which is the only visible tell and a reason not to "fix" the UI to hide it.

## What this does not fix

- **`trade_assets.from_team_id`** has no `league_id` column, so an asset row naming a team in a third league stays representable, and `resolveTrade` maps any non-proposer `from_team_id` to the proposer. Unreachable through `proposeTrade` now that both trade teams are pinned; closing it properly needs a column, a backfill and a trigger. Filed separately.
- **`resolveDueTrades` catches only `ASSET_GONE` and rethrows everything else**, and its query has no `ORDER BY`. If an import collides with a player already rostered in the destination league, the raw `23505` aborts that league's whole resolve run — every hour, forever, with the trade stuck `ACCEPTED` and uninvolved managers' players frozen for the season. That allowlist-inside-a-loop is the shape `CLAUDE.md` names as itself the bug. Unreachable going forward once `0026` lands, but it is a live defect in its own right. Filed separately.
- **`ROSTER_WOULD_OVERFLOW` is declared, mapped to a 409, and thrown nowhere.** Deliberately *not* implemented here: `RULES.md` says rosters may change size and a two-for-one is a normal trade. The dead thing is the error code, not a missing check.
- **Parts 2, 3 and 4 of #77** stay open. 2 and 3 belong together in one PR — the fix for 2 is one helper called by every release path, and the fix for 3 is calling it inside the transaction; shipping 2 first would replicate the racy read into four call sites instead of one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
