### PR TITLE
fix(core,db): the most recent weekly lock is not 168 hours ago

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,6 +832,19 @@ hoard claims.
 **Eastern**, which is 07:00 UTC — so a test using "Wednesday 18:00 UTC" is _after_ the
 clear, not before it. One test asserted the opposite and was wrong.
 
+**"A week ago" is not `now - 7 * 24h`, and use `latestWeekly` rather than writing it
+again.** Consecutive weekly moments are 169 hours apart across the November fall-back and
+167 across the spring change — a week of _local days_, which is the entire reason the rules
+carry a weekday and an hour instead of an offset. Both `everyoneIsOnWaivers` and
+`transactionWeek` used to find the most recent lock by asking the strictly-after
+`nextWeekly` from exactly 168 hours back, which lands _on_ the previous lock and is then
+skipped, so for the hour of **Monday 2 November 2026, 23:00–23:59 ET** they answered with a
+lock in the future: free agency closed early, and `transactionWeek` named week 10 while week
+9's Monday night game was being played — which sends §6's kickoff lock to look up games that
+have not started, during the one game it most needs to refuse. The spring change had the
+mirror of it. `latestWeekly` walks instead of assuming an interval, and assumes nothing about
+how long a week is.
+
 ### The bracket
 
 `packages/core/src/season/bracket.ts` (pure), `packages/db/src/playoffs.ts` (state),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,6 +139,7 @@ export {
   availabilityAt,
   everyoneIsOnWaivers,
   dropDestination,
+  latestWeekly,
   nextProcessingAt,
   nextWeekly,
   nextWeeklyLockAt,

--- a/packages/core/src/waivers/schedule.ts
+++ b/packages/core/src/waivers/schedule.ts
@@ -149,6 +149,35 @@ export function nextWeekly(after: Date, moment: WeeklyMoment, timeZone: string):
   );
 }
 
+/**
+ * The most recent occurrence of a weekly moment at or before `now`.
+ *
+ * **Consecutive weekly moments are not 168 hours apart.** Across a fall-back
+ * they are 169, across a spring-forward 167, and a jurisdiction with a two-hour
+ * transition moves them further still. Both callers of this used to find the
+ * previous lock by asking `nextWeekly` from exactly `now - 7 * 24h`, and a
+ * 168-hour lookback cannot span a 169-hour gap: it lands precisely *on* the
+ * previous lock, `nextWeekly` is strictly-after so it skips it, and the answer
+ * is a lock **one hour in the future**.
+ *
+ * That was live for the hour of Monday 2 November 2026, 23:00–23:59 ET, on the
+ * shipped default rules — see the tests.
+ *
+ * So walk instead of guessing an interval. Starting nine days back guarantees at
+ * least one occurrence in range whatever the transition, and stepping forward
+ * while the next is still `<= now` lands on the last one. At most two
+ * iterations, and it assumes nothing about how long a week is.
+ */
+export function latestWeekly(now: Date, moment: WeeklyMoment, timeZone: string): Date {
+  let cursor = nextWeekly(new Date(now.getTime() - 9 * DAY_MS), moment, timeZone);
+
+  for (;;) {
+    const next = nextWeekly(cursor, moment, timeZone);
+    if (next.getTime() > now.getTime()) return cursor;
+    cursor = next;
+  }
+}
+
 /** The next waiver processing run strictly after `now`. */
 export function nextProcessingAt(now: Date, rules: WaiverRules): Date {
   return nextWeekly(now, rules.processing, rules.timezone);
@@ -198,14 +227,7 @@ export function nextWeeklyLockAt(now: Date, rules: WaiverRules): Date {
  * answers first, and it outlives this window.
  */
 export function everyoneIsOnWaivers(now: Date, rules: WaiverRules): boolean {
-  // `nextWeekly` is strictly-after, so asking it from a week earlier yields the
-  // most recent lock at or before `now` — the same trick `transactionWeek` uses
-  // to find the cycle it is in.
-  const lock = nextWeekly(
-    new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
-    rules.weeklyLock,
-    rules.timezone,
-  );
+  const lock = latestWeekly(now, rules.weeklyLock, rules.timezone);
 
   return now.getTime() < nextProcessingAt(lock, rules).getTime();
 }

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -7,6 +7,7 @@ import {
   availabilityAt,
   dropDestination,
   everyoneIsOnWaivers,
+  latestWeekly,
   nextProcessingAt,
   nextWeeklyLockAt,
   waiverClearsAt,
@@ -69,6 +70,109 @@ describe("RULES.md §6 — every unrostered player returns to waivers on Tuesday
     const novLock = new Date("2026-11-17T05:00:00Z");
     expect(everyoneIsOnWaivers(new Date(novLock.getTime() - 1), RULES)).toBe(false);
     expect(everyoneIsOnWaivers(novLock, RULES)).toBe(true);
+  });
+});
+
+describe("the week before a weekly lock is not always 168 hours", () => {
+  // US clocks go back on Sunday 1 November 2026, so the Tuesday locks either
+  // side of it are 169 hours apart:
+  //   2026-10-27T04:00Z (Tue 00:00 EDT) -> 2026-11-03T05:00Z (Tue 00:00 EST)
+  // Both callers used to find "the most recent lock" by asking `nextWeekly` from
+  // exactly `now - 7 * 24h`. That lands *on* the earlier lock, and `nextWeekly`
+  // is strictly-after, so it skipped it and answered with a lock in the future.
+  const OCT_LOCK = new Date("2026-10-27T04:00:00Z");
+  const NOV_LOCK = new Date("2026-11-03T05:00:00Z");
+
+  it("has a 169-hour gap across the fall-back", () => {
+    expect(nextWeeklyLockAt(new Date("2026-10-26T12:00:00Z"), RULES)).toEqual(OCT_LOCK);
+    expect(nextWeeklyLockAt(new Date("2026-11-02T12:00:00Z"), RULES)).toEqual(NOV_LOCK);
+    expect(NOV_LOCK.getTime() - OCT_LOCK.getTime()).toBe(169 * 3600 * 1000);
+  });
+
+  it("still names the October lock in the hour a 168-hour lookback loses", () => {
+    // Monday 2 November, 23:00-23:59 ET. Across that whole hour `now - 168h`
+    // lands at or after OCT_LOCK, so a strictly-after search from there skips
+    // the lock it was supposed to find and returns the November one instead.
+    for (const iso of [
+      "2026-11-03T04:00:00Z",
+      "2026-11-03T04:30:00Z",
+      "2026-11-03T04:59:59Z",
+    ]) {
+      const now = new Date(iso);
+      expect(now.getTime() - 7 * 24 * 3600 * 1000, iso).toBeGreaterThanOrEqual(
+        OCT_LOCK.getTime(),
+      );
+
+      expect(latestWeekly(now, RULES.weeklyLock, RULES.timezone), iso).toEqual(OCT_LOCK);
+    }
+  });
+
+  it("keeps free agency open until the lock actually arrives", () => {
+    // The consequence, and the reason this is a rule and not a rounding error:
+    // §6 opens free agency from Wednesday 03:00 to Tuesday 00:00, and Monday
+    // night is when Monday Night Football is being played.
+    for (const iso of [
+      "2026-11-03T03:59:59Z", // Mon 22:59 ET
+      "2026-11-03T04:00:00Z", // Mon 23:00 ET — was reported ON_WAIVERS
+      "2026-11-03T04:59:59Z", // Mon 23:59 ET
+    ]) {
+      expect(everyoneIsOnWaivers(new Date(iso), RULES), iso).toBe(false);
+    }
+
+    expect(everyoneIsOnWaivers(NOV_LOCK, RULES)).toBe(true);
+  });
+
+  it("returns the moment itself when now is exactly on it", () => {
+    // "At or before", not "strictly before" — the lock instant belongs to the
+    // cycle it opens.
+    expect(latestWeekly(NOV_LOCK, RULES.weeklyLock, RULES.timezone)).toEqual(NOV_LOCK);
+    expect(
+      latestWeekly(new Date(NOV_LOCK.getTime() - 1), RULES.weeklyLock, RULES.timezone),
+    ).toEqual(OCT_LOCK);
+  });
+
+  it("holds across the spring-forward, where the gap is 167 hours", () => {
+    // The other direction, in case anyone is tempted to hardcode 169.
+    const before = new Date("2027-03-09T05:00:00Z"); // Tue 00:00 EST
+    const after = new Date("2027-03-16T04:00:00Z"); // Tue 00:00 EDT
+
+    expect(after.getTime() - before.getTime()).toBe(167 * 3600 * 1000);
+    expect(
+      latestWeekly(new Date(after.getTime() - 1), RULES.weeklyLock, RULES.timezone),
+    ).toEqual(before);
+
+    // And the mirror of the November hole, which the 168-hour lookback also had
+    // and in the other direction: half an hour *into* the new lock, `now - 168h`
+    // falls before the previous one, so the old trick answered with the stale
+    // cycle and left the pool open while it should have been shut.
+    const justInside = new Date(after.getTime() + 30 * 60 * 1000);
+    expect(latestWeekly(justInside, RULES.weeklyLock, RULES.timezone)).toEqual(after);
+    expect(everyoneIsOnWaivers(justInside, RULES)).toBe(true);
+  });
+
+  it("never answers with a moment in the future", () => {
+    // The whole class of bug rather than the two instants that expose it, swept
+    // hourly across both transitions — the only places the property can break.
+    // Deliberately not swept across the whole season: `schedule.ts` builds a
+    // fresh `Intl.DateTimeFormat` per probe, so a season-long fine grid costs
+    // minutes for coverage of weeks where every gap is exactly 168 hours.
+    for (const [from, days] of [
+      ["2026-10-27T00:00:00Z", 10], // fall-back, 1 Nov 2026
+      ["2027-03-07T00:00:00Z", 11], // spring-forward, 14 Mar 2027
+    ] as const) {
+      const start = new Date(from).getTime();
+
+      for (let hour = 0; hour < 24 * days; hour++) {
+        const now = new Date(start + hour * 3600 * 1000);
+        const lock = latestWeekly(now, RULES.weeklyLock, RULES.timezone);
+
+        expect(lock.getTime(), now.toISOString()).toBeLessThanOrEqual(now.getTime());
+        // And it is the *most recent* one: the next is genuinely after `now`.
+        expect(nextWeeklyLockAt(lock, RULES).getTime(), now.toISOString()).toBeGreaterThan(
+          now.getTime(),
+        );
+      }
+    }
   });
 });
 

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -14,6 +14,7 @@ import {
   persistSchedule,
   resolveLeagueWeek,
   resolveLeagueWeeksThrough,
+  transactionWeek,
 } from "./week.js";
 
 let db: PGliteClient | undefined;
@@ -168,6 +169,77 @@ async function addGame(fx: Fixture, ref: string, status: string, week = WEEK): P
 async function schedule(fx: Fixture): Promise<void> {
   await persistSchedule(fx.client, fx.leagueId, generateSchedule(fx.teamIds, 14, "seed"));
 }
+
+describe("transactionWeek across the November fall-back", () => {
+  // The 2026 clocks go back on Sunday 1 November, so the Tuesday locks either
+  // side are 169 hours apart. `transactionWeek` used to find "the most recent
+  // lock" by asking from exactly `at - 7 * 24h`, which lands *on* the earlier
+  // lock and is then skipped by a strictly-after search — so for one hour it
+  // named the lock a week ahead, and therefore the wrong week.
+  const OCT_LOCK = new Date("2026-10-27T04:00:00Z"); // Tue 00:00 EDT
+  const WEEK_9_SUNDAY = new Date("2026-11-01T18:00:00Z"); // Sun 1 Nov 13:00 EST
+  const WEEK_9_MNF = new Date("2026-11-03T01:15:00Z"); // Mon 2 Nov 20:15 EST
+  const WEEK_10_TNF = new Date("2026-11-06T01:15:00Z"); // Thu 5 Nov 20:15 EST
+
+  /** Monday 2 November, 23:30 ET — Monday Night Football is being played. */
+  const DURING_MNF = new Date("2026-11-03T04:30:00Z");
+
+  async function withNovemberGames(): Promise<Fixture> {
+    const fx = await setup();
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+
+    for (const [ref, week, kickoff] of [
+      ["w9-sun", 9, WEEK_9_SUNDAY],
+      ["w9-mnf", 9, WEEK_9_MNF],
+      ["w10-tnf", 10, WEEK_10_TNF],
+    ] as const) {
+      await fx.client.query(
+        `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status)
+         VALUES ($1, $2, $3, $4, 'CIN', 'BAL', $5, 'SCHEDULED')`,
+        [sport!.id, ref, SEASON, week, kickoff],
+      );
+    }
+
+    return fx;
+  }
+
+  it("names week 9 while week 9 is still being played", async () => {
+    const fx = await withNovemberGames();
+
+    // `at - 168h` lands past the October lock, which is what used to lose it.
+    expect(DURING_MNF.getTime() - 7 * 24 * 3600 * 1000).toBeGreaterThanOrEqual(
+      OCT_LOCK.getTime(),
+    );
+
+    expect(await transactionWeek(fx.client, fx.rules, DURING_MNF)).toBe(9);
+  });
+
+  it("keeps RULES.md §6's kickoff lock enforceable during Monday night", async () => {
+    // The consequence. Naming week 10 sends every kickoff check to week 10's
+    // games, none of which has started — so a manager could cut an injured
+    // player mid-game, which is the exact thing §6 forbids.
+    const fx = await withNovemberGames();
+    const week = await transactionWeek(fx.client, fx.rules, DURING_MNF);
+
+    const [game] = await fx.client.query<{ kickoff_at: string }>(
+      `SELECT kickoff_at FROM games WHERE season = $1 AND week = $2
+        ORDER BY kickoff_at DESC LIMIT 1`,
+      [SEASON, week],
+    );
+
+    expect(new Date(game!.kickoff_at).getTime()).toBeLessThanOrEqual(DURING_MNF.getTime());
+  });
+
+  it("moves to week 10 once the lock actually passes", async () => {
+    const fx = await withNovemberGames();
+    const afterLock = new Date("2026-11-03T05:00:00Z"); // Tue 00:00 EST
+
+    expect(await transactionWeek(fx.client, fx.rules, afterLock)).toBe(10);
+  });
+});
 
 describe("persistSchedule", () => {
   it("writes every matchup", async () => {

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -44,7 +44,7 @@
 import {
   generateSchedule,
   indexScoringRules,
-  nextWeekly,
+  latestWeekly,
   resolveWeek,
   winnerOf,
 } from "@rostr/core";
@@ -138,13 +138,10 @@ export async function transactionWeek(
   rules: LeagueRules,
   at: Date,
 ): Promise<number | null> {
-  // The most recent weekly lock at or before `at`. `nextWeekly` is
-  // strictly-after, so asking it from a week earlier yields this cycle's.
-  const since = nextWeekly(
-    new Date(at.getTime() - 7 * 24 * 60 * 60 * 1000),
-    rules.waivers.weeklyLock,
-    rules.waivers.timezone,
-  );
+  // The most recent weekly lock at or before `at`. This used to ask `nextWeekly`
+  // from exactly `at - 7 * 24h`, which is an hour short across the fall-back and
+  // named the *next* week for that hour — see `latestWeekly`.
+  const since = latestWeekly(at, rules.waivers.weeklyLock, rules.waivers.timezone);
 
   const [row] = await db.query<{ week: number }>(
     `SELECT g.week


### PR DESCRIPTION
Found while reviewing #79 part 3. **That bug is unreachable; this one is not.** It needs no configuration — it is the shipped default rules on a dated 2026 fixture, four weeks before kickoff.

## A week is not 168 hours

`everyoneIsOnWaivers` and `transactionWeek` both found "the most recent lock at or before now" the same way: ask the strictly-after `nextWeekly` from exactly `now - 7 * 24h`.

```
lock 1: 2026-10-27T04:00:00Z  Tue, 10/27, 00:00 EDT
lock 2: 2026-11-03T05:00:00Z  Tue, 11/03, 00:00 EST
gap   : 169 hours          <- the lookback assumes 168
```

Consecutive weekly moments are 169 hours apart across the November fall-back and 167 across the spring change — a week of **local days**, which is the entire reason the rules carry a weekday and an hour instead of a UTC offset. A 168-hour lookback cannot span a 169-hour gap: it lands precisely *on* the previous lock, the strictly-after search skips it, and the answer is **a lock one hour in the future**.

```
2026-11-03T03:59:59Z  Mon, 11/02, 22:59 ET   everyoneIsOnWaivers = false
2026-11-03T04:00:00Z  Mon, 11/02, 23:00 ET   everyoneIsOnWaivers = true   <- wrong
2026-11-03T04:59:59Z  Mon, 11/02, 23:59 ET   everyoneIsOnWaivers = true   <- wrong
```

## Two consequences, and the second is the one that matters

**Free agency closes an hour early.** `availabilityOf` reports `ON_WAIVERS` for every unrostered player with no wire row, so the Add button becomes Claim sixty minutes before §6 says it should.

**`transactionWeek` names week 10 instead of week 9.** `refuseIfKickedOff` then looks up each player's *week 10* game — none of which has kicked off — so `GAME_STARTED` never fires.

**Monday Night Football is being played at 23:00 ET.** That is `docs/RULES.md` §6, in the document whose hash every member signs:

> A player cannot be added or dropped once **his own game has kicked off**. Otherwise a manager could cut an injured player mid-game, or add one after his touchdown.

Defeated for an hour, on a real 2026 date, in the one game it most needs to refuse. Week 9 is 2 November 2026.

**The spring change has the mirror of it.** At 167 hours the lookback falls *before* the previous lock, so half an hour into a new lock the pool still reads as open. Both directions are covered by the same fix and both are tested.

## The fix

`latestWeekly` walks instead of guessing an interval: from nine days back — which guarantees at least one occurrence in range whatever the transition does — then forward while the next is still at or before `now`. At most two iterations, and it **assumes nothing about how long a week is**, which is the property the old code was missing rather than a wider constant.

Nine rather than eight because the bound has to hold for a two-hour transition as well as a one-hour one, and the cost of an extra iteration is nil.

## Provenance, stated plainly

**The `everyoneIsOnWaivers` half is mine, shipped in #123 two commits ago.** The comment I wrote there says it uses *"the same trick `transactionWeek` uses to find the cycle it is in"* — and it did. I copied a pre-existing bug rather than inventing one, which is exactly what that sentence should have made someone check.

## Tests

Six new, on the real 2026 and 2027 calendars, and **the mutation is the old lookback itself** — restoring `nextWeekly(now - 7 * DAY_MS)` kills four of the five core tests and both `transactionWeek` tests, deterministically.

| test | pins |
|---|---|
| has a 169-hour gap across the fall-back | the premise, so a future reader does not have to trust it |
| still names the October lock in the hour a 168-hour lookback loses | all three instants across the bad hour |
| keeps free agency open until the lock actually arrives | the `everyoneIsOnWaivers` consequence |
| returns the moment itself when now is exactly on it | "at or before", not "strictly before" |
| holds across the spring-forward, where the gap is 167 hours | the other direction, **and** the mirror hole half an hour into a new lock |
| never answers with a moment in the future | the class rather than the instances — hourly across both transitions |

Plus three at the db layer:

| test | pins |
|---|---|
| names week 9 while week 9 is still being played | `transactionWeek` on real week 9/10 kickoffs |
| keeps RULES.md §6's kickoff lock enforceable during Monday night | that the named week's last kickoff is actually in the past |
| moves to week 10 once the lock actually passes | that the fix does not simply lag by a week |

The sweep is deliberately hourly across the two transition windows rather than fine-grained across the season: `schedule.ts` builds a fresh `Intl.DateTimeFormat` per probe, so a season-long half-hourly grid took **minutes** for coverage of weeks where every gap is exactly 168 hours. The comment in the test says so, since the obvious "improvement" is to widen it.

**1246 tests, typecheck, lint, format green.**

`CLAUDE.md` gains the trap under Waivers, because "a week ago" is the kind of thing that gets written again from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
