### PR TITLE
fix(db,web): every trade state write is guarded, and an error is never a state

### DIFF
--- a/apps/web/src/app/api/cron/trades/route.ts
+++ b/apps/web/src/app/api/cron/trades/route.ts
@@ -14,6 +14,13 @@ import { cronForbidden } from "@/lib/cron";
  * Hourly is enough for a 48-hour window, and running more often is harmless:
  * `resolveDueTrades` skips open windows and a resolved trade leaves the
  * `ACCEPTED` state, so it is never settled twice.
+ *
+ * That last clause was true of one run at a time and false under overlap, which
+ * is what a sentence inviting more frequent runs ought not to be. Two runs could
+ * both select the same trade; one executed it and the other, finding the assets
+ * moved, recorded it `EXPIRED` over the top — "rosters untouched", written about
+ * rosters that had just moved. Every state write is now conditional on the state
+ * it expects, so the loser of that race writes nothing.
  */
 export async function GET(request: Request): Promise<NextResponse> {
   const forbidden = cronForbidden(request);
@@ -28,17 +35,24 @@ export async function GET(request: Request): Promise<NextResponse> {
     executed?: number;
     vetoed?: number;
     expired?: number;
+    /**
+     * Trades this run could not settle. They are still ACCEPTED and will be
+     * retried next hour — reported because a trade that can never execute would
+     * otherwise look healthy forever, the same reason `bracketProblem` exists.
+     */
+    failures?: { tradeId: string; reason: string }[];
     error?: string;
   }[] = [];
 
   for (const leagueId of due) {
     try {
-      const resolutions = await resolveDueTrades(client, leagueId, now);
+      const { resolutions, failures } = await resolveDueTrades(client, leagueId, now);
       runs.push({
         leagueId,
         executed: resolutions.filter((r) => r.outcome === "EXECUTED").length,
         vetoed: resolutions.filter((r) => r.outcome === "VETOED").length,
         expired: resolutions.filter((r) => r.outcome === "EXPIRED").length,
+        ...(failures.length > 0 ? { failures: [...failures] } : {}),
       });
     } catch (error) {
       // One league's bad state must not hold up everyone else's trades.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -215,6 +215,7 @@ export {
   vetoTrade,
   withdrawTrade,
   type ProposeTradeInput,
+  type DueTradesOutcome,
   type TradeResolution,
   type TradeState,
   type TradeSummary,

--- a/packages/db/src/trades.race.test.ts
+++ b/packages/db/src/trades.race.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Issue #77 part 4 and #112 — every trade state write is guarded, and an error
+ * is never a terminal state.
+ *
+ * ## What these prove, and what they cannot
+ *
+ * PGlite is a single connection, so nothing here proves two production requests
+ * overlap in wall-clock time, and `FOR UPDATE` holds nothing in it. The repo
+ * says so in `migrations/README.md`, and the lineup and freeze races elsewhere
+ * are genuinely untestable here for that reason.
+ *
+ * **These are different, and that is why the file exists.** `withdrawTrade` and
+ * `declineTrade` open **no transaction at all**: their state read and their state
+ * write are two separate autocommit statements. `resolveDueTrades`' pending
+ * `SELECT` is likewise outside any transaction. So the production interleaving —
+ * an acceptance committing between one caller's read and its write — is
+ * reproducible exactly, on one connection, deterministically, by running the
+ * real competing call at the instruction boundary where it would have landed.
+ * No pausing, no threads, no pretending.
+ *
+ * A two-connection race differs only in mechanics: the loser blocks on the row
+ * lock, wakes when the winner commits, and re-evaluates its `WHERE` against the
+ * committed row at READ COMMITTED. Same predicate, same zero rows.
+ *
+ * ## Why the ordinary tests could not catch any of this
+ *
+ * `trades.test.ts`'s `"cannot be accepted twice"` looks like coverage of the one
+ * guard that already existed and is not: delete `AND state = 'PROPOSED'` from
+ * that statement and it still passes, because the second accept is refused by an
+ * in-memory read that never reaches the SQL. Every guard in this file is reached
+ * only when the state changes *after* that read — which is precisely what these
+ * tests arrange and what nothing else in the suite does.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNflPprRules, NFL } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import type { SqlClient } from "./client.js";
+import { createLeague } from "./leagues.js";
+import { createUser } from "./identity.js";
+import { seedSport } from "./sports.js";
+import { addTestTeam, createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import {
+  acceptTrade,
+  declineTrade,
+  lockedByTrade,
+  proposeTrade,
+  resolveDueTrades,
+  withdrawTrade,
+} from "./trades.js";
+import { dropPlayer } from "./waivers.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: 1_756_400_000,
+};
+
+const HOUR = 3600 * 1000;
+const DAY = 24 * HOUR;
+const MONDAY = new Date("2026-10-12T18:00:00Z");
+/** Past the 48-hour veto window. */
+const AFTER_WINDOW = new Date(MONDAY.getTime() + 49 * HOUR);
+
+const WEEK1_THURSDAY = new Date("2026-09-11T00:15:00Z");
+const SLOTS = [0, 2 * DAY + 16 * HOUR + 45 * 60 * 1000, 4 * DAY];
+
+/**
+ * The 2026 regular season, because the deadline is derived from the schedule.
+ *
+ * `transactionWeek` answers `null` when the season holds no games, and `null` is
+ * past every deadline — deliberately, so an unschedulable league cannot trade
+ * rather than trading forever. None of these tests is about that rule, so they
+ * need a league that is simply in season.
+ */
+async function seedSchedule(client: PGliteClient, sportId: string): Promise<void> {
+  const rows: string[] = [];
+  const values: unknown[] = [sportId];
+
+  for (let week = 1; week <= 18; week++) {
+    for (const [slot, offset] of SLOTS.entries()) {
+      const at = new Date(WEEK1_THURSDAY.getTime() + (week - 1) * 7 * DAY + offset);
+      values.push(`w${week}g${slot}`, week, at.toISOString());
+      const i = values.length;
+      rows.push(`($1, $${i - 2}, 2026, $${i - 1}, 'CIN', 'CLE', $${i})`);
+    }
+  }
+
+  await client.query(
+    `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at)
+     VALUES ${rows.join(", ")}`,
+    values,
+  );
+}
+
+interface Fixture {
+  client: PGliteClient;
+  leagueId: string;
+  teams: string[];
+  players: Map<string, string>;
+}
+
+/** Four teams, one player each. Teams 1 and 2 trade. */
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const commissioner = await createUser(db, "commish@example.com", "Commish");
+  const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules;
+  const league = await createLeague(db, NFL, {
+    name: "Race League",
+    commissionerId: commissioner.id,
+    rules,
+  });
+
+  const teams: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);
+  }
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const [position] = await db.query<{ id: string }>(
+    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+    [sport!.id],
+  );
+
+  const players = new Map<string, string>();
+  for (const [index, teamId] of teams.entries()) {
+    const handle = `p${index + 1}`;
+    const [row] = await db.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, position!.id],
+    );
+    players.set(handle, row!.id);
+
+    await db.query(
+      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+       VALUES ($1, $2, 'DRAFT', $3)`,
+      [teamId, row!.id, new Date(MONDAY.getTime() - 7 * 24 * HOUR)],
+    );
+  }
+
+  await seedSchedule(db, sport!.id);
+
+  return { client: db, leagueId: league.id, teams, players };
+}
+
+async function propose(fx: Fixture): Promise<string> {
+  const { tradeId } = await proposeTrade(fx.client, {
+    leagueId: fx.leagueId,
+    proposerTeamId: fx.teams[0]!,
+    receiverTeamId: fx.teams[1]!,
+    proposerGives: [fx.players.get("p1")!],
+    receiverGives: [fx.players.get("p2")!],
+    now: MONDAY,
+  });
+  return tradeId;
+}
+
+const stateOf = async (fx: Fixture, tradeId: string): Promise<string> => {
+  const [row] = await fx.client.query<{ state: string }>(
+    "SELECT state FROM trades WHERE id = $1",
+    [tradeId],
+  );
+  return row!.state;
+};
+
+/**
+ * A client that runs somebody else's call in the middle of yours.
+ *
+ * `fire` runs once, on the connection underneath, immediately **after** the
+ * first query matching `arm` returns — so the caller has already read the state
+ * it is about to act on, and the competing write commits before the caller's own
+ * write is issued. That is the interleaving, produced rather than raced.
+ */
+class InterleavingClient implements SqlClient {
+  private fired = false;
+
+  constructor(
+    private readonly inner: SqlClient,
+    private readonly arm: (sql: string) => boolean,
+    private readonly fire: (inner: SqlClient) => Promise<void>,
+  ) {}
+
+  exec(sql: string): Promise<void> {
+    return this.inner.exec(sql);
+  }
+
+  async query<T = Record<string, unknown>>(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<T[]> {
+    const rows = await this.inner.query<T>(sql, params);
+
+    if (!this.fired && this.arm(sql)) {
+      this.fired = true;
+      await this.fire(this.inner);
+    }
+
+    return rows;
+  }
+}
+
+/** Matches the `SELECT` `loadTrade` issues — the read every guard has to outlive. */
+const readsTheTrade = (sql: string): boolean => sql.includes("FROM trades WHERE id = $1");
+
+describe("a write that loses its race writes nothing", () => {
+  it("refuses a withdrawal when the trade was accepted after the state was read", async () => {
+    // The exploit this closes. `withdrawTrade` reads PROPOSED, the receiver's
+    // acceptance commits, and the stomping write used to set WITHDRAWN over the
+    // top — which did not merely mislabel the row. `lockedByTrade` counts only
+    // ACCEPTED trades, so it **unfroze both players in the same statement**, and
+    // the proposer could then drop the player they had promised. The route has
+    // no rate limit, so a proposer wanting out could fire withdrawals until one
+    // landed on the accept.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+
+    const racing = new InterleavingClient(fx.client, readsTheTrade, async (inner) => {
+      await acceptTrade(inner, tradeId, fx.teams[1]!, MONDAY);
+    });
+
+    await expect(withdrawTrade(racing, tradeId, fx.teams[0]!, MONDAY)).rejects.toMatchObject({
+      code: "WRONG_STATE",
+    });
+
+    expect(await stateOf(fx, tradeId)).toBe("ACCEPTED");
+
+    // The freeze survived, which is the half that had teeth.
+    const frozen = await lockedByTrade(fx.client, fx.leagueId);
+    expect(frozen.has(fx.players.get("p1")!)).toBe(true);
+    expect(frozen.has(fx.players.get("p2")!)).toBe(true);
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("p1")!, MONDAY),
+    ).rejects.toMatchObject({ code: "IN_A_TRADE" });
+  });
+
+  it("refuses a decline when the trade was accepted after the state was read", async () => {
+    // Needs one manager and one browser rather than two people racing:
+    // `TradeBlock` renders Accept and Decline side by side on a PROPOSED trade,
+    // and the panel only re-reads after the mutation returns.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+
+    const racing = new InterleavingClient(fx.client, readsTheTrade, async (inner) => {
+      await acceptTrade(inner, tradeId, fx.teams[1]!, MONDAY);
+    });
+
+    await expect(declineTrade(racing, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "WRONG_STATE",
+    });
+
+    expect(await stateOf(fx, tradeId)).toBe("ACCEPTED");
+  });
+
+  it("does not relabel an executed trade EXPIRED when a second run overlaps it", async () => {
+    // Part 4(a). Two overlapping cron runs both select the trade. The first
+    // executes it and commits; the second's release `UPDATE ... WHERE
+    // released_at IS NULL` then matches nothing, raises ASSET_GONE, and used to
+    // record EXPIRED unguarded — "rosters untouched", written about rosters that
+    // had just moved, and reported to both managers.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    let overlapRan = false;
+    const racing = new InterleavingClient(
+      fx.client,
+      (sql) => sql.includes("FROM trade_assets"),
+      async (inner) => {
+        await resolveDueTrades(inner, fx.leagueId, AFTER_WINDOW);
+        overlapRan = true;
+      },
+    );
+
+    const outcome = await resolveDueTrades(racing, fx.leagueId, AFTER_WINDOW);
+
+    expect(overlapRan).toBe(true);
+    expect(await stateOf(fx, tradeId)).toBe("EXECUTED");
+
+    // The losing run reports nothing settled and writes nothing at all.
+    expect(outcome.resolutions).toEqual([]);
+
+    // And the swap happened exactly once — one live row per player.
+    const rows = await fx.client.query<{ team_id: string; player_id: string }>(
+      `SELECT team_id, player_id FROM roster_entries
+        WHERE league_id = $1 AND released_at IS NULL AND acquired_via = 'TRADE'`,
+      [fx.leagueId],
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.player_id)).size).toBe(2);
+  });
+  it("does not execute a trade that was vetoed while it was executing", async () => {
+    // The case the `EXECUTED` write's own guard exists for, and the reason that
+    // one write must **throw** rather than answer "somebody got there first":
+    // it sits inside the transaction that has already swapped both rosters.
+    //
+    // Reachable from two overlapping runs. Both select the trade as ACCEPTED;
+    // the first reads the votes before a blocking veto is cast and heads for
+    // execution, the second reads them after and writes VETOED. Without the
+    // guard the executing run overwrites VETOED with EXECUTED and commits the
+    // swap — a trade the league blocked, performed anyway. Answering "already
+    // settled" without throwing would be just as wrong: it commits the swap and
+    // leaves the row saying VETOED, so the players have moved under a state that
+    // says they did not.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    // Fired on `loadTrade`'s read, which is **before** `withTransaction` opens.
+    // That ordering is forced rather than chosen: PGlite is a single connection,
+    // so a write injected after `BEGIN` would join the executing transaction and
+    // roll back with it — proving nothing. Committing first is also the honest
+    // model of the production interleaving, where the vetoing run is a separate
+    // connection that has already committed.
+    const racing = new InterleavingClient(fx.client, readsTheTrade, async (inner) => {
+      await inner.query("UPDATE trades SET state = 'VETOED', resolved_at = $2 WHERE id = $1", [
+        tradeId,
+        AFTER_WINDOW.toISOString(),
+      ]);
+    });
+
+    const outcome = await resolveDueTrades(racing, fx.leagueId, AFTER_WINDOW);
+
+    // The swap rolled back whole, which is what the transaction is for.
+    expect(await stateOf(fx, tradeId)).toBe("VETOED");
+    expect(outcome.resolutions).toEqual([]);
+    expect(outcome.failures).toEqual([{ tradeId, reason: "WRONG_STATE" }]);
+
+    const moved = await fx.client.query<{ id: string }>(
+      `SELECT id FROM roster_entries
+        WHERE league_id = $1 AND acquired_via = 'TRADE'`,
+      [fx.leagueId],
+    );
+    expect(moved).toEqual([]);
+
+    // And both players are still where they started.
+    const [p1] = await fx.client.query<{ team_id: string }>(
+      "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
+      [fx.players.get("p1")!],
+    );
+    expect(p1?.team_id).toBe(fx.teams[0]);
+  });
+});
+
+describe("an error is never a terminal state", () => {
+  /** A client whose transactions all fail the way a saturated pool fails. */
+  class DeadlockingClient implements SqlClient {
+    constructor(private readonly inner: SqlClient) {}
+
+    async exec(sql: string): Promise<void> {
+      if (sql === "BEGIN") {
+        const error = new Error("deadlock detected") as Error & { code: string };
+        error.code = "40P01";
+        throw error;
+      }
+      return this.inner.exec(sql);
+    }
+
+    query<T = Record<string, unknown>>(sql: string, params?: readonly unknown[]): Promise<T[]> {
+      return this.inner.query<T>(sql, params);
+    }
+  }
+
+  it("leaves a trade ACCEPTED when execution fails for an infrastructure reason", async () => {
+    // The blocking finding on #112. Widening the catch to every error is right —
+    // an allowlist of one code inside a loop is the shape `CLAUDE.md` names as
+    // the defect. But "record and continue" must mean *record in the return
+    // value*, as `resolveLeagueWeeksThrough` does, and not write EXPIRED.
+    //
+    // `withTransaction` calls `connect()` before `BEGIN` and the pool has a
+    // connect timeout, so one saturated pool during an hourly run would expire
+    // every due trade in every league, in one pass and permanently — nothing
+    // revisits EXPIRED. RULES.md defines EXPIRED as the deadline case, "rosters
+    // untouched, nobody's fault", and §9 forbids reversing trades. Expiring on a
+    // blip is the system reversing a trade the league approved.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const outcome = await resolveDueTrades(
+      new DeadlockingClient(fx.client),
+      fx.leagueId,
+      AFTER_WINDOW,
+    );
+
+    expect(await stateOf(fx, tradeId)).toBe("ACCEPTED");
+    expect(outcome.resolutions).toEqual([]);
+    expect(outcome.failures).toEqual([{ tradeId, reason: "deadlock detected" }]);
+  });
+
+  it("still settles the other trades when one fails that way", async () => {
+    // The half #112 is actually about: the failure must not abort the loop. It
+    // used to rethrow, so a healthy trade queued behind a poisoned one stayed
+    // ACCEPTED too and uninvolved managers' players stayed frozen — every hour,
+    // for the rest of the season.
+    const fx = await setup();
+    const poisoned = await propose(fx);
+    await acceptTrade(fx.client, poisoned, fx.teams[1]!, MONDAY);
+
+    const { tradeId: healthy } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[2]!,
+      receiverTeamId: fx.teams[3]!,
+      proposerGives: [fx.players.get("p3")!],
+      receiverGives: [fx.players.get("p4")!],
+      now: MONDAY,
+    });
+    await acceptTrade(fx.client, healthy, fx.teams[3]!, MONDAY);
+
+    // Fail only the first transaction, so the second trade takes the real path.
+    let failures = 1;
+    const flaky: SqlClient = {
+      exec: async (sql) => {
+        if (sql === "BEGIN" && failures > 0) {
+          failures--;
+          const error = new Error("deadlock detected") as Error & { code: string };
+          error.code = "40P01";
+          throw error;
+        }
+        return fx.client.exec(sql);
+      },
+      query: (sql, params) => fx.client.query(sql, params),
+    };
+
+    const outcome = await resolveDueTrades(flaky, fx.leagueId, AFTER_WINDOW);
+
+    expect(outcome.failures).toHaveLength(1);
+    expect(outcome.resolutions).toHaveLength(1);
+    expect(outcome.resolutions[0]?.outcome).toBe("EXECUTED");
+
+    // The one that failed is untouched and will be retried next hour; the other
+    // settled.
+    const failed = outcome.failures[0]!.tradeId;
+    const settled = outcome.resolutions[0]!.tradeId;
+    expect(await stateOf(fx, failed)).toBe("ACCEPTED");
+    expect(await stateOf(fx, settled)).toBe("EXECUTED");
+    expect(new Set([failed, settled])).toEqual(new Set([poisoned, healthy]));
+  });
+});
+
+describe("the guards do not refuse a write that should happen", () => {
+  /** Counts rows returned by each `UPDATE trades`, readable only via RETURNING. */
+  class CountingClient implements SqlClient {
+    readonly stateWrites: number[] = [];
+
+    constructor(private readonly inner: SqlClient) {}
+
+    exec(sql: string): Promise<void> {
+      return this.inner.exec(sql);
+    }
+
+    async query<T = Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): Promise<T[]> {
+      const rows = await this.inner.query<T>(sql, params);
+      if (sql.includes("UPDATE trades SET state")) this.stateWrites.push(rows.length);
+      return rows;
+    }
+  }
+
+  it("writes exactly one row on an ordinary execution", async () => {
+    // The negative test that matters most. A predicate pasted against the wrong
+    // state would silently refuse every write while `resolveDueTrades` still
+    // returned the outcome it computed in memory, and nothing else in the suite
+    // would notice — the assertions elsewhere read the return value, not the row.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const counting = new CountingClient(fx.client);
+    const outcome = await resolveDueTrades(counting, fx.leagueId, AFTER_WINDOW);
+
+    expect(outcome.resolutions[0]?.outcome).toBe("EXECUTED");
+    expect(counting.stateWrites).toEqual([1]);
+    expect(await stateOf(fx, tradeId)).toBe("EXECUTED");
+  });
+
+  it("writes exactly one row when a proposer legitimately withdraws", async () => {
+    const fx = await setup();
+    const tradeId = await propose(fx);
+
+    const counting = new CountingClient(fx.client);
+    await withdrawTrade(counting, tradeId, fx.teams[0]!, MONDAY);
+
+    expect(counting.stateWrites).toEqual([1]);
+    expect(await stateOf(fx, tradeId)).toBe("WITHDRAWN");
+  });
+});

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -281,6 +281,17 @@ async function propose(fx: Fixture, now = MONDAY): Promise<string> {
   return tradeId;
 }
 
+/**
+ * `resolveDueTrades`, keeping only the resolutions.
+ *
+ * It returns `{resolutions, failures}` — failures being trades this run could
+ * not settle, for which **nothing was written**. Tests that care about those
+ * call `resolveDueTrades` directly; everything else wants the list it used to
+ * return.
+ */
+const settle = async (...args: Parameters<typeof resolveDueTrades>) =>
+  (await resolveDueTrades(...args)).resolutions;
+
 describe("proposing", () => {
   it("records both sides", async () => {
     const fx = await setup();
@@ -528,7 +539,7 @@ describe("the freeze between acceptance and execution", () => {
     const fx = await setup();
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, new Date(MONDAY.getTime() + 49 * HOUR));
+    await settle(fx.client, fx.leagueId, new Date(MONDAY.getTime() + 49 * HOUR));
 
     expect(await lockedByTrade(fx.client, fx.leagueId)).toEqual(new Set());
   });
@@ -701,7 +712,7 @@ describe("the freeze between acceptance and execution", () => {
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[3]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    await settle(fx.client, fx.leagueId, AFTER_WINDOW);
 
     await expect(
       dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, p1, QUIET),
@@ -749,7 +760,7 @@ describe("no double-spend across trades", () => {
     const trades = await listTrades(fx.client, fx.leagueId);
     expect(trades.find((t) => t.tradeId === b.tradeId)?.state).toBe("PROPOSED");
 
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    await settle(fx.client, fx.leagueId, AFTER_WINDOW);
 
     const owners = await fx.client.query<{ team_id: string }>(
       "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
@@ -783,7 +794,7 @@ describe("no double-spend across trades", () => {
       [fx.teams[0]!, p1],
     );
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
 
     // Recorded, not retried hourly for the rest of the season, and not executed.
     expect(resolution?.outcome).toBe("EXPIRED");
@@ -834,7 +845,7 @@ describe("no double-spend across trades", () => {
       [fx.teams[0]!, p1],
     );
 
-    const resolutions = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const resolutions = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
 
     expect(resolutions.find((r) => r.tradeId === broken.tradeId)?.outcome).toBe("EXPIRED");
     expect(resolutions.find((r) => r.tradeId === healthy.tradeId)?.outcome).toBe("EXECUTED");
@@ -930,7 +941,7 @@ describe("vetoing", () => {
     expect(trade?.vetoes).toBe(0);
 
     // And the trade the outsider tried to block still goes through.
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
     expect(resolution?.outcome).toBe("EXECUTED");
   });
 
@@ -1072,7 +1083,7 @@ describe("vetoing", () => {
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
     expect(resolution?.outcome).toBe("EXECUTED");
 
     expect(await ownerOf(fx, fx.players.get("p1")!)).toBe(fx.teams[1]);
@@ -1104,7 +1115,7 @@ describe("vetoing", () => {
     const [trade] = await listTrades(fx.client, fx.leagueId);
     expect(trade?.vetoes).toBe(0);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
     expect(resolution?.outcome).toBe("EXECUTED");
   });
 
@@ -1121,7 +1132,7 @@ describe("vetoing", () => {
     const [trade] = await listTrades(fx.client, fx.leagueId);
     expect(trade?.vetoes).toBe(2);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WINDOW);
     expect(resolution?.outcome).toBe("VETOED");
   });
 
@@ -1161,7 +1172,7 @@ describe("vetoing", () => {
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
 
-    const [resolution] = await resolveDueTrades(
+    const [resolution] = await settle(
       fx.client,
       fx.leagueId,
       new Date(MONDAY.getTime() + 49 * HOUR),
@@ -1178,7 +1189,7 @@ describe("resolution", () => {
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
 
-    const resolved = await resolveDueTrades(
+    const resolved = await settle(
       fx.client,
       fx.leagueId,
       new Date(MONDAY.getTime() + 47 * HOUR),
@@ -1194,7 +1205,7 @@ describe("resolution", () => {
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
 
-    const [resolution] = await resolveDueTrades(
+    const [resolution] = await settle(
       fx.client,
       fx.leagueId,
       new Date(MONDAY.getTime() + 48 * HOUR),
@@ -1207,7 +1218,7 @@ describe("resolution", () => {
     const fx = await setup();
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
     const owners = await fx.client.query<{ player_id: string; team_id: string }>(
       `SELECT player_id, team_id FROM roster_entries
@@ -1230,7 +1241,7 @@ describe("resolution", () => {
     const fx = await setup();
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
     const history = await fx.client.query<{ team_id: string; released_at: string | null }>(
       "SELECT team_id, released_at FROM roster_entries WHERE player_id = $1 ORDER BY acquired_at",
@@ -1250,7 +1261,7 @@ describe("resolution", () => {
     const fx = await setup();
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
     expect(await availabilityOf(fx.client, fx.leagueId, fx.players.get("p1")!, AFTER)).toBe(
       "ROSTERED",
@@ -1264,7 +1275,7 @@ describe("resolution", () => {
     await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[3]!, MONDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER);
 
     expect(resolution?.outcome).toBe("VETOED");
     expect(resolution?.vetoes).toBe(2);
@@ -1277,7 +1288,7 @@ describe("resolution", () => {
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER);
 
     expect(resolution?.outcome).toBe("EXECUTED");
   });
@@ -1288,7 +1299,7 @@ describe("resolution", () => {
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY);
     await vetoTrade(fx.client, tradeId, fx.teams[3]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
     const [row] = await fx.client.query<{ team_id: string }>(
       "SELECT team_id FROM roster_entries WHERE player_id = $1 AND released_at IS NULL",
@@ -1303,13 +1314,9 @@ describe("resolution", () => {
     const fx = await setup();
     const tradeId = await propose(fx);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
-    const again = await resolveDueTrades(
-      fx.client,
-      fx.leagueId,
-      new Date(AFTER.getTime() + HOUR),
-    );
+    const again = await settle(fx.client, fx.leagueId, new Date(AFTER.getTime() + HOUR));
 
     expect(again).toEqual([]);
     const owners = await fx.client.query<{ team_id: string }>(
@@ -1330,7 +1337,7 @@ describe("resolution", () => {
     const tradeId = await propose(fx, WEEK11_FRIDAY);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, AFTER_WEEK12_LOCK);
+    const [resolution] = await settle(fx.client, fx.leagueId, AFTER_WEEK12_LOCK);
 
     expect(resolution?.outcome).toBe("EXPIRED");
 
@@ -1349,7 +1356,7 @@ describe("resolution", () => {
     const tradeId = await propose(fx, WEEK11_FRIDAY);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
 
-    const [resolution] = await resolveDueTrades(fx.client, fx.leagueId, BEFORE_WEEK12_LOCK);
+    const [resolution] = await settle(fx.client, fx.leagueId, BEFORE_WEEK12_LOCK);
 
     expect(resolution?.outcome).toBe("EXECUTED");
   });
@@ -1366,11 +1373,7 @@ describe("resolution", () => {
     const tradeId = await propose(fx, WEEK11_FRIDAY);
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, WEEK11_FRIDAY);
 
-    const [resolution] = await resolveDueTrades(
-      fx.client,
-      fx.leagueId,
-      new Date("2027-01-20T12:00:00Z"),
-    );
+    const [resolution] = await settle(fx.client, fx.leagueId, new Date("2027-01-20T12:00:00Z"));
 
     expect(resolution?.outcome).toBe("EXPIRED");
   });
@@ -1389,7 +1392,7 @@ describe("resolution", () => {
       now: MONDAY,
     });
     await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
-    await resolveDueTrades(fx.client, fx.leagueId, AFTER);
+    await settle(fx.client, fx.leagueId, AFTER);
 
     const sizes = await fx.client.query<{ team_id: string; n: number }>(
       `SELECT team_id, count(*)::int AS n FROM roster_entries

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -477,7 +477,10 @@ export async function acceptTrade(
     // different trades sharing two players could take them in opposite orders
     // and deadlock. An unordered `SELECT` is not a stable order, it is whatever
     // the plan produces. Sorting on the same key in every caller makes the cycle
-    // unconstructible.
+    // unconstructible — and that is only true once **every** caller sorts.
+    // `resolveTrade` did not when this comment was first written, so the cycle it
+    // claims to have removed was still constructible between these two functions;
+    // it sorts on the same key now.
     const assets = await tx.query<{ from_team_id: string; player_id: string }>(
       "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1 ORDER BY player_id",
       [tradeId],
@@ -511,10 +514,20 @@ export async function acceptTrade(
       }
     }
 
-    await tx.query(
-      "UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2 WHERE id = $1 AND state = 'PROPOSED'",
+    // `RETURNING id` is what makes the predicate observable. `SqlClient.query`
+    // hands back rows and discards `rowCount`, so without it a refused write and
+    // a successful one are the same empty array — the guard would be real and
+    // its result unreadable, and this function would report an acceptance it did
+    // not perform.
+    const accepted = await tx.query<{ id: string }>(
+      `UPDATE trades SET state = 'ACCEPTED', veto_deadline = $2
+        WHERE id = $1 AND state = 'PROPOSED'
+      RETURNING id`,
       [tradeId, deadline.toISOString()],
     );
+    if (accepted.length === 0) {
+      throw new TradeError("This trade is no longer open", "WRONG_STATE");
+    }
 
     return loadTrade(tx, tradeId);
   });
@@ -545,10 +558,21 @@ export async function declineTrade(
     throw new TradeError("Only the team offered a trade can decline it", "NOT_YOUR_TRADE");
   }
 
-  await db.query("UPDATE trades SET state = 'WITHDRAWN', resolved_at = $2 WHERE id = $1", [
-    tradeId,
-    now.toISOString(),
-  ]);
+  // The state test above reads a snapshot taken before this statement, so it
+  // cannot be the guard — it is the error message. This is the guard.
+  //
+  // Reachable from one manager and one browser, which is why it matters more
+  // than the withdraw race: `TradeBlock` renders Accept and Decline side by side
+  // on a PROPOSED trade, so two in-flight requests need no second person.
+  const declined = await db.query<{ id: string }>(
+    `UPDATE trades SET state = 'WITHDRAWN', resolved_at = $2
+      WHERE id = $1 AND state = 'PROPOSED'
+    RETURNING id`,
+    [tradeId, now.toISOString()],
+  );
+  if (declined.length === 0) {
+    throw new TradeError("This trade is no longer open", "WRONG_STATE");
+  }
 }
 
 /**
@@ -579,10 +603,27 @@ export async function withdrawTrade(
     throw new TradeError("Only the proposing team can withdraw", "NOT_YOUR_TRADE");
   }
 
-  await db.query("UPDATE trades SET state = 'WITHDRAWN', resolved_at = $2 WHERE id = $1", [
-    tradeId,
-    now.toISOString(),
-  ]);
+  // This function opens no transaction, so the read above and this write are two
+  // autocommit statements with an acceptance able to commit between them. That
+  // is not theoretical — it is reproduced in `trades.race.test.ts`.
+  //
+  // The stomping write did not merely mislabel the row. `lockedByTrade` counts
+  // only ACCEPTED trades, so overwriting the state **unfroze both players in the
+  // same statement**, and the proposer could then drop the player they had
+  // promised. With no rate limit on the route, a proposer wanting out could fire
+  // withdrawals until one landed on the accept.
+  const withdrawn = await db.query<{ id: string }>(
+    `UPDATE trades SET state = 'WITHDRAWN', resolved_at = $2
+      WHERE id = $1 AND state = 'PROPOSED'
+    RETURNING id`,
+    [tradeId, now.toISOString()],
+  );
+  if (withdrawn.length === 0) {
+    throw new TradeError(
+      "This trade has been accepted — it is now up to the league.",
+      "WRONG_STATE",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -656,6 +697,19 @@ export interface TradeResolution {
   readonly required: number;
 }
 
+export interface DueTradesOutcome {
+  readonly resolutions: readonly TradeResolution[];
+  /**
+   * Trades this run could not settle, and why. **Nothing was written for these.**
+   *
+   * Surfaced rather than swallowed, and surfaced *here* rather than recorded in
+   * the database — the distinction `resolveLeagueWeeksThrough` already draws.
+   * A trade that cannot execute must not be given a terminal state by an error
+   * handler; see the comment on the catch that fills this.
+   */
+  readonly failures: readonly { tradeId: string; reason: string }[];
+}
+
 /**
  * Settle every accepted trade whose window has closed.
  *
@@ -667,16 +721,20 @@ export async function resolveDueTrades(
   db: SqlClient,
   leagueId: string,
   now: Date,
-): Promise<readonly TradeResolution[]> {
+): Promise<DueTradesOutcome> {
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
 
+  // No `ORDER BY`, deliberately. Every due trade is now attempted whatever
+  // happens to the ones before it, and their inputs are disjoint, so the order
+  // cannot change the outcome — the same conclusion `score-week`'s league query
+  // reached, and it still has none either.
   const pending = await db.query<{ id: string; veto_deadline: string }>(
     `SELECT id, veto_deadline FROM trades
       WHERE league_id = $1 AND state = 'ACCEPTED' AND veto_deadline IS NOT NULL`,
     [leagueId],
   );
-  if (pending.length === 0) return [];
+  if (pending.length === 0) return { resolutions: [], failures: [] };
 
   // The deadline binds on the week a trade *executes*, which is this one — the
   // proposal check can only bound the earliest week it might land in, and a
@@ -692,6 +750,7 @@ export async function resolveDueTrades(
   );
 
   const out: TradeResolution[] = [];
+  const failures: { tradeId: string; reason: string }[] = [];
 
   for (const row of pending) {
     // The window is stored, but the *rule* about when it closes lives in core —
@@ -707,24 +766,60 @@ export async function resolveDueTrades(
       continue;
     }
 
-    // One trade that cannot execute must not stop the rest from settling —
-    // the same rule as every other loop over leagues or weeks in this repo.
-    //
-    // An asset that has left its roster is not recoverable: the trade can never
-    // execute, and rosters are untouched. That is exactly what EXPIRED means, so
-    // it is recorded as that rather than left ACCEPTED to be retried hourly for
+    // One trade that cannot execute must not stop the rest from settling — the
+    // same rule as every other loop over leagues or weeks in this repo. This
+    // used to rethrow anything that was not `ASSET_GONE`, which is the
+    // allowlist-inside-a-loop shape `CLAUDE.md` names as itself the defect: the
+    // offending trade stayed ACCEPTED forever, every trade queued behind it
+    // stayed ACCEPTED too, and uninvolved managers' players stayed frozen for
     // the rest of the season.
+    //
+    // **But widening the catch must not widen what gets written.** The obvious
+    // reading — record and continue, marking the trade EXPIRED — is a worse bug
+    // than the one it fixes. `withTransaction` calls `db.connect()` before
+    // `BEGIN` and the pool has a connect timeout, so one saturated pool during
+    // an hourly run would expire *every due trade in every league*, in one pass,
+    // permanently: nothing revisits EXPIRED. The same goes for a 40P01 deadlock,
+    // a 57014 statement timeout, or any bug of ours.
+    //
+    // `RULES.md` defines EXPIRED as the deadline case — "rosters untouched,
+    // nobody's fault" — and §9 forbids forcing or reversing trades. Expiring on
+    // an infrastructure blip is the system reversing a trade the league
+    // approved, wearing a legitimate expiry's costume.
+    //
+    // So: `ASSET_GONE` is the only error that writes a terminal state, because
+    // it is the only one that establishes the trade can *never* execute — the
+    // asset is gone and no retry brings it back. Everything else is recorded in
+    // the return value and the trade stays ACCEPTED to be retried next hour,
+    // which is what `resolveLeagueWeeksThrough` means by record-and-continue.
     try {
-      out.push(await resolveTrade(db, row.id, stored.rules, now, pastDeadline));
+      const resolution = await resolveTrade(db, row.id, stored.rules, now, pastDeadline);
+      // `null` is a trade another run settled between our select and our write.
+      // Not a failure, and not ours to report.
+      if (resolution) out.push(resolution);
     } catch (error) {
-      if (!(error instanceof TradeError) || error.code !== "ASSET_GONE") throw error;
+      const reason =
+        error instanceof TradeError
+          ? error.code
+          : error instanceof Error
+            ? error.message
+            : String(error);
 
-      await tradeCannotExecute(db, row.id, now);
-      out.push({ tradeId: row.id, outcome: "EXPIRED", vetoes: 0, required: 0 });
+      if (error instanceof TradeError && error.code === "ASSET_GONE") {
+        // Guarded, so an overlapping run that already executed this trade does
+        // not get it relabelled EXPIRED over the top of a completed swap — which
+        // is how "rosters untouched" came to be reported for moved rosters.
+        if (await tradeCannotExecute(db, row.id, now)) {
+          out.push({ tradeId: row.id, outcome: "EXPIRED", vetoes: 0, required: 0 });
+        }
+        continue;
+      }
+
+      failures.push({ tradeId: row.id, reason });
     }
   }
 
-  return out;
+  return { resolutions: out, failures };
 }
 
 /**
@@ -734,11 +829,19 @@ export async function resolveDueTrades(
  * reader should be able to tell them apart, even though the state is the same:
  * nothing moved, and nothing will.
  */
-async function tradeCannotExecute(db: SqlClient, tradeId: string, now: Date): Promise<void> {
-  await db.query("UPDATE trades SET state = 'EXPIRED', resolved_at = $2 WHERE id = $1", [
-    tradeId,
-    now.toISOString(),
-  ]);
+async function tradeCannotExecute(db: SqlClient, tradeId: string, now: Date): Promise<boolean> {
+  // Guarded, and deliberately silent when it matches nothing. This runs from a
+  // `catch` on an autocommit connection with no transaction to roll back, and
+  // zero rows here means another run already settled the trade — which is the
+  // benign outcome, not an error to raise on top of the one being handled.
+  const expired = await db.query<{ id: string }>(
+    `UPDATE trades SET state = 'EXPIRED', resolved_at = $2
+      WHERE id = $1 AND state = 'ACCEPTED'
+    RETURNING id`,
+    [tradeId, now.toISOString()],
+  );
+
+  return expired.length > 0;
 }
 
 async function resolveTrade(
@@ -747,30 +850,48 @@ async function resolveTrade(
   rules: LeagueRules,
   now: Date,
   pastDeadline: boolean,
-): Promise<TradeResolution> {
+): Promise<TradeResolution | null> {
   const trade = await loadTrade(db, tradeId);
   const electorate = await uninvolvedManagersFor(db, tradeId);
   const required = vetoesRequired(electorate, rules.trades);
 
+  // Neither of these two may throw on a refusal. Both run on `db` in autocommit
+  // with no transaction open, so there is nothing to roll back and nothing was
+  // written — zero rows means another run settled this trade first, and the
+  // caller reports one fewer resolution rather than an error. `null` says "not
+  // mine to report", which is different from "it failed".
   if (pastDeadline) {
-    await db.query("UPDATE trades SET state = 'EXPIRED', resolved_at = $2 WHERE id = $1", [
-      tradeId,
-      now.toISOString(),
-    ]);
+    const expired = await db.query<{ id: string }>(
+      `UPDATE trades SET state = 'EXPIRED', resolved_at = $2
+        WHERE id = $1 AND state = 'ACCEPTED'
+      RETURNING id`,
+      [tradeId, now.toISOString()],
+    );
+    if (expired.length === 0) return null;
+
     return { tradeId, outcome: "EXPIRED", vetoes: trade.vetoes, required };
   }
 
   if (isVetoed(trade.vetoes, electorate, rules.trades)) {
-    await db.query("UPDATE trades SET state = 'VETOED', resolved_at = $2 WHERE id = $1", [
-      tradeId,
-      now.toISOString(),
-    ]);
+    const vetoed = await db.query<{ id: string }>(
+      `UPDATE trades SET state = 'VETOED', resolved_at = $2
+        WHERE id = $1 AND state = 'ACCEPTED'
+      RETURNING id`,
+      [tradeId, now.toISOString()],
+    );
+    if (vetoed.length === 0) return null;
+
     return { tradeId, outcome: "VETOED", vetoes: trade.vetoes, required };
   }
 
   await withTransaction(db, async (tx) => {
+    // `ORDER BY player_id`, the same key `acceptTrade` takes its locks in. Two
+    // functions that lock the same rows in different orders can deadlock, and
+    // this one used to take them in whatever order the plan produced — so the
+    // cycle `acceptTrade`'s comment claims to have removed was still
+    // constructible between the two of them.
     const assets = await tx.query<{ from_team_id: string; player_id: string }>(
-      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1",
+      "SELECT from_team_id, player_id FROM trade_assets WHERE trade_id = $1 ORDER BY player_id",
       [tradeId],
     );
 
@@ -818,10 +939,27 @@ async function resolveTrade(
       );
     }
 
-    await tx.query("UPDATE trades SET state = 'EXECUTED', resolved_at = $2 WHERE id = $1", [
-      tradeId,
-      now.toISOString(),
-    ]);
+    // **This one must throw**, and it is the only one of the six that must.
+    //
+    // It sits inside the transaction that has already swapped both rosters. If
+    // another run settled the trade first, answering "somebody got there
+    // ahead of me" would return normally and **commit the swap** with the trade
+    // still ACCEPTED — so the next hourly run would select it again and execute
+    // it a second time, releasing the player from the team that just received
+    // him. Throwing rolls the swap back, which is the whole reason it is in a
+    // transaction.
+    const executed = await tx.query<{ id: string }>(
+      `UPDATE trades SET state = 'EXECUTED', resolved_at = $2
+        WHERE id = $1 AND state = 'ACCEPTED'
+      RETURNING id`,
+      [tradeId, now.toISOString()],
+    );
+    if (executed.length === 0) {
+      throw new TradeError(
+        "This trade was settled by another run while it was executing",
+        "WRONG_STATE",
+      );
+    }
   });
 
   return { tradeId, outcome: "EXECUTED", vetoes: trade.vetoes, required };


### PR DESCRIPTION
Closes #112. Closes #77 part 4.

## Seven state writes, one guard

| write | had a guard |
|---|---|
| → `ACCEPTED` | ✅ |
| → `WITHDRAWN` (decline) | ✗ |
| → `WITHDRAWN` (withdraw) | ✗ |
| → `EXPIRED` (deadline) | ✗ |
| → `EXPIRED` (asset gone) | ✗ |
| → `VETOED` | ✗ |
| → `EXECUTED` | ✗ |

And `resolveDueTrades` selected `state = 'ACCEPTED'` with no lock and never re-checked. Every write now carries `AND state = '<expected>'` and `RETURNING id`.

**`RETURNING id` is load-bearing, not tidiness.** `SqlClient.query` returns rows and discards `rowCount`, so without it a refused write and a successful one are the same empty array — the guard would be real and its result *unreadable*, and the loser of the race would still be told it won.

## The six need six different answers, and a uniform rule is wrong in both directions

- **accept, decline, withdraw** — throw `WRONG_STATE`; the route already maps it to a 409.
- **the deadline and veto writes** — must **not** throw. They run in autocommit with no transaction to roll back, and zero rows means another run settled the trade first. `resolveTrade` returns `null`: *not mine to report*, which is a different thing from *it failed*.
- **the `EXECUTED` write** — **must** throw, and it is the only one that must. It sits inside the transaction that has **already swapped both rosters**. Answering "somebody got there first" would return normally and commit the swap with the trade still `ACCEPTED`, so the next hourly run would select it again and execute it a second time — releasing the player from the team that had just received him. Throwing rolls the swap back, which is the whole reason it is in a transaction.

## The withdraw race is the one with teeth

`withdrawTrade` reads `PROPOSED`, the receiver's acceptance commits, and the stomping write set `WITHDRAWN` over the top. That did not merely mislabel the row: **`lockedByTrade` counts only `ACCEPTED` trades, so it unfroze both players in the same statement** — and the proposer could then drop the player they had promised. The route has no rate limit and no idempotency, so a proposer wanting out could fire withdrawals until one landed on the accept.

`declineTrade` is byte-identical in shape and **needs only one manager and one browser**: `TradeBlock` renders Accept and Decline side by side on a `PROPOSED` trade, and the panel only re-reads after the mutation returns.

## #112: widen the catch, do not widen what gets written

The rethrow was the allowlist-inside-a-loop shape `CLAUDE.md` names as itself the defect — the offending trade stayed `ACCEPTED` forever, **every trade queued behind it stayed `ACCEPTED` too**, and uninvolved managers' players stayed frozen, every hour, for the rest of the season.

**But #112's own suggested fix — "record and continue, marking the trade EXPIRED" — would have been a worse bug than the one it fixes**, and this is the part worth reading twice. `withTransaction` calls `db.connect()` *before* `BEGIN`, and the pool has a connect timeout. So one saturated pool during an hourly run would expire **every due trade in every league**, in a single pass, permanently — nothing revisits `EXPIRED`. Same for a `40P01` deadlock, a `57014` statement timeout, or any bug of ours.

`RULES.md` defines `EXPIRED` as the deadline case — *"rosters untouched, nobody's fault"* — and §9 forbids forcing or reversing trades. Expiring on an infrastructure blip is the system reversing a trade the league approved, wearing a legitimate expiry's costume.

So `ASSET_GONE` remains the **only** error that writes a terminal state, because it is the only one that establishes the trade can *never* execute. Everything else goes into the return value: `resolveDueTrades` now answers `{resolutions, failures}` and the cron surfaces the failures. That is what `resolveLeagueWeeksThrough` means by record-and-continue — record in the **return value**, not in the database.

No `ORDER BY` was added to the pending query, and #112's premise there is wrong: `score-week`'s league query still has none after its own fix, because once nothing aborts the loop every item is attempted regardless of order, and these items' inputs are disjoint. Said so in a comment rather than silently omitted.

## One correction to a comment shipped in #118

`acceptTrade` says sorting the asset read *"on the same key in every caller makes the cycle unconstructible"*. `resolveTrade` is a caller and did **not** sort — so the deadlock cycle that comment claims to have removed was still constructible between the two functions. `resolveTrade` now sorts on the same key, and the comment says what was actually true when it was written.

## Tests: named for races, and not lying about it

This repo's standing position is that PGlite cannot test a race and a test named for one would lie. **That is true of the lineup and freeze races and false here**, which is why this file exists: `withdrawTrade` and `declineTrade` open **no transaction at all** — their state read and their state write are two separate autocommit statements — and `resolveDueTrades`' pending `SELECT` is likewise outside any transaction. So the production interleaving is reproduced *exactly*, deterministically, by running the real competing call at the instruction boundary where it would have landed. No pausing, no threads.

Every guard has a test that fails without it:

| mutation | what breaks |
|---|---|
| drop the two `PROPOSED` guards | withdraw and decline both stomp an accepted trade |
| `if (true)` in place of the `ASSET_GONE` check | **a deadlock leaves the trade `EXPIRED`** — the exact regression |
| drop the `EXECUTED` guard | **a vetoed trade executes**, and the swap commits |
| drop `tradeCannotExecute`'s guard | an executed trade is relabelled `EXPIRED` over a completed swap |

The vetoed-during-execution case was found *because* the first pass of the mutation check did not catch the `EXECUTED` guard — the overlap test never reaches that write, since the release fails with `ASSET_GONE` first. That gap is now covered by its own test, and it is the most serious case in the file: a trade the league blocked, performed anyway.

Two positive tests count rows written and assert **exactly one** on an ordinary execution and an ordinary withdrawal. Without them a predicate pasted against the wrong state would silently refuse every write while `resolveDueTrades` still returned the outcome it computed in memory, and nothing else in the suite would notice — the other assertions read the return value, not the row.

Worth recording: `trades.test.ts`'s `"cannot be accepted twice"` looks like coverage of the one guard that already existed and is not. Delete `AND state = 'PROPOSED'` from that statement and it still passes, because the second accept is refused by an in-memory read that never reaches the SQL.

**1254 tests, typecheck, lint, format green.**

## Knowingly left open

`vetoTrade` reads state from an unlocked `loadTrade` and then blind-inserts, so a vote cast while `resolveTrade` executes is written and silently discarded — the member's veto never counts and nothing tells them. It is not a state write, so it is outside part 4, but a PR titled "every state write is guarded" would otherwise be read as covering it. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
