### PR TITLE
fix(db,core,web): the field locks when the seed exists, not when the order is drawn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,36 @@ Four things close it, and removing any one reopens it:
    is no "try again a few slots later". `SolanaBeacon.verify` is what proves a recorded
    slot really is that one, in two RPC calls.
 3. A trigger rejects any second write to the draw or to any team's `draft_position`.
-4. A trigger locks the field: no team may join once the order is drawn.
+4. A trigger locks the field **at `scheduledAt`** — the instant the seed becomes
+   computable — on INSERT _and_ DELETE (migration `0028`).
+
+**Item 4 said "once the order is drawn" until 2026-08-14, and that was the wrong event.**
+The seed is the first block at or after `scheduledAt` mixed with the league id and the
+rules hash, all public and frozen, so anyone can compute it the moment that time passes —
+while the draw is a button the commissioner presses, with no upper bound, and `joinLeague`
+only checks the league is still FORMING. `0010`'s own header describes the right condition
+("after the seed is known") and gated on the other one. So there was a window of arbitrary
+length in which the seed was public and the field could still change.
+
+**And it is not the attack every comment here described.** Re-minting a bot with a fresh
+UUID does nothing: `generateDraftOrder` shuffles _positions_ and `seededIndex` takes no
+team id. Two things were measured rather than argued. For a team already holding a slot
+the grind is **one-directional** — growing the field only ever moves it to the last pick
+(12,268 changes over 3,000 seeds, zero improvements), so an honest commissioner and a
+grinding one both draw immediately. The real lever is that **`createLeague` seats nobody**,
+so a commissioner joins like anyone else and can choose _when_: inserting themselves last,
+after the seed is public, gives a mean pick of **1.64** against a fair 6.50, and pick 1
+fifty-seven percent of the time. That is what `0028` closes.
+
+`drafts.scheduled_at` is now the lock instant, so `0028` also makes it write-once and
+checks it against `league_rules.rule_json` — the lock has to be the number members signed,
+not a copy that happens to agree. They already disagreed by a year in the draft fixtures.
+
+**The cost, stated rather than discovered later:** a league that has not filled by its
+draft time can no longer add anyone. Two to eleven teams still draft and play; the one new
+dead end is a **one-member pot league**, which can never reach two and has no dissolve
+path. `docs/RULES.md` already promises auto-dissolve with refunds for exactly that case and
+nothing implements it — the program has five instructions and none is a dissolve.
 
 `SolanaBeacon.firstBlockAtOrAfter` is a binary search over block times, tolerating
 skipped slots. Roughly twenty RPC calls; a linear walk would be millions. **Verification

--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import {
   buildNflPprRules,
   CanonicalEncodingError,
+  draftDateProblem,
   NFL,
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
@@ -190,6 +191,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: `Unknown payout shape: ${String(body.pot.payout)}` },
       { status: 400 },
     );
+  }
+
+  // The draft time is when the field locks, so a league created to draft in the
+  // past would refuse its own first join — the commissioner's included — and
+  // rules are immutable, so it could never be corrected, only recreated under a
+  // new id. `validateLeagueRules` cannot check this: it must stay a pure function
+  // of the frozen document so a league can be re-validated years later.
+  const draftProblem = draftDateProblem(body.draftAt, new Date());
+  if (draftProblem) {
+    return NextResponse.json({ error: draftProblem }, { status: 400 });
   }
 
   const pot: PotRules | null = body.pot

--- a/apps/web/src/components/CreateLeagueForm.tsx
+++ b/apps/web/src/components/CreateLeagueForm.tsx
@@ -94,8 +94,24 @@ const MAX_BUY_IN_USDC = MAX_BUY_IN_BASE_UNITS / 1_000_000;
  */
 const TRADE_DEADLINE_WEEKS = [8, 9, 10, 11, 12, 13, 14];
 
-/** The Aug 22 deadline: leagues must be draftable by then. */
-const DEFAULT_DRAFT_AT = "2026-08-22T14:00";
+/**
+ * A week out, at 2pm local.
+ *
+ * **Derived from `now`, not typed out**, for the same reason `defaultRefundUnlock`
+ * below is. It was the constant `"2026-08-22T14:00"`, with a comment naming the
+ * deadline it was written for — which was fine until that date passed, and then
+ * it would have proposed a draft in the past to every creator. Harmless before
+ * the field locked at the draft time; league-destroying afterwards, because such
+ * a league refuses its own first join and its rules can never be corrected.
+ *
+ * A week gives people time to be invited and join, which is the thing the draft
+ * date now bounds.
+ */
+function defaultDraftAt(now: Date): string {
+  const at = new Date(now.getTime() + 7 * 24 * 3600 * 1000);
+  at.setHours(14, 0, 0, 0);
+  return unixToLocalInput(Math.floor(at.getTime() / 1000));
+}
 
 function localToUnix(value: string): number {
   return Math.floor(new Date(value).getTime() / 1000);
@@ -144,7 +160,9 @@ export function CreateLeagueForm() {
 
   const [name, setName] = useState("");
   const [visibility, setVisibility] = useState<"PRIVATE" | "PUBLIC">("PRIVATE");
-  const [draftAt, setDraftAt] = useState(DEFAULT_DRAFT_AT);
+  // Computed once, on mount. A module-level constant would be evaluated at
+  // import time and shared by every render of a long-lived server process.
+  const [draftAt, setDraftAt] = useState(() => defaultDraftAt(new Date()));
   const [mode, setMode] = useState<"FAST" | "SLOW">("SLOW");
   const [pickSeconds, setPickSeconds] = useState(14_400);
   const [tradeDeadlineWeek, setTradeDeadlineWeek] = useState(11);
@@ -154,7 +172,9 @@ export function CreateLeagueForm() {
   // Seeded from the draft date, and follows it until the commissioner sets one
   // themselves. Moving the draft back a fortnight would otherwise leave a refund
   // date the server refuses, and the error would name a field they never touched.
-  const [refundUnlock, setRefundUnlock] = useState(() => defaultRefundUnlock(DEFAULT_DRAFT_AT));
+  const [refundUnlock, setRefundUnlock] = useState(() =>
+    defaultRefundUnlock(defaultDraftAt(new Date())),
+  );
   const [refundTouched, setRefundTouched] = useState(false);
 
   const [submitting, setSubmitting] = useState(false);

--- a/packages/core/src/draft/order.ts
+++ b/packages/core/src/draft/order.ts
@@ -46,8 +46,16 @@ function seededIndex(seed: string, counter: number, max: number): number {
  * A Solana slot hash at or after the frozen `draft.scheduledAt` satisfies both
  * halves: nobody can know it in advance, and anyone can verify it afterwards.
  *
- * Until that is wired up (it needs the chain integration), callers should treat
- * the order as fair only for leagues without a pot.
+ * **That is wired up.** `SolanaBeacon` in `@rostr/db` fetches the block and
+ * `drawDraftOrder` records the slot, so the order is drawn from the chain in
+ * every league, pot or not. This paragraph used to end "until that is wired up
+ * … treat the order as fair only for leagues without a pot", which stopped being
+ * true when the beacon landed and then told readers the opposite of the truth
+ * about exactly the leagues where it matters most.
+ *
+ * The other half — that the field cannot change once the seed exists — is
+ * migration `0028`. It was `0010`, which described that condition and gated on a
+ * different one.
  */
 export function generateDraftOrder(
   teamIds: readonly string[],

--- a/packages/core/src/draft/seed.ts
+++ b/packages/core/src/draft/seed.ts
@@ -69,8 +69,17 @@ export function deriveOrderSeed(input: OrderSeedInput): string {
 /**
  * Instructions for checking a draft order by hand.
  *
- * Rendered in the UI next to the order. A verification nobody can perform is
- * indistinguishable from no verification.
+ * **Not rendered anywhere yet**, and this used to say it was. A verification
+ * nobody can perform is indistinguishable from no verification — which was
+ * written here as the reason to show it, and had become an accurate description
+ * of the shipped state instead. It is written, tested and exported, and no
+ * screen calls it. Filed separately; the sentence stays because it is the
+ * argument for fixing that.
+ *
+ * The text below is true as of migration `0028`. Before it, the closing claim —
+ * that nobody could have known the blockhash while teams were still joining —
+ * was false: the seed existed from the scheduled draft time and the field stayed
+ * open until the commissioner pressed the button.
  */
 export function explainOrderDraw(input: OrderSeedInput): string {
   return [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,7 +64,9 @@ export {
 
 export { encodeLeagueRules, hashLeagueRules, verifyLeagueRulesHash } from "./rules/hash.js";
 export {
+  draftDateProblem,
   earliestRefundUnlock,
+  MIN_DRAFT_LEAD_SECONDS,
   latestRefundUnlock,
   validateLeagueRules,
 } from "./rules/validate.js";

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -12,7 +12,13 @@ import {
   NFL_WINNER_TAKE_ALL_PAYOUT,
 } from "./nfl-ppr.js";
 import type { LeagueRules, PotRules } from "./types.js";
-import { earliestRefundUnlock, latestRefundUnlock, validateLeagueRules } from "./validate.js";
+import {
+  draftDateProblem,
+  earliestRefundUnlock,
+  latestRefundUnlock,
+  MIN_DRAFT_LEAD_SECONDS,
+  validateLeagueRules,
+} from "./validate.js";
 
 /**
  * A fully-specified rule set with every free variable pinned. Its hash is a
@@ -650,6 +656,47 @@ describe("validateLeagueRules", () => {
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("at least 2 humans"),
     );
+  });
+});
+
+describe("draftDateProblem", () => {
+  // The draft time is when the field locks, so a league created to draft in the
+  // past would refuse its own first join — the commissioner's included — and its
+  // rules are immutable, so it could never be corrected, only recreated under a
+  // new id. That became reachable by accepting the create form's default from
+  // 22 August 2026 onward, when its hardcoded date passed.
+  const NOW = new Date("2026-08-14T12:00:00Z");
+  const at = (offsetSeconds: number): number =>
+    Math.floor(NOW.getTime() / 1000) + offsetSeconds;
+
+  it("accepts a draft comfortably in the future", () => {
+    expect(draftDateProblem(at(7 * 24 * 3600), NOW)).toBeNull();
+  });
+
+  it("refuses a draft in the past, and one at this very instant", () => {
+    expect(draftDateProblem(at(-1), NOW)).toMatch(/already passed/);
+    expect(draftDateProblem(at(0), NOW)).toMatch(/already passed/);
+  });
+
+  it("refuses a draft too soon for anyone to join", () => {
+    // The field closes at the draft time, so a league scheduled minutes out is
+    // born locked around whoever happened to be in it.
+    expect(draftDateProblem(at(MIN_DRAFT_LEAD_SECONDS - 1), NOW)).toMatch(/at least an hour/);
+    expect(draftDateProblem(at(MIN_DRAFT_LEAD_SECONDS), NOW)).toBeNull();
+  });
+
+  it("refuses an unset or nonsensical time", () => {
+    expect(draftDateProblem(0, NOW)).toMatch(/must be set/);
+    expect(draftDateProblem(Number.NaN, NOW)).toMatch(/must be set/);
+  });
+
+  it("is deliberately not part of validateLeagueRules", () => {
+    // That function has to stay a pure function of the frozen document, so a
+    // league can be re-validated years later to check it was legal when it was
+    // made. A clock in there would fail every league in the repository the day
+    // after it drafted — and this fixture's own draft is in 2025.
+    expect(validateLeagueRules(FIXTURE, NFL)).toEqual([]);
+    expect(draftDateProblem(FIXTURE.draft.scheduledAt, NOW)).toMatch(/already passed/);
   });
 });
 

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -407,6 +407,53 @@ function validateTrades(rules: LeagueRules, out: string[]): void {
  * not immediately follow the regular season, and counting the array's length
  * would then finish early.
  */
+/**
+ * The shortest gap between creating a league and its draft.
+ *
+ * An hour. Enough to send the link round; short enough not to constrain anyone
+ * who genuinely wants to draft this afternoon.
+ */
+export const MIN_DRAFT_LEAD_SECONDS = 3600;
+
+/**
+ * Why this draft time cannot be used, or `null` if it can.
+ *
+ * **Separate from `validateLeagueRules`, and it has to be.** That function is
+ * pure in the strong sense — same rules, same answer, forever — which is what
+ * lets it be re-run against a frozen document years later to check the league was
+ * legal when it was made. A rule that consults the clock cannot live there: every
+ * league in the repository would start failing its own validation the day after
+ * it drafted, and the golden fixture's `scheduledAt` is in 2025.
+ *
+ * So the clock is the caller's, passed explicitly, and this is called at the one
+ * moment it makes sense — creation. The same shape as `earliestRefundUnlock`, and
+ * for the same reason: the form and the route share one definition, so the form
+ * cannot suggest a date the server refuses.
+ *
+ * **Why it matters now.** The draft time is when the field locks: the order's
+ * seed is the first Solana block at or after it, so anyone can compute the seed
+ * from that instant and a field that could still change afterwards is grindable.
+ * A league created with a draft time already past would therefore refuse its
+ * own first join — including the commissioner's — and rules are immutable, so it
+ * could never be corrected, only recreated under a new id. That was reachable by
+ * accepting the create form's default from 22 August 2026 onward.
+ */
+export function draftDateProblem(scheduledAt: number, now: Date): string | null {
+  if (!Number.isFinite(scheduledAt) || scheduledAt <= 0) {
+    return "draft scheduledAt must be set at creation";
+  }
+
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (scheduledAt <= nowSeconds) {
+    return "the draft time has already passed — a league cannot be created to draft in the past";
+  }
+  if (scheduledAt - nowSeconds < MIN_DRAFT_LEAD_SECONDS) {
+    return "the draft must be at least an hour away, so there is time for anyone to join";
+  }
+
+  return null;
+}
+
 export function earliestRefundUnlock(input: {
   readonly draftScheduledAt: number;
   readonly regularSeasonWeeks: number;

--- a/packages/db/migrations/0028_the_field_locks_when_the_seed_exists.sql
+++ b/packages/db/migrations/0028_the_field_locks_when_the_seed_exists.sql
@@ -1,0 +1,131 @@
+-- The field locks when the seed exists, not when the order is drawn.
+--
+-- `0010` wrote the right sentence and gated on the wrong event. Its header says:
+--
+--   "Letting a team join after the seed is known would restore the whole attack:
+--    watch the block land, compute what adding a bot would do, then add it."
+--
+-- and then it refuses only once `order_drawn_at IS NOT NULL`. Those are the same
+-- instant only if the draw happens the moment the seed exists, and it does not:
+-- the draw is a button the commissioner presses, `drawDraftOrder` refuses only
+-- *before* `scheduled_at` and has no upper bound, and `joinLeague` gates on the
+-- league still being FORMING — which it is until `startDraft` runs, after the
+-- draw. So there was a window of arbitrary length in which the seed was public
+-- and `teams` rows still inserted.
+--
+-- The seed is the first Solana block at or after `drafts.scheduled_at`, mixed
+-- with the league id and the rules hash. All three are public and frozen, so the
+-- seed is computable by anyone the instant that time passes. `scheduled_at` is
+-- therefore the moment the field has to close, and it is the moment
+-- `docs/RULES.md` already names: "A league never reaches 2 humans by the draft
+-- date" is written against the draft date being the filling deadline.
+--
+-- ## Not the attack the old comments describe
+--
+-- Every comment in the repo describes re-minting a bot with a fresh UUID.
+-- That has never worked: `generateDraftOrder` shuffles *positions* and
+-- `seededIndex` takes no team id, so identities are inert payload. The real
+-- lever is the **size** of the field, and the sharpest form of it is a
+-- commissioner who has not yet joined choosing when to insert themselves —
+-- measured at a mean pick of 1.64 against a fair 6.50.
+--
+-- ## DELETE as well as INSERT
+--
+-- `0010` guarded INSERT only. Removing a team changes the field exactly as
+-- adding one does, and delete-then-add is an unbounded re-roll rather than a
+-- single blind draw. Only an application check in `removeBot` stood in the way,
+-- in a function with no production caller.
+
+CREATE OR REPLACE FUNCTION teams_locked_after_order_draw() RETURNS trigger AS $$
+DECLARE
+  d record;
+  league uuid := COALESCE(NEW.league_id, OLD.league_id);
+BEGIN
+  SELECT order_drawn_at, scheduled_at INTO d
+    FROM drafts WHERE league_id = league;
+
+  -- No draft row yet. `createLeague` and `createDraftRecord` are two separate
+  -- transactions, so this is the ordinary state of a league between them, and
+  -- nothing is locked because nothing has been scheduled.
+  IF NOT FOUND THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  IF d.order_drawn_at IS NOT NULL THEN
+    RAISE EXCEPTION
+      'League % has already drawn its draft order; the field is locked', league
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+
+  -- `clock_timestamp()`, not `now()`. `now()` is the transaction's start time, so
+  -- a transaction opened a moment before the scheduled time would insert under
+  -- the old rule however long it then took. The window is microseconds and not
+  -- reachable through the app; it costs nothing to be right about it.
+  IF d.scheduled_at <= clock_timestamp() THEN
+    RAISE EXCEPTION
+      'League % was scheduled to draft at %; the field locked then', league, d.scheduled_at
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER teams_locked_after_draw ON teams;
+
+CREATE TRIGGER teams_locked_after_draw
+  BEFORE INSERT OR DELETE ON teams
+  FOR EACH ROW EXECUTE FUNCTION teams_locked_after_order_draw();
+
+-- ---------------------------------------------------------------------------
+-- The lock instant is the one members signed
+-- ---------------------------------------------------------------------------
+
+-- `drafts.scheduled_at` now decides when the field closes, so it has to be the
+-- same number the members signed rather than a copy that happens to agree.
+--
+-- Two things were true before this and both are the reason it is here. Nothing
+-- made the column immutable — no trigger touched it — so whoever could reach the
+-- database could move the lock. And nothing checked it against
+-- `league_rules.rule_json`, which is itself immutable by trigger (`0004`): the
+-- route sets them from one value at creation and no test held it to that, so the
+-- two were free to drift. They already had: the draft fixtures froze rules at one
+-- instant and wrote `scheduled_at` a year later, and nothing noticed.
+--
+-- Comparing against the frozen document is what keeps this checkable by a
+-- stranger. It is the property that rules out deriving the seed from a "close the
+-- field" timestamp of our own: an instant our server writes is one an auditor has
+-- to trust, and the whole point of drawing from the chain is that they do not.
+CREATE FUNCTION drafts_scheduled_at_matches_frozen_rules() RETURNS trigger AS $$
+DECLARE
+  frozen bigint;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.scheduled_at IS DISTINCT FROM OLD.scheduled_at THEN
+    RAISE EXCEPTION
+      'Draft % has a scheduled time frozen at league creation; it cannot be moved',
+      OLD.id
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+
+  SELECT (rule_json -> 'draft' ->> 'scheduledAt')::bigint INTO frozen
+    FROM league_rules WHERE league_id = NEW.league_id;
+
+  IF frozen IS NULL THEN
+    RAISE EXCEPTION 'League % has no frozen rules to schedule against', NEW.league_id
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+
+  IF NEW.scheduled_at <> to_timestamp(frozen) THEN
+    RAISE EXCEPTION
+      'Draft scheduled for % but the frozen rules say %',
+      NEW.scheduled_at, to_timestamp(frozen)
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER drafts_scheduled_at_frozen
+  BEFORE INSERT OR UPDATE ON drafts
+  FOR EACH ROW EXECUTE FUNCTION drafts_scheduled_at_matches_frozen_rules();

--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -40,16 +40,33 @@ afterEach(async () => {
   db = undefined;
 });
 
+/**
+ * The scheduled draft time, thirty days out — and **relative**, not a literal.
+ *
+ * The field now locks at this instant (migration `0028`), and the trigger
+ * compares it against the database's own clock. A fixed date would therefore
+ * pass until it arrived and then fail every test in this file that adds a team,
+ * on a day nobody would connect to a change made months earlier. It used to be
+ * `2026-08-22T18:00:00Z`.
+ */
+const SCHEDULED = new Date(Math.floor(Date.now() / 1000) * 1000 + 30 * 24 * 3600 * 1000);
+const SCHEDULED_SECONDS = Math.floor(SCHEDULED.getTime() / 1000);
+
+/**
+ * `scheduledAt` matches `SCHEDULED` exactly, and `0028` requires it to.
+ *
+ * These were a year apart — the frozen rules said 2025 and the `drafts` row said
+ * 2026 — because nothing compared them. Now that the row decides when the field
+ * locks, it has to be the number members actually signed.
+ */
 const DRAFT: DraftRules = {
   type: "SNAKE",
   mode: "FAST",
   pickSeconds: 90,
-  scheduledAt: 1_756_400_000,
+  scheduledAt: SCHEDULED_SECONDS,
 };
 
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
-const SCHEDULED = new Date("2026-08-22T18:00:00Z");
-const SCHEDULED_SECONDS = Math.floor(SCHEDULED.getTime() / 1000);
 
 /**
  * A stand-in chain: one block just before the scheduled time and one just after.

--- a/packages/db/src/membership.test.ts
+++ b/packages/db/src/membership.test.ts
@@ -9,10 +9,11 @@ import {
   NFL_DEFAULT_PAYOUT,
 } from "@rostr/core";
 import type { DraftRules, LeagueRules, PotRules } from "@rostr/core";
-import { createLeague, recordChainAnchor } from "./leagues.js";
+import { createLeague, getLeagueRules, recordChainAnchor } from "./leagues.js";
 import { createUser, linkWallet } from "./identity.js";
 import {
   addBot,
+  getJoinMessage,
   getMembershipProofs,
   getOnChainDeposit,
   getOnChainJoin,
@@ -38,18 +39,32 @@ afterEach(async () => {
   db = undefined;
 });
 
+/**
+ * Thirty days out, relative rather than a literal date.
+ *
+ * The field locks at the scheduled draft time (migration `0028`), compared
+ * against the database clock — so a fixed date would pass until it arrived and
+ * then start failing every test here that adds a team. `0028` also requires
+ * `drafts.scheduled_at` to equal this exact number.
+ */
+const SCHEDULED = new Date(Math.floor(Date.now() / 1000) * 1000 + 30 * 24 * 3600 * 1000);
+const SCHEDULED_SECONDS = Math.floor(SCHEDULED.getTime() / 1000);
+
 const DRAFT: DraftRules = {
   type: "SNAKE",
   mode: "SLOW",
   pickSeconds: 14_400,
-  scheduledAt: 1_756_400_000,
+  scheduledAt: SCHEDULED_SECONDS,
 };
 
 const POT: PotRules = {
   tokenMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
   buyInBaseUnits: "50000000",
   payout: NFL_DEFAULT_PAYOUT,
-  refundUnlockAt: 1_773_000_000,
+  // Derived, because the floor is derived. `earliestRefundUnlock` is roughly the
+  // draft plus 186 days, so a literal here silently became "376 days too early"
+  // the moment the draft date started moving with the clock.
+  refundUnlockAt: SCHEDULED_SECONDS + 200 * 24 * 3600,
   feeBps: NFL_DEFAULT_FEE_BPS,
   feeRecipient: "6dNUCTMTgoHhbfgDzKtiPvBpJ2LzMwGqBpKmUDgQtNMK",
 };
@@ -122,6 +137,233 @@ function signJoin(fx: Fixture, address: string, secret: Uint8Array): string {
   });
   return bs58.encode(ed25519.sign(new TextEncoder().encode(message), secret));
 }
+
+describe("the field locks when the seed exists", () => {
+  /**
+   * A free league whose scheduled draft time is already behind us.
+   *
+   * The rules carry the same past instant the `drafts` row does — `0028` requires
+   * that — and nothing refuses a past draft date at *this* layer: the create
+   * route does, through `draftDateProblem`, because `validateLeagueRules` has to
+   * stay a pure function of the frozen document.
+   */
+  async function draftTimePassed(minutesAgo = 5): Promise<Fixture> {
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+
+    // Truncated to whole seconds: the rules store `scheduledAt` in seconds, and
+    // `0028` compares the two exactly. The production route builds the date as
+    // `scheduledAt * 1000`, so it is exact there by construction.
+    const scheduled = new Date(Math.floor((Date.now() - minutesAgo * 60_000) / 1000) * 1000);
+    const commissioner = await createUser(db, "commish@example.com", "Commish");
+    const rules = buildNflPprRules({
+      seasonYear: 2026,
+      draft: { ...DRAFT, scheduledAt: Math.floor(scheduled.getTime() / 1000) },
+    }) as LeagueRules;
+
+    const league = await createLeague(db, NFL, {
+      name: "Late League",
+      commissionerId: commissioner.id,
+      rules,
+    });
+    await recordChainAnchor(db, league.id, {
+      signature: "5".repeat(88),
+      cluster: "localnet",
+    });
+
+    // The team is seated *before* the draft row exists, which is the only order
+    // that still works — and is how a real league fills.
+    await addTestTeam(db, league.id, "Early Bird");
+
+    await createDraftRecord(db, {
+      leagueId: league.id,
+      rounds: 14,
+      pickSeconds: 14_400,
+      scheduledAt: scheduled,
+    });
+
+    const stored = await getLeagueRules(db, league.id);
+    return {
+      client: db,
+      leagueId: league.id,
+      leagueName: "Late League",
+      rulesHash: stored!.hash,
+      rules: stored!.rules,
+    };
+  }
+
+  it("refuses a join once the scheduled draft time has passed", async () => {
+    const fx = await draftTimePassed();
+    const m = await member(fx, 9, "late@example.com");
+
+    await expect(
+      joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Too Late",
+      }),
+    ).rejects.toSatisfy((e: unknown) => e instanceof JoinError && e.code === "FIELD_LOCKED");
+  });
+
+  it("refuses to hand out a join message it would then refuse to honour", async () => {
+    // A signature costs a wallet approval. Issuing one for a seat that cannot be
+    // taken is worse than saying no.
+    const fx = await draftTimePassed();
+
+    await expect(getJoinMessage(fx.client, fx.leagueId, keypair(9).address)).rejects.toSatisfy(
+      (e: unknown) => e instanceof JoinError && e.code === "FIELD_LOCKED",
+    );
+  });
+
+  it("refuses a team insert at the database, with no application check involved", async () => {
+    // **This is the test that pins the security property.** Everything else
+    // pins the error message. The application checks are a courtesy; the trigger
+    // is the guarantee, and it holds for any path that reaches the table.
+    const fx = await draftTimePassed();
+    const [user] = await fx.client.query<{ id: string }>(
+      "INSERT INTO users (email, display_name) VALUES ('raw@example.test', 'Raw') RETURNING id",
+    );
+
+    await expect(
+      fx.client.query(
+        `INSERT INTO teams (league_id, owner_id, is_bot, name, slot)
+         VALUES ($1, $2, false, 'Raw', 99)`,
+        [fx.leagueId, user!.id],
+      ),
+    ).rejects.toThrow(/field locked/i);
+  });
+
+  it("refuses a team delete at the database too", async () => {
+    // Removing a team changes the field exactly as adding one does, and
+    // delete-then-add is an unbounded re-roll rather than a single blind draw.
+    // `0010` guarded INSERT only.
+    const fx = await draftTimePassed();
+    const [team] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM teams WHERE league_id = $1",
+      [fx.leagueId],
+    );
+
+    await expect(
+      fx.client.query("DELETE FROM teams WHERE id = $1", [team!.id]),
+    ).rejects.toThrow(/field locked/i);
+  });
+
+  it("still accepts a join before the scheduled time", async () => {
+    // The negative control. Without it, a trigger that refused every insert
+    // would pass every test above.
+    const fx = await setup();
+    const m = await member(fx, 8, "early@example.com");
+
+    const result = await joinLeague(fx.client, {
+      leagueId: fx.leagueId,
+      userId: m.userId,
+      walletAddress: m.address,
+      signature: signJoin(fx, m.address, m.secret),
+      teamName: "In Time",
+    });
+
+    expect(result.slot).toBe(1);
+  });
+
+  it("accepts a join into a league that has not scheduled a draft yet", async () => {
+    // `createLeague` and `createDraftRecord` are separate transactions, so a
+    // league with no `drafts` row is the ordinary state between them — not a
+    // locked field.
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    const commissioner = await createUser(db, "c2@example.com", "Commish");
+    const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules;
+    const league = await createLeague(db, NFL, {
+      name: "Unscheduled",
+      commissionerId: commissioner.id,
+      rules,
+    });
+
+    await expect(addTestTeam(db, league.id, "Anybody")).resolves.toBeTruthy();
+  });
+
+  it("refuses removeBot once the scheduled time has passed", async () => {
+    // The residual grind, and the direction that matters most: shrinking the
+    // field and re-adding is a repeatable re-roll.
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+
+    const scheduled = new Date(Math.floor((Date.now() - 5 * 60_000) / 1000) * 1000);
+    const commissioner = await createUser(db, "c3@example.com", "Commish");
+    const rules = buildNflPprRules({
+      seasonYear: 2026,
+      draft: { ...DRAFT, scheduledAt: Math.floor(scheduled.getTime() / 1000) },
+    }) as LeagueRules;
+    const league = await createLeague(db, NFL, {
+      name: "Bot League",
+      commissionerId: commissioner.id,
+      rules,
+    });
+    await addTestTeam(db, league.id, "Human 1");
+    await addBot(db, league.id, "Robo");
+
+    await createDraftRecord(db, {
+      leagueId: league.id,
+      rounds: 14,
+      pickSeconds: 14_400,
+      scheduledAt: scheduled,
+    });
+
+    await expect(removeBot(db, league.id)).rejects.toSatisfy(
+      (e: unknown) => e instanceof JoinError && e.code === "FIELD_LOCKED",
+    );
+  });
+
+  it("refuses addBot once the scheduled time has passed", async () => {
+    const fx = await draftTimePassed();
+
+    await expect(addBot(fx.client, fx.leagueId, "Robo")).rejects.toSatisfy(
+      (e: unknown) => e instanceof JoinError && e.code === "FIELD_LOCKED",
+    );
+  });
+
+  it("refuses a drafts row whose time disagrees with the frozen rules", async () => {
+    // The lock instant has to be the number members signed. These two were a
+    // year apart in this repo's own fixtures, and nothing noticed.
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    const commissioner = await createUser(db, "c4@example.com", "Commish");
+    const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules;
+    const league = await createLeague(db, NFL, {
+      name: "Mismatched",
+      commissionerId: commissioner.id,
+      rules,
+    });
+
+    await expect(
+      createDraftRecord(db, {
+        leagueId: league.id,
+        rounds: 14,
+        pickSeconds: 14_400,
+        scheduledAt: new Date(SCHEDULED.getTime() + 86_400_000),
+      }),
+    ).rejects.toThrow(/frozen rules/i);
+  });
+
+  it("refuses to move a scheduled draft time", async () => {
+    const fx = await setup();
+    await createDraftRecord(fx.client, {
+      leagueId: fx.leagueId,
+      rounds: 14,
+      pickSeconds: 14_400,
+      scheduledAt: SCHEDULED,
+    });
+
+    await expect(
+      fx.client.query("UPDATE drafts SET scheduled_at = $2 WHERE league_id = $1", [
+        fx.leagueId,
+        new Date(SCHEDULED.getTime() + 3_600_000),
+      ]),
+    ).rejects.toThrow(/cannot be moved/i);
+  });
+});
 
 describe("joinLeague", () => {
   it("joins with a valid signature and takes slot 1", async () => {
@@ -530,7 +772,7 @@ describe("bots", () => {
         leagueId: fx.leagueId,
         rounds: 14,
         pickSeconds: 90,
-        scheduledAt: new Date("2026-08-22T18:00:00Z"),
+        scheduledAt: SCHEDULED,
       });
       await drawDraftOrder(fx.client, {
         leagueId: fx.leagueId,
@@ -538,10 +780,10 @@ describe("bots", () => {
           {
             slot: 1,
             blockhash: "5xot9PVkphiX2adznghwrAuxGs2zeWisNSxMW6hU6Hkj",
-            blockTime: Math.floor(new Date("2026-08-22T18:00:01Z").getTime() / 1000),
+            blockTime: SCHEDULED_SECONDS + 1,
           },
         ]),
-        now: new Date("2026-08-22T18:00:05Z"),
+        now: new Date(SCHEDULED.getTime() + 5_000),
       });
 
       await expect(removeBot(fx.client, fx.leagueId)).rejects.toSatisfy(

--- a/packages/db/src/membership.ts
+++ b/packages/db/src/membership.ts
@@ -55,7 +55,8 @@ export class JoinError extends Error {
       | "BOT_LIMIT"
       | "EVEN_WITHOUT_BOT"
       | "BOT_NOT_FOUND"
-      | "DRAFT_ALREADY_DRAWN",
+      | "DRAFT_ALREADY_DRAWN"
+      | "FIELD_LOCKED",
   ) {
     super(message);
     this.name = "JoinError";
@@ -88,6 +89,12 @@ export async function getJoinMessage(
   );
   if (!league) throw new JoinError("League not found", "LEAGUE_NOT_FOUND");
 
+  // Refused here too, so nobody is asked to sign a message that `joinLeague`
+  // would then refuse. The signature is over the rules hash and costs a wallet
+  // approval; handing one out for a seat that cannot be taken is worse than
+  // saying no.
+  await requireOpenField(db, leagueId);
+
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new JoinError("League has no stored rules", "RULES_MISSING");
 
@@ -98,6 +105,42 @@ export async function getJoinMessage(
     walletAddress,
     seasonYear: stored.rules.seasonYear,
   });
+}
+
+/**
+ * Refuse to change the field once the draft order's seed exists.
+ *
+ * The seed is the first Solana block at or after `drafts.scheduled_at`, mixed
+ * with the league id and the rules hash — all public and frozen — so it is
+ * computable by anyone the instant that time passes. A field that can still
+ * change after that is the whole attack migration `0010` was written to close,
+ * reached by waiting rather than by redrawing.
+ *
+ * **The database is what enforces this** (`0028`, on INSERT and DELETE). This is
+ * the translation, so the ordinary path answers `FIELD_LOCKED` rather than
+ * letting a raw trigger exception surface as a 500. Do not remove it on the
+ * grounds that the trigger already refuses: the trigger is the guarantee, this is
+ * the error message.
+ */
+async function requireOpenField(db: SqlClient, leagueId: string): Promise<void> {
+  const [draft] = await db.query<{ order_drawn_at: string | null; scheduled_at: string }>(
+    "SELECT order_drawn_at, scheduled_at FROM drafts WHERE league_id = $1",
+    [leagueId],
+  );
+
+  // No draft scheduled yet, so there is no seed to be known and nothing to lock.
+  if (!draft) return;
+
+  if (draft.order_drawn_at) {
+    throw new JoinError("The draft order has been drawn", "DRAFT_ALREADY_DRAWN");
+  }
+
+  if (new Date(draft.scheduled_at) <= new Date()) {
+    throw new JoinError(
+      "This league's draft time has passed, so its field is locked",
+      "FIELD_LOCKED",
+    );
+  }
 }
 
 /**
@@ -122,6 +165,8 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
       "LEAGUE_CLOSED",
     );
   }
+
+  await requireOpenField(db, league.id);
 
   const stored = await getLeagueRules(db, league.id);
   if (!stored) {
@@ -266,6 +311,8 @@ export async function addBot(
   const { maxBots, maxTeams } = stored.rules.league;
 
   return withTransaction(db, async (tx) => {
+    await requireOpenField(tx, leagueId);
+
     const [counts] = await tx.query<{ taken: number; bots: number; humans: number }>(
       `SELECT count(*)::int AS taken,
               count(*) FILTER (WHERE is_bot)::int AS bots,
@@ -339,12 +386,21 @@ export async function teamForUser(
  * Remove the bot.
  *
  * The seat is a placeholder for a person, so when a sixth friend turns up it has
- * to be possible to give it back. Refused once the draft order is drawn — the
- * order is derived from the set of teams, and a trigger locks the field at that
- * moment precisely so nobody can change it afterwards.
+ * to be possible to give it back. Refused once the field locks, which is the
+ * league's scheduled draft time — the order is derived from the set of teams and
+ * the seed exists from that instant, so a removal afterwards re-rolls it.
+ *
+ * **Removing is not the harmless direction.** A single join after the seed is
+ * known is one blind, irreversible draw; remove-then-add is an unbounded re-roll,
+ * because `addBot` inserts a fresh row and the order is a function of the field.
+ * That is the attack `0010`'s header describes, and until `0028` the trigger
+ * guarded INSERT only — so this check was the only thing standing in its way, in
+ * a function with no production caller.
  */
 export async function removeBot(db: SqlClient, leagueId: string): Promise<{ removed: string }> {
   return withTransaction(db, async (tx) => {
+    // Kept ahead of the field check so a league whose order is already drawn
+    // still answers `DRAFT_ALREADY_DRAWN`, which is the more specific fact.
     const [draft] = await tx.query<{ order_drawn_at: string | null }>(
       "SELECT order_drawn_at FROM drafts WHERE league_id = $1",
       [leagueId],
@@ -355,6 +411,8 @@ export async function removeBot(db: SqlClient, leagueId: string): Promise<{ remo
         "DRAFT_ALREADY_DRAWN",
       );
     }
+
+    await requireOpenField(tx, leagueId);
 
     const [bot] = await tx.query<{ id: string }>(
       "SELECT id FROM teams WHERE league_id = $1 AND is_bot ORDER BY slot LIMIT 1",


### PR DESCRIPTION
Closes #78.

## `0010` wrote the right sentence and gated on the wrong event

Its own header:

> Letting a team join after **the seed is known** would restore the whole attack: watch the block land, compute what adding a bot would do, then add it.

and then it refuses only once `order_drawn_at IS NOT NULL`. Those are the same instant only if the draw happens the moment the seed exists, and it does not:

- the seed is the first Solana block at or after the frozen `scheduledAt`, mixed with the league id and the rules hash — **all public**, so anyone can compute it the moment that time passes;
- `drawDraftOrder` refuses only *before* `scheduledAt` and has **no upper bound**;
- `joinLeague` checks only that the league is still `FORMING`, which it is until `startDraft` runs — after the draw.

So there was a window of arbitrary length in which the seed was public and the field could still change. `CLAUDE.md` asserted the opposite as a documented invariant.

## Two corrections to the issue, both measured

**The attack every comment in this repo describes has never worked.** Re-minting a bot with a fresh UUID changes nothing: `generateDraftOrder` shuffles *positions* and `seededIndex` takes no team id. Verified against the built function — identical permutations for labelled ids and for two independent sets of v4 UUIDs, at every field size 4–12.

**And for a team already holding a slot, the grind is one-directional.** Growing the field can only move it to the *last* pick, never improve it — over 3,000 seeds × slots 1–4 × every step from 4 to 12: **12,268 changes, 12,268 landing on the last pick, zero improvements.** A commissioner already seated maximises their pick by drawing immediately, which is what an honest one does. Distinct reachable outcomes: mean 2.04, and a third of the time exactly one.

**The lever that does work is that `createLeague` seats nobody.** The commissioner joins through `joinLeague` like everyone else, so they choose *when*:

| | mean best pick | P(pick 1) | P(pick ≤ 3) |
|---|---|---|---|
| commissioner inserts themselves last | **1.64** | **57.0%** | **95.6%** |
| fair 12-team baseline | 6.50 | 8.3% | 25.0% |

Undetectable — every order verifies, the recorded slot checks out, `verifyDraftOrder` returns `ok`.

**Be honest about the money, though:** buy-in caps at $50, so a full 12-team pot is at most $600 and the champion's share $420. Moving championship probability from ~1/12 to ~1/9 is roughly **$10–15 of expected value**, and a snake draft flattens exactly this. The damage is the claim, not the cash — this project's thesis is that you don't have to trust an administrator, and five places in the repo said this was closed.

## What ships

**Migration `0028` locks the field at `scheduled_at`, on INSERT *and* DELETE.** Delete matters and has never been covered: `0010` guarded INSERT only, so removing a team was stopped solely by an application check in a function with **no production caller** — and remove-then-add is an *unbounded re-roll* rather than one blind draw.

**`drafts.scheduled_at` becomes the lock instant, so `0028` makes it write-once and checks it against the frozen `league_rules.rule_json`.** The lock has to be the number members signed, not a copy that happens to agree — and they already disagreed **by a year** in this repo's own draft fixtures, with nothing to notice. The trigger immediately caught a millisecond-vs-second mismatch in a fixture I wrote while adding it.

Application mirrors in `joinLeague`, `getJoinMessage`, `addBot` and `removeBot` so the ordinary path answers `FIELD_LOCKED` instead of surfacing a raw trigger exception as a 500. `getJoinMessage` refuses too: a signature costs a wallet approval, and issuing one for a seat that cannot be taken is worse than saying no.

## The design that was rejected, and why

Deriving the seed from a commissioner-chosen "close the field" instant would preserve late filling. It was rejected on this project's own terms: it moves the anchor **from a number inside the signed document to a row in our database**, so an auditor has to take our word for it. That is not theoretical — pick the field, look at blocks already produced, find a hash you like, write `field_closed_at` just before it. Write-once doesn't help, because *the first write is the whole attack*. It would also falsify `RULES.md`'s "The order is drawn once, from the chain" for people who have already signed it — the ground PR #31 was closed on two days ago.

## The date landmine — this is why (A) could not ship alone

```ts
// CreateLeagueForm.tsx, before
const DEFAULT_DRAFT_AT = "2026-08-22T14:00";
```

Hardcoded, and `validateLeagueRules` only checked `scheduledAt <= 0` — **nothing refused a draft date in the past.** Once the field locks at the draft time, every league created by accepting that default from 22 August onward would be born with its field already locked: it would **refuse its own first join**, the commissioner's included, and rules are immutable so it could never be corrected, only recreated under a new id.

So the default now derives from `now`, and `draftDateProblem` is a new pure helper the create route calls. It is **deliberately not part of `validateLeagueRules`** — that function must stay a pure function of the frozen document so a league can be re-validated years later, and a clock in it would fail every league in the repository the day after it drafted. There is a test asserting exactly that separation.

## The cost, stated rather than discovered later

A league that has not filled by its draft time can no longer add anyone. **Two to eleven teams still draft and play normally.** The one genuinely new dead end is a **one-member pot league** — it can never reach two, and there is no dissolve instruction. `docs/RULES.md` already promises *"A league never reaches 2 humans by the draft date → Auto-dissolve, full refunds"* and nothing implements it. Filed separately, along with `minHumans` being signed and enforced nowhere.

## Tests

Both layers pinned independently, and the mutation results say why that matters:

| mutation | what fails |
|---|---|
| disable the `scheduled_at` branch in `0028` | the two **raw-SQL** tests — the app-level ones still pass, because they pin the message |
| disable the app-level check | the four **`FIELD_LOCKED`** tests — the raw ones still pass, because the trigger still holds |

That split is the point: the trigger is the guarantee, the application checks are the error message, and each is tested against the other being removed. Plus a negative control (a join *before* the time still succeeds), a league with no `drafts` row still accepting joins, and both new `drafts` triggers.

**Fixture note:** `draft.test.ts` and `membership.test.ts` had `SCHEDULED = 2026-08-22`, itself eight days from expiring. Both are now relative to `now`, and their frozen `scheduledAt` matches the `drafts` row exactly — which `0028` now requires.

**1269 tests, typecheck, lint, format green. No rules field added, so the golden hash does not move.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
