### PR TITLE
fix(db): give every clause of the box-score work list a ceiling

### DIFF
--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -387,3 +387,157 @@ describe("syncBoxScores", () => {
     expect(result.games).toBe(0);
   });
 });
+
+/**
+ * The work list is the only thing pacing a metered provider.
+ *
+ * The loop inside `syncBoxScores` has no delay in it, so a clause that can stay
+ * true indefinitely is a provider call every ten minutes until the season ends.
+ * Each of the three below was unbounded, and none of them had a test — which is
+ * how they stayed unbounded.
+ */
+describe("the work list bounds what one run can spend", () => {
+  /** A second game, so a fixture can express more than one due row. */
+  async function addGame(fx: Fixture, ref: string, columns: string): Promise<void> {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                          kickoff_at, status, final_at)
+       VALUES ($1, $2, $3, $4, 'PHI', 'DAL', ${columns})`,
+      [sport!.id, ref, SEASON, WEEK],
+    );
+  }
+
+  it("stops treating a game as live once it is long over", async () => {
+    // An in-progress game is re-read every run, which is the point. What it must
+    // not do is run forever — and a status that never advances is not
+    // hypothetical, because `mapGameStatus` answers SCHEDULED for wording it
+    // does not recognise and only two of the five statuses have been observed.
+    const fx = await setup("IN_PROGRESS");
+    await fx.client.query(
+      "UPDATE games SET kickoff_at = now() - interval '30 hours', stats_synced_at = now()",
+    );
+
+    const result = await syncBoxScores(fx.client, fakeProvider(new Map()), NFL.key, SEASON);
+
+    expect(result.games).toBe(0);
+  });
+
+  it("still reads a game that is genuinely in progress", async () => {
+    // The control. Without it the test above passes just as well against a rule
+    // that never treats anything as live.
+    const fx = await setup("IN_PROGRESS");
+    await fx.client.query(
+      "UPDATE games SET kickoff_at = now() - interval '2 hours', stats_synced_at = now()",
+    );
+
+    const box = boxScore("g1", { qb1: [line("pass_yd", 120)], ...bothDefenses });
+    const result = await syncBoxScores(
+      fx.client,
+      fakeProvider(new Map([["g1", box]])),
+      NFL.key,
+      SEASON,
+    );
+
+    expect(result.games).toBe(1);
+  });
+
+  it("stops retrying a warning-bearing game once its window closes", async () => {
+    // `stats_error` is set by ordinary warnings, not only failures — a
+    // field-goal count that disagrees with the plays parsed from it, a defence
+    // missing from the box score. Those do not resolve on a re-read, so without
+    // a window bound one such game was fetched seventy-two times a day for the
+    // rest of the season, and sixteen of them would exceed the daily quota.
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays',
+                       stats_synced_at = now() - interval '1 hour',
+                       final_at = now() - interval '9 days'`,
+    );
+
+    const result = await syncBoxScores(fx.client, fakeProvider(new Map()), NFL.key, SEASON);
+
+    expect(result.games).toBe(0);
+  });
+
+  it("still retries a warning-bearing game inside its window", async () => {
+    // The control for the bound above.
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays',
+                       stats_synced_at = now() - interval '1 hour',
+                       final_at = now() - interval '2 hours'`,
+    );
+
+    const box = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses });
+    const result = await syncBoxScores(
+      fx.client,
+      fakeProvider(new Map([["g1", box]])),
+      NFL.key,
+      SEASON,
+    );
+
+    expect(result.games).toBe(1);
+  });
+
+  it("fetches at most MAX_GAMES_PER_RUN in one pass", async () => {
+    // A season backfill puts every game of a played season inside the correction
+    // window at once, because `final_at` is stamped when a game is first
+    // *observed* final rather than when it was played. `pnpm db:sync 2025` is a
+    // planned task, and without a ceiling its first run fetches hundreds of box
+    // scores in a tight loop against a metered provider.
+    // Twenty-five is a literal, not `MAX_GAMES_PER_RUN + 5`. Sizing the fixture
+    // from the constant under test makes the assertion move with it, so raising
+    // the ceiling — or deleting the LIMIT — would leave this green. The number
+    // is a spend bound; changing it should have to be deliberate and visible.
+    const DUE = 25;
+    const fx = await setup();
+    const boxes = new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 1)] })]]);
+    for (let i = 2; i <= DUE; i++) {
+      const ref = `g${i}`;
+      await addGame(fx, ref, "now() - interval '4 hours', 'FINAL', now() - interval '1 hour'");
+      boxes.set(ref, boxScore(ref, { qb1: [line("pass_yd", i)] }));
+    }
+
+    const result = await syncBoxScores(fx.client, fakeProvider(boxes), NFL.key, SEASON);
+
+    expect(result.games).toBe(20);
+    expect(result.games, "every due game was fetched — the LIMIT is not binding").toBeLessThan(
+      DUE,
+    );
+  });
+
+  it("reads a never-read game before re-reading one it already has", async () => {
+    // The ordering earns its keep only once there is a LIMIT: a game nobody has
+    // read scores its players zero *right now*, where a re-read only refines a
+    // number that already exists. Plain kickoff order would let a backlog of old
+    // games starve today's.
+    const fx = await setup();
+    await fx.client.query(
+      // The original game is old, already read, and due only for a recheck.
+      `UPDATE games SET kickoff_at = now() - interval '5 days',
+                       stats_synced_at = now() - interval '7 hours',
+                       final_at = now() - interval '5 days'`,
+    );
+    await addGame(fx, "g2", "now() - interval '3 hours', 'FINAL', now() - interval '1 hour'");
+
+    const boxes = new Map([
+      ["g1", boxScore("g1", { qb1: [line("pass_yd", 1)] })],
+      ["g2", boxScore("g2", { qb1: [line("pass_yd", 2)] })],
+    ]);
+
+    // Both are due; only one may be fetched.
+    const [first] = await fx.client.query<{ external_ref: string }>(
+      `SELECT external_ref FROM games
+        ORDER BY (stats_synced_at IS NULL) DESC, (status = 'IN_PROGRESS') DESC, kickoff_at
+        LIMIT 1`,
+    );
+    expect(first?.external_ref).toBe("g2");
+
+    const result = await syncBoxScores(fx.client, fakeProvider(boxes), NFL.key, SEASON);
+    expect(result.games).toBe(2);
+  });
+});

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -44,6 +44,42 @@ export const FINAL_RECHECK_HOURS = 6;
 /** How soon a game whose last read did not fully succeed is tried again. */
 export const FAILED_RETRY_MINUTES = 20;
 
+/**
+ * How long after kickoff a game may still be treated as live.
+ *
+ * An in-progress game is re-read on **every** run, which is the point — that is
+ * what live scoring is. What it must not do is run forever. A game whose status
+ * never advances past `IN_PROGRESS` would otherwise be fetched every ten minutes
+ * for the rest of the season, and that is not hypothetical: `mapGameStatus`
+ * answers `SCHEDULED` for wording it does not recognise, the three endpoints
+ * disagree about how they spell a finished game, and only two of the five
+ * statuses have ever been observed live.
+ *
+ * Eight hours is roughly two and a half times a real game, so it cannot end a
+ * game that is genuinely being played — including overtime and a weather delay
+ * — and it bounds the runaway at one afternoon instead of one season. Past it
+ * the game is still re-read by the correction sweep below, just on a six-hour
+ * cadence rather than a ten-minute one.
+ */
+export const LIVE_WINDOW_HOURS = 8;
+
+/**
+ * The most games one run will fetch.
+ *
+ * A bound on *spend*, not on work: the provider is metered, a run makes one call
+ * per game, and nothing else in this query limits how many games it can select
+ * at once. A season backfill — `pnpm db:sync 2025`, which is a planned task —
+ * puts every game of a played season inside the correction window at once,
+ * because `final_at` is stamped when a game is first *observed* final rather
+ * than when it was played. Without a ceiling the first run of that fetches
+ * hundreds of box scores in a tight loop and exhausts the daily quota.
+ *
+ * Twenty is comfortably above a full NFL week, so a normal Sunday never touches
+ * it, and the leftovers of an abnormal one are picked up on the next run ten
+ * minutes later rather than being dropped.
+ */
+export const MAX_GAMES_PER_RUN = 20;
+
 export interface BoxScoreSyncResult {
   readonly games: number;
   /** Stat lines seen for the first time — revision 0. */
@@ -118,15 +154,39 @@ export async function syncBoxScores(
         -- either, and RULES.md section 10 already scores those players 0 through
         -- the absence of a stat line.
         AND g.status IN ('IN_PROGRESS', 'FINAL')
+        -- **Every clause here needs a ceiling.** This query is the only thing
+        -- pacing a metered provider — the loop below has no delay in it — so a
+        -- clause that can stay true indefinitely is a call every ten minutes
+        -- until the season ends.
         AND (
               g.stats_synced_at IS NULL
-           OR g.status = 'IN_PROGRESS'
+           -- Live, and bounded by the clock rather than by the provider
+           -- agreeing to move the status on.
+           OR (g.status = 'IN_PROGRESS'
+               AND g.kickoff_at > now() - make_interval(hours => $7::int))
+           -- Retry, bounded by the same window as the sweep below. Without the
+           -- final_at bound this never expired: stats_error is set by
+           -- ordinary *warnings* as well as failures — a field-goal count that
+           -- disagrees with the plays parsed from it, a defence missing from the
+           -- box score — so one game with a permanent discrepancy was re-read
+           -- seventy-two times a day for the rest of the season, and sixteen of
+           -- them would have exceeded the daily quota outright.
            OR (g.stats_error IS NOT NULL
-               AND g.stats_synced_at < now() - make_interval(mins => $4::int))
+               AND g.stats_synced_at < now() - make_interval(mins => $4::int)
+               AND g.final_at > now() - make_interval(hours => $5::int))
+           -- The NFL stat-correction sweep.
            OR (g.final_at > now() - make_interval(hours => $5::int)
                AND g.stats_synced_at < now() - make_interval(hours => $6::int))
         )
-      ORDER BY g.kickoff_at`,
+      -- Never-read first, then live, then everything else oldest-first. The
+      -- order is doing real work now that there is a LIMIT: a game nobody has
+      -- read scores its players zero *right now*, where a re-read only refines a
+      -- number that already exists, and plain kickoff order would let a backlog
+      -- of old games starve today's.
+      ORDER BY (g.stats_synced_at IS NULL) DESC,
+               (g.status = 'IN_PROGRESS') DESC,
+               g.kickoff_at
+      LIMIT $8`,
     [
       ids.sportId,
       season,
@@ -134,6 +194,8 @@ export async function syncBoxScores(
       FAILED_RETRY_MINUTES,
       CORRECTION_WINDOW_HOURS,
       FINAL_RECHECK_HOURS,
+      LIVE_WINDOW_HOURS,
+      MAX_GAMES_PER_RUN,
     ],
   );
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -151,6 +151,8 @@ export {
   CORRECTION_WINDOW_HOURS,
   FAILED_RETRY_MINUTES,
   FINAL_RECHECK_HOURS,
+  LIVE_WINDOW_HOURS,
+  MAX_GAMES_PER_RUN,
   syncBoxScores,
   type BoxScoreSyncResult,
 } from "./box-scores.js";


### PR DESCRIPTION
`Refs #96.` **A prerequisite for wiring the ingest cron, not a follow-up.**

The loop inside `syncBoxScores` has no delay in it, so this query is the only thing pacing a metered provider. A clause that can stay true indefinitely is a provider call every ten minutes until the season ends — and three of them could.

None of the three had a test, which is how they stayed unbounded.

## 1. The retry clause never expired

It fired on any game carrying a `stats_error`, with no window bound — unlike every clause beside it.

And `stats_error` is set by ordinary **warnings**, not only failures: a field-goal count that disagrees with the plays parsed from it, a defence missing from the box score. Those do not resolve on a re-read. So one game with a permanent discrepancy was **72 calls a day for the rest of the season**, and sixteen of them — one bad week — exceeds the 1,000/day Pro cap outright.

This is not speculative: #81's remaining adapter items are exactly the class that produces persistent warnings.

## 2. The live clause had no bound at all

Re-reading an in-progress game on every run is the point — that *is* live scoring. What it must not do is run forever, and a status that never advances past `IN_PROGRESS` is not hypothetical:

- `mapGameStatus` answers `SCHEDULED` for any wording it does not recognise
- the three endpoints **disagree** about how they spell a finished game (`"Final"` vs `"Completed"`, measured in #144)
- only two of the five statuses have ever been observed live

Now bounded by the clock at **8 hours** — roughly two and a half times a real game, so it cannot end one that is genuinely being played including overtime and a weather delay, and it caps the runaway at an afternoon instead of a season. Past it the game is still re-read by the correction sweep, just at six hours rather than ten minutes.

## 3. Nothing limited how many games one run could select

A season backfill puts **every game of a played season inside the correction window at once**, because `final_at` is stamped when a game is first *observed* final rather than when it was played. So the first run of `pnpm db:sync 2025` — a planned task, item 5 in the repo's own next-steps — would fetch hundreds of box scores in a tight loop against a metered provider.

`LIMIT 20` is comfortably above a full NFL week, so a normal Sunday never touches it, and the leftovers of an abnormal one arrive on the next run ten minutes later rather than being dropped.

**The ordering earns its keep now that there is a LIMIT:** never-read first, then live, then oldest. A game nobody has read scores its players **zero right now**, where a re-read only refines a number that already exists — and plain kickoff order would let a backlog of old games starve today's.

## Verification

Six new tests, each bound with a control the other way — the bound *and* the case it must not break:

| control | fails |
|---|---|
| widen `LIVE_WINDOW_HOURS` | only "stops treating a game as live once it is long over" |
| widen the retry window | only "stops retrying a warning-bearing game once its window closes" |
| widen `MAX_GAMES_PER_RUN` | only "fetches at most MAX_GAMES_PER_RUN in one pass" |

**One of those tests was wrong first time and it is worth recording why.** It sized its fixture as `MAX_GAMES_PER_RUN + 5`, so raising the ceiling moved the expectation with it and the test passed against a 500-game limit. It now uses a literal 25 and asserts a literal 20, plus that fewer games were fetched than were due. A spend bound should have to change deliberately and visibly.

All 10 pre-existing box-score tests unchanged and passing. Full suite **1293 passed, 2 skipped**; typecheck, lint, format clean.

## Scope

Query only. No route, no new dependency, no config, no behaviour change to what is *written* — only to what is *fetched*. The cron itself is the next PR and is waiting on confirmation of the Vercel plan, since Hobby permits two cron jobs at daily granularity and `vercel.json` already declares four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)