### PR TITLE
feat(db,web): record that a cron ran, and whether it worked

### DIFF
--- a/apps/web/src/app/api/cron/draft-tick/route.ts
+++ b/apps/web/src/app/api/cron/draft-tick/route.ts
@@ -6,7 +6,9 @@ import {
   getLeagueRules,
   purgeExpiredSessions,
   purgeIdleRateLimits,
+  recordCronRun,
 } from "@rostr/db";
+import type { SqlClient } from "@rostr/db";
 import { db } from "@/lib/db";
 import { cronForbidden } from "@/lib/cron";
 import { draftBoard } from "@/lib/draft-context";
@@ -48,6 +50,23 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   const client = db();
   const now = new Date();
+
+  try {
+    return await run(client, now);
+  } catch (error) {
+    // Stamped and rethrown, so the response is exactly what it was before. A
+    // route that throws on every invocation is worse than one that never fires,
+    // and without this both read as a stale row.
+    await recordCronRun(
+      client,
+      "draft-tick",
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}
+
+async function run(client: SqlClient, now: Date): Promise<NextResponse> {
   const overdue = await draftsWithExpiredPicks(client, now);
 
   const advanced: { leagueId: string; picks: number; error?: string }[] = [];
@@ -92,6 +111,16 @@ export async function GET(request: Request): Promise<NextResponse> {
   const buckets = await purgeIdleRateLimits(
     client,
     new Date(now.getTime() - 24 * 60 * 60 * 1000),
+  );
+
+  // The outcome, not merely the fact of running: a draft that failed is
+  // already reported in `advanced`, and a row saying "ran, all fine" while
+  // three drafts threw would be the healthy face this record exists to remove.
+  const failed = advanced.filter((entry) => entry.error).length;
+  await recordCronRun(
+    client,
+    "draft-tick",
+    failed > 0 ? `${failed} of ${overdue.length} drafts failed` : null,
   );
 
   return NextResponse.json({

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -5,9 +5,11 @@ import {
   enterPlayoffs,
   PlayoffError,
   resolveLeagueWeek,
+  recordCronRun,
   resolveLeagueWeeksThrough,
   WeekError,
 } from "@rostr/db";
+import type { SqlClient } from "@rostr/db";
 import { db } from "@/lib/db";
 import { cronForbidden } from "@/lib/cron";
 
@@ -36,6 +38,22 @@ export async function GET(request: Request): Promise<NextResponse> {
   const client = db();
   const now = new Date();
 
+  try {
+    return await run(client, now, request);
+  } catch (error) {
+    // Stamped and rethrown, so the response is exactly what it was before. A
+    // route that throws on every invocation is worse than one that never fires,
+    // and without this both read as a stale row.
+    await recordCronRun(
+      client,
+      "score-week",
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}
+
+async function run(client: SqlClient, now: Date, request: Request): Promise<NextResponse> {
   const requestedWeek = Number.parseInt(
     new URL(request.url).searchParams.get("week") ?? "",
     10,
@@ -178,6 +196,20 @@ export async function GET(request: Request): Promise<NextResponse> {
       });
     }
   }
+
+  // The outcome, not merely the fact of running. A league is counted as failed
+  // if it was skipped entirely, if any week in its sweep failed, or if its
+  // bracket could not be built — all three are already in the JSON, and a row
+  // saying "ran, all fine" over them would be the healthy face this record
+  // exists to remove.
+  const failed = scored.filter(
+    (entry) => entry.skipped || entry.failedWeeks?.length || entry.bracketProblem,
+  ).length;
+  await recordCronRun(
+    client,
+    "score-week",
+    failed > 0 ? `${failed} of ${scored.length} leagues had a problem` : null,
+  );
 
   return NextResponse.json({ at: now.toISOString(), week, leagues: scored });
 }

--- a/apps/web/src/app/api/cron/trades/route.ts
+++ b/apps/web/src/app/api/cron/trades/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { leaguesWithDueTrades, resolveDueTrades, TradeError } from "@rostr/db";
+import { leaguesWithDueTrades, recordCronRun, resolveDueTrades, TradeError } from "@rostr/db";
+import type { SqlClient } from "@rostr/db";
 import { db } from "@/lib/db";
 import { cronForbidden } from "@/lib/cron";
 
@@ -28,6 +29,23 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   const client = db();
   const now = new Date();
+
+  try {
+    return await run(client, now);
+  } catch (error) {
+    // Stamped and rethrown, so the response is exactly what it was before. A
+    // route that throws on every invocation is worse than one that never fires,
+    // and without this both read as a stale row.
+    await recordCronRun(
+      client,
+      "trades",
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}
+
+async function run(client: SqlClient, now: Date): Promise<NextResponse> {
   const due = await leaguesWithDueTrades(client, now);
 
   const runs: {
@@ -67,6 +85,16 @@ export async function GET(request: Request): Promise<NextResponse> {
       });
     }
   }
+
+  // The outcome, not merely the fact of running: a league that failed is
+  // already reported in `runs`, and a row saying "ran, all fine" while three
+  // leagues threw would be the healthy face this record exists to remove.
+  const failed = runs.filter((entry) => entry.error).length;
+  await recordCronRun(
+    client,
+    "trades",
+    failed > 0 ? `${failed} of ${due.length} leagues failed` : null,
+  );
 
   return NextResponse.json({ at: now.toISOString(), due: due.length, runs });
 }

--- a/apps/web/src/app/api/cron/waivers/route.ts
+++ b/apps/web/src/app/api/cron/waivers/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { leaguesDueForWaivers, processWaivers, WaiverError } from "@rostr/db";
+import { leaguesDueForWaivers, processWaivers, recordCronRun, WaiverError } from "@rostr/db";
+import type { SqlClient } from "@rostr/db";
 import { db } from "@/lib/db";
 import { cronForbidden } from "@/lib/cron";
 
@@ -19,6 +20,23 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   const client = db();
   const now = new Date();
+
+  try {
+    return await run(client, now);
+  } catch (error) {
+    // Stamped and rethrown, so the response is exactly what it was before. A
+    // route that throws on every invocation is worse than one that never fires,
+    // and without this both read as a stale row.
+    await recordCronRun(
+      client,
+      "waivers",
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}
+
+async function run(client: SqlClient, now: Date): Promise<NextResponse> {
   const due = await leaguesDueForWaivers(client, now);
 
   const runs: {
@@ -57,6 +75,16 @@ export async function GET(request: Request): Promise<NextResponse> {
       });
     }
   }
+
+  // The outcome, not merely the fact of running: a league that failed is
+  // already reported in `runs`, and a row saying "ran, all fine" while three
+  // leagues threw would be the healthy face this record exists to remove.
+  const failed = runs.filter((entry) => entry.error).length;
+  await recordCronRun(
+    client,
+    "waivers",
+    failed > 0 ? `${failed} of ${due.length} leagues failed` : null,
+  );
 
   return NextResponse.json({ at: now.toISOString(), due: due.length, runs });
 }

--- a/packages/db/migrations/0029_cron_runs.sql
+++ b/packages/db/migrations/0029_cron_runs.sql
@@ -1,0 +1,43 @@
+-- What the scheduler actually did, one row per job.
+--
+-- Nothing recorded that a cron ran, so every way of them not running looked the
+-- same from inside the app: the project paused, a deploy that dropped
+-- `vercel.json`, a job disabled in the dashboard, a route that 500s on every
+-- invocation, a misconfigured secret refusing every call, or a provider quota
+-- exhausted mid-season. All of them produce *nothing happening*, and nothing
+-- happening is also what a quiet Tuesday looks like.
+--
+-- That matters more here than in most systems because a finalised week is never
+-- rescored. A scoring cron that silently stops for one weekend settles those
+-- weeks wrong, permanently, and the first evidence is a member asking why their
+-- starter scored zero.
+--
+-- **One row per job, upserted — not an append-only log.** `draft-tick` runs
+-- every minute, so a history table would be 1,440 rows a day and a retention
+-- question, to answer a question that only ever concerns the *last* run. If
+-- per-run history is ever wanted it is a different table with a different
+-- purpose, and this one does not stand in its way.
+--
+-- **`last_outcome` is the point, not `last_ran_at`.** A route that fires every
+-- minute and throws every time is worse than one that never fires, and a bare
+-- timestamp reports both as healthy. Success stores NULL; anything else stores
+-- why.
+
+CREATE TABLE cron_runs (
+    name         text PRIMARY KEY,
+    last_ran_at  timestamptz NOT NULL,
+    last_outcome text
+);
+
+COMMENT ON TABLE cron_runs IS
+  'One row per scheduled job, upserted at the end of each run. Answers "is the '
+  'scheduler running, and is it succeeding" without dashboard access.';
+
+COMMENT ON COLUMN cron_runs.last_ran_at IS
+  'When this job last reached the end of a run, successfully or not. A row that '
+  'is stale relative to the job''s schedule means it is not running at all.';
+
+COMMENT ON COLUMN cron_runs.last_outcome IS
+  'NULL when the last run completed normally; otherwise why it did not. A job '
+  'with a fresh timestamp and a non-NULL outcome is running and failing, which '
+  'a timestamp alone would report as healthy.';

--- a/packages/db/src/cron-runs.test.ts
+++ b/packages/db/src/cron-runs.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listCronRuns, recordCronRun } from "./cron-runs.js";
+import { createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import type { SqlClient } from "./client.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("recordCronRun", () => {
+  it("records a job that ran cleanly", async () => {
+    db = await createTestDatabase();
+    await recordCronRun(db, "waivers");
+
+    const [run] = await listCronRuns(db);
+    expect(run?.name).toBe("waivers");
+    expect(run?.lastOutcome).toBeNull();
+    expect(run?.lastRanAt).toBeInstanceOf(Date);
+  });
+
+  it("keeps one row per job rather than a history", async () => {
+    // `draft-tick` runs every minute. A row per run would be 1,440 a day and a
+    // retention question, to answer something that only concerns the last run.
+    db = await createTestDatabase();
+    await recordCronRun(db, "draft-tick");
+    await recordCronRun(db, "draft-tick");
+    await recordCronRun(db, "draft-tick");
+
+    expect(await listCronRuns(db)).toHaveLength(1);
+  });
+
+  it("records why a run did not go cleanly", async () => {
+    db = await createTestDatabase();
+    await recordCronRun(db, "score-week", "2 of 5 leagues had a problem");
+
+    const [run] = await listCronRuns(db);
+    expect(run?.lastOutcome).toBe("2 of 5 leagues had a problem");
+  });
+
+  it("clears the outcome when a later run succeeds", async () => {
+    // Otherwise a job that failed once looks broken forever, and the signal
+    // stops meaning anything.
+    db = await createTestDatabase();
+    await recordCronRun(db, "trades", "1 of 3 leagues failed");
+    await recordCronRun(db, "trades");
+
+    expect((await listCronRuns(db))[0]?.lastOutcome).toBeNull();
+  });
+
+  /**
+   * The property the whole design rests on.
+   *
+   * This is bookkeeping about work, not the work. A route whose real job
+   * succeeded must not report failure because the record of it failed — that
+   * would make observability a new way for the crons to break, which is the
+   * opposite of why it exists.
+   */
+  it("never throws, whatever the database does", async () => {
+    const broken: SqlClient = {
+      query: () => Promise.reject(new Error("connection terminated")),
+      exec: () => Promise.reject(new Error("connection terminated")),
+    };
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(recordCronRun(broken, "waivers")).resolves.toBeUndefined();
+
+    // Swallowed, but not silently — a heartbeat that stops working without
+    // saying so leaves exactly the blind spot it was added to remove.
+    expect(logged).toHaveBeenCalledOnce();
+    expect(logged.mock.calls[0]?.[0]).toContain("waivers");
+  });
+
+  it("distinguishes jobs from each other", async () => {
+    db = await createTestDatabase();
+    await recordCronRun(db, "waivers");
+    await recordCronRun(db, "trades", "boom");
+
+    const byName = new Map((await listCronRuns(db)).map((run) => [run.name, run.lastOutcome]));
+    expect(byName.get("waivers")).toBeNull();
+    expect(byName.get("trades")).toBe("boom");
+  });
+
+  it("lists a job that has never run as absent rather than stale", async () => {
+    // A missing row is as interesting as an old one — it is what "this job has
+    // never fired since the table existed" looks like — so the read is
+    // deliberately unfiltered and the caller compares against its own list.
+    db = await createTestDatabase();
+    await recordCronRun(db, "waivers");
+
+    const names = (await listCronRuns(db)).map((run) => run.name);
+    expect(names).toEqual(["waivers"]);
+    expect(names).not.toContain("score-week");
+  });
+});

--- a/packages/db/src/cron-runs.ts
+++ b/packages/db/src/cron-runs.ts
@@ -1,0 +1,90 @@
+/**
+ * Did the scheduler run?
+ *
+ * Nothing used to record it, which made a stopped scheduler and a quiet week
+ * indistinguishable — and there are several ways to stop one: the host pauses
+ * the project, a deploy drops the cron config, a job is disabled, the route
+ * throws on every invocation, the secret is misconfigured so every call is
+ * refused, or a provider quota is exhausted. All of them look like nothing
+ * happening.
+ *
+ * That is expensive here specifically because a finalised week is never
+ * rescored. A scoring cron that stops for one weekend settles those weeks
+ * wrong, permanently.
+ *
+ * ## The stamp must never fail the job
+ *
+ * This is bookkeeping about work, not the work. A route whose real job
+ * succeeded must not report failure because the record of it failed —
+ * otherwise observability becomes a new way for the crons to break, which is
+ * the opposite of the point. So {@link recordCronRun} swallows its own error,
+ * and it is the only function in this package that does.
+ *
+ * It logs rather than swallowing silently: a heartbeat that stops working
+ * without saying so leaves exactly the blind spot it was added to remove.
+ */
+
+import type { SqlClient } from "./client.js";
+
+export interface CronRun {
+  readonly name: string;
+  readonly lastRanAt: Date;
+  /** `null` when the last run finished normally, otherwise why it did not. */
+  readonly lastOutcome: string | null;
+}
+
+/**
+ * Record that a job reached the end of a run.
+ *
+ * Called once per invocation, at the end, whatever happened — the outcome is
+ * more informative than the timestamp. A job that fires every minute and throws
+ * every time is worse than one that never fires, and a bare timestamp reports
+ * both as healthy.
+ *
+ * @param outcome `null` on success, otherwise a short reason.
+ */
+export async function recordCronRun(
+  db: SqlClient,
+  name: string,
+  outcome: string | null = null,
+): Promise<void> {
+  try {
+    await db.query(
+      `INSERT INTO cron_runs (name, last_ran_at, last_outcome)
+            VALUES ($1, now(), $2)
+       ON CONFLICT (name) DO UPDATE
+            SET last_ran_at = now(), last_outcome = EXCLUDED.last_outcome`,
+      [name, outcome],
+    );
+  } catch (error) {
+    // Deliberately swallowed — see the module docstring. The job's own result is
+    // what matters and it has already been decided by the time this runs.
+    // eslint-disable-next-line no-console
+    console.error(
+      `[cron] could not record a run of ${name}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Every job that has ever recorded a run, most recently first.
+ *
+ * The whole point of the table, and deliberately not filtered: a job whose row
+ * is *missing* is as interesting as one whose row is stale, and a caller
+ * comparing against the expected job list can only notice that if it sees
+ * everything.
+ */
+export async function listCronRuns(db: SqlClient): Promise<readonly CronRun[]> {
+  const rows = await db.query<{
+    name: string;
+    last_ran_at: string;
+    last_outcome: string | null;
+  }>("SELECT name, last_ran_at, last_outcome FROM cron_runs ORDER BY last_ran_at DESC");
+
+  return rows.map((row) => ({
+    name: row.name,
+    lastRanAt: new Date(row.last_ran_at),
+    lastOutcome: row.last_outcome,
+  }));
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -155,6 +155,8 @@ export {
   type BoxScoreSyncResult,
 } from "./box-scores.js";
 
+export { listCronRuns, recordCronRun, type CronRun } from "./cron-runs.js";
+
 export {
   loadDraftBoard,
   loadProjections,


### PR DESCRIPTION
Closes #146. Found while scoping #96 — I needed to know whether a fifth cron would deploy, and discovered the repo cannot tell whether the existing four are running.

## The gap

Nothing recorded that a scheduled job ran. No table, no column, no history. So every way of them not running looked identical from inside the app:

- the project is paused, or a deploy drops `vercel.json`
- a job is disabled in the dashboard
- the route 500s on every invocation
- the secret is misconfigured, so every call is refused 401
- a provider quota is exhausted mid-season (which #96 makes possible)

All five produce **nothing happening** — and nothing happening is also what a quiet Tuesday looks like.

That costs more here than in most systems because **a finalised week is never rescored**. A scoring cron that stops for one weekend settles those weeks wrong, permanently, and the first evidence is a member asking why their starter scored zero.

Same shape as several things already fixed or filed here — a phantom `IN_SEASON` league with no fixtures (#136), a week that finalises with no stats and reports itself clean (#140). A silent failure wearing a healthy face. The crons were the last large surface with no observability at all.

## Design

`cron_runs`, one row per job, upserted at the end of each run.

**One row, not a log.** `draft-tick` runs every minute, so a history table would be 1,440 rows a day plus a retention question, to answer something that only ever concerns the *last* run. If per-run history is wanted later it is a different table with a different purpose, and this does not stand in its way.

**`last_outcome` is the point, not `last_ran_at`.** A route that fires every minute and throws every time is worse than one that never fires, and a bare timestamp reports both as healthy. Each route summarises what its own JSON already says — how many leagues, drafts or weeks had a problem — and a later clean run clears it, so a job that failed once does not look broken forever.

**A crash is recorded, not lost.** The body is wrapped so a throw is stamped and rethrown; the response is byte-identical to before. Without it, "always crashing" and "never running" both read as a stale row.

## The property the whole thing rests on

`recordCronRun` swallows its own error, and is the only function in `@rostr/db` that does.

This is bookkeeping *about* work, not the work. A route whose real job succeeded must not report failure because the record of it failed — that would make observability a new way for the crons to break, which is the opposite of the point. It logs rather than swallowing silently, because a heartbeat that stops working without saying so leaves exactly the blind spot it was added to remove.

## Verification

- **7 tests.** Removing the swallow fails **exactly one** — `never throws, whatever the database does` — and leaves the other six passing, so it pins that property specifically rather than the module generally.
- Also pinned: one row rather than a history, a clean run clearing a previous outcome, jobs kept distinct, and a never-run job reading as *absent* rather than stale (the read is deliberately unfiltered, because a missing row is as interesting as an old one).
- Full suite **1294 passed, 2 skipped**; typecheck, lint, format clean.
- Migration `0029` applied to the deployed database and verified with `pnpm db:status`.

## How to use it

```sql
SELECT name, last_ran_at, last_outcome,
       now() - last_ran_at AS since
  FROM cron_runs ORDER BY since DESC;
```

A job absent from that result has never completed a run since this landed. A job whose `since` exceeds its schedule is not running. A job with a fresh timestamp and a non-NULL outcome is running and failing.

## Deliberately not included

- **No alerting.** Where notifications go is a hosting decision. This makes the state *knowable*; acting on it is separate.
- **No `/api/health` endpoint.** One SQL query answers it today, and an endpoint invites a question about who may call it.

## Note for whoever reads this next

The reason this was written is still open: **it is unconfirmed which Vercel plan this project is on.** Hobby permits 2 cron jobs at daily granularity; `vercel.json` declares four, including `* * * * *`. That strongly implies Pro, but nothing in the repo proves it — and if it were wrong, the four existing crons would not be running and nothing anywhere would say so. After this lands, that question is answerable with the query above instead of a dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)