### PR TITLE
fix(stats): a return touchdown paid the returner but not the defence

### DIFF
--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -409,3 +409,42 @@ describe("return touchdowns are credited from the main clause", () => {
     expect(scorePlayer(shaheed, RULES)).toBeGreaterThanOrEqual(6000);
   });
 });
+
+describe("the D/ST unit is paid for a special teams return touchdown", () => {
+  /**
+   * Same play as the `ret_td` case above, from the other side.
+   *
+   * `RULES.md` pays the returner 6 for the return *and* the unit 6 for a
+   * "defensive or special teams touchdown" — deliberately, because they are
+   * different roster spots. We paid only the returner: `def_td` came solely
+   * from `DST.defTD`, which counts defensive scores, and Tank01 reports it as
+   * **0** for Seattle in this game despite the punt return.
+   */
+  const seaDst = new Map(
+    (returnGame.teamDefense.get("SEA") ?? []).map((line) => [line.statKey, line.value]),
+  );
+  const larDst = new Map(
+    (returnGame.teamDefense.get("LAR") ?? []).map((line) => [line.statKey, line.value]),
+  );
+
+  it("credits the returning unit, which the DST block reports as zero", () => {
+    expect(rawReturnGame.DST.home.defTD).toBe("0");
+    expect(seaDst.get("def_td")).toBe(1);
+  });
+
+  it("does not credit the opponent", () => {
+    expect(larDst.get("def_td")).toBeUndefined();
+  });
+
+  it("still pays the returner his own six", () => {
+    // Both halves of the same play. Losing either is six points.
+    expect(returnStats(SHAHEED).get("ret_td")).toBe(1);
+  });
+
+  it("leaves a game with no return touchdown alone", () => {
+    // The Cowboys-Eagles fixture has none, so neither unit may gain one.
+    for (const lines of box.teamDefense.values()) {
+      expect(lines.find((l) => l.statKey === "def_td")).toBeUndefined();
+    }
+  });
+});

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -321,8 +321,37 @@ function translateTeamDefense(
     }
 
     for (const play of scoringPlays) {
-      if (!isBlockedKick(play.score ?? "")) continue;
-      if (blockingTeamOf(play, teamAbvs) === teamAbv) accumulate(totals, "def_blk_kick", 1);
+      const text = play.score ?? "";
+
+      if (isBlockedKick(text) && blockingTeamOf(play, teamAbvs) === teamAbv) {
+        accumulate(totals, "def_blk_kick", 1);
+      }
+
+      // A kickoff or punt return pays the **unit** as well as the returner.
+      //
+      // `RULES.md` §1 pays the D/ST for a "defensive or special teams
+      // touchdown", and §1 also says the returner keeps his own `ret_td` for the
+      // same play — different roster spots, usually different managers, so this
+      // is not double-counting. We were paying only the returner, because
+      // `def_td` came solely from `DST.defTD`, which counts *defensive* scores.
+      // Ten times in weeks 1-6 of 2025 alone, at 6 points each.
+      //
+      // `play.team` is the team that scored, which for a return is the returning
+      // team — the opposite of the blocked-kick case above, where the block is
+      // usually noted on the opponent's score. That is why this cannot reuse
+      // `blockingTeamOf`.
+      //
+      // Gated on `scoreType` so a non-scoring play that merely mentions a return
+      // cannot pay six points, and `isSpecialTeamsReturnTouchdown` already
+      // refuses interception and fumble returns, which `DST.defTD` has counted
+      // already.
+      if (
+        play.scoreType === "TD" &&
+        isSpecialTeamsReturnTouchdown(text) &&
+        play.team === teamAbv
+      ) {
+        accumulate(totals, "def_td", 1);
+      }
     }
 
     result.set(teamAbv, toStatLines(totals));


### PR DESCRIPTION
fix(stats): a return touchdown paid the returner but not the defence

`RULES.md` §1 pays the D/ST unit for a "defensive or special teams touchdown",
and pays the returning player his own `ret_td` for the same play — deliberately,
because they are different roster spots usually owned by different managers.

We paid only the player. `def_td` came solely from `DST.defTD`, which counts
*defensive* scores, so a kickoff or punt return taken to the house credited the
unit with nothing:

    week 2, 20250914_NE@MIA — both units, one game
      [NE]  Antonio Gibson 90 Yd Kickoff Return   NE  DST.defTD = 0
      [MIA] Malik Washington 74 Yd Punt Return    MIA DST.defTD = 0

Ten occurrences in weeks 1-6 of the 2025 season, at 6 points each — roughly
1.7 a week, on a starting slot every league has, where a typical score is 5-15.

`play.team` is the team that scored, which for a return is the **returning**
team. That is the opposite of the blocked-kick case immediately above it, where
the block is usually annotated on the opponent's score, which is why this cannot
reuse `blockingTeamOf` however similar the two lines look.

Gated on `scoreType === "TD"` so a non-scoring play mentioning a return cannot
pay six points, and `isSpecialTeamsReturnTouchdown` already refuses interception
and fumble returns — those are in `DST.defTD` already, and counting them here as
well would pay one play twice under two different rules.

The fixture captured for #153 turns out to carry this too: Seattle returned a
punt 58 yards for a touchdown and Tank01 reports their `defTD` as "0". The test
asserts that raw "0" alongside our 1, so it cannot pass by the fixture quietly
changing.

Scope: this is *which unit is credited for a play we already recognise*. It does
not widen recognition — the three blocked-kick recoveries in #158 still match
neither pattern and still score for nobody.

Negative control: removing the credit fails exactly one test, the one naming it.

1326 tests pass. Typecheck, lint and format clean.

Closes #156
