### PR TITLE
docs: correct the handoff where it had gone stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Do not build it in August.
 
 See [`docs/BUILD-PLAN.md`](docs/BUILD-PLAN.md) for the full commit-by-commit plan.
 
-**Done — 909 tests, CI green:**
+**Done — 1222 tests, CI green:**
 
 - Full specification — rules, data model, live scoring, build plan
 - A1: pnpm monorepo, TS strict, vitest, eslint, prettier, CI
@@ -201,9 +201,11 @@ moment it does.
 Two outside reviewers have opened PRs. **They are not the same kind of contribution and
 should not be treated the same way.**
 
-**0x-SquidSol.** Seven PRs already merged (#3, #5, #8, #10, #12, #14, #16), each followed
-by a fix of our own on top. Four still open — **#32, #34, #36, #38 — and every one of them
-addresses a bug that is live on `main` right now.** Verified individually on 2026-08-10:
+**0x-SquidSol.** Seven PRs merged (#3, #5, #8, #10, #12, #14, #16), each followed by a fix
+of our own on top. Four more — **#32, #34, #36, #38 — all now closed**, each superseded by
+our own version of the same fix. They are kept below because the _diagnoses_ are the
+record: every one named a bug that was live on `main` when it was filed, and the pattern
+of what they found is worth more than their status. Verified individually on 2026-08-10:
 
 - **#32** — `verifyLeagueAnchor` compares `rulesHash` and nothing else. `OnChainLeague` does
   not even expose `refundUnlockAt`, `feeRecipient` or `payoutBps`, so three of the economic
@@ -222,9 +224,10 @@ addresses a bug that is live on `main` right now.** Verified individually on 202
   rethrows it and one undersized league aborts scoring for every league.
 
 **Three of those four are bugs in code written in this repo the same week** (#34 and #38 in
-the playoff work, #36 in trades). Squid's diagnoses have been right every time so far. What
-has _not_ been checked is whether each proposed **fix** is correct — that is a separate
-question from whether the bug is real, and it is the one still open.
+the playoff work, #36 in trades). Squid's diagnoses have been right every time. The lesson
+that outlasted the PRs: **a correct diagnosis and a correct fix are separate questions**,
+and on this repo the second has needed our own work every time — which is why each of the
+four was closed in favour of a version written here rather than merged as sent.
 
 **vip-ultr (Ammar).** Three PRs. **Two are now merged**, each as a follow-up built on his
 commit rather than a replacement, so his authorship is in `main`. His diagnoses have been
@@ -293,8 +296,17 @@ still needs Rust and a decision before Aug 22:
 
 **Next, in order:**
 
-0. **The PR queue above.** Squid's four still fix live bugs and outrank new features.
-   Ammar's are all resolved: #29 and #30 superseded and merged, #31 reviewed and closed.
+0. **The PR queue is empty as of 2026-08-14**, for the first time since it formed. Sixteen
+   PRs landed in one pass and `main` is green on both CI and Anchor. Squid's four and
+   Ammar's three are all resolved — merged, superseded, or reviewed and closed.
+
+   **Two things that made the queue expensive, so they do not recur.** It had gone
+   unmerged since 2026-08-11 while growing to nineteen, and by then it contained the same
+   fix twice, twice: #85 duplicated #88 and #86 duplicated #89, from the two machines. It
+   also contained two migrations at `0025`, which would have failed every database-backed
+   test on `main` the moment both merged. **Land work sooner; a queue this deep is where
+   both of those came from.** Migration numbering now has a CI guard and `main` requires
+   branches to be up to date, so the second cannot happen silently again.
 
    **`anchor test` is not a reason to defer a PR.** `.github/workflows/anchor.yml` runs it
    on CI for anything touching `programs/**`, `Anchor.toml`, `Cargo.*` or
@@ -1749,12 +1761,30 @@ Docker, no credentials. `createTestDatabase()` in `packages/db/src/testing.ts` g
 fresh migrated database per test.
 
 The real database is **Supabase** (hosted, so it follows you between machines; also
-matches the stack in `percolator-launch`). Not set up yet — see
-[`docs/SETUP-REQUIRED.md`](docs/SETUP-REQUIRED.md).
+matches the stack in `percolator-launch`). **Provisioned since 2026-08-06** — the
+connection string is in `.env`, which is gitignored and has never been committed. This
+file and `SETUP-REQUIRED.md` both said "not set up yet" until 2026-08-14, and that
+staleness cost real time: a migration renumber was reasoned about on the premise that
+nothing had ever been applied.
+
+**It is not automatically in sync with `main`.** Nothing in CI runs migrations against it
+— there is no Postgres service in `ci.yml`, and every test builds a fresh PGlite database
+— so it only moves when somebody runs `pnpm db:migrate` by hand. On 2026-08-14 it was at
+version 20 while `main` carried through 0027. Check with `pnpm db:status` before assuming.
 
 Migrations are **forward-only** plain SQL. There are no down migrations: a league's rules
 are immutable and its history must stay auditable, so the answer to a bad migration is
 another migration. Editing an already-applied file makes the runner refuse to start.
+
+**Numbering is the part that only bites across machines**, and it is not the runner's job
+— read [`packages/db/migrations/README.md`](packages/db/migrations/README.md) before adding
+one. Two branches can pick the same number, and on this project they have: #72 and #95
+both took `0025` against a `main` at `0024`, both went green, and merging both would have
+thrown `Duplicate migration version 25` on load and failed every database-backed test.
+Take the next number **above main's highest**, renumber on rebase if main moved, and never
+merge a PR whose number is at or below main's head. CI now refuses the second half of that
+(`scripts/check-migration-numbers.mjs`); the first half is caught only by requiring
+branches be up to date before merging, which `main`'s protection does.
 
 ---
 
@@ -1928,7 +1958,7 @@ Expect ~30–60 minutes; compiling AVM from source is the slow part.
 
 ```bash
 pnpm install
-pnpm test        # 909 tests, all green
+pnpm test        # 1222 tests, all green
 pnpm typecheck
 pnpm lint
 ```
@@ -2019,6 +2049,12 @@ single credential.
 
 The two that matter most right now:
 
-- **The escrow audit** — 2–4 weeks of calendar time, gates pot leagues opening on Aug 22.
-  Should be quoted _now_, before the program is finished.
+- **The escrow review** — and note this is **not** a commercial audit. That was decided on
+  2026-08-05: no firm for the 2026 season, because the 2–4 week booking lead time sat on
+  the critical path. The owner reviews the program himself and has a professional auditor
+  who will look once the tech is mostly built; a commercial audit is deferred past the
+  season, not dropped. `SETUP-REQUIRED.md` carries the decision and, more importantly, the
+  four things that limit exposure without a firm's sign-off — the $50 buy-in cap and the
+  unconditional timelock refund being the two that do the work. This entry described a
+  booking that had already been decided against.
 - **Bot draft sophistication** — a scope decision needed before Milestone B.

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -92,12 +92,23 @@ endpoint sign in as any address they name.
 **To do:** sign up at resend.com, verify a sending domain, put the key and a from-address
 in `.env`.
 
-### ⬜ Supabase project
+### ✅ Supabase project
 
-**Blocks:** the web app past its home page, and the session that league creation and
-joining both need. Migrations and their tests run on PGlite (in-process Postgres, no
-service) and do not need this.
-**Needed by:** now. This is the current blocker.
+**Done 2026-08-06.** The connection string is in `.env` (gitignored, never committed) and
+points at a session pooler on port 5432, which is what `packages/db/migrations/README.md`
+requires. This entry read "⬜ … Needed by: now. This is the current blocker" until
+2026-08-14, eight days after it stopped being true.
+
+**Migrations are not applied automatically.** `ci.yml` has no Postgres service and never
+runs `db:migrate`; every test builds a fresh in-process PGlite database. So the hosted
+database only advances when somebody runs `pnpm db:migrate` by hand, and it drifts behind
+`main` in the meantime — on 2026-08-14 it held through version 20 while `main` carried 0027. `pnpm db:status` tells you which; run it before assuming either way.
+
+**Still to do here:** move to Pro before Week 1, per the note below.
+
+**Blocks:** nothing now. Historically: the web app past its home page, and the session that
+league creation and joining both need. Migrations and their tests run on PGlite (in-process
+Postgres, no service) and never needed this.
 
 **Cost:** Free ($0) is fine for development — 500 MB database, 5 GB egress, 50k monthly
 active users, 2 active projects. Our data is tiny.
@@ -123,13 +134,16 @@ to the result. The credentials go in `.env`, which is gitignored, so they must b
 to each machine by hand — move them through a password manager, not chat or email. Sign up
 with the same email as GitHub so the account does not get orphaned.
 
-**To do:**
+**Done, and kept as the recipe for the second machine** — the credentials are per-machine
+because `.env` is gitignored, so a fresh checkout still needs steps 2 onward:
 
-1. Create a project at supabase.com.
-2. Put its connection string in `.env` as `DATABASE_URL` (see `.env.example`).
-3. `pnpm db:migrate` — applies the schema.
-4. `pnpm db:seed` — inserts the NFL registry.
-5. `pnpm db:status` — confirms what is applied.
+1. ~~Create a project at supabase.com.~~ Done 2026-08-06.
+2. Put its connection string in `.env` as `DATABASE_URL` (see `.env.example`). Move it
+   through a password manager, not chat or email.
+3. `pnpm db:status` — **first**, not last. It tells you what the hosted database already
+   has, and running `db:migrate` blind is how a forward-only runner meets a surprise.
+4. `pnpm db:migrate` — applies whatever is pending.
+5. `pnpm db:seed` — inserts the NFL registry.
 
 ---
 


### PR DESCRIPTION
Four claims in the two documents the machines read first were false. One of them cost real time today.

## Supabase has been provisioned since 2026-08-06

Both `CLAUDE.md` and `SETUP-REQUIRED.md` said "not set up yet" / "⬜ … **Needed by:** now. This is the current blocker." It is live, the connection string is in `.env` (gitignored, never committed), and it has been migrated four times.

This is not a cosmetic correction. A migration renumber earlier today was reasoned about on the premise that nothing had ever been applied. That happened to be true of the file in question, but not for the reason given — and establishing it required querying the database, which is a check nobody should have needed to run.

It also records something the docs never said: **nothing applies migrations automatically.** `ci.yml` has no Postgres service and never runs `db:migrate`; every test builds a fresh PGlite database. So the hosted database only advances by hand and drifts behind `main` in between — today it held through version 20 while `main` carried `0027`. The "To do" list is kept as the second-machine recipe, reordered so `db:status` comes **first**: running `db:migrate` blind against a forward-only runner is how you meet a surprise.

## The escrow audit was decided against on 2026-08-05

`CLAUDE.md` still listed it as *"2–4 weeks of calendar time, gates pot leagues opening on Aug 22. Should be quoted now."* `SETUP-REQUIRED.md` had already superseded that: no commercial firm for the 2026 season, precisely because the booking lead time sat on the critical path. Two documents disagreeing about whether an audit is happening is worse than either answer, and the one that was wrong is the one read first.

## Four of Squid's PRs were listed as still open

\#32, #34, #36, #38 — all closed, each superseded by our own version of the same fix. The section is kept rather than deleted, because the diagnoses are the record: every one named a bug that was live on `main` when it was filed. What changed is the framing — the durable lesson is that **a correct diagnosis and a correct fix are separate questions**, and here the second has needed our own work every time.

## The test count said 909

It is 1222.

## And the one rule that only bites across machines

`CLAUDE.md` never mentioned migration numbering and never linked `packages/db/migrations/README.md`, which documents it properly — including that it has already gone wrong three times in one day. The file that exists to hand state between two machines omitted the rule that only matters *because* there are two machines. Now covered, with the #72/#95 collision as the worked example and a note on which half CI catches and which half branch protection catches.

## Verified

Every claim checked before writing: PR states via `gh`, the test count by running the suite, the Supabase version by reading `schema_migrations`, the audit decision by reading both documents side by side.

One thing I could **not** pin down and am flagging rather than hiding: on the first local run of the full suite one test file failed, and on the second all 1222 passed. I did not capture which file. CI on `main` is green across both workflows. Worth watching for a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)