### PR TITLE
fix(core,db): the weekly waiver lock, which was implemented nowhere

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ export {
 
 export {
   availabilityAt,
+  everyoneIsOnWaivers,
   dropDestination,
   nextProcessingAt,
   nextWeekly,

--- a/packages/core/src/waivers/schedule.ts
+++ b/packages/core/src/waivers/schedule.ts
@@ -159,6 +159,57 @@ export function nextWeeklyLockAt(now: Date, rules: WaiverRules): Date {
   return nextWeekly(now, rules.weeklyLock, rules.timezone);
 }
 
+/**
+ * Whether every unrostered player is on waivers right now.
+ *
+ * `docs/RULES.md` §6's cycle table, which members sign:
+ *
+ * > | **Tuesday 00:00**               | Every unrostered player returns to waivers |
+ * > | **Wednesday 03:00**             | Claims process, blind, by priority         |
+ * > | Wednesday 03:00 → Tuesday 00:00 | Free agency, first come first served       |
+ * >
+ * > This is the substance of the system, not the drop rule below it. A backup
+ * > who breaks out on Sunday is claimed by priority on Wednesday morning — not
+ * > by whoever happens to be refreshing on Sunday night.
+ *
+ * That is ESPN's model, verified against their published rules: *"All players
+ * not on a fantasy roster reside on waivers following each week of play."* It is
+ * **not** Sleeper's, which holds only recently-dropped players and instead locks
+ * the pool during games — and Sleeper's is what this codebase actually
+ * implemented, because the only writers of `waiver_wire` are drop-driven. Two
+ * coherent designs got crossed and the members signed the other one.
+ *
+ * ## Derived, never stored
+ *
+ * The obvious reading of "returns to waivers" is a job that writes a wire row per
+ * unrostered player each Tuesday — thousands of rows per league per week, a
+ * clears-at for players who never landed anywhere, and a new failure mode every
+ * time it half-runs. None of that is needed. Availability is already computed
+ * rather than stored, and the weekly lock is a *default*: outside the window an
+ * unrostered player with no wire row is a free agent, inside it he is on waivers.
+ * One predicate, no writes, no migration, no job to fail.
+ *
+ * The window is half-open — `[lock, run)` — so the run itself is not inside it.
+ * That matters: `processWaivers` executes *at* the processing instant, and its
+ * claims must resolve against a pool that has already reopened, or the run would
+ * be reasoning about a lock it is in the act of lifting.
+ *
+ * A player serving his own waiver period is unaffected either way: his wire row
+ * answers first, and it outlives this window.
+ */
+export function everyoneIsOnWaivers(now: Date, rules: WaiverRules): boolean {
+  // `nextWeekly` is strictly-after, so asking it from a week earlier yields the
+  // most recent lock at or before `now` — the same trick `transactionWeek` uses
+  // to find the cycle it is in.
+  const lock = nextWeekly(
+    new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+    rules.weeklyLock,
+    rules.timezone,
+  );
+
+  return now.getTime() < nextProcessingAt(lock, rules).getTime();
+}
+
 export type DropDestination = "WAIVERS" | "FREE_AGENT";
 
 /**

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -6,6 +6,7 @@ import type { DraftablePlayer } from "../draft/roster.js";
 import {
   availabilityAt,
   dropDestination,
+  everyoneIsOnWaivers,
   nextProcessingAt,
   nextWeeklyLockAt,
   waiverClearsAt,
@@ -27,6 +28,49 @@ const eastern = (date: Date): string =>
     month: "2-digit",
     day: "2-digit",
   }).format(date);
+
+describe("RULES.md §6 — every unrostered player returns to waivers on Tuesday", () => {
+  // Week 2 of 2026, EDT throughout. The cycle §6 describes:
+  //   Tue 00:00 -> Wed 03:00  waivers, claims only
+  //   Wed 03:00 -> Tue 00:00  free agency, first come first served
+  const TUE_LOCK = new Date("2026-09-15T04:00:00Z"); // Tue 00:00 EDT
+  const WED_RUN = new Date("2026-09-16T07:00:00Z"); // Wed 03:00 EDT
+
+  it("locks the pool from the Tuesday boundary", () => {
+    expect(everyoneIsOnWaivers(new Date(TUE_LOCK.getTime() - 1), RULES)).toBe(false);
+    expect(everyoneIsOnWaivers(TUE_LOCK, RULES)).toBe(true);
+  });
+
+  it("reopens it at the processing run, not after it", () => {
+    // Half-open, `[lock, run)`. The run itself must be outside the window:
+    // `processWaivers` executes *at* this instant, and its claims resolve
+    // against a pool that has already reopened — otherwise the run would be
+    // reasoning about a lock it is in the act of lifting.
+    expect(everyoneIsOnWaivers(new Date(WED_RUN.getTime() - 1), RULES)).toBe(true);
+    expect(everyoneIsOnWaivers(WED_RUN, RULES)).toBe(false);
+  });
+
+  it("leaves the rest of the week open", () => {
+    // Thursday, Sunday, and the Monday night that makes this rule matter: a
+    // breakout is claimed by priority on Wednesday, not taken by whoever is
+    // refreshing fastest on Sunday.
+    for (const instant of [
+      "2026-09-17T18:00:00Z",
+      "2026-09-20T20:00:00Z",
+      "2026-09-15T02:00:00Z",
+    ]) {
+      expect(everyoneIsOnWaivers(new Date(instant), RULES)).toBe(false);
+    }
+  });
+
+  it("follows the timezone rather than a fixed offset", () => {
+    // The lock is a weekday and a local hour, so it moves with the November DST
+    // change instead of sliding an hour through it. Tue 00:00 EST is 05:00Z.
+    const novLock = new Date("2026-11-17T05:00:00Z");
+    expect(everyoneIsOnWaivers(new Date(novLock.getTime() - 1), RULES)).toBe(false);
+    expect(everyoneIsOnWaivers(novLock, RULES)).toBe(true);
+  });
+});
 
 describe("processing schedule", () => {
   it("finds the next Wednesday 03:00 Eastern", () => {

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -570,7 +570,12 @@ describe("the freeze between acceptance and execution", () => {
    * and the freeze both refuse a drop, and a test that cannot tell which one
    * refused proves nothing about the freeze.
    */
-  const QUIET = new Date("2026-10-13T06:00:00Z");
+  // Wednesday 08:00 ET: after that week's processing run and before week 6's
+  // Thursday kickoff. **Both halves are load-bearing.** Before the run, §6's
+  // weekly lock puts every unrostered player on waivers, so an add is refused
+  // with `NOT_A_FREE_AGENT` and never reaches the freeze check these tests are
+  // about — which is exactly what the first version of this constant did.
+  const QUIET = new Date("2026-10-14T12:00:00Z");
 
   const holds = async (fx: Fixture, teamId: string, playerId: string): Promise<boolean> => {
     const rows = await fx.client.query(

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -32,6 +32,7 @@
 
 import {
   availabilityAt,
+  everyoneIsOnWaivers,
   buildRosterShape,
   dropDestination,
   initialWaiverPriority,
@@ -151,7 +152,16 @@ export async function availabilityOf(
     "SELECT clears_at FROM waiver_wire WHERE league_id = $1 AND player_id = $2",
     [leagueId, playerId],
   );
-  if (!wire) return "FREE_AGENT";
+
+  // No wire row means free — **except inside the weekly lock**, when `RULES.md`
+  // §6 puts every unrostered player back on waivers. See `everyoneIsOnWaivers`
+  // for why that is a derived default rather than a job that writes a row per
+  // player. Without this the table members sign describes a cycle the code does
+  // not run, and a breakout is taken by whoever refreshes fastest on Sunday
+  // night rather than allocated by priority on Wednesday.
+  if (!wire) {
+    return everyoneIsOnWaivers(now, stored.rules.waivers) ? "ON_WAIVERS" : "FREE_AGENT";
+  }
 
   // `clears_at` was computed when he landed. Re-deriving from it keeps one
   // definition of "cleared" rather than comparing timestamps in two places.
@@ -172,6 +182,9 @@ export async function availablePlayers(
     clearsAt: Date | null;
   }[]
 > {
+  const stored = await getLeagueRules(db, leagueId);
+  if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
+
   const rows = await db.query<{
     id: string;
     full_name: string;
@@ -198,14 +211,21 @@ export async function availablePlayers(
     [leagueId],
   );
 
+  const locked = everyoneIsOnWaivers(now, stored.rules.waivers);
+
   return rows.map((row) => {
     const clearsAt = row.clears_at ? new Date(row.clears_at) : null;
     return {
       playerId: row.id,
       fullName: row.full_name,
       positions: row.positions,
+      // The exact complement of `availabilityOf`, including the weekly lock —
+      // the two must not be able to disagree, because this decides what the
+      // screen offers and that decides what the server accepts.
       availability:
-        clearsAt && clearsAt > now ? ("ON_WAIVERS" as const) : ("FREE_AGENT" as const),
+        (clearsAt && clearsAt > now) || locked
+          ? ("ON_WAIVERS" as const)
+          : ("FREE_AGENT" as const),
       clearsAt,
     };
   });


### PR DESCRIPTION
Closes #107.

## The clause, and what was actually running

`docs/RULES.md` §6's cycle table — rendered above the join control, hashed into what every member signs:

| When (Eastern) | What happens |
|---|---|
| **Tuesday 00:00** | Every unrostered player returns to waivers |
| **Wednesday 03:00** | Claims process, blind, by priority |
| Wed 03:00 → Tue 00:00 | Free agency, first come first served |

> This is the substance of the system, not the drop rule below it. A backup who breaks out on Sunday is claimed by priority on Wednesday morning — not by whoever happens to be refreshing on Sunday night.

**Nothing implemented the first row.** `rules.waivers.weeklyLock` was read by validation, by `transactionWeek`, and by the kickoff lock — and by nothing that decides availability. Both writers of `waiver_wire` are drop-driven, so only players somebody had actively dropped ever reached the wire.

## It was the other product's model

Verified against both, rather than assumed:

| | Who sits on waivers | Window |
|---|---|---|
| **ESPN** | *"All players not on a fantasy roster reside on waivers following each week of play"* | Tuesday morning → clears 3 a.m. ET |
| **Sleeper** | *"The only ones who may not be [free agents] are any that have recently been dropped"* | Free agency Wed → kickoff, then locked through Tuesday |

`CLAUDE.md` says this repo copies ESPN's cycle, and §6 describes ESPN's. The code implemented Sleeper's. **Not a missing feature — two coherent designs crossed, and the members signed the other one.**

Also confirmed while checking: `waiverPeriodDays: 1` with a Wednesday 03:00 run is ESPN's *default* setting (1 Day, clearing Wednesday; 2 Days clears Thursday). So the existing configuration was already right and needed no change.

## Derived, never stored

The obvious reading of "returns to waivers" is a Tuesday job writing a wire row per unrostered player: thousands of rows per league per week, a `clears_at` for players who never landed anywhere, and a new failure mode every time it half-runs.

None of that is needed. **Availability is already computed rather than stored, and the weekly lock is a *default*.** Outside the window an unrostered player with no wire row is a free agent; inside it he is on waivers. One predicate, no writes, no migration, no job that can fail, and no decision required about *which* players — it is literally every unrostered one, because it is derived rather than enumerated.

A player serving his own waiver period is unaffected either way: his wire row answers first and outlives the window.

## The window is half-open

`[lock, run)` — the processing instant is **outside** it. `processWaivers` executes *at* that instant, and its claims must resolve against a pool that has already reopened, or the run would be reasoning about a lock it is in the act of lifting. Pinned from both sides, to the millisecond.

`availablePlayers` gets the same predicate as the exact complement of `availabilityOf`. The screen decides what to offer and the server decides what to accept; those two must not be able to disagree.

## What managers will notice

For 27 hours a week the **Add** button is replaced by **Claim**, landing right after Monday Night Football — which is precisely when people most want to grab a breakout, and precisely the behaviour §6 promises instead. Confirmed as ESPN's behaviour: during the window managers must claim, and only after a player clears can he be *"picked up on a first-come, first-serve basis."*

Load, stated rather than discovered later: contested claims go from rare to routine, since the whole pool is claimable each week. `resolveWaiverClaims` is unchanged and handles it — the volume is new, not the logic.

## Verification

Four new tests on the real 2026 calendar, pinning both boundaries to the millisecond and the DST transition:

| test | pins |
|---|---|
| locks the pool from the Tuesday boundary | closed at `lock - 1ms`, open at `lock` |
| reopens it at the processing run, not after it | the half-open end — `run - 1ms` locked, `run` open |
| leaves the rest of the week open | Thursday, Sunday, and Monday night |
| follows the timezone rather than a fixed offset | Tue 00:00 **EST** is 05:00Z in November, not 04:00Z |

**And it immediately caught a live test instant.** `QUIET` in `trades.test.ts`, added in #118, was Tuesday 02:00 EDT — inside the window — so the add started being refused with `NOT_A_FREE_AGENT` before reaching the freeze check that test is about. Moved past the run, with a comment saying why. That is the shortest available demonstration that the predicate does something.

1233 tests, typecheck, lint green. **No schema change, no rules change, golden hash untouched** — the rule values were already there and already correct; only the code that reads them was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
