### PR TITLE
docs(stats): record the gameStatus vocabulary, measured rather than assumed

### DIFF
--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -44,6 +44,46 @@ exist under that name.
 
 ---
 
+## `gameStatus` — three endpoints, two vocabularies
+
+Captured live on 2026-08-15, verbatim. `mapGameStatus` was written from
+documentation, and this is what the endpoints actually say.
+
+| endpoint             | `gameStatus`  | `gameStatusCode` | games seen |
+| -------------------- | ------------- | ---------------- | ---------- |
+| `getNFLGamesForWeek` | `"Final"`     | `"2"`            | 32         |
+| `getNFLGamesForWeek` | `"Scheduled"` | `"0"`            | 16         |
+| `getNFLScoresOnly`   | `"Completed"` | `"2"`            | 1 date     |
+| `getNFLBoxScore`     | `"Completed"` | `"2"`            | 1 game     |
+
+**`getNFLGamesForWeek` is the odd one out.** A finished game is `"Final"` there
+and `"Completed"` on the other two — and `getNFLScoresOnly` is the endpoint the
+game watcher is supposed to poll, so anything written against the schedule
+endpoint's vocabulary would read every finished game as unstarted. `mapGameStatus`
+survives it only because matching is by prefix, which was a hedge rather than a
+plan.
+
+**`gameStatusCode` is the stable half.** `"2"` means finished on all three;
+`"0"` means not started. It is the better discriminator and it is _not_ what the
+code keys on today — deliberately, because only two of its values have been
+observed and guessing the rest is how the field names in this document were wrong
+four times. Worth switching to once the in-progress and postponed codes are seen.
+
+**Not yet observed, and honestly outstanding:** `IN_PROGRESS`, `POSTPONED` and
+`CANCELLED`. None exists out of season, so these need a live Sunday. Until then
+`mapGameStatus`'s handling of them is documentation, not evidence — and its
+fallback warns loudly and answers `SCHEDULED`, which for a _finished_ game means
+finalisation falls to `RULES.md` §10's postponement path.
+
+Reproduce with `pnpm stats:probe`, or:
+
+```
+curl --url 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLGamesForWeek?week=1&seasonType=reg&season=2025' \
+     --header 'x-rapidapi-key: <key>'
+```
+
+---
+
 ## The shape of a box score
 
 `getNFLBoxScore` returns one object with these parts:

--- a/packages/stats/src/tank01/adapter.test.ts
+++ b/packages/stats/src/tank01/adapter.test.ts
@@ -199,9 +199,16 @@ describe("listGames", () => {
     // unrecognised status there means `syncGames` writes a finished game as
     // unstarted, and every week in the season finalises down the postponement
     // fallback.
+    // The first four are *observed*, not typed: probed live on 2026-08-15 and
+    // recorded in `docs/TANK01.md`. The endpoints disagree with each other — a
+    // finished game is `Final` from `getNFLGamesForWeek` and `Completed` from
+    // both `getNFLScoresOnly` and `getNFLBoxScore` — and the scores endpoint is
+    // the one the game watcher polls, so dropping either form is enough to read
+    // every finished game as unstarted. The rest below remain documentation.
     const statuses = [
       ["Completed", "FINAL"],
       ["Final", "FINAL"],
+      ["Scheduled", "SCHEDULED"],
       ["Final/OT", "FINAL"],
       ["Live - In Progress", "IN_PROGRESS"],
       ["In Progress", "IN_PROGRESS"],

--- a/packages/stats/src/tank01/adapter.ts
+++ b/packages/stats/src/tank01/adapter.ts
@@ -121,6 +121,26 @@ interface RawGame {
  * vocabulary is inconsistent (`"Completed"`, and `docs/TANK01.md` records
  * `"Final/OT"` elsewhere), and treat an unrecognised value as `SCHEDULED` **but
  * say so** — a silent default is what hid this.
+ *
+ * ## The prefix hedge earned its keep, measured 2026-08-15
+ *
+ * Probed live, and the endpoints do not agree with each other. A finished game
+ * is `"Final"` from `getNFLGamesForWeek` and `"Completed"` from both
+ * `getNFLScoresOnly` and `getNFLBoxScore` — and the scores endpoint is the one
+ * the game watcher polls, so a mapping written against the schedule endpoint
+ * alone would have read every finished game as unstarted. Full table in
+ * `docs/TANK01.md`.
+ *
+ * **`gameStatusCode` is the stable half and this deliberately does not use it.**
+ * `"2"` means finished on all three endpoints and `"0"` means not started, which
+ * is a better discriminator than any string. Only those two values have been
+ * seen: no game is in progress, postponed or cancelled in August, so the rest of
+ * the code vocabulary is unknown. Switching to it now would mean guessing the
+ * remaining values, which is exactly how four field names in this file were
+ * wrong. Switch after a live Sunday, not before.
+ *
+ * For the same reason `IN_PROGRESS`, `POSTPONED` and `CANCELLED` below are still
+ * documentation rather than evidence.
  */
 function mapGameStatus(status: string | undefined): ProviderGame["status"] {
   const raw = (status ?? "").trim().toLowerCase();


### PR DESCRIPTION
`Refs #93` (item 2). Probed live on 2026-08-15 with the Pro key. Three calls.

## What was unverified

`mapGameStatus` was written from documentation. The only captured response in the repo comes from `getNFLBoxScore`, and whether `getNFLGamesForWeek` used the same words was an open question — with the whole season riding on it. An unrecognised status falls to `SCHEDULED`, so `syncGames` writes every finished game as unstarted, `finalizationHold` counts zero finished games, and every week finalises down `RULES.md` §10's postponement fallback.

## What the endpoints actually say

| endpoint | `gameStatus` | `gameStatusCode` | seen |
|---|---|---|---|
| `getNFLGamesForWeek` | `"Final"` | `"2"` | 32 games |
| `getNFLGamesForWeek` | `"Scheduled"` | `"0"` | 16 games |
| `getNFLScoresOnly` | `"Completed"` | `"2"` | 1 date |
| `getNFLBoxScore` | `"Completed"` | `"2"` | 1 game |

**They disagree, and the schedule endpoint is the odd one out.** A finished game is `"Final"` there and `"Completed"` on the other two — including `getNFLScoresOnly`, which is the endpoint the game watcher is supposed to poll and the cheap one #96 depends on (~440 calls a season against 6,000 for polling box scores).

So anything written against one endpoint's wording would have been wrong about the other two. **The prefix matching added as a hedge in #92 is what makes it work** — that hedge is now evidence rather than caution.

## What this deliberately does not do

**`gameStatusCode` is the stable half** — `"2"` means finished and `"0"` means not started on all three endpoints, which is a better discriminator than any string. This does not switch to it. Only those two values have been observed, because nothing is in progress, postponed or cancelled in August, and guessing the rest is precisely how four field names in this file came to be wrong. Recorded as the change to make after a live Sunday.

For the same reason `IN_PROGRESS`, `POSTPONED` and `CANCELLED` remain **documentation rather than measurement**, and both the doc and the docstring now say so instead of implying the vocabulary is settled.

## Change

- `docs/TANK01.md` gains a `gameStatus` section with the table, the reproduction command, and the honest statement of what is still unobserved.
- `mapGameStatus`'s docstring records the measurement and why the code field is not used yet.
- The two observed forms plus `"Scheduled"` move to the head of the mapping test, labelled as observed, so a future edit cannot drop either and stay green.

No behaviour changes. 106 tests in `packages/stats`, typecheck, lint, format clean.

## Still open on #93

- **Item 1 — the Pro upgrade — is done.** `SETUP-REQUIRED.md` should be flipped from "still to do" in whichever PR next touches it.
- **The three unobserved statuses** need a live Sunday.
- **A dedicated inactives endpoint may now exist.** `docs/LIVE-SCORING.md:134` says Tank01 "documents no dedicated inactives endpoint", and the RapidAPI console now lists **Get Inactive Players by Game Week**. Four candidate paths returned 404, so the real path is unknown and guessing it is the failure mode above. That matters more than it looks: LIVE-SCORING.md argues inactives are the *one* feed worth paying for, the current source is the hourly roster refresh, and the recorded mitigation is SportsDataIO at \$99–149/month. Worth one look at the console URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)