### PR TITLE
fix(core,db): a team's own claims resolve in the order it filed them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -803,10 +803,26 @@ player's availability rather than by which button was pressed. A client that cou
 would be able to ask for an immediate add on a player who is on waivers — which is exactly
 what waivers exist to prevent.
 
-Two properties of `processWaivers` are load-bearing: it is **blind** (resolution cannot
-depend on submission order) and **replayable** (pure, so a disputed run can be re-run
-rather than argued about). Both come from `resolveWaiverClaims`; do not reimplement them
-here.
+Two properties of `processWaivers` are load-bearing: it is **blind** (no team's outcome
+depends on when another team filed — priority decides every contest between teams, and
+submission time only orders a team's own claims against each other) and **replayable**
+(pure, so a disputed run can be re-run rather than argued about). Both come from
+`resolveWaiverClaims`; do not reimplement them here.
+
+This used to say the resolution could not depend on submission order **at all**, and the
+code never did that either: one team's two claims tie on priority and fell through to
+`claimId`, a v4 UUID. A coin flip chose which of a team's own claims was tried first — and
+therefore which player was left on the board for the next team down, so it moved outcomes
+**across** teams, not merely within one. `created_at` is deliberately left to the database
+rather than written from `input.now`: now that it decides who gets a player, a caller-
+settable submission time would be a way to file a claim and then move it to the front of
+your own queue.
+
+**ESPN, Sleeper and Yahoo all let a manager rank their own pending claims** — ESPN's
+*Pending Moves* panel says "Reorder claims by dragging them into your preferred priority".
+Filing order is an *approximation* of that, not conformance with it, and the app shows the
+order without labelling it. The explicit rank is separate work; do not describe the current
+behaviour as matching ESPN.
 
 Priority is seeded at draft completion, reversed from the draft order. Winners move to the
 back, losers do not move at all — a failed claim costs nothing, so there is no reason to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,8 +819,8 @@ settable submission time would be a way to file a claim and then move it to the 
 your own queue.
 
 **ESPN, Sleeper and Yahoo all let a manager rank their own pending claims** — ESPN's
-*Pending Moves* panel says "Reorder claims by dragging them into your preferred priority".
-Filing order is an *approximation* of that, not conformance with it, and the app shows the
+_Pending Moves_ panel says "Reorder claims by dragging them into your preferred priority".
+Filing order is an _approximation_ of that, not conformance with it, and the app shows the
 order without labelling it. The explicit rank is separate work; do not describe the current
 behaviour as matching ESPN.
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -362,7 +362,7 @@ which would leave the rest of the league no real chance to claim him.
 - A team that wins several claims in one run moves once.
 - Starting order is the **reverse of the draft order**.
 - **Your own claims are tried in the order you filed them.** Priority decides every contest
-  with another manager; filing order only decides which of *your* claims gets your last
+  with another manager; filing order only decides which of _your_ claims gets your last
   roster spot. So file the player you want most first.
 
 #### Locks

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -361,6 +361,9 @@ which would leave the rest of the league no real chance to claim him.
   reason to hoard claims.
 - A team that wins several claims in one run moves once.
 - Starting order is the **reverse of the draft order**.
+- **Your own claims are tried in the order you filed them.** Priority decides every contest
+  with another manager; filing order only decides which of *your* claims gets your last
+  roster spot. So file the player you want most first.
 
 #### Locks
 

--- a/packages/core/src/waivers/claims.ts
+++ b/packages/core/src/waivers/claims.ts
@@ -4,13 +4,27 @@
  * Claims are **blind**: nobody sees anyone else's until they process. That is
  * the property that makes waivers fair, and the one place this project could
  * eventually beat ESPN — there, you trust their server not to peek before
- * processing; a commit-reveal scheme would make it provable. Not v1, but the
- * resolution below is deliberately independent of *when* claims arrived, so
- * adding that later changes nothing here.
+ * processing; a commit-reveal scheme would make it provable. Not v1.
+ *
+ * **Blind means no team's outcome depends on when another team filed**, and the
+ * resolution below is written so it does not: waiver priority decides every
+ * contest *between* teams, and submission time is consulted only to order one
+ * team's own claims against each other. Filing early buys you nothing against
+ * anybody but yourself. A commit-reveal scheme still works — a team commits to
+ * its own ordering inside the commitment and reveals it to nobody early.
+ *
+ * This paragraph used to claim the stronger property, that the resolution was
+ * "deliberately independent of *when* claims arrived", and the code never
+ * implemented it either. Two claims by one team tie on priority, so the sort
+ * fell through to `claimId` — `gen_random_uuid()`, a v4 UUID. A coin flip
+ * decided which of a team's own claims was tried first, and therefore which
+ * player was still on the board for the next team down: it moved outcomes
+ * *across* teams, not merely within one.
  *
  * Resolution is otherwise simple and entirely deterministic:
  *
- *   1. Sort claims by the claiming team's waiver priority.
+ *   1. Sort claims by the claiming team's waiver priority, then by the order
+ *      that team filed its own.
  *   2. Award each in turn, skipping any whose player is already gone or whose
  *      roster cannot take him.
  *   3. A team that wins moves to the back of the order. A team that loses does
@@ -26,6 +40,15 @@ export interface WaiverClaim {
   readonly addPlayerId: string;
   /** Player to drop to make room. Required when the roster is full. */
   readonly dropPlayerId: string | null;
+  /**
+   * When the team filed this claim — `waiver_claims.created_at`.
+   *
+   * Orders a team's *own* claims against each other and decides nothing else;
+   * see the sort in `resolveWaiverClaims`. It is data on the claim rather than
+   * a clock read, so the function stays pure and a disputed run replays from
+   * the stored rows exactly.
+   */
+  readonly submittedAt: Date;
 }
 
 export type ClaimFailure =
@@ -63,22 +86,47 @@ export interface ResolveInput {
 /**
  * Resolve a round of waiver claims.
  *
- * Pure: no clock, no database. The same inputs always produce the same
- * outcomes, which is what lets a disputed waiver run be replayed exactly.
+ * Pure: no clock, no database. `submittedAt` arrives as data on each claim —
+ * this function never asks what time it is — so the same inputs always produce
+ * the same outcomes, which is what lets a disputed waiver run be replayed
+ * exactly.
  */
 export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
   const { claims, priority, rosters, pool, shape } = input;
 
   const rank = new Map(priority.map((teamId, index) => [teamId, index]));
 
-  // Priority first, then submission order within a team so a team's own claims
-  // resolve in the order they intended. `claimId` breaks any remaining tie,
-  // because a resolution that depended on array order would not be replayable.
+  // Priority first. Then, within one team, the order that team filed its own
+  // claims, so a manager with one open spot and two claims gets the player they
+  // asked for first. `claimId` closes the sort so it stays total: a comparator
+  // that returned 0 for two distinct claims would leave the result riding on
+  // `sort` stability, and therefore on database row order.
+  //
+  // **`submittedAt` is only ever compared between two claims that tied on
+  // priority, and a tie means one team.** `loadWaiverPriority` lists every team
+  // in the league exactly once, so two claims share a rank only when they share
+  // a team. That is what keeps this blind: no team's outcome can move because of
+  // when a *different* team filed.
+  //
+  // Do **not** try to enforce that by making the time term conditional on
+  // `a.teamId === b.teamId`. It looks tighter and it is not transitive — A < B
+  // by time, B < C by id, C < A by id is constructible — and a non-transitive
+  // comparator makes the sort depend on input order, which is exactly the
+  // replayability this function exists to provide.
+  //
+  // The one residue: claims from a team *absent* from `priority` share the
+  // `MAX_SAFE_INTEGER` fallback, so two of those from different teams would
+  // compare on time. Nothing produces that state — and such a claim would be
+  // awarded a player in a league it does not belong to long before its ordering
+  // mattered, which is a schema gap filed separately, not an ordering one.
   const ordered = [...claims].sort((a, b) => {
     const byPriority =
       (rank.get(a.teamId) ?? Number.MAX_SAFE_INTEGER) -
       (rank.get(b.teamId) ?? Number.MAX_SAFE_INTEGER);
-    return byPriority !== 0 ? byPriority : a.claimId.localeCompare(b.claimId);
+    if (byPriority !== 0) return byPriority;
+
+    const byTime = a.submittedAt.getTime() - b.submittedAt.getTime();
+    return byTime !== 0 ? byTime : a.claimId.localeCompare(b.claimId);
   });
 
   const working = new Map<string, DraftablePlayer[]>(

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -358,7 +358,9 @@ describe("resolveWaiverClaims", () => {
       shape: SHAPE,
     });
 
-    expect(result.outcomes.filter((o) => o.awarded).map((o) => o.addPlayerId)).toEqual(["star"]);
+    expect(result.outcomes.filter((o) => o.awarded).map((o) => o.addPlayerId)).toEqual([
+      "star",
+    ]);
     expect(result.outcomes.find((o) => o.addPlayerId === "other")).toMatchObject({
       awarded: false,
       reason: "ROSTER_FULL",
@@ -428,7 +430,12 @@ describe("resolveWaiverClaims", () => {
       claim("c9", "team-a", "star", null, same),
       claim("c1", "team-a", "other", null, same),
     ];
-    const args = { priority, rosters: new Map([["team-a", nearlyFull]]), pool: POOL, shape: SHAPE };
+    const args = {
+      priority,
+      rosters: new Map([["team-a", nearlyFull]]),
+      pool: POOL,
+      shape: SHAPE,
+    };
 
     const forwards = resolveWaiverClaims({ ...args, claims });
     const backwards = resolveWaiverClaims({ ...args, claims: [...claims].reverse() });

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -12,7 +12,7 @@ import {
   waiverClearsAt,
 } from "./schedule.js";
 import { initialWaiverPriority, resolveWaiverClaims } from "./claims.js";
-import type { WaiverClaim } from "./claims.js";
+import type { WaiverClaim, WaiverResolution } from "./claims.js";
 
 const RULES = NFL_DEFAULT_WAIVERS;
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
@@ -200,12 +200,19 @@ const player = (id: string, positions: string[] = ["WR"]): DraftablePlayer => ({
   rank: 1,
 });
 
+/** Wednesday 03:00 ET — the processing instant — plus n minutes. */
+const AT = (minutes: number): Date => new Date(Date.UTC(2026, 8, 16, 7, minutes));
+
+// `submittedAt` defaults to one shared instant, so every test that does not care
+// about filing order ties there and falls through to `claimId` exactly as it did
+// before that term existed.
 const claim = (
   claimId: string,
   teamId: string,
   addPlayerId: string,
   dropPlayerId: string | null = null,
-): WaiverClaim => ({ claimId, teamId, addPlayerId, dropPlayerId });
+  submittedAt: Date = AT(0),
+): WaiverClaim => ({ claimId, teamId, addPlayerId, dropPlayerId, submittedAt });
 
 const POOL = new Map(["star", "other", "third"].map((id) => [id, player(id)] as const));
 
@@ -334,31 +341,103 @@ describe("resolveWaiverClaims", () => {
     });
   });
 
-  it("is independent of the order claims were submitted in", () => {
-    // Blind claims must not reward being early. Same claims, shuffled input,
-    // identical result.
+  it("tries a team's own claims in the order the team filed them", () => {
+    // One open spot, two claims. The claim ids are chosen so `c9` sorts *after*
+    // `c1`: an id-only tiebreak awards "other" and fails "star", so this fails
+    // deterministically rather than half the time.
+    const nearlyFull = Array.from({ length: SHAPE.totalSlots - 1 }, (_, i) => player(`p${i}`));
+
+    const result = resolveWaiverClaims({
+      claims: [
+        claim("c9", "team-a", "star", null, AT(1)),
+        claim("c1", "team-a", "other", null, AT(2)),
+      ],
+      priority,
+      rosters: new Map([["team-a", nearlyFull]]),
+      pool: POOL,
+      shape: SHAPE,
+    });
+
+    expect(result.outcomes.filter((o) => o.awarded).map((o) => o.addPlayerId)).toEqual(["star"]);
+    expect(result.outcomes.find((o) => o.addPlayerId === "other")).toMatchObject({
+      awarded: false,
+      reason: "ROSTER_FULL",
+    });
+  });
+
+  it("does not let one team's filing order decide a rival's claim by chance", () => {
+    // The reason this is a defect and not a preference. team-a outranks team-b
+    // and has one spot; it filed for "star" first, so "other" must still be on
+    // the board when team-b's claim is tried. Order team-a's own claims the
+    // other way and team-b is awarded nothing — a coin flip deciding the
+    // outcome of a team that is not party to it.
+    const nearlyFull = Array.from({ length: SHAPE.totalSlots - 1 }, (_, i) => player(`p${i}`));
+
+    const result = resolveWaiverClaims({
+      claims: [
+        claim("c9", "team-a", "star", null, AT(1)),
+        claim("c1", "team-a", "other", null, AT(2)),
+        claim("c5", "team-b", "other", null, AT(3)),
+      ],
+      priority,
+      rosters: new Map([...emptyRosters, ["team-a", nearlyFull]]),
+      pool: POOL,
+      shape: SHAPE,
+    });
+
+    const awarded = new Map(
+      result.outcomes.filter((o) => o.awarded).map((o) => [o.addPlayerId, o.teamId]),
+    );
+    expect(awarded.get("star")).toBe("team-a");
+    expect(awarded.get("other")).toBe("team-b");
+  });
+
+  it("is independent of the order the claims are passed in", () => {
+    // Not the order they were *submitted* in — a team's own claims are tried in
+    // filing order, so submission time is an input and it decides things. What
+    // must never matter is the order the array happens to arrive in, which is
+    // database row order: a resolution that moved with it would not be
+    // replayable. team-a files twice deliberately — the version of this test
+    // that predated intra-team ordering used one claim per team and compared
+    // only the awarded team ids, so it could not have caught the bug it was
+    // named after.
     const claims = [
-      claim("c1", "team-c", "star"),
-      claim("c2", "team-a", "star"),
-      claim("c3", "team-b", "other"),
+      claim("c1", "team-c", "star", null, AT(3)),
+      claim("c2", "team-a", "star", null, AT(2)),
+      claim("c3", "team-a", "other", null, AT(1)),
+      claim("c4", "team-b", "third", null, AT(4)),
     ];
     const args = { priority, rosters: emptyRosters, pool: POOL, shape: SHAPE };
 
     const forwards = resolveWaiverClaims({ ...args, claims });
     const backwards = resolveWaiverClaims({ ...args, claims: [...claims].reverse() });
 
-    expect(
-      forwards.outcomes
-        .filter((o) => o.awarded)
-        .map((o) => o.teamId)
-        .sort(),
-    ).toEqual(
-      backwards.outcomes
-        .filter((o) => o.awarded)
-        .map((o) => o.teamId)
-        .sort(),
-    );
+    const key = (r: WaiverResolution): string =>
+      JSON.stringify([...r.outcomes].sort((x, y) => x.claimId.localeCompare(y.claimId)));
+
+    expect(key(forwards)).toEqual(key(backwards));
     expect(forwards.priorityAfter).toEqual(backwards.priorityAfter);
+  });
+
+  it("falls back to the claim id when a team files twice in the same instant", () => {
+    // The residue, pinned rather than hoped about: two claims that tie on time
+    // still order totally, so the result cannot ride on `sort` stability.
+    const nearlyFull = Array.from({ length: SHAPE.totalSlots - 1 }, (_, i) => player(`p${i}`));
+    const same = AT(7);
+    const claims = [
+      claim("c9", "team-a", "star", null, same),
+      claim("c1", "team-a", "other", null, same),
+    ];
+    const args = { priority, rosters: new Map([["team-a", nearlyFull]]), pool: POOL, shape: SHAPE };
+
+    const forwards = resolveWaiverClaims({ ...args, claims });
+    const backwards = resolveWaiverClaims({ ...args, claims: [...claims].reverse() });
+
+    const won = (r: WaiverResolution): string | undefined =>
+      r.outcomes.find((o) => o.awarded)?.claimId;
+
+    expect(won(forwards)).toBe("c1");
+    expect(won(backwards)).toBe("c1");
   });
 
   it("resolves nothing when there are no claims", () => {

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -373,6 +373,58 @@ describe("processing", () => {
     expect(winner?.team_id).toBe(fx.teams[3]);
   });
 
+  it("tries a team's own claims in the order it filed them", async () => {
+    // The wiring, which no test in `@rostr/core` can see: that `created_at` is
+    // actually selected and threaded into `WaiverClaim`. Room is expressed as a
+    // shared drop rather than by fabricating a full roster — whichever claim is
+    // tried first spends `spare`, and the other fails DROP_NOT_ON_ROSTER.
+    const fx = await setup();
+    const team = fx.teams[3]!; // best priority, the reverse of the draft order
+    const rival = fx.teams[1]!;
+
+    await fx.client.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [team, fx.players.get("spare")!, new Date(MONDAY.getTime() - 7 * DAY)],
+    );
+
+    // On waivers at MONDAY, cleared by the Wednesday run.
+    for (const handle of ["target", "other"]) {
+      await fx.client.query(
+        "INSERT INTO waiver_wire (league_id, player_id, clears_at) VALUES ($1, $2, $3)",
+        [fx.leagueId, fx.players.get(handle)!, new Date(MONDAY.getTime() + DAY)],
+      );
+    }
+
+    const file = (teamId: string, add: string, drop: string | null = null): Promise<unknown> =>
+      submitClaim(fx.client, {
+        leagueId: fx.leagueId,
+        teamId,
+        addPlayerId: fx.players.get(add)!,
+        dropPlayerId: drop === null ? null : fx.players.get(drop)!,
+        now: MONDAY,
+      });
+
+    // `target` first — that is the whole assertion. `created_at` comes from the
+    // database, so these must stay sequential and awaited.
+    await file(team, "target", "spare");
+    await file(team, "other", "spare");
+    await file(rival, "other");
+
+    await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    const rows = await fx.client.query<{ team_id: string; player_id: string }>(
+      `SELECT team_id, player_id FROM roster_entries
+        WHERE league_id = $1 AND released_at IS NULL AND acquired_via = 'WAIVER'`,
+      [fx.leagueId],
+    );
+    const owner = new Map(rows.map((r) => [r.player_id, r.team_id]));
+
+    expect(owner.get(fx.players.get("target")!)).toBe(team);
+    // And the rival gets the player the first team could no longer take.
+    expect(owner.get(fx.players.get("other")!)).toBe(rival);
+  });
+
   it("sends the winner to the back of the order", async () => {
     const fx = await setup();
     await contested(fx, [3]);

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -20,9 +20,14 @@
  * `processWaivers` is where contested players are awarded, and it is the moment
  * a league is most likely to feel cheated. Two properties matter:
  *
- *   * **Blind.** Nobody sees anyone else's claims before they resolve, so the
- *     resolution cannot depend on submission order — and `resolveWaiverClaims`
- *     is written so it does not.
+ *   * **Blind.** Nobody sees anyone else's claims before they resolve, so no
+ *     team's outcome may depend on when another team filed — and
+ *     `resolveWaiverClaims` is written so it does not: waiver priority decides
+ *     every contest between teams, and submission time only orders a team's own
+ *     claims against each other. This used to say the resolution "cannot depend
+ *     on submission order" at all. That is stronger than blindness needs, and it
+ *     was untrue of the code: two claims by one team tie on priority and the
+ *     sort fell through to a v4 UUID.
  *   * **Replayable.** The resolution is pure. Given the same claims, priority and
  *     rosters, it produces the same outcome, so a disputed run can be re-run
  *     exactly rather than argued about.
@@ -649,6 +654,14 @@ async function placeDroppedPlayer(
  * Nothing happens until processing. Claims are blind, so this deliberately tells
  * the claimant nothing about who else has claimed — and a failed claim costs
  * nothing, so there is no reason to hoard them.
+ *
+ * **`created_at` is left to the database, and that now decides something.** The
+ * column defaults to `now()` and this function deliberately does not write
+ * `input.now`, so the order a team's own claims are tried in comes from the
+ * server clock at the instant each INSERT commits and no caller can name it.
+ * Since that order became load-bearing, that is a property rather than an
+ * omission: a writable submission time is a way to file a claim and then move it
+ * to the front of your own queue. `input.now` decides availability only.
  */
 export async function submitClaim(
   db: SqlClient,
@@ -710,12 +723,15 @@ export async function cancelClaim(
 }
 
 /**
- * A team's own pending claims, newest last.
+ * A team's own pending claims, newest last — which is the order they will be
+ * tried in.
  *
- * **Not the order they resolve in**, which it used to claim. Resolution is by
- * waiver priority first, and a claim for a player who has not cleared yet waits
- * for a later run than one filed after it — so submission order predicts neither
- * the ordering nor the run.
+ * **Their order relative to each other, and nothing further.** Waiver priority
+ * decides every contest against another team, and a claim for a player who has
+ * not cleared yet waits for a later run than one filed after it — so this
+ * predicts neither who wins nor which run resolves it. It used to say it was
+ * "not the order they resolve in" at all, which stopped being true when the
+ * intra-team tiebreak stopped being a random UUID.
  */
 export async function pendingClaims(
   db: SqlClient,
@@ -812,13 +828,16 @@ export async function processWaivers(
     // between the read below and the writes either.
     await tx.query("SELECT id FROM leagues WHERE id = $1 FOR UPDATE", [leagueId]);
 
+    // No `ORDER BY`: `resolveWaiverClaims` sorts, and one here would suggest the
+    // array order it is handed matters. It must not.
     const claims = await tx.query<{
       id: string;
       team_id: string;
       add_player_id: string;
       drop_player_id: string | null;
+      created_at: string;
     }>(
-      `SELECT id, team_id, add_player_id, drop_player_id
+      `SELECT id, team_id, add_player_id, drop_player_id, created_at
          FROM waiver_claims WHERE league_id = $1 AND state = 'PENDING'`,
       [leagueId],
     );
@@ -937,6 +956,10 @@ export async function processWaivers(
           teamId: row.team_id,
           addPlayerId: row.add_player_id,
           dropPlayerId: row.drop_player_id,
+          // Wrapped, following this file's convention for timestamp columns:
+          // both drivers hand `timestamptz` back as a `Date` already, and the
+          // wrap normalises the string shape too if one ever stops.
+          submittedAt: new Date(row.created_at),
         })),
       priority,
       rosters,


### PR DESCRIPTION
Closes #79 part 2. Part 1 landed in #106; part 3 (`nextWeekly` and the spring-forward Sunday) stays open behind this.

## A coin flip, and it lands on somebody else

`resolveWaiverClaims` sorted by `(waiver priority, claimId)`. Two claims from one team tie on priority, so the whole decision fell to `claimId` — `gen_random_uuid()`, a **v4** UUID with no extension installed. Genuinely random, not accidentally almost right.

The obvious framing is "a manager submitting ranked fallbacks can't say which they want most". That undersells it. **The variance falls entirely on a team that is not party to the claims.**

Team A holds priority 1 and one open roster spot, and claims P1 and P2. Team B holds priority 2 and claims P2.

| A's claims tried | A gets | B gets | league total |
|---|---|---|---|
| P1 first | P1 | **P2** | 2 players |
| P2 first | P2 | **nothing** | 1 player |

A's own outcome is identical either way — exactly one player. Only B's moves, and one ordering leaves P1 unclaimed who would otherwise have been rostered. So it is not merely arbitrary: it is arbitrary *and* one ordering is Pareto-superior for the league, and the loser is never the team whose UUIDs decided it.

**Reachable and routine, not a corner case.** `submitClaim`'s duplicate guard is scoped to a single `add_player_id`, the only index on `waiver_claims` is non-unique, and none of the three pre-resolution filters (`alreadyHeld`, `notYetClear`, `dropIsFrozen`) is per-team. `docs/RULES.md` §6 explicitly contemplates a team winning several claims in one run. And the full-roster variant is the *common* mid-season shape: two claims naming the same `drop_player_id`, where whichever is tried first spends the drop and the other returns `DROP_NOT_ON_ROSTER`.

## The fix

`(priority, submittedAt, claimId)`. `submittedAt` is `waiver_claims.created_at`, which has existed since `0005` and was never read. **No migration, no rules change, no UI, golden hash untouched.**

Three things about it are load-bearing.

**`claimId` stays as the final term.** A comparator that returned `0` for two distinct claims would leave the result riding on `Array.prototype.sort` stability and therefore on database row order — the replayability this function exists to provide.

**The time term is deliberately *not* conditional on `a.teamId === b.teamId`.** That is the intuitive way to make blindness airtight and it is **not transitive** — A < B by time, B < C by id, C < A by id is constructible — which reintroduces exactly the input-order dependence it was meant to prevent. Blindness comes instead from `loadWaiverPriority` listing every team in the league exactly once, so a rank tie *is* a same-team tie. There is a comment saying so, because the conditional version is what the next person will reach for.

**`submitClaim` still does not write `input.now`.** This was the one place the three reviews disagreed, and the conclusion reversed the initial recommendation. Before this change `created_at` decided nothing; now it decides who gets a player. A caller-settable submission time is a way to file a claim and then move it to the front of your own queue — the same shape as every "taken from the request body" defect in this repo's history. Leaving it to `DEFAULT now()` keeps one authoritative Postgres clock instead of many serverless app clocks, and nothing to forge. Recorded in the docstring so it is not re-litigated.

## Blind still means blind — the definition just got honest

`claims.ts` and `waivers.ts` both asserted the resolution was *"deliberately independent of when claims arrived"*. That was **stronger than blindness needs and untrue of the code** — the sort already fell through to a UUID on exactly the tie that sentence was about.

What blindness actually protects: **no team's outcome depends on when another team filed.** That still holds exactly, and a commit-reveal scheme still works — a team commits to its own ordering inside the commitment and reveals it to nobody early.

Four docstrings and the `CLAUDE.md` copy are rewritten rather than left standing, per this repo's rule that a false comment is a defect in its own right. Two of them are worth calling out: the comment directly above the sort **already described this behaviour** and the code had never done it, and the module header contradicted the sort comment 66 lines below it — the file disagreed with itself.

## Verified against all three products, not assumed

| | Can a manager rank their own claims? |
|---|---|
| **ESPN** | Yes — *Pending Moves*: "Reorder claims by dragging them into your preferred priority" |
| **Sleeper** | Yes, among equal bids: "You can only update the waiver order for bids with the same amount" |
| **Yahoo** | Yes — the control is named *Edit Waiver Priority* |

**So filing order is an approximation of ESPN, not conformance with it**, and every note in this change says so rather than claiming parity. The divergence is real and predictable: you claim your third choice Monday as insurance, the breakout back hits waivers Tuesday and you claim him second — ESPN lets you drag him to the top, filing order hands you the insurance pick. The explicit rank is filed separately as the actual conformance item, along with the fact that a manager still cannot express "at most one of these three".

`docs/RULES.md` §6 promised nothing about intra-team order, so nothing signed was violated in either direction. It now says what happens, in the document members actually read: *"file the player you want most first."*

## Tests, and what each one would catch

Four new, all mutation-checked — and reverting to `main` is **not** an acceptable check here, because on `main` the outcome is a coin flip and a test that fails half the time has not been shown to work. Every mutation below fails deterministically.

| test | mutation that kills it |
|---|---|
| tries a team's own claims in the order it filed them | remove the time term → `c1` sorts before `c9`, wrong player awarded |
| does not let one team's filing order decide a rival's claim by chance | same, and reversing the comparison → B is awarded nothing |
| is independent of the order the claims are passed in | comparator returns `0` on a tie → forwards ≠ backwards |
| falls back to the claim id when a team files twice in the same instant | same `return 0` |

Claim ids are chosen so an id-only tiebreak picks the *wrong* one, which is what makes the failures deterministic rather than 50/50.

**The old test was renamed, not deleted, and that is the point.** `"is independent of the order claims were submitted in"` proved its property by *reversing an array* — so it would have stayed green while the property it named was deleted. It also used one claim per team and compared only awarded team ids, so it could never have caught the bug it was named after. It is now `"is independent of the order the claims are **passed** in"`, has team A filing twice, and compares full outcomes.

The db test pins the wiring no core test can see — that `created_at` is actually selected and threaded. Its sequential-submit timing was measured rather than hoped about: 60 trials against PGlite gave 0 ties, minimum gap 6 ms, median 11 ms.

**1237 tests, typecheck, lint green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
