### PR TITLE
feat(core)!: score exactly what ESPN scores

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -58,13 +58,20 @@ roster spots, usually owned by different managers.
 | ---------------------- | ------ |
 | Field goal 0–39 yards  | **3**  |
 | Field goal 40–49 yards | **4**  |
-| Field goal 50+ yards   | **5**  |
+| Field goal 50–59 yards | **5**  |
+| Field goal 60+ yards   | **6**  |
 | Extra point            | **1**  |
-| Missed field goal      | **0**  |
+| Missed field goal      | **−1** |
 | Missed extra point     | **0**  |
 
-Misses are not penalised. Penalising them is a common house rule but punishes the
-kicker for his coach's decision to attempt a long field goal.
+A missed field goal costs a point whatever its distance. This reversed an earlier
+decision — misses used to score nothing, on the argument that penalising them punishes
+the kicker for his coach's decision to attempt a 55-yarder. That argument still holds;
+matching ESPN exactly won anyway, and a distance-independent penalty is also the only
+form this data can support, because a miss is not a scoring play and no distance for it
+reaches us.
+
+Missed extra points are unpenalised, which is ESPN's default too.
 
 ### Defense / Special Teams
 
@@ -83,16 +90,38 @@ Scored as a single unit.
 
 | Points allowed | Points |
 | -------------- | ------ |
-| 0              | **10** |
-| 1–6            | **7**  |
-| 7–13           | **4**  |
-| 14–20          | **1**  |
-| 21–27          | **0**  |
+| 0              | **5**  |
+| 1–6            | **4**  |
+| 7–13           | **3**  |
+| 14–17          | **1**  |
+| 18–27          | **0**  |
 | 28–34          | **−1** |
-| 35+            | **−4** |
+| 35–45          | **−3** |
+| 46+            | **−5** |
 
-Points allowed counts every point the opposing team scores, including points scored by
-their defense and special teams.
+**Yards allowed**, on the same unit and the same week:
+
+| Yards allowed | Points |
+| ------------- | ------ |
+| Under 100     | **5**  |
+| 100–199       | **3**  |
+| 200–299       | **2**  |
+| 300–349       | **0**  |
+| 350–399       | **−1** |
+| 400–449       | **−3** |
+| 450–499       | **−5** |
+| 500–549       | **−6** |
+| 550+          | **−7** |
+
+Both ladders are ESPN's. This table previously paid 10 for a shutout and bottomed out
+at −4, and carried no yards ladder at all — so a unit that bent without breaking scored
+identically to one that did not.
+
+An earlier version of this section said points allowed "counts every point the opposing
+team scores, including points scored by their defense and special teams". That was our
+own rule and is not ESPN's; the sentence has been removed rather than reworded, because
+the exact definition is ESPN's and is recorded with the alignment work in
+`docs/TANK01.md`.
 
 ---
 

--- a/packages/core/src/rules/nfl-ppr.ts
+++ b/packages/core/src/rules/nfl-ppr.ts
@@ -49,10 +49,16 @@ export const NFL_PPR_SCORING: readonly ScoringRule[] = [
   // are different roster spots, usually owned by different managers.
   { statKey: "ret_td", kind: "LINEAR", milliPointsPerUnit: pts(6) },
 
-  // Kicking — by distance, misses unpenalised
+  // Kicking — by distance, and a miss costs a point.
+  //
+  // Misses used to be unpenalised, on the argument that they punish a kicker for
+  // his coach's decision to attempt a 55-yarder. ESPN charges -1 regardless of
+  // distance, and matching ESPN is the point of this table.
   { statKey: "fg_0_39", kind: "LINEAR", milliPointsPerUnit: pts(3) },
   { statKey: "fg_40_49", kind: "LINEAR", milliPointsPerUnit: pts(4) },
-  { statKey: "fg_50_plus", kind: "LINEAR", milliPointsPerUnit: pts(5) },
+  { statKey: "fg_50_59", kind: "LINEAR", milliPointsPerUnit: pts(5) },
+  { statKey: "fg_60_plus", kind: "LINEAR", milliPointsPerUnit: pts(6) },
+  { statKey: "fg_missed", kind: "LINEAR", milliPointsPerUnit: pts(-1) },
   { statKey: "xp_made", kind: "LINEAR", milliPointsPerUnit: pts(1) },
 
   // Defense / special teams
@@ -62,17 +68,43 @@ export const NFL_PPR_SCORING: readonly ScoringRule[] = [
   { statKey: "def_safety", kind: "LINEAR", milliPointsPerUnit: pts(2) },
   { statKey: "def_td", kind: "LINEAR", milliPointsPerUnit: pts(6) },
   { statKey: "def_blk_kick", kind: "LINEAR", milliPointsPerUnit: pts(2) },
+  // Both defensive tiers are ESPN's, decoded from their own published data
+  // rather than from documentation: their scoring API returns values keyed by
+  // numeric stat id with no names, so the boundaries were pinned by recomputing
+  // every player's weekly total and checking it against the total ESPN itself
+  // published. 11,507 player-weeks of the 2025 season reconcile exactly. See
+  // `docs/TANK01.md` for the method.
+  //
+  // The previous points-allowed table paid 10 for a shutout against ESPN's 5 —
+  // roughly twice as generous at the top, and short of ESPN's -5 floor at the
+  // bottom. It appears to have been transcribed from an out-of-date page.
   {
     statKey: "def_pts_allowed",
     kind: "TIERED",
     tiers: [
-      { min: 0, max: 0, milliPoints: pts(10) },
-      { min: 1, max: 6, milliPoints: pts(7) },
-      { min: 7, max: 13, milliPoints: pts(4) },
-      { min: 14, max: 20, milliPoints: pts(1) },
-      { min: 21, max: 27, milliPoints: pts(0) },
+      { min: 0, max: 0, milliPoints: pts(5) },
+      { min: 1, max: 6, milliPoints: pts(4) },
+      { min: 7, max: 13, milliPoints: pts(3) },
+      { min: 14, max: 17, milliPoints: pts(1) },
+      { min: 18, max: 27, milliPoints: pts(0) },
       { min: 28, max: 34, milliPoints: pts(-1) },
-      { min: 35, max: null, milliPoints: pts(-4) },
+      { min: 35, max: 45, milliPoints: pts(-3) },
+      { min: 46, max: null, milliPoints: pts(-5) },
+    ],
+  },
+  {
+    statKey: "def_yds_allowed",
+    kind: "TIERED",
+    tiers: [
+      { min: 0, max: 99, milliPoints: pts(5) },
+      { min: 100, max: 199, milliPoints: pts(3) },
+      { min: 200, max: 299, milliPoints: pts(2) },
+      { min: 300, max: 349, milliPoints: pts(0) },
+      { min: 350, max: 399, milliPoints: pts(-1) },
+      { min: 400, max: 449, milliPoints: pts(-3) },
+      { min: 450, max: 499, milliPoints: pts(-5) },
+      { min: 500, max: 549, milliPoints: pts(-6) },
+      { min: 550, max: null, milliPoints: pts(-7) },
     ],
   },
 ];
@@ -224,7 +256,7 @@ export function buildNflPprRules(overrides: NflPprOverrides): LeagueRules {
   const pot = overrides.pot ?? null;
 
   return structuredClone({
-    schemaVersion: 5,
+    schemaVersion: 6,
     sportKey: "nfl",
     seasonYear: overrides.seasonYear,
     scoring: NFL_PPR_SCORING,

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -45,9 +45,13 @@ describe("NFL sport registry", () => {
     expect(validateSport(NFL)).toEqual([]);
   });
 
-  it("marks only points allowed as tiered", () => {
+  it("marks both defensive ladders as tiered, and nothing else", () => {
+    // Two since the ESPN alignment. Pinned as a list rather than a count: the
+    // translator has to emit a tiered stat even at zero, because absent means
+    // "did not play" to the engine — so a new one appearing here and nowhere
+    // else is a silent forfeit of whatever bonus it carries.
     const tiered = NFL.statKeys.filter((s) => s.kind === "TIERED").map((s) => s.key);
-    expect(tiered).toEqual(["def_pts_allowed"]);
+    expect(tiered).toEqual(["def_pts_allowed", "def_yds_allowed"]);
   });
 
   it("lets FLEX take RB, WR, or TE", () => {
@@ -92,17 +96,60 @@ describe("NFL PPR defaults", () => {
     expect(100 + 200).toBe(300);
   });
 
-  it("covers every points-allowed bucket contiguously and unbounded at the top", () => {
+  it.each(["def_pts_allowed", "def_yds_allowed"])(
+    "covers every %s bucket contiguously and unbounded at the top",
+    (statKey) => {
+      const rule = NFL_PPR_SCORING.find((r) => r.statKey === statKey);
+      if (rule?.kind !== "TIERED") throw new Error("expected a tiered rule");
+
+      // A gap throws at score time rather than scoring zero — deliberate,
+      // because a hole in the ladder means the feed or the table is wrong, and
+      // burying it is how a defence silently scores nothing.
+      expect(rule.tiers[0]?.min).toBe(0);
+      expect(rule.tiers.at(-1)?.max).toBeNull();
+
+      for (const [i, tier] of rule.tiers.entries()) {
+        const prev = rule.tiers[i - 1];
+        if (prev) expect(tier.min).toBe((prev.max ?? -1) + 1);
+      }
+    },
+  );
+
+  it("matches ESPN's points-allowed ladder exactly", () => {
+    // Decoded from ESPN's own published player totals rather than from any
+    // documentation — see the note in `nfl-ppr.ts`. The top of this ladder used
+    // to pay 10 and now pays 5, which is the single largest scoring change in
+    // the alignment.
     const rule = NFL_PPR_SCORING.find((r) => r.statKey === "def_pts_allowed");
     if (rule?.kind !== "TIERED") throw new Error("expected a tiered rule");
 
-    expect(rule.tiers[0]).toEqual({ min: 0, max: 0, milliPoints: 10_000 });
-    expect(rule.tiers.at(-1)).toEqual({ min: 35, max: null, milliPoints: -4000 });
+    expect(rule.tiers.map((t) => [t.min, t.max, t.milliPoints / 1000])).toEqual([
+      [0, 0, 5],
+      [1, 6, 4],
+      [7, 13, 3],
+      [14, 17, 1],
+      [18, 27, 0],
+      [28, 34, -1],
+      [35, 45, -3],
+      [46, null, -5],
+    ]);
+  });
 
-    for (const [i, tier] of rule.tiers.entries()) {
-      const prev = rule.tiers[i - 1];
-      if (prev) expect(tier.min).toBe((prev.max ?? -1) + 1);
-    }
+  it("matches ESPN's yards-allowed ladder exactly", () => {
+    const rule = NFL_PPR_SCORING.find((r) => r.statKey === "def_yds_allowed");
+    if (rule?.kind !== "TIERED") throw new Error("expected a tiered rule");
+
+    expect(rule.tiers.map((t) => [t.min, t.max, t.milliPoints / 1000])).toEqual([
+      [0, 99, 5],
+      [100, 199, 3],
+      [200, 299, 2],
+      [300, 349, 0],
+      [350, 399, -1],
+      [400, 449, -3],
+      [450, 499, -5],
+      [500, 549, -6],
+      [550, null, -7],
+    ]);
   });
 
   it("pays the champion the largest share, summing to 100%", () => {
@@ -781,9 +828,27 @@ describe("hashLeagueRules", () => {
     //   be able to award meant `championship().complete` could never become
     //   true, so the pot never settled and frozen rules made it uncorrectable.
     //   The consolation bracket is still played; it just carries no share.
+    // Moved 2026-08-16: schemaVersion 5 -> 6, aligning the scoring table with
+    //   ESPN's PPR defaults. Both a *schema* change (two new stat keys and a new
+    //   tiered rule) and a *defaults* change, and the largest single move this
+    //   constant has made. What changed:
+    //     - `fg_50_plus` split into `fg_50_59` (5) and `fg_60_plus` (6)
+    //     - `fg_missed` added at -1. Misses used to be unpenalised, on the
+    //       argument that they punish a kicker for his coach's decision to try a
+    //       55-yarder. ESPN charges for them, and matching ESPN won.
+    //     - `def_yds_allowed` added, a second tiered ladder. We scored the
+    //       defensive unit on points alone, so a unit that bent without breaking
+    //       scored the same as one that did not.
+    //     - the points-allowed ladder replaced wholesale. It paid 10 for a
+    //       shutout against ESPN's 5, and stopped at -4 where ESPN reaches -5.
+    //       The old table appears to have been transcribed from a stale page.
+    //   Every value is ESPN's own, decoded from their published player totals
+    //   rather than from documentation, and checked by recomputing all 11,507
+    //   player-weeks of the 2025 season against the totals ESPN itself
+    //   published. See `docs/TANK01.md`.
     // No leagues existed on any of these occasions.
     expect(hashLeagueRules(FIXTURE)).toBe(
-      "8fa9b46a9dfd0d0939d0736b3e6db32a73e8a6b5aff547351a8ed2291f60bcf2",
+      "78f352c59a0716f3a333fcd5eb641e4f1c32dbe7c31033cb4450535f96275ec3",
     );
   });
 });

--- a/packages/core/src/rules/types.ts
+++ b/packages/core/src/rules/types.ts
@@ -349,7 +349,7 @@ export type LeagueRules = {
    * one does, a schema change means supporting both versions — the rules of a
    * created league can never be re-encoded.
    */
-  readonly schemaVersion: 5;
+  readonly schemaVersion: 6;
   readonly sportKey: string;
   readonly seasonYear: number;
   readonly scoring: readonly ScoringRule[];

--- a/packages/core/src/scoring/engine.test.ts
+++ b/packages/core/src/scoring/engine.test.ts
@@ -116,19 +116,23 @@ describe("scorePlayer — tiered rules", () => {
     scorePlayer([{ statKey: "def_pts_allowed", value }], RULES);
 
   it("scores every boundary of the points-allowed ladder", () => {
-    // Both edges of every bucket. Off-by-one here silently changes results.
-    expect(tier(0)).toBe(10_000);
-    expect(tier(1)).toBe(7000);
-    expect(tier(6)).toBe(7000);
-    expect(tier(7)).toBe(4000);
-    expect(tier(13)).toBe(4000);
+    // Both edges of every bucket. Off-by-one here silently changes results,
+    // and this ladder moved wholesale on 2026-08-16 to match ESPN — the values
+    // below are theirs, decoded from their own published totals.
+    expect(tier(0)).toBe(5000);
+    expect(tier(1)).toBe(4000);
+    expect(tier(6)).toBe(4000);
+    expect(tier(7)).toBe(3000);
+    expect(tier(13)).toBe(3000);
     expect(tier(14)).toBe(1000);
-    expect(tier(20)).toBe(1000);
-    expect(tier(21)).toBe(0);
+    expect(tier(17)).toBe(1000);
+    expect(tier(18)).toBe(0);
     expect(tier(27)).toBe(0);
     expect(tier(28)).toBe(-1000);
     expect(tier(34)).toBe(-1000);
-    expect(tier(35)).toBe(-4000);
+    expect(tier(35)).toBe(-3000);
+    expect(tier(45)).toBe(-3000);
+    expect(tier(46)).toBe(-5000);
   });
 
   it("has no gaps across the whole plausible range", () => {
@@ -138,7 +142,7 @@ describe("scorePlayer — tiered rules", () => {
   });
 
   it("keeps scoring above the last bounded tier", () => {
-    expect(tier(99)).toBe(-4000);
+    expect(tier(99)).toBe(-5000);
   });
 
   it("throws rather than silently scoring zero for an uncovered value", () => {

--- a/packages/core/src/scoring/fixtures.ts
+++ b/packages/core/src/scoring/fixtures.ts
@@ -88,15 +88,19 @@ export const SCORING_FIXTURES: readonly ScoringFixture[] = [
     stats: [
       { statKey: "fg_0_39", value: 2 },
       { statKey: "fg_40_49", value: 1 },
-      { statKey: "fg_50_plus", value: 1 },
+      { statKey: "fg_50_59", value: 1 },
+      { statKey: "fg_60_plus", value: 1 },
+      { statKey: "fg_missed", value: 2 },
       { statKey: "xp_made", value: 3 },
     ],
-    // 2 x 3000 = 6000
-    // 1 x 4000 = 4000
-    // 1 x 5000 = 5000
-    // 3 x 1000 = 3000
-    expected: 6000 + 4000 + 5000 + 3000,
-    workedOut: "6000 + 4000 + 5000 + 3000 = 18000 (18.00 pts)",
+    // 2 x 3000  = 6000
+    // 1 x 4000  = 4000
+    // 1 x 5000  = 5000
+    // 1 x 6000  = 6000   (the 60+ bucket, new with the ESPN alignment)
+    // 2 x -1000 = -2000  (misses, which used to be free)
+    // 3 x 1000  = 3000
+    expected: 6000 + 4000 + 5000 + 6000 - 2000 + 3000,
+    workedOut: "6000 + 4000 + 5000 + 6000 - 2000 + 3000 = 22000 (22.00 pts)",
   },
   {
     name: "defense, shutout",
@@ -106,33 +110,38 @@ export const SCORING_FIXTURES: readonly ScoringFixture[] = [
       { statKey: "def_int", value: 2 },
       { statKey: "def_fum_rec", value: 1 },
       { statKey: "def_td", value: 1 },
+      { statKey: "def_yds_allowed", value: 180 },
     ],
-    // tier 0        = 10000
-    // 4 x 1000      = 4000
-    // 2 x 2000      = 4000
-    // 1 x 2000      = 2000
-    // 1 x 6000      = 6000
-    expected: 10_000 + 4000 + 4000 + 2000 + 6000,
-    workedOut: "10000 + 4000 + 4000 + 2000 + 6000 = 26000 (26.00 pts)",
+    // pts tier 0      = 5000   (ESPN pays 5 for a shutout, not 10)
+    // yds tier 100-199 = 3000
+    // 4 x 1000        = 4000
+    // 2 x 2000        = 4000
+    // 1 x 2000        = 2000
+    // 1 x 6000        = 6000
+    expected: 5000 + 3000 + 4000 + 4000 + 2000 + 6000,
+    workedOut: "5000 + 3000 + 4000 + 4000 + 2000 + 6000 = 24000 (24.00 pts)",
   },
   {
     name: "defense, blown out",
     stats: [
       { statKey: "def_pts_allowed", value: 41 },
       { statKey: "def_sack", value: 1 },
+      { statKey: "def_yds_allowed", value: 470 },
     ],
-    // tier 35+   = -4000
-    // 1 x 1000   = 1000
-    expected: -4000 + 1000,
-    workedOut: "-4000 + 1000 = -3000 (-3.00 pts)",
+    // pts tier 35-45  = -3000
+    // yds tier 450-499 = -5000
+    // 1 x 1000        = 1000
+    expected: -3000 - 5000 + 1000,
+    workedOut: "-3000 - 5000 + 1000 = -7000 (-7.00 pts)",
   },
   {
     name: "defense, exactly on a tier boundary",
-    stats: [{ statKey: "def_pts_allowed", value: 21 }],
-    // The 21–27 tier scores nothing. A boundary that lands on the zero tier is
-    // the easiest one to get wrong by an off-by-one.
+    stats: [{ statKey: "def_pts_allowed", value: 18 }],
+    // The 18–27 tier scores nothing. A boundary that lands on the zero tier is
+    // the easiest one to get wrong by an off-by-one, and 18 is the first value
+    // in it — under the old table it was worth a point.
     expected: 0,
-    workedOut: "tier 21-27 = 0",
+    workedOut: "tier 18-27 = 0",
   },
   {
     name: "player who did not appear",

--- a/packages/core/src/sports/nfl.ts
+++ b/packages/core/src/sports/nfl.ts
@@ -43,10 +43,14 @@ export const NFL_STAT_KEYS = [
   // unit's touchdown: an interception or fumble return is not this.
   { key: "ret_td", displayName: "Return Touchdowns", kind: "LINEAR" },
 
-  // Kicking
+  // Kicking. `fg_50_plus` was split into 50-59 and 60+ on 2026-08-16 to match
+  // ESPN, which pays 6 for a 60-yarder — twelve of them were kicked in 2025, so
+  // it is a real bucket rather than a theoretical one.
   { key: "fg_0_39", displayName: "Field Goals 0-39 Yards", kind: "LINEAR" },
   { key: "fg_40_49", displayName: "Field Goals 40-49 Yards", kind: "LINEAR" },
-  { key: "fg_50_plus", displayName: "Field Goals 50+ Yards", kind: "LINEAR" },
+  { key: "fg_50_59", displayName: "Field Goals 50-59 Yards", kind: "LINEAR" },
+  { key: "fg_60_plus", displayName: "Field Goals 60+ Yards", kind: "LINEAR" },
+  { key: "fg_missed", displayName: "Field Goals Missed", kind: "LINEAR" },
   { key: "xp_made", displayName: "Extra Points Made", kind: "LINEAR" },
 
   // Defense / special teams
@@ -57,6 +61,10 @@ export const NFL_STAT_KEYS = [
   { key: "def_td", displayName: "Defensive/Special Teams Touchdowns", kind: "LINEAR" },
   { key: "def_blk_kick", displayName: "Blocked Kicks", kind: "LINEAR" },
   { key: "def_pts_allowed", displayName: "Points Allowed", kind: "TIERED" },
+  // Yards allowed, added 2026-08-16. ESPN scores the defensive unit on both
+  // points and yards; we had only points, which meant a unit that bent without
+  // breaking scored identically to one that did not.
+  { key: "def_yds_allowed", displayName: "Yards Allowed", kind: "TIERED" },
 ] as const satisfies SportDef["statKeys"];
 
 export const NFL_POSITIONS = [

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -73,8 +73,9 @@ describe("kicking", () => {
     // sub-40, which is exactly the bug distance parsing exists to prevent.
     const aubrey = statsFor(AUBREY);
     expect(aubrey.get("fg_40_49")).toBe(1);
-    expect(aubrey.get("fg_50_plus")).toBe(1);
+    expect(aubrey.get("fg_50_59")).toBe(1);
     expect(aubrey.get("fg_0_39")).toBeUndefined();
+    expect(aubrey.get("fg_60_plus")).toBeUndefined();
   });
 
   it("reads extra points from the direct field", () => {
@@ -82,7 +83,12 @@ describe("kicking", () => {
   });
 
   it("scores Aubrey correctly end to end", () => {
-    // 1 x 40-49 FG (4) + 1 x 50+ FG (5) + 2 XP (2) = 11.00 points
+    // 1 x 40-49 (4) + 1 x 50-59 (5) + 2 XP (2) = 11.00. He went 2 for 2, so the
+    // new miss penalty does not bite — kept as the control case. `fgMissed` is
+    // present in the fixture reading "0", so this also pins that a zero count
+    // is not emitted as a stat line.
+    expect(statsFor(AUBREY).get("fg_missed")).toBeUndefined();
+
     const lines = box.players.get(AUBREY) as StatLine[];
     expect(scorePlayer(lines, RULES)).toBe(11_000);
   });
@@ -111,13 +117,17 @@ describe("team defense", () => {
   });
 
   it("scores the Philadelphia defense end to end", () => {
-    // PHI allowed 20 points (the 14-20 tier = 1.00) and recovered 1 fumble (2.00).
+    // PHI allowed 20 points (18-27 = 0.00) and 307 yards (300-349 = 0.00), and
+    // recovered 1 fumble (2.00). The same game scored 3.00 under the old table,
+    // whose ladder paid 1 for 20 points allowed and had no yards rung at all.
     const lines = box.teamDefense.get("PHI") as StatLine[];
-    expect(scorePlayer(lines, RULES)).toBe(3000);
+    expect(scorePlayer(lines, RULES)).toBe(2000);
   });
 
   it("scores the Dallas defense end to end", () => {
-    // DAL allowed 24 (the 21-27 tier = 0.00) with 1 sack (1.00).
+    // DAL allowed 24 (18-27 = 0.00) and 302 yards (300-349 = 0.00), with 1 sack
+    // (1.00). Unchanged at 1.00 — both new ladders happen to pay zero here,
+    // which is why this one is worth keeping beside Philadelphia's.
     const lines = box.teamDefense.get("DAL") as StatLine[];
     expect(scorePlayer(lines, RULES)).toBe(1000);
   });

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -86,6 +86,18 @@ function accumulate(into: Map<string, number>, statKey: string, value: number): 
   into.set(statKey, (into.get(statKey) ?? 0) + value);
 }
 
+/**
+ * The team-defence rules scored from a tier table rather than per unit.
+ *
+ * These are the ones where **absent is not zero**. The scoring engine reads a
+ * missing stat as "did not play", so a unit that pitched a shutout and reported
+ * nothing would forfeit the bonus rather than earn it. `def_pts_allowed` was
+ * the only member until `def_yds_allowed` arrived with the ESPN alignment; the
+ * comments here used to say "the sport's only tiered rule" and that is why this
+ * is a set rather than a comparison.
+ */
+const TIERED_DST_KEYS: ReadonlySet<string> = new Set(["def_pts_allowed", "def_yds_allowed"]);
+
 function toStatLines(totals: ReadonlyMap<string, number>): StatLine[] {
   return [...totals].map(([statKey, value]) => ({ statKey, value }));
 }
@@ -182,6 +194,12 @@ function translatePlayer(
   // 3. Cross-check parsed field goals against the count Tank01 reports.
   //    Text parsing in a scoring path fails quietly; this is what makes it fail
   //    loudly instead.
+  //
+  //    Missed field goals are *not* derived here. `Kicking.fgMissed` is a real
+  //    field — verified in the captured fixture — so it is mapped directly in
+  //    `TANK01_STAT_MAP` like any other count. Computing `fgAttempts - fgMade`
+  //    instead would have been a second definition of the same number, free to
+  //    disagree with the first.
   const kicking = player["Kicking"] as Record<string, unknown> | undefined;
   const fgMade = parseStatValue(kicking?.["fgMade"]) ?? 0;
   if (fgMade !== fieldGoalsParsed) {
@@ -276,26 +294,28 @@ function translateTeamDefense(
       if (parsed === null) {
         // This translator used to be the only one with no `warnings` array, so a
         // missing or unparseable field vanished in silence. That matters most
-        // for `def_pts_allowed`: it is the sport's only TIERED rule, absent is
-        // not zero, and a unit that still emits a sack looks like it played and
-        // scored 2 rather than 12. The rest are worth reporting too — a field
-        // the provider renamed should not read as a quiet zero.
+        // for the tiered rules: absent is not zero, and a unit that still emits
+        // a sack looks like it played and scored 2 rather than 12. The rest are
+        // worth reporting too — a field the provider renamed should not read as
+        // a quiet zero.
         if (unit[field] !== undefined) {
           warnings.push(
             `${teamAbv}: ${field} is ${JSON.stringify(unit[field])}, which is not a number — ` +
               `${statKey} was dropped`,
           );
-        } else if (statKey === "def_pts_allowed") {
+        } else if (TIERED_DST_KEYS.has(statKey)) {
           warnings.push(
             `${teamAbv}: the box score carries no ${field}, so ${statKey} was dropped — ` +
-              `this is the only tiered rule in the sport and absent is not zero`,
+              `it is a tiered rule and absent is not zero`,
           );
         }
         continue;
       }
 
-      // Points allowed is meaningful at zero; the rest are not worth emitting.
-      if (parsed !== 0 || statKey === "def_pts_allowed") {
+      // The tiered rules are meaningful at zero; the rest are not worth
+      // emitting. A shutout that reported nothing would silently forfeit its
+      // bonus, and so would a defence that allowed no yards.
+      if (parsed !== 0 || TIERED_DST_KEYS.has(statKey)) {
         accumulate(totals, statKey, parsed);
       }
     }

--- a/packages/stats/src/tank01/stat-map.test.ts
+++ b/packages/stats/src/tank01/stat-map.test.ts
@@ -52,8 +52,8 @@ describe("parseFieldGoalYards", () => {
 describe("bucketFieldGoal", () => {
   it("buckets the real distances correctly", () => {
     expect(bucketFieldGoal(41)).toBe("fg_40_49");
-    expect(bucketFieldGoal(53)).toBe("fg_50_plus");
-    expect(bucketFieldGoal(58)).toBe("fg_50_plus");
+    expect(bucketFieldGoal(53)).toBe("fg_50_59");
+    expect(bucketFieldGoal(58)).toBe("fg_50_59");
   });
 
   it("is right at every boundary", () => {
@@ -61,7 +61,13 @@ describe("bucketFieldGoal", () => {
     expect(bucketFieldGoal(39)).toBe("fg_0_39");
     expect(bucketFieldGoal(40)).toBe("fg_40_49");
     expect(bucketFieldGoal(49)).toBe("fg_40_49");
-    expect(bucketFieldGoal(50)).toBe("fg_50_plus");
+    expect(bucketFieldGoal(50)).toBe("fg_50_59");
+    // 59/60 is the boundary the ESPN alignment added, and the only one worth a
+    // point on its own: a 59-yarder pays 5 and a 60-yarder pays 6. Twelve were
+    // kicked in 2025, so it is reachable rather than theoretical.
+    expect(bucketFieldGoal(59)).toBe("fg_50_59");
+    expect(bucketFieldGoal(60)).toBe("fg_60_plus");
+    expect(bucketFieldGoal(66)).toBe("fg_60_plus");
   });
 });
 
@@ -255,7 +261,9 @@ describe("mapping integrity", () => {
     "two_pt",
     "fg_0_39",
     "fg_40_49",
-    "fg_50_plus",
+    "fg_50_59",
+    "fg_60_plus",
+    "fg_missed",
     "xp_made",
     "def_sack",
     "def_int",
@@ -264,6 +272,7 @@ describe("mapping integrity", () => {
     "def_td",
     "def_blk_kick",
     "def_pts_allowed",
+    "def_yds_allowed",
   ]);
 
   it("maps only to registry stat keys", () => {
@@ -290,7 +299,7 @@ describe("mapping integrity", () => {
     const mapped = Object.values(TANK01_STAT_MAP);
     expect(mapped).not.toContain("fg_0_39");
     expect(mapped).not.toContain("fg_40_49");
-    expect(mapped).not.toContain("fg_50_plus");
+    expect(mapped).not.toContain("fg_50_59");
     expect(mapped).not.toContain("two_pt");
   });
 

--- a/packages/stats/src/tank01/stat-map.ts
+++ b/packages/stats/src/tank01/stat-map.ts
@@ -41,6 +41,15 @@ export const TANK01_STAT_MAP: Readonly<Record<string, string>> = {
   "Defense.fumblesRecovered": "def_fum_rec",
 
   "Kicking.xpMade": "xp_made",
+  // Missed field goals cost a point each under ESPN's table. `fgMissed` is a
+  // real field — confirmed in the captured fixture — so it is read rather than
+  // derived from `fgAttempts - fgMade`, which would be a second definition of
+  // the same number and free to disagree with the first.
+  //
+  // Distance is deliberately not consulted: a miss is not a scoring play, so it
+  // never appears in the text the made distances are parsed from. ESPN charging
+  // a flat -1 is what makes the category computable from this feed at all.
+  "Kicking.fgMissed": "fg_missed",
 };
 
 /**
@@ -56,6 +65,10 @@ export const TANK01_STAT_MAP: Readonly<Record<string, string>> = {
  */
 export const TANK01_DST_MAP: Readonly<Record<string, string>> = {
   ptsAllowed: "def_pts_allowed",
+  // Added 2026-08-16 with the ESPN alignment. ESPN scores the unit on yards as
+  // well as points, and this is the only place the figure appears. Like
+  // `ptsAllowed` it must be emitted even at zero, for the same reason.
+  ydsAllowed: "def_yds_allowed",
   sacks: "def_sack",
   defensiveInterceptions: "def_int",
   fumblesRecovered: "def_fum_rec",
@@ -240,9 +253,19 @@ export function isDefensiveReturnTouchdown(scoreText: string): boolean {
   return DEFENSIVE_RETURN.test(scoreText);
 }
 
-/** Bucket a made field goal into the three keys the scoring table uses. */
-export function bucketFieldGoal(yards: number): "fg_0_39" | "fg_40_49" | "fg_50_plus" {
-  if (yards >= 50) return "fg_50_plus";
+/**
+ * Bucket a made field goal into the four keys the scoring table uses.
+ *
+ * `fg_50_plus` became `fg_50_59` and `fg_60_plus` on 2026-08-16, because ESPN
+ * pays 6 for a 60-yarder and 5 for a 55-yarder. Twelve 60+ field goals were
+ * kicked in the 2025 season, so the bucket is real rather than theoretical, and
+ * a kicker who hits one is worth a point more than this used to say.
+ */
+export function bucketFieldGoal(
+  yards: number,
+): "fg_0_39" | "fg_40_49" | "fg_50_59" | "fg_60_plus" {
+  if (yards >= 60) return "fg_60_plus";
+  if (yards >= 50) return "fg_50_59";
   if (yards >= 40) return "fg_40_49";
   return "fg_0_39";
 }


### PR DESCRIPTION
feat(core)!: score exactly what ESPN scores

rostr's scoring was believed to be ESPN's defaults. Most of it was — every
offensive category matched to the point. The kicking and defensive tables did
not, and the defensive one was not close: it paid **10** for a shutout against
ESPN's **5**, and bottomed out at −4 where ESPN reaches −5. It looks transcribed
from a page that has since moved.

schemaVersion 5 -> 6. The golden rules hash moves with it. No league exists, and
this is the last comfortable moment to do it — after 22 August a schema bump
means supporting two versions rather than editing one.

## Where these numbers came from

Not from documentation. ESPN's public pages disagree with each other and with
ESPN — one of them dates from 2003 — so the table was decoded from ESPN's own
API instead.

`leaguedefaults/3` ("FFL PPR Scoring") returns 46 scoring entries keyed by
numeric stat id with no labels. Guessing which id is the 14–17 points-allowed
boundary is exactly the "probably 6 points is not good enough" failure
`CLAUDE.md` forbids, so the ids were pinned against ESPN's **own published player
totals**: recompute every player's week from the table, compare to the number
ESPN printed, and a wrong value cannot survive.

**11,507 of 11,507 player-weeks of the 2025 season reconcile exactly** — QB, RB,
WR, TE, K and D/ST. That is what makes this a decode rather than a reading.

## What changed

Kicking:

  - `fg_50_plus` splits into `fg_50_59` (5) and `fg_60_plus` (6). Twelve 60-yard
    field goals were kicked in 2025, so the bucket is reachable.
  - `fg_missed` added at −1. Misses used to score nothing, on the argument that
    penalising them punishes a kicker for his coach's decision to try a
    55-yarder. That argument still holds; matching ESPN won anyway. It is also
    the only form this feed can support — a miss is not a scoring play, so no
    distance for one ever reaches us, and ESPN charging a flat −1 is what makes
    the category computable at all.

Defense:

  - The points-allowed ladder replaced wholesale: 5/4/3/1/0/−1/−3/−5 against the
    old 10/7/4/1/0/−1/−4.
  - `def_yds_allowed` added — a second tiered ladder we did not have. Without it
    a unit that bent without breaking scored identically to one that did not.

`RULES.md` §1 loses a sentence rather than gaining one: it claimed points allowed
"counts every point the opposing team scores, including points scored by their
defense and special teams". That was our rule and is not ESPN's, and I nearly
shipped a "fix" enforcing it — ESPN's figure is a separate stat that excludes
some scores, and on the game I had quoted as proof of a bug, Tank01 matched ESPN
exactly. The sentence is removed rather than reworded because the true definition
belongs with the alignment work, not in a rule table.

## Verification

Beyond the suite: our own engine, under these rules, was run over ESPN's raw
stat lines for the whole 2025 season and compared against ESPN's published
totals. **11,505 of 11,507 match to the cent.**

The two residuals are both D/ST and both exactly +2, and they trace to a single
unmapped 2-point category (ESPN `statId 206`) that occurs twice in the season.
That is a stat we do not ingest, not a rule value we got wrong — every tier
boundary and every per-unit value reconciles. Recorded here rather than rounded
away; identifying it is follow-up work.

Also fixed while in the area: `TANK01_DST_MAP` gains `ydsAllowed`, and
`Kicking.fgMissed` is mapped directly rather than derived from
`fgAttempts - fgMade` — a second definition of the same number is free to
disagree with the first.

The "only tiered rule" language around `def_pts_allowed` is now a set, because
there are two and the next one must not silently miss the emit-at-zero rule that
stops a shutout forfeiting its own bonus.

1322 tests pass. Typecheck, lint and format clean.
