### PR TITLE
fix(db,web): refuse the draft draw below minHumans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,12 +321,22 @@ tests, and every docstring the change falsified rewritten in the same commit:
 
 **Read these three before picking anything up:**
 
-- **#136 is live on `main` and it bites the draft.** A one-team league draws, starts, and then
-  hangs **permanently** — the final pick calls `generateSeasonSchedule`, which throws below two
-  teams _inside the pick's own transaction_, so it rolls back forever, and `ScheduleError` is not
-  `DraftContextError` so the draft room 500s on every poll. `minHumans` is in the signed rules and
-  read by nothing. #135 removed the "wait for a second member" escape, so this is now the first
-  thing to fix on the draft path, and Aug 22 is the draft deadline.
+- **#136 — fixed, and the mechanism this file gave for it was wrong.** It said a one-team league
+  hangs permanently because the final pick's `generateSeasonSchedule` throws inside the pick's own
+  transaction and the room then 500s on every poll. **It does not.** `generateSeasonSchedule`
+  guards `if (teams.length < 2) return { written: 0 }` (`packages/db/src/week.ts`) _before_ calling
+  `generateSchedule`, and that is the only non-test call site of the generator — so no
+  `ScheduleError` ever reaches the transaction, the pick commits, and nothing 500s. The guard has
+  been there since the function was written. Two agents refuted this independently; it was believed
+  because `draft.ts` and `schedule.ts` were read without opening the function in between.
+
+  What was real: `minHumans` sat in the signed rules and was compared to nothing, so a short
+  league drafted to completion and reached `IN_SEASON` **with no fixtures** — and that state is
+  terminal, because there is no redraft, the draw is write-once by trigger, the field is locked by
+  `0028`, and the only moment that writes a schedule has passed. `drawDraftOrder` now refuses below
+  `minHumans`, counting humans rather than rows. It was never an Aug 22 blocker; the draft path
+  worked throughout.
+
 - **#75/#96 is the Sep 9 blocker.** `syncBoxScores` exists and no cron runs it, so `stat_lines`
   is empty and **every player scores zero**. #81's adapter defects are latent _only_ because
   nothing calls `getBoxScore` — land #81 first or in the same pass, or they go live together.

--- a/apps/web/src/app/api/leagues/[id]/draft/start/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/start/route.ts
@@ -4,9 +4,13 @@ import { BeaconError } from "@rostr/db";
 import { db } from "@/lib/db";
 import { draftContext, DraftContextError } from "@/lib/draft-context";
 
+// A code missing from this map falls through to 400 below, which ships a good
+// message under the wrong status — so a new `DraftPersistenceError` code belongs
+// here in the same change that introduces it.
 const STATUS: Record<string, number> = {
   DRAFT_NOT_FOUND: 404,
   NO_TEAMS: 409,
+  BELOW_MIN_HUMANS: 409,
   ORDER_ALREADY_DRAWN: 409,
   TOO_EARLY_TO_DRAW: 425,
   ORDER_NOT_DRAWN: 409,

--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -12,6 +12,7 @@ import type { DraftablePlayer, DraftRules, LeagueRules } from "@rostr/core";
 import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
 import { seedSport } from "./sports.js";
+import { addBot } from "./membership.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import { FixedBeacon } from "./randomness.js";
@@ -1352,5 +1353,101 @@ describe("queues", () => {
 
     expect(queues.get(fx.teamIds[0]!)).toEqual(ids.slice(0, 3));
     expect(queues.get(fx.teamIds[1]!)).toEqual(ids.slice(3, 5));
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
+ * `minHumans` is in the frozen rule set and the draw is where it binds.
+ *
+ * `docs/RULES.md` §3 — "minimum humans to start: 2" — was signed by every member
+ * and compared to nothing. What made that worth a guard is not the draft itself,
+ * which completes fine: it is that a short league then reaches `IN_SEASON` with
+ * no fixtures and **cannot be recovered**. There is no redraft, the draw is
+ * write-once by trigger, the field is locked, and the one moment that writes a
+ * schedule has passed.
+ *
+ * The boundary is exercised in both directions here: one human refused, two
+ * allowed. Note also `setup(2)` in the suites above — those drafts run against
+ * the default `minHumans: 2`, so they are a standing detector for anyone who
+ * writes `<=` where the guard needs `<`.
+ */
+describe("the draw refuses a field below minHumans", () => {
+  it("refuses a single-manager league", async () => {
+    const fx = await setup(1);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toMatchObject({ code: "BELOW_MIN_HUMANS" });
+  });
+
+  it("says how many it has and how many it needs", async () => {
+    // The commissioner is the only person who ever sees this string, and it is
+    // the only thing telling them what to do about it.
+    const fx = await setup(1);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toThrow(/1 manager and its rules require 2/);
+  });
+
+  it("still answers NO_TEAMS for an empty league", async () => {
+    // Zero teams is the more specific fact and keeps its own code, which is why
+    // the human count is checked after it rather than before.
+    const fx = await setup(0);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toMatchObject({ code: "NO_TEAMS" });
+  });
+
+  it("counts humans, not rows: one manager and a bot is still one manager", async () => {
+    // Reachable today — `addBot` permits a bot at an odd human count, and one is
+    // odd. A bot is a placeholder for a person who is missing from an otherwise
+    // playable league (`RULES.md` §3), and it cannot be paid, so it can never
+    // satisfy a minimum denominated in humans. A `count(*)` here would pass this
+    // league straight through.
+    const fx = await setup(1);
+    await addBot(fx.client, fx.leagueId, "Sub");
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toMatchObject({ code: "BELOW_MIN_HUMANS" });
+  });
+
+  it("allows exactly minHumans, and the bot still joins the order", async () => {
+    // `validateLeagueRules` permits `maxTeams == minHumans`, so a league of
+    // exactly two is legal and must remain draftable — `<=` here would brick it
+    // permanently, against frozen rules nobody could correct.
+    //
+    // The bot is refused a seat in the *count* and keeps its seat in the *draft*:
+    // filtering the query rather than the count would shorten the rotation.
+    const fx = await setup(3);
+    await addBot(fx.client, fx.leagueId, "Sub");
+
+    const order = await scheduled(fx);
+
+    expect(order).toHaveLength(4);
+    expect(new Set(order).size).toBe(4);
+  });
+
+  it("lets a two-manager league draw", async () => {
+    // The control, in its cheap form. Without something like it the guard could
+    // be refusing every league and every test above would still pass.
+    //
+    // The expensive half already exists: "starts the season when the draft
+    // completes" drafts a two-team league to completion and asserts fourteen
+    // fixtures. It runs through this same guard, so it is a standing control
+    // that a short-field refusal has not swallowed a legal one.
+    const fx = await setup(2);
+
+    const order = await scheduled(fx);
+
+    expect(order).toHaveLength(2);
   });
 });

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -46,6 +46,7 @@ import {
 import { deriveOrderSeed } from "@rostr/core";
 import type { DraftablePlayer, DraftPick, DraftState, RosterShape } from "@rostr/core";
 import type { SqlClient } from "./client.js";
+import { getLeagueRules } from "./leagues.js";
 import { isUniqueViolation } from "./pg-errors.js";
 import type { RandomnessBeacon } from "./randomness.js";
 import { withTransaction } from "./transaction.js";
@@ -63,6 +64,7 @@ export class DraftPersistenceError extends Error {
       | "ORDER_NOT_DRAWN"
       | "ORDER_ALREADY_DRAWN"
       | "TOO_EARLY_TO_DRAW"
+      | "BELOW_MIN_HUMANS"
       | "RULES_MISSING"
       | "NOT_IN_PROGRESS"
       | "ALREADY_STARTED"
@@ -196,6 +198,31 @@ export interface DrawOrderInput {
  * Being able to *check* the draw matters as much as making it. Everything a
  * sceptic needs is recorded; `explainOrderDraw` in `@rostr/core` prints the
  * instructions.
+ *
+ * ## And it refuses a field too small to play
+ *
+ * `docs/RULES.md` §3 says "minimum humans to start: 2", and `minHumans` sits in
+ * the frozen rule set every member signs. Nothing compared it to the roster,
+ * which mattered because of what happens *after* a short draft rather than
+ * during one: the draft completes normally, and `generateSeasonSchedule`
+ * declines to write fixtures below two teams, so the league reaches `IN_SEASON`
+ * holding drafted rosters and no games.
+ *
+ * **That state is terminal.** `createDraftRecord` refuses a redraft, the draw is
+ * write-once by trigger, the field is locked by migration `0028`, and the only
+ * moment that writes a schedule — the completing pick — has already passed and
+ * cannot recur. It is also silent: the league looks finished. Every other
+ * failure on this path is something an operator can undo.
+ *
+ * So the draw is where it is caught, because it is the last moment before any of
+ * that is written. It is deliberately *not* also checked in `startDraft`: the
+ * order exists by then, and refusing there would strand a league holding an
+ * order it may never use.
+ *
+ * This refuses the draw; it does not dissolve the league. `RULES.md` §10
+ * promises auto-dissolve with refunds for a league that never reaches two
+ * humans, and nothing implements that yet (#137). A stake is still returned by
+ * the unconditional timelock refund, which no part of this touches.
  */
 export async function drawDraftOrder(
   db: SqlClient,
@@ -223,6 +250,11 @@ export async function drawDraftOrder(
     );
   }
 
+  // Read outside the transaction, like `addBot` does: `league_rules` is
+  // immutable by trigger, so there is nothing to hold a lock against.
+  const stored = await getLeagueRules(db, input.leagueId);
+  if (!stored) throw new DraftPersistenceError("League has no rules", "RULES_MISSING");
+
   // Fetched outside the transaction: an RPC round trip should not hold a lock,
   // and the block is immutable once produced, so nothing changes underneath.
   const block = await input.beacon.firstBlockAtOrAfter(scheduledAt);
@@ -246,12 +278,38 @@ export async function drawDraftOrder(
     // Ordered by join slot so the input to the shuffle is deterministic. Without
     // it the order would depend on how Postgres happened to return the rows, and
     // a seed anyone can check would produce an order nobody can reproduce.
-    const teams = await tx.query<{ id: string }>(
-      "SELECT id FROM teams WHERE league_id = $1 ORDER BY slot",
+    // `is_bot` comes back with the rows rather than as a second aggregate query,
+    // because this result *is* the shuffle input — an aggregate is a different
+    // row shape, and filtering the query itself would drop the bot out of the
+    // draft order entirely and shorten the rotation.
+    const teams = await tx.query<{ id: string; is_bot: boolean }>(
+      "SELECT id, is_bot FROM teams WHERE league_id = $1 ORDER BY slot",
       [input.leagueId],
     );
     if (teams.length === 0) {
       throw new DraftPersistenceError("League has no teams to draft", "NO_TEAMS");
+    }
+
+    // After `NO_TEAMS`, so an empty league still answers the more specific fact —
+    // the same ordering `removeBot` keeps for `DRAFT_ALREADY_DRAWN`.
+    //
+    // **Humans, not rows.** A bot is a placeholder for a person who is missing
+    // from an otherwise playable league — `RULES.md` §3's five friends who do not
+    // want a stranger — and it cannot be paid, so it can never satisfy a rule
+    // denominated in humans. Counting rows would wave through a free league of
+    // one human and one bot, which is reachable today.
+    //
+    // **`<`, never `<=`.** `validateLeagueRules` permits `maxTeams == minHumans`,
+    // so a league created with two of each is legal; `<=` would make it
+    // undraftable forever, and the rules are frozen so nobody could correct it.
+    const humans = teams.filter((team) => !team.is_bot).length;
+    if (humans < stored.rules.league.minHumans) {
+      throw new DraftPersistenceError(
+        `This league has ${humans} manager${humans === 1 ? "" : "s"} and its rules ` +
+          `require ${stored.rules.league.minHumans} to start. A bot cannot fill the ` +
+          `gap: it is a placeholder for a person, not a person.`,
+        "BELOW_MIN_HUMANS",
+      );
     }
 
     const seed = deriveOrderSeed({

--- a/packages/db/src/membership.test.ts
+++ b/packages/db/src/membership.test.ts
@@ -765,7 +765,15 @@ describe("bots", () => {
       // field at the draw precisely so nobody can change it afterwards. This is
       // the check that makes deleting a team safe at all — before the draw the
       // bot has no roster, no lineup and no matchup to orphan.
-      const fx = await freeLeague();
+      //
+      // Three humans, not the default one, because the draw now refuses a field
+      // below `minHumans` and a bot cannot make up the difference. Not two: a
+      // bot is only permitted at an *odd* human count, so `addBot` would refuse
+      // first and this test would never reach the draw it is about. Two humans
+      // and no bot would also pass, and vacuously — `removeBot` checks the draw
+      // before it checks whether a bot exists, so it would throw the right error
+      // for the wrong reason.
+      const fx = await freeLeague(3);
       await addBot(fx.client, fx.leagueId, "Robo");
 
       await createDraftRecord(fx.client, {

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -9,6 +9,7 @@ import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import {
   finalizationHours,
+  generateSeasonSchedule,
   loadScheduledWeek,
   loadWeekResults,
   persistSchedule,
@@ -809,5 +810,41 @@ describe("standings from resolved weeks", () => {
     await schedule(fx);
 
     expect(await loadWeekResults(fx.client, fx.leagueId, WEEK)).toEqual([]);
+  });
+});
+
+/**
+ * The guard that decides what a too-small league does instead of crashing.
+ *
+ * `generateSchedule` in `@rostr/core` throws below two teams, and this wrapper
+ * is the only thing in the repo that calls it — from inside the final draft
+ * pick's transaction, where a throw would roll the pick back. It returns
+ * `{ written: 0 }` instead, which is why a short draft completes rather than
+ * hanging.
+ *
+ * Nothing pinned that, and it is load-bearing in both directions: remove the
+ * guard and the last pick of a one-team draft rolls back forever; widen it and a
+ * real league silently loses its fixtures. The draw now refuses a field this
+ * small (`drawDraftOrder`), so this is the second line rather than the first.
+ */
+describe("generateSeasonSchedule below two teams", () => {
+  it("writes nothing instead of throwing", async () => {
+    const fx = await setup(1);
+
+    await expect(generateSeasonSchedule(fx.client, fx.leagueId, "seed")).resolves.toEqual({
+      written: 0,
+    });
+
+    expect(await loadScheduledWeek(fx.client, fx.leagueId, 1)).toEqual([]);
+  });
+
+  it("writes a full season at two", async () => {
+    // The boundary is exactly two, and it is the generator's own bound —
+    // asserting it here keeps the wrapper honest if that bound ever moves.
+    const fx = await setup(2);
+
+    const { written } = await generateSeasonSchedule(fx.client, fx.leagueId, "seed");
+
+    expect(written).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #136. `Refs #68` (item 4 is the same finding, filed first — #68 is a seven-part umbrella, so it is struck by hand rather than auto-closed). `Refs #137`.

## First: #136's stated mechanism is wrong, and this PR corrects the record

The issue — and `CLAUDE.md`, which promoted it to "read this before picking anything up" — says a one-team league **hangs permanently**: the final pick calls `generateSeasonSchedule`, which throws `ScheduleError` below two teams inside the pick's own transaction, so it rolls back forever, and the draft room 500s on every poll.

**It does not.** [`week.ts:625`](packages/db/src/week.ts#L625) guards `if (teams.length < 2) return { written: 0 };` *before* calling `generateSchedule`, and `week.ts:630` is the generator's **only non-test call site** in the repo. No `ScheduleError` ever reaches the transaction. The pick commits, the draft completes, nothing 500s. That guard arrived in the same commit that introduced `generateSeasonSchedule`, so the claim was never true.

Two reviewers refuted it independently. It was believed because `draft.ts` and `schedule.ts` were read without opening the function in between.

There was no Aug 22 draft-path emergency. The draft path works.

## What is actually wrong

`minHumans` is in the frozen, hashed, member-signed rule set, defaults to 2, is validated as a *value* at creation, and is rendered above the join control. A full census found **10 references repo-wide and zero that compare it to a roster.** `drawDraftOrder` never even called `getLeagueRules`.

So a short league drafts every pick, completes, and lands in `IN_SEASON` **with no fixtures** — exactly the *"looks finished and is unplayable"* state the comment at `draft.ts:709-711` says the schedule draw exists to prevent.

**And that state is terminal**, which is the whole argument for an eight-line guard:

- `createDraftRecord` refuses a redraft
- the draw is write-once by trigger (`0010`)
- the field is locked by `0028`, so a second member can never arrive
- the only moment that writes a schedule — the completing pick — has passed and cannot recur

It is silent, too. The league looks finished; only the scoring cron notices, recording `NO_SCHEDULE` per league on every run. Every other failure on this path is operator-recoverable. This one is not.

Reachability is the ordinary path, no database manipulation: create a league, one person joins, nobody else joins before the scheduled draft time, `0028` locks the field at one.

## The fix

Refuse the draw below `minHumans` in `drawDraftOrder`, counting **human** teams.

It is deliberately **not** also checked in `startDraft` — the order exists by then, and refusing there would strand a league holding an order it can never use. It is also unnecessary: `startDraft` requires `order_drawn_at`, so a refused draw closes it transitively.

Three details are load-bearing, each pinned by a test:

1. **Humans, not rows.** A bot is a placeholder for a person missing from an otherwise playable league (`RULES.md` §3's five friends), and it cannot be paid — so it can never satisfy a minimum denominated in humans. A `count(*)` would pass a free league of one human and one bot.
2. **`<`, never `<=`.** `validateLeagueRules` accepts `maxTeams == minHumans`, so a league of exactly two is legal and must stay draftable. `<=` would brick it permanently against frozen rules nobody can amend.
3. **Filter the result, not the query.** That result *is* the shuffle input; filtering the SQL would drop the bot out of the draft order and shorten the rotation.

Placed **after** the `NO_TEAMS` check so an empty league still answers the more specific fact — the ordering `removeBot` already keeps for `DRAFT_ALREADY_DRAWN`. The route's `STATUS` map gains `BELOW_MIN_HUMANS: 409`, without which a good message ships under a 400.

## An intended behaviour change, called out rather than discovered

This also refuses a **free league of one human plus a bot**, which today draws, drafts and plays a two-team season. That league violates `RULES.md` §3 — the bot is a placeholder for a person, not a person — so refusing it implements the signed document. But it is a behaviour change, not a bug fix, and it is only reachable because `addBot`'s odd-count test (`humans % 2 === 1`) happens to be true at one. `addBot` arguably wants its own `minHumans` check; that is a separate issue and the draw guard covers the harmful outcome either way.

No bot exists in the deployed database, so nothing in the wild changes.

## Verification

- **6 new tests** on the guard, plus 2 on the `week.ts` guard that refuted the issue — which had **no direct coverage anywhere** despite being what makes a short draft complete rather than hang.
- **Three negative controls, each behaving differently:** removing the guard fails 3 tests; changing `<` to `<=` fails **7**, including six pre-existing `setup(2)` drafts that are a standing off-by-one detector; counting rows instead of humans fails exactly the one test that distinguishes them.
- **1 test fixture updated** — `membership.test.ts`'s `removeBot` test used one human plus a bot. Now `freeLeague(3)`: not 2, because `addBot` refuses an even human count and the test would never reach the draw; and not "2 humans, no bot", because `removeBot` checks the draw before it checks whether a bot exists, so it would pass vacuously.
- Full suite **1277 passed, 2 skipped**, run twice. Typecheck, lint, format clean.

## Scope

- **Forward-only, and there is nothing to grandfather.** Verified read-only against the deployed database: **no league has ever drawn an order** (39 leagues, all probe artifacts, zero teams, zero bots, zero pots). Re-run before a real deployment:
  ```sql
  SELECT l.id, l.name FROM leagues l
    JOIN league_rules r ON r.league_id = l.id
    JOIN drafts d ON d.league_id = l.id
   WHERE d.order_drawn_at IS NOT NULL
     AND (SELECT count(*) FROM teams t WHERE t.league_id = l.id AND NOT t.is_bot)
         < (r.rule_json #>> '{league,minHumans}')::int;
  ```
- **This is half of what `RULES.md` promises.** §10 says *"A league never reaches 2 humans by the draft date → Auto-dissolve, full refunds."* This makes that condition detectable and stops the league corrupting itself; it does not implement the remedy. That is #137, and until it lands a sub-minimum pot league's stake waits for the timelock — floor draft + 186 days. **The money position is unchanged in both directions**: `refund_stake` consults only the clock, `deposited` and `refunded`, so it works for a league that never drafted.
- **The custom-payout guard is not bundled.** `CLAUDE.md` has wanted a second guard at this same call site since 2026-08-10 — a custom payout naming a prize a small field can never award. It shares a call site, not an implementation, and it is unreachable from the create route today. Filing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)