### PR TITLE
fix(web): the league nav offered doors that 404

### DIFF
--- a/apps/web/src/app/(app)/leagues/[id]/lobby/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/lobby/page.tsx
@@ -100,6 +100,9 @@ export default async function LobbyPage({ params }: { params: Promise<{ id: stri
             : `Draft lobby · ${view.humans} of ${teams.length} seats taken by managers`
         }
         rulesHash={stored.hash}
+        // This page already `notFound()`s a non-member above, so anyone who
+        // renders it can reach every tab.
+        navOpen
         active=""
       />
 

--- a/apps/web/src/app/(app)/leagues/[id]/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   getWallets,
 } from "@rostr/db";
 import { LeagueChrome } from "@/components/LeagueChrome";
+import { leagueNavOpen } from "@/lib/visibility";
 import { RulesView } from "@/components/RulesView";
 import { JoinPanel } from "@/components/JoinPanel";
 import { AnchorPanel } from "@/components/AnchorPanel";
@@ -57,6 +58,11 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
   const myWallet = user ? await memberWallet(client, id, user.id) : null;
   const resumable = myWallet !== null && (await getOnChainJoin(client, id, myWallet)) === null;
 
+  // Whether the six tabs and the two buttons below lead anywhere for this
+  // viewer. Derived from the same gate those destinations enforce, so the nav
+  // and the 404 cannot disagree — see `leagueNavOpen`.
+  const navOpen = await leagueNavOpen(id);
+
   return (
     <div className="space-y-10">
       <LeagueChrome
@@ -67,6 +73,7 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
           .replace("_", " ")}`}
         rulesHash={stored.hash}
         active=""
+        navOpen={navOpen}
       />
 
       {/*
@@ -77,20 +84,27 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
         the permanent nav would leave a dead link for most of the season. They
         are surfaced from the body instead, when there is something behind them.
       */}
-      <div className="flex flex-wrap gap-3">
-        <a
-          href={`/leagues/${league.id}/draft`}
-          className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
-        >
-          Draft room
-        </a>
-        <a
-          href={`/leagues/${league.id}/bracket`}
-          className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
-        >
-          Playoff bracket
-        </a>
-      </div>
+      {/*
+        Gated on the same boolean as the tabs. These two 404 on exactly the same
+        check, so hiding the nav and leaving them would be half a fix — the
+        commissioner would still hit a dead end from the same screen.
+      */}
+      {navOpen ? (
+        <div className="flex flex-wrap gap-3">
+          <a
+            href={`/leagues/${league.id}/draft`}
+            className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
+          >
+            Draft room
+          </a>
+          <a
+            href={`/leagues/${league.id}/bracket`}
+            className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
+          >
+            Playoff bracket
+          </a>
+        </div>
+      ) : null}
 
       {/*
         The rules render above the join control, always, and in full. A join

--- a/apps/web/src/components/LeagueChrome.tsx
+++ b/apps/web/src/components/LeagueChrome.tsx
@@ -34,6 +34,7 @@ export function LeagueChrome({
   subtitle,
   rulesHash,
   active,
+  navOpen,
 }: {
   readonly leagueId: string;
   readonly name: string;
@@ -42,6 +43,23 @@ export function LeagueChrome({
   readonly rulesHash: string;
   /** The tab to mark current, as its `href` suffix. `""` is Home. */
   readonly active: (typeof TABS)[number]["href"];
+  /**
+   * Whether these tabs lead anywhere for this viewer — `leagueNavOpen`.
+   *
+   * Five of the six 404 for a non-member, because the league is private and
+   * `leagueReadAccess` refuses. That refusal is correct and must stay: a "this
+   * league is private" page would confirm the league exists to anyone holding
+   * the URL. What was wrong was offering the doors.
+   *
+   * The commissioner is the person most likely to meet this. Creating a league
+   * seats nobody — see #165 — so they land on their own league with six tabs
+   * and no team, and every one of them fails.
+   *
+   * **Required rather than optional-defaulting-to-true.** `CLAUDE.md`: "an
+   * optional filter defaulting to 'all' is not a filter." A default would let
+   * the next caller inherit the bug by saying nothing.
+   */
+  readonly navOpen: boolean;
 }) {
   return (
     <div className="mb-10 border-b border-nocturne-neutral-900 pb-0">
@@ -64,25 +82,38 @@ export function LeagueChrome({
         </span>
       </div>
 
-      <nav className="mt-7 flex flex-wrap gap-7">
-        {TABS.map((tab) => {
-          const current = tab.href === active;
-          return (
-            <a
-              key={tab.label}
-              href={`/leagues/${leagueId}${tab.href}`}
-              aria-current={current ? "page" : undefined}
-              className={`-mb-px border-b-2 pb-3 text-[14px] transition-colors ${
-                current
-                  ? "border-nocturne-accent text-nocturne-text"
-                  : "border-transparent text-nocturne-neutral-500 hover:text-nocturne-text"
-              }`}
-            >
-              {tab.label}
-            </a>
-          );
-        })}
-      </nav>
+      {/*
+        Hidden, not greyed out.
+
+        A disabled tab is a promise about a future that may never arrive — for a
+        stranger who will never join, "Standings, once you join" is simply
+        false. And this codebase already decided the general case: the draft and
+        bracket are not tabs because a dead link for most of a season would be
+        one, and `CLAUDE.md` says a greyed-out Week 16 fixture "would be an
+        invention". Five greyed labels would also compete for attention with the
+        one control that does work, which is the join panel below.
+      */}
+      {!navOpen ? null : (
+        <nav className="mt-7 flex flex-wrap gap-7">
+          {TABS.map((tab) => {
+            const current = tab.href === active;
+            return (
+              <a
+                key={tab.label}
+                href={`/leagues/${leagueId}${tab.href}`}
+                aria-current={current ? "page" : undefined}
+                className={`-mb-px border-b-2 pb-3 text-[14px] transition-colors ${
+                  current
+                    ? "border-nocturne-accent text-nocturne-text"
+                    : "border-transparent text-nocturne-neutral-500 hover:text-nocturne-text"
+                }`}
+              >
+                {tab.label}
+              </a>
+            );
+          })}
+        </nav>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/visibility.ts
+++ b/apps/web/src/lib/visibility.ts
@@ -57,3 +57,28 @@ export async function leagueReadAccess(leagueId: string): Promise<LeagueReadAcce
 
   return { ok: false, reason: "PRIVATE" };
 }
+
+/**
+ * Whether the league-scoped tabs will actually open for this viewer.
+ *
+ * **Derived from the gate, never a second copy of the rule.** The nav and the
+ * 404 have to agree, and this repo has twice been bitten by one rule
+ * implemented in two places — the trade deadline computed separately in
+ * `proposeTrade` and `resolveDueTrades`, and the lineup lock computed from a
+ * roster map in both the screen and the server. Re-deriving "is this person a
+ * member" from `visibility` and a wallet row would be the same mistake a third
+ * time, and its failure mode is a nav that offers doors the gate refuses.
+ *
+ * **Deliberately not named `leagueReadAccess`, and not a re-export.**
+ * `/leagues/[id]/page.tsx` is one of the two files that must never refuse
+ * anybody — `RULES.md` requires the full rule set to be readable before someone
+ * joins, and an invitee is by definition not yet a member. That file is listed
+ * in `OPEN` in `league-read.test.ts`, and `/leagueReadAccess\(/` is one of that
+ * sweep's `GATES` patterns. Calling the gate directly from the entrance would
+ * put a gate's name in a file that does not gate — which is exactly the shape
+ * that test exists to catch, and would silently certify the entrance the day
+ * anybody removed its `OPEN` entry.
+ */
+export async function leagueNavOpen(leagueId: string): Promise<boolean> {
+  return (await leagueReadAccess(leagueId)).ok;
+}


### PR DESCRIPTION
The league nav offered six tabs and two buttons. For a commissioner who created
a league but has not joined it, seven of the eight 404.

The 404 is correct and unchanged: the league is PRIVATE, `leagueReadAccess`
refuses a non-member, and a "this league is private" page would confirm the
league exists to anyone holding the URL. What was wrong was offering the doors.

The commissioner is the person most likely to meet this, on a league they made
thirty seconds earlier. `createLeague` seats nobody — see #165.

**It is eight, not six.** The "Draft room" and "Playoff bracket" buttons on the
league page 404 on the same gate. Hiding the tabs and leaving those would be
half a fix: the same screen, the same dead end.

## Derived from the gate, not recomputed

`leagueNavOpen` delegates to `leagueReadAccess` rather than re-deriving
membership from `visibility` and a wallet row. This repo has twice shipped one
rule implemented in two places — the trade deadline in `proposeTrade` versus
`resolveDueTrades`, and the lineup lock computed from a roster map in both the
screen and the server. A third would fail the same way: a nav that offers what
the gate refuses.

It is deliberately **not** named `leagueReadAccess` and not a re-export.
`/leagues/[id]/page.tsx` is one of the two files that must never refuse anybody,
and it is listed in `OPEN` in `league-read.test.ts` — where `/leagueReadAccess\(/`
is one of the `GATES` patterns. Calling the gate directly from the entrance would
put a gate's name in a file that does not gate, which is the exact shape that
sweep exists to catch, and would silently certify the entrance the day anyone
removed its `OPEN` entry.

## Hidden, not greyed out

A disabled tab is a promise about a future that may never arrive: for a stranger
who will never join, "Standings, once you join" is false. The codebase already
decided the general case — the draft and bracket are not tabs because a dead
link for most of a season would be one, and `CLAUDE.md` says a greyed-out Week 16
fixture "would be an invention".

`navOpen` is required rather than optional-defaulting-to-true, because "an
optional filter defaulting to 'all' is not a filter" and a default would let the
next caller inherit the bug by saying nothing.

## Scope

This does not close #165. The commissioner still has no team, and the fairness
argument in that issue is untouched — worth stating plainly, because #165 claims
seating the commissioner closes the draft-order grinding hole and it does not.
The measurement in `CLAUDE.md` belongs to whoever joins **last**, not to the
commissioner specifically, so migration `0028` remains essential.

What this does is stop the nav lying, and it covers the failure cases #165's own
fix will still have: the window between create and join, and the four leagues
already in the deployed database that can never be backfilled — `league_memberships`
requires a real signature, and inventing one would forge the consent proof the
system exists to provide.

1349 tests pass, including the gate sweep, which still reads the entrance as
open. Typecheck, lint and the production build are clean.

Refs #165
