### PR TITLE
ci: refuse a migration numbered at or below the base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The migration check below compares against the base branch, and
+          # checkout does not fetch it: it is a single-refspec fetch rather than
+          # a clone, so `origin/main` does not exist in the runner at all and
+          # `git ls-tree origin/main` fails outright.
+          fetch-depth: 0
+
+      # Deliberately before install: it needs only git and node, so a numbering
+      # mistake is reported in seconds rather than behind a full install and
+      # build. Runs on every pull request rather than being filtered to
+      # `packages/db/migrations/**` — a required check that never fires reads as
+      # permanently pending and blocks the merge, so it exits early instead.
+      - name: Migration numbering
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-migration-numbers.mjs "origin/${{ github.base_ref }}"
 
       - uses: pnpm/action-setup@v4
 

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadMigrations, migrate, MigrationError } from "./migrate.js";
 import { createTestDatabase } from "./testing.js";
@@ -29,6 +30,23 @@ describe("loadMigrations", () => {
     for (const m of loadMigrations()) {
       expect(m.checksum).toMatch(/^[0-9a-f]{64}$/);
     }
+  });
+
+  it("leaves no .sql file in the directory unloaded", () => {
+    // A filename the pattern does not match is **silently skipped**, not
+    // rejected: `loadMigrations` filters on the pattern, and so does the CI
+    // numbering check. So `25_thing.sql`, `0025-thing.sql` or `0025_Thing.sql`
+    // is a migration that never runs, on any database, with nothing anywhere
+    // saying so — while reading as applied to anyone looking at the directory.
+    //
+    // Hermetic on purpose: it reads the same directory the runner does and
+    // needs no database, so it fails on the machine that made the typo rather
+    // than on the one that deploys.
+    const onDisk = readdirSync(new URL("../migrations", import.meta.url))
+      .filter((name) => name.endsWith(".sql"))
+      .sort();
+
+    expect(loadMigrations().map((m) => m.filename)).toEqual(onDisk);
   });
 });
 

--- a/scripts/check-migration-numbers.mjs
+++ b/scripts/check-migration-numbers.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Refuse a migration numbered at or below the base branch's highest.
+ *
+ * `packages/db/migrations/README.md` states the rule:
+ *
+ *   > Take the next number **above main's highest**, and **renumber on rebase if
+ *   > main moved**. Never merge a PR whose migration number is at or below
+ *   > main's head.
+ *
+ * ## Why this cannot be a test
+ *
+ * The runner already refuses a file numbered below one already applied, and
+ * `migrate.test.ts` already refuses two files sharing a number. Neither can see
+ * this case, and the reason is the same for both: `createTestDatabase()` builds
+ * an **empty** PGlite database, so `schema_migrations` is empty, `maxApplied` is
+ * 0, and every filename order is legal. The suite is green and the deployed
+ * database — which has an applied maximum — refuses to start. That asymmetry is
+ * on the record in this repo's own history: *"on a fresh database migrations
+ * sort and apply in order so maxApplied never overtakes, which means CI stays
+ * green while a deployed database refuses to start."*
+ *
+ * So it needs the base branch, which a test does not have and git does.
+ *
+ * ## What deliberately is not here
+ *
+ * An earlier draft also asked the GitHub API what numbers other open pull
+ * requests had claimed. That is the case where two branches each correctly take
+ * the next free number — and it is covered better by requiring branches to be up
+ * to date before merging, which makes the merge ref contain whatever just
+ * landed, so the repo's **own** duplicate check fires before the merge instead
+ * of on `main` after it. A status check is stamped on a head SHA and does not
+ * re-run when the base moves, so an API answer here is a photograph that branch
+ * protection would treat as current.
+ *
+ * That leaves this with no network call, no token, and no behaviour difference
+ * on a pull request from a fork — which matters, because two of the outside
+ * contributions to this repo have come from forks.
+ *
+ * ## Run it on every pull request
+ *
+ * Not path-filtered to `packages/db/migrations/**`. GitHub reports a required
+ * check that never fires as permanently pending, so a filtered job as a required
+ * context blocks every pull request that does not touch the filtered paths. It
+ * exits 0 quickly when there is nothing to say instead.
+ *
+ * Usage: `node scripts/check-migration-numbers.mjs <base-ref>`
+ * Needs the base ref fetched — `fetch-depth: 0` on the checkout.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const MIGRATIONS_DIR = "packages/db/migrations";
+const FILENAME = /^(\d{4})_[a-z0-9_]+\.sql$/;
+
+/** Exit codes. 1 is a real finding; 3 is "could not tell", which is not the same. */
+const FOUND_A_PROBLEM = 1;
+const BAD_USAGE = 2;
+const COULD_NOT_TELL = 3;
+
+const baseRef = process.argv[2];
+if (!baseRef) {
+  console.error("usage: check-migration-numbers.mjs <base-ref>");
+  process.exit(BAD_USAGE);
+}
+
+/**
+ * Migration filenames at a git ref.
+ *
+ * A failure here means the ref is missing or git is unhappy — an infrastructure
+ * problem, not a numbering one. It exits 3 rather than 1 so that a red check
+ * means what it says. A check that goes red for reasons unrelated to the diff is
+ * a check people learn to ignore, and this one only earns its place by being
+ * believed.
+ */
+function migrationsAt(ref) {
+  let out;
+  try {
+    out = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", MIGRATIONS_DIR], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    console.error(
+      `Could not read ${MIGRATIONS_DIR} at "${ref}".\n` +
+        `  git said: ${String(error.stderr ?? error.message).trim()}\n\n` +
+        `  This is a checkout problem, not a numbering problem. The base ref has to\n` +
+        `  be fetched — set "fetch-depth: 0" on actions/checkout, which does not\n` +
+        `  fetch it by default.`,
+    );
+    process.exit(COULD_NOT_TELL);
+  }
+
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((path) => path.slice(MIGRATIONS_DIR.length + 1))
+    .filter((name) => FILENAME.test(name));
+}
+
+const versionOf = (name) => Number(FILENAME.exec(name)[1]);
+
+const baseNames = migrationsAt(baseRef);
+const baseVersions = new Set(baseNames.map(versionOf));
+const baseHighest = baseNames.reduce((max, name) => Math.max(max, versionOf(name)), 0);
+
+// On a pull request, HEAD is the merge ref — base plus this branch — so
+// subtracting the base's own files leaves exactly what this branch adds. A
+// rename shows up as one addition, because the old name never existed at the
+// merge base.
+const ours = migrationsAt("HEAD").filter((name) => !baseNames.includes(name));
+
+const problems = [];
+
+for (const name of ours) {
+  const version = versionOf(name);
+  if (version > baseHighest) continue;
+
+  problems.push(
+    baseVersions.has(version)
+      ? `${name} is version ${version}, and ${baseRef} already has a migration at ` +
+          `that version.\n` +
+          `    Both files would sit in one tree, and \`loadMigrations\` throws\n` +
+          `    \`Duplicate migration version ${version}\` — failing every\n` +
+          `    database-backed test in the repo.`
+      : `${name} is version ${version}, at or below ${baseRef}'s highest ` +
+          `(${baseHighest}).\n` +
+          `    Migrations are forward-only, so any database that has already applied\n` +
+          `    version ${baseHighest} will refuse this one permanently — while a fresh\n` +
+          `    database applies it happily, which is why the test suite cannot see this.\n` +
+          `    Renumber it above ${baseHighest}.`,
+  );
+}
+
+if (problems.length > 0) {
+  console.error(`Migration numbering against ${baseRef} (highest ${baseHighest}):\n`);
+  for (const problem of problems) console.error(`  - ${problem}\n`);
+  console.error("See packages/db/migrations/README.md.");
+  process.exit(FOUND_A_PROBLEM);
+}
+
+console.log(
+  ours.length === 0
+    ? `No new migrations against ${baseRef}.`
+    : `Migration numbering fine: ${ours.join(", ")} (${baseRef} highest ${baseHighest}).`,
+);


### PR DESCRIPTION
Follows the 0025 collision between #72 and #95 (now #72=0025, #110=0026, #95=0027).

## What actually went wrong

Two branches each correctly took the next free number. Neither PR's tree contained the other's file, so both were green — and merging both would have put two 0025 files in one tree, where `loadMigrations` throws `Duplicate migration version 25` and every database-backed test fails.

**The detector already existed and was already correct.** A `pull_request` workflow runs against a merge ref — base plus the branch — so once one 0025 merged, the other's merge ref *would* have contained both files and *would* have failed. It just never re-ran: a status check is stamped on a head SHA and does not re-run when the base moves.

So that half is fixed by branch protection, not by code. `main` now requires branches to be up to date before merging, which forces the re-run. No script can substitute for it — anything computed at push time is a photograph that branch protection would treat as current.

## What this adds, which protection does not cover

A migration numbered **at or below the base's highest**. The runner refuses one below a database's applied maximum, but **no test can see it**: `createTestDatabase()` builds an empty PGlite database, so `schema_migrations` is empty, `maxApplied` is 0, and every filename order is legal. CI green, deployed database refuses to start. This repo has hit that before and said so in a commit message.

That needs the base branch, which a test does not have and git does.

PR #31 (fork) is in exactly this state today — `0022` against a `main` whose `0022` is already applied.

## Deliberately not included

An earlier draft asked the GitHub API which numbers other open PRs had claimed. Dropped: it needs a token, behaves differently on fork PRs (two outside contributions here came from forks), and answers with a snapshot. Requiring branches be up to date covers that case properly.

## Details that are load-bearing

- **`fetch-depth: 0`.** `actions/checkout` does a single-refspec fetch rather than a clone, so `origin/main` does not exist in the runner and `git ls-tree origin/main` fails outright. Reproduced.
- **Exit 3, not 1, when it cannot tell.** A missing ref is a checkout problem. A check that goes red for reasons unrelated to the diff is one people stop believing, and this earns its place only by being believed.
- **Not path-filtered.** GitHub reports a required check that never fires as permanently pending, so filtering to `packages/db/migrations/**` would block every PR touching no migration. It exits 0 early instead.
- **Before `pnpm install`**, so a numbering mistake reports in seconds rather than behind a full build.

## The hermetic half

`migrate.test.ts` gains a test that every `.sql` file in the directory is actually loaded. A filename the pattern does not match — `25_thing.sql`, `0025-thing.sql`, `0025_Thing.sql` — is **silently skipped** by both the runner and this script. That is a migration that never runs on any database while reading as applied to anyone looking at the directory.

## Verified

- clean tree: exit 0, `No new migrations against origin/main`
- a migration at 0022 against `main` at 0024: exit 1, names the duplicate
- missing base ref: exit 3, with the `fetch-depth` cause, not a stack trace
- PR #95's renumber passes — GitHub diffs against the merge base, so a rename appears as one addition

The workflow change itself cannot be tested until this PR runs. 21 migrate tests pass; format and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)