### PR TITLE
fix(db): hold the trade freeze on every path that releases a player

### DIFF
--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -6,7 +6,14 @@ import { createUser } from "./identity.js";
 import { seedSport } from "./sports.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
-import { availabilityOf, dropPlayer } from "./waivers.js";
+import {
+  addFreeAgent,
+  availabilityOf,
+  dropPlayer,
+  processWaivers,
+  seedWaiverPriority,
+  submitClaim,
+} from "./waivers.js";
 import {
   acceptTrade,
   declineTrade,
@@ -524,6 +531,176 @@ describe("the freeze between acceptance and execution", () => {
     await resolveDueTrades(fx.client, fx.leagueId, new Date(MONDAY.getTime() + 49 * HOUR));
 
     expect(await lockedByTrade(fx.client, fx.leagueId)).toEqual(new Set());
+  });
+
+  /**
+   * A player rostered by nobody, so he can be added or claimed.
+   *
+   * `active` matters: `availablePlayers` and the draft board both filter on it,
+   * and a player who is not active cannot be claimed at all.
+   */
+  async function unrostered(fx: Fixture, handle: string): Promise<string> {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [position] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [row] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $2, $3, 'CIN') RETURNING id`,
+      [sport!.id, handle, position!.id],
+    );
+    fx.players.set(handle, row!.id);
+    return row!.id;
+  }
+
+  /**
+   * An instant with no kickoff behind it, so `GAME_STARTED` stays silent.
+   *
+   * Every player in this fixture belongs to `CIN`, and at `MONDAY` week 5's
+   * games have already started — which is fine for the trade machinery and
+   * fatal for anything that has to *succeed* at dropping somebody. Week 6's
+   * cycle opens Tuesday 04:00Z and its first game is the Thursday, so this sits
+   * in the gap between them.
+   *
+   * Worth stating rather than quietly picking a magic number: `refuseIfKickedOff`
+   * and the freeze both refuse a drop, and a test that cannot tell which one
+   * refused proves nothing about the freeze.
+   */
+  const QUIET = new Date("2026-10-13T06:00:00Z");
+
+  const holds = async (fx: Fixture, teamId: string, playerId: string): Promise<boolean> => {
+    const rows = await fx.client.query(
+      "SELECT 1 FROM roster_entries WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL",
+      [teamId, playerId],
+    );
+    return rows.length > 0;
+  };
+
+  it("refuses the add-with-drop that cuts a frozen player", async () => {
+    // The hole, and it needed no concurrency: accept a trade, then cut the
+    // player you promised through a different button. `dropPlayer` refused it
+    // and this path did not, so the guard there was decorative.
+    //
+    // Worse than one lost player. `resolveTrade` throws `ASSET_GONE` and rolls
+    // the whole swap back, so in a multi-asset trade dropping the *cheapest*
+    // frozen player destroys the trade and returns everything else — a
+    // unilateral cancel after acceptance, which `withdrawTrade` refuses on
+    // purpose and which `RULES.md` §9 denies even the commissioner.
+    const fx = await setupWithSecondLeague();
+    const fa = await unrostered(fx, "fa");
+    const p1 = fx.players.get("p1")!;
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fa,
+        dropPlayerId: p1,
+        now: QUIET,
+      }),
+    ).rejects.toMatchObject({ code: "IN_A_TRADE" });
+
+    // **The property, not the code.** An assertion on the error alone passes
+    // against a check placed before the transaction — which would close this
+    // hole and leave the racy read of part 3 exactly as it was.
+    expect(await holds(fx, fx.teams[0]!, p1)).toBe(true);
+    expect(await holds(fx, fx.teams[0]!, fa)).toBe(false);
+  });
+
+  it("fails a claim whose drop is frozen, and gives the player to the next priority", async () => {
+    // **The half a per-player check at the write cannot do.**
+    //
+    // `resolveWaiverClaims` marks a player taken the moment a claim wins him and
+    // fails every later claim with `PLAYER_TAKEN`. So refusing the winner's
+    // award afterwards leaves the runner-up already rejected and the player
+    // awarded to nobody — one manager's frozen drop silently denying him to the
+    // whole league. Filtering before resolution lets the next priority win.
+    const fx = await setupWithSecondLeague();
+    const wire = await unrostered(fx, "wire");
+
+    // Team 1 claims first, team 3 second — priority is the reverse of the draft
+    // order, so seeding it descending makes team 1 the best.
+    for (const [index, teamId] of fx.teams.entries()) {
+      await fx.client.query("UPDATE teams SET draft_position = $1 WHERE id = $2", [
+        fx.teams.length - index,
+        teamId,
+      ]);
+    }
+    await seedWaiverPriority(fx.client, fx.leagueId);
+
+    // He has to be genuinely on the wire, or `submitClaim` sends the manager to
+    // the add button instead.
+    await fx.client.query(
+      `INSERT INTO waiver_wire (league_id, player_id, clears_at) VALUES ($1, $2, $3)`,
+      [fx.leagueId, wire, QUIET.toISOString()],
+    );
+
+    // The best priority claims him and offers `p1` — who is about to be frozen.
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[0]!,
+      addPlayerId: wire,
+      dropPlayerId: fx.players.get("p1")!,
+      now: MONDAY,
+    });
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[2]!,
+      addPlayerId: wire,
+      now: MONDAY,
+    });
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, QUIET);
+
+    // The runner-up gets him. Under a check-at-the-write fix, nobody does.
+    expect(await holds(fx, fx.teams[2]!, wire)).toBe(true);
+    expect(outcome.awarded).toBe(1);
+    expect(outcome.failed).toBe(1);
+    expect(outcome.deferred).toBe(0);
+  });
+
+  it("still allows an ordinary drop while another player is frozen", async () => {
+    // The negative that stops the fix being worse than the bug. A league with an
+    // accepted trade in it must remain an ordinary league for everyone else.
+    const fx = await setupWithSecondLeague();
+    const spare = fx.players.get("spare")!;
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, spare, QUIET),
+    ).resolves.toMatchObject({ destination: "WAIVERS" });
+    expect(await holds(fx, fx.teams[0]!, spare)).toBe(false);
+    expect(await holds(fx, fx.teams[0]!, fx.players.get("p1")!)).toBe(true);
+  });
+
+  it("lets the player go once the trade that froze him is vetoed", async () => {
+    // The freeze is `state = 'ACCEPTED'` and nothing else, so it lifts by
+    // itself. Widening it — to PROPOSED, say — would let any manager freeze an
+    // opponent's roster for free, because a proposal needs no consent.
+    const fx = await setupWithSecondLeague();
+    const p1 = fx.players.get("p1")!;
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
+    await vetoTrade(fx.client, tradeId, fx.teams[3]!, MONDAY);
+    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, p1, QUIET),
+    ).resolves.toMatchObject({ destination: "WAIVERS" });
   });
 });
 

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -472,8 +472,14 @@ export async function acceptTrade(
     // blocks, wakes after the winner commits, re-checks a snapshot that predates
     // it, and passes. Both trades reach ACCEPTED and the player is minted. The
     // lock would be doing real work and guarding a value already read.
+    // **`ORDER BY player_id`, and it is not cosmetic.** Pass one takes a row
+    // lock per asset in whatever order this returns, so two accepts of two
+    // different trades sharing two players could take them in opposite orders
+    // and deadlock. An unordered `SELECT` is not a stable order, it is whatever
+    // the plan produces. Sorting on the same key in every caller makes the cycle
+    // unconstructible.
     const assets = await tx.query<{ from_team_id: string; player_id: string }>(
-      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1",
+      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1 ORDER BY player_id",
       [tradeId],
     );
 

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -270,6 +270,85 @@ export async function availablePlayers(
  * synthesis would make the entire free-agent pool unaddable for most of every
  * week. This asks for the player's own game directly instead.
  */
+/**
+ * Take the roster row and hold it, so a decision made about it stays true.
+ *
+ * **`FOR UPDATE OF r`, not a bare `FOR UPDATE`, and the league comes from the
+ * row rather than a join.** A bare `FOR UPDATE` on a joined query locks a row in
+ * *every* table in the FROM list — so joining `teams` for league scoping would
+ * quietly take a lock on the team row as well. `processWaivers` holds the league
+ * row and ends by updating `teams.waiver_priority`; a drop holding a `teams` row
+ * and waiting on a roster row the run has already released is a deadlock cycle
+ * that does not exist today only because this function did not lock at all.
+ *
+ * `roster_entries.league_id` has been `NOT NULL` and trigger-maintained since
+ * migration `0022`, so the join was never needed for correctness — and
+ * `availabilityOf` and `processWaivers` already read it directly.
+ */
+async function lockRosterRow(
+  tx: SqlClient,
+  leagueId: string,
+  teamId: string,
+  playerId: string,
+): Promise<{ id: string; acquired_at: string } | undefined> {
+  const [entry] = await tx.query<{ id: string; acquired_at: string }>(
+    `SELECT r.id, r.acquired_at FROM roster_entries r
+      WHERE r.league_id = $1 AND r.team_id = $2 AND r.player_id = $3
+        AND r.released_at IS NULL
+      FOR UPDATE OF r`,
+    [leagueId, teamId, playerId],
+  );
+  return entry;
+}
+
+/**
+ * Refuse to release a player an accepted trade has committed.
+ *
+ * Between acceptance and execution the players are in escrow: `docs/RULES.md` §6
+ * says a committed player "cannot be dropped, claimed away, or entered into a
+ * second trade", and that sentence is in the document members sign. It was true
+ * of exactly one of the three paths that release a roster row.
+ *
+ * **`addFreeAgent`'s drop leg was the hole**, and it needed no concurrency: a
+ * manager could accept a trade and then cut the player they promised through the
+ * add-with-drop button, one request, no race. Worse than it sounds in a
+ * multi-asset trade — `resolveTrade` throws `ASSET_GONE` and rolls back, so
+ * dropping the *cheapest* frozen asset destroys the whole trade and hands the
+ * proposer back everything else. `withdrawTrade` refuses after acceptance
+ * precisely to prevent that ("it is now up to the league"), and `RULES.md` §9
+ * denies the power even to the commissioner.
+ *
+ * ## Call it inside the transaction, after the roster row is locked
+ *
+ * `acceptTrade` already documents why, twenty lines away: *"Take every row lock
+ * first, and only then read the freeze set."* Read the other way round and both
+ * callers compute a freeze set before either takes a lock; the loser blocks,
+ * wakes after the winner commits, re-checks a snapshot that predates it, and
+ * passes. `dropPlayer` did exactly that — read on `db`, before `withTransaction`,
+ * with no lock — so an `acceptTrade` committing in between left a trade
+ * `ACCEPTED`, the state whose whole meaning is "these players are frozen", with
+ * its player on waivers.
+ *
+ * **This is correct only under READ COMMITTED**, which is Postgres's default and
+ * what `withTransaction`'s bare `BEGIN` gets. Each statement takes a fresh
+ * snapshot, so this read — issued *after* the lock was granted — sees any
+ * `acceptTrade` that committed before it. Under REPEATABLE READ it would read
+ * the transaction's original snapshot and silently revert to the bug.
+ */
+async function refuseIfFrozen(
+  tx: SqlClient,
+  leagueId: string,
+  playerId: string,
+): Promise<void> {
+  const committed = await lockedByTrade(tx, leagueId);
+  if (committed.has(playerId)) {
+    throw new WaiverError(
+      "That player is committed to an accepted trade and cannot be dropped until it resolves",
+      "IN_A_TRADE",
+    );
+  }
+}
+
 async function refuseIfKickedOff(
   db: SqlClient,
   rules: LeagueRules,
@@ -326,28 +405,19 @@ export async function dropPlayer(
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
 
-  // An accepted trade has already committed this player. Between acceptance and
-  // execution he is effectively in escrow — dropping him would leave the trade
-  // with a hole where a roster spot used to be.
-  const committed = await lockedByTrade(db, leagueId);
-  if (committed.has(playerId)) {
-    throw new WaiverError(
-      "That player is committed to an accepted trade and cannot be dropped until it resolves",
-      "IN_A_TRADE",
-    );
-  }
-
-  await refuseIfKickedOff(db, stored.rules, playerId, now, "dropped");
-
   return withTransaction(db, async (tx) => {
-    const [entry] = await tx.query<{ id: string; acquired_at: string }>(
-      `SELECT r.id, r.acquired_at FROM roster_entries r
-         JOIN teams t ON t.id = r.team_id
-        WHERE t.league_id = $1 AND r.team_id = $2 AND r.player_id = $3
-          AND r.released_at IS NULL`,
-      [leagueId, teamId, playerId],
-    );
+    const entry = await lockRosterRow(tx, leagueId, teamId, playerId);
     if (!entry) throw new WaiverError("That player is not on this roster", "NOT_ON_ROSTER");
+
+    // **After the lock, not before.** Both of these used to run on `db` above,
+    // outside the transaction — see `refuseIfFrozen` for what that cost.
+    //
+    // The ownership check comes first now, and that is a small improvement of
+    // its own: a team that does not hold the player used to be told
+    // `IN_A_TRADE`, which discloses that a trade exists involving somebody
+    // else's player.
+    await refuseIfFrozen(tx, leagueId, playerId);
+    await refuseIfKickedOff(tx, stored.rules, playerId, now, "dropped");
 
     await tx.query("UPDATE roster_entries SET released_at = $2 WHERE id = $1", [
       entry.id,
@@ -457,12 +527,17 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
     if (input.dropPlayerId) {
       // Inside the same transaction, so a full roster never briefly holds one
       // player too many and never briefly holds one too few.
-      const [entry] = await tx.query<{ id: string }>(
-        `SELECT id FROM roster_entries
-          WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
-        [input.teamId, input.dropPlayerId],
-      );
+      //
+      // **Locked, and the freeze read after it.** This is the same release
+      // `dropPlayer` performs, reached through a different button, and until now
+      // it asked none of the questions that one asks — so an accepted trade's
+      // player could be cut here with no concurrency at all. The comment above
+      // makes exactly this argument about the kickoff lock ("without it the
+      // guard there is decorative") and it applies unchanged to the freeze.
+      const entry = await lockRosterRow(tx, input.leagueId, input.teamId, input.dropPlayerId);
       if (!entry) throw new WaiverError("That player is not on this roster", "NOT_ON_ROSTER");
+
+      await refuseIfFrozen(tx, input.leagueId, input.dropPlayerId);
 
       await tx.query("UPDATE roster_entries SET released_at = $2 WHERE id = $1", [
         entry.id,
@@ -798,9 +873,45 @@ export async function processWaivers(
       return clears !== undefined && clears.getTime() > now.getTime();
     };
 
+    /**
+     * Claims whose *drop* player an accepted trade has committed.
+     *
+     * **A third exclusion set, and it has to be computed before resolution —
+     * not checked when the award is written.** `resolveWaiverClaims` marks a
+     * player taken the moment a claim wins him, and fails every later claim for
+     * him with `PLAYER_TAKEN`. So refusing the winner's award afterwards leaves
+     * the runner-up already rejected and the player awarded to nobody: one
+     * manager's frozen drop would quietly deny the player to the whole league.
+     * Filtering here lets the next priority win him, which is what the rules
+     * say should happen.
+     *
+     * **Failed, not deferred.** The freeze is temporary — at most the veto
+     * window plus cron lag — so deferring looks tempting. It does not help: the
+     * sweep below deletes the *add* player's wire row in this same run, so he
+     * becomes a free agent within the hour and is gone before any later run
+     * could award him. `RULES.md` §6 says a failed claim costs nothing and
+     * priority moves only on success, so the manager re-files with a different
+     * drop and loses nothing but the week. Deferring would also make
+     * `deferred`'s own docstring false — it says "has not cleared waivers yet",
+     * which is a statement about the add player's wire clock, not this.
+     *
+     * `processWaivers` cannot refuse by throwing, unlike the two member-facing
+     * paths: the whole run is one transaction, so a throw rolls back every award
+     * and leaves every claim PENDING for the next run to fail on identically.
+     * That is the permanent wedge this module's other filters exist to avoid.
+     */
+    const frozen = await lockedByTrade(tx, leagueId);
+    const dropIsFrozen = (row: { drop_player_id: string | null }): boolean =>
+      row.drop_player_id !== null && frozen.has(row.drop_player_id);
+
     const resolution = resolveWaiverClaims({
       claims: claims
-        .filter((row) => !alreadyHeld.has(row.add_player_id) && !notYetClear(row.add_player_id))
+        .filter(
+          (row) =>
+            !alreadyHeld.has(row.add_player_id) &&
+            !notYetClear(row.add_player_id) &&
+            !dropIsFrozen(row),
+        )
         .map((row): WaiverClaim => ({
           claimId: row.id,
           teamId: row.team_id,
@@ -816,19 +927,21 @@ export async function processWaivers(
     let awarded = 0;
     let failed = 0;
 
-    // **Two filters above, and only one of them is a failure.**
+    // **Three filters above, and two of them are failures.**
     //
-    // A claim for a player somebody already holds can never succeed, so it is
-    // written FAILED here — leaving it PENDING would retry it hourly forever.
-    // A claim for a player who has not cleared yet is not failed, it is *early*:
-    // it stays PENDING deliberately and is resolved by the run after he clears.
+    // A claim for a player somebody already holds can never succeed, and one
+    // naming a frozen player as its drop cannot be honoured as written — both
+    // are written FAILED here, because leaving them PENDING would retry them
+    // hourly forever. A claim for a player who has not cleared yet is not
+    // failed, it is *early*: it stays PENDING deliberately and is resolved by
+    // the run after he clears.
     //
-    // So this loop keys on `alreadyHeld` specifically. Do not "simplify" it to
+    // So this loop keys on those two sets specifically. Do not "simplify" it to
     // "anything missing from `resolution.outcomes` failed" — that would turn
     // every deferral into a permanent rejection, silently, and the manager would
     // be told their claim lost to a player nobody had.
     for (const row of claims) {
-      if (!alreadyHeld.has(row.add_player_id)) continue;
+      if (!alreadyHeld.has(row.add_player_id) && !dropIsFrozen(row)) continue;
 
       await tx.query(
         "UPDATE waiver_claims SET state = 'FAILED', processed_at = $2 WHERE id = $1",


### PR DESCRIPTION
Closes #77 parts 2 and 3. Parts 1 and 4 are separate — part 1 landed as #110, part 4 is still open and pairs with #112.

## The clause members sign, and it was false

`docs/RULES.md` §6, rendered above the join control:

> **A player committed to an accepted trade is frozen** until it resolves. He cannot be dropped, claimed away, or entered into a second trade. Without that, a manager could accept a trade and cut the player they promised, and execution would find a hole where a roster spot used to be.

The sentence after the dash describes an exploit that was **live, and needed no concurrency**. `dropPlayer` refused it. `addFreeAgent`'s drop leg — the same release, reached through a different button — asked nothing:

```
[A] owner of frozen p1 after add: null
[A] availability of p1: ON_WAIVERS
[A] trade state right after: [ 'ACCEPTED' ]
[A] freeze set still holds p1: true
```

One request. `processWaivers` released a claim's drop player the same way.

**It is worse than losing one player.** `resolveTrade` throws `ASSET_GONE` and rolls the whole swap back, so in a multi-asset trade, dropping the **cheapest** frozen asset destroys the trade and returns everything else. That is a unilateral cancel *after* acceptance — exactly what `withdrawTrade` refuses on purpose (*"it is now up to the league"*), and what §9 denies even the commissioner. Nothing records it: the trade reads `EXPIRED`, byte-identical to a deadline expiry, and the cron collapses every outcome to a count.

**`RULES.md` is not edited here.** The fix makes it true. Editing a signed document to match the code is the inversion this project exists to prevent.

## Two new call sites, not three

The issue counts four release paths. The fourth is `resolveTrade` — the trade *executing* — and guarding it would expire every trade in the league. A "guard every release path" sweep finds it; it must be left alone. There is now a comment saying so.

## The waiver check is a filter, not a check at the write

This is the part that a straightforward reading gets wrong, and it is the difference between fixing the bug and creating a worse one.

`resolveWaiverClaims` marks a player taken the moment a claim wins him, and fails every later claim with `PLAYER_TAKEN`. So refusing the *winner's* award afterwards leaves the runner-up **already rejected** and the player awarded to nobody — one manager's frozen drop silently denying a contested player to the whole league.

```
both claims in            -> A awarded, B PLAYER_TAKEN
A filtered pre-resolution -> B awarded
```

So it goes beside `alreadyHeld` and `notYetClear`, the two exclusion sets that exist for this reason.

**FAILED, not deferred.** The freeze is temporary, which makes deferral tempting — but the sweep deletes the *add* player's wire row in the same run, so he is a free agent within the hour and gone before any later run could award him. Deferring postpones the same failure by a week and tells the manager nothing. §6: a failed claim costs nothing, priority moves only on success. It would also make `deferred`'s own docstring false — that field is about the add player's wire clock — and worsen open #108.

**`submitClaim` is deliberately unchanged.** A claim is an intention resolved days later; the freeze lasts at most the veto window. Refusing at submission would reject claims that are perfectly legal by the time they run — and it opens no transaction, so a check there would replicate the racy shape this PR removes, into a fourth site.

## Part 3: lock first, then read

`dropPlayer` read the freeze set on `db`, before its transaction, with no lock — the exact inversion `acceptTrade` documents as wrong twenty lines away:

> **Order is the whole of the concurrency argument.** Take every row lock first, and only then read the freeze set.

Both member-facing paths now do that. Two details are load-bearing:

**`FOR UPDATE OF r`, and the `teams` join is gone.** A bare `FOR UPDATE` on a joined query locks a row in *every* table in the FROM list — verified against `pg_locks`. A drop holding a `teams` row while `processWaivers` updates `waiver_priority` is a deadlock cycle that does not exist today **only because this path took no lock at all**. `roster_entries.league_id` has been trigger-maintained since `0022`, so the join was never needed.

**It is correct only under READ COMMITTED**, which is the default and what the bare `BEGIN` gets: each statement takes a fresh snapshot, so a read issued *after* the lock is granted sees whatever committed before it. Under REPEATABLE READ it would read the transaction's original snapshot and silently revert to the bug. That is now a comment rather than an assumption.

Also included, pre-existing and unrelated to the freeze: **`ORDER BY player_id` on `acceptTrade`'s asset lock.** Two accepts of two trades sharing two players could take the locks in opposite orders and deadlock.

## Verification

**No existing test failed under this bug** — the entire freeze block was green, because every test exercised `dropPlayer`, the one already-guarded path. Worse, `refuses to execute a trade whose asset left the roster after acceptance` reproduces the release in **raw SQL** with a comment naming the real path (*"a free-agent add's drop leg does exactly this"*), asserting only the `ASSET_GONE` backstop. It made the suite look like it covered the gap.

Four new tests, each asserting **roster state, not just an error code** — a code-only assertion passes against a fix that closes part 2 and leaves part 3 open, which is what the existing test already does:

| test | pins |
|---|---|
| refuses the add-with-drop that cuts a frozen player | the exploit, plus that the *add* rolled back too |
| fails a claim whose drop is frozen, **and gives the player to the next priority** | the pre-resolution property |
| still allows an ordinary drop while another player is frozen | the negative — a league with a trade in it stays ordinary |
| lets the player go once the trade that froze him is vetoed | the freeze lifts by itself |

**Mutation-checked.** Removing the `addFreeAgent` check fails the first; removing the waiver filter fails the second with `expected false to be true` — the runner-up doesn't get the player.

The tests needed an instant with no kickoff behind it. At the fixture's `MONDAY` every player's game has started, so `GAME_STARTED` fires and masks the freeze entirely — which is also why moving the check inside the transaction had to keep `IN_A_TRADE` ahead of the kickoff refusal rather than reversing that precedence by accident.

**What cannot be tested, stated rather than faked:** part 3's race. PGlite is single-connection and two overlapping `withTransaction` calls **collapse into one transaction** — the second `BEGIN` is a warning and `FOR UPDATE` blocks nothing — so a test named for the race would pass against the bug. Got right by reading, as `CLAUDE.md` already records for `acceptTrade`.

1229 tests, typecheck, lint green. No schema change, no rules change, **golden hash untouched.**

## Not fixed here

- **`CLAUDE.md` and `DECISIONS.md`** both describe where the freeze is consulted, and `DECISIONS.md` draws *"so a committed player cannot leave by any path"* from a list of two call sites. Correcting them belongs with the follow-ups below rather than inflating this diff.
- **`PlayerMarket` never mentions the freeze** — `players/route.ts` does not call `lockedByTrade`, so the drop select and Drop buttons are live on a frozen player. The server refuses, so this is a UI follow-up.
- **Nothing distinguishes an `ASSET_GONE` expiry from a deadline expiry** in the row, the return value, or the cron output — making `tradeCannotExecute`'s docstring (*"a reader should be able to tell them apart"*) false. A reason column is a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
