### PR TITLE
The commissioner is not in their own league, and now the screen says so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,25 @@ is 2.
   cost an hour and looked like a code bug twice.
 - **`CI=true` is required** for anything running pnpm without a TTY, or it aborts
   trying to purge `node_modules`.
+- **An interrupted pnpm install poisons every later one, and the error names the
+  wrong thing.** pnpm relinks by renaming each package symlink to `.ignored_<name>`
+  first; if the run dies partway, those directories survive, and the next install
+  fails with `EPERM: operation not permitted, rename '…/eslint' → '…/.ignored_eslint'`
+  because on Windows `rename` will not overwrite an existing directory. It reads as
+  a file lock or a permissions problem and is neither — nothing is holding the file,
+  and no amount of retrying or closing editors helps. Delete the leftovers and
+  reinstall:
+
+  ```powershell
+  Get-ChildItem . -Recurse -Force -Directory -Filter '.ignored_*' |
+    ForEach-Object { cmd /c rmdir "$($_.FullName)" }
+  ```
+
+  It also **empties the workspace root's `node_modules`** on the way through, so
+  `pnpm typecheck` then fails with `'tsc' is not recognized` — which looks like a
+  missing toolchain and is the same interrupted install. Cost about twenty minutes
+  on 2026-08-17.
+
 - **Stale servers on 3000/3001/3002** made half of them answer and half not. Check
   which port is actually live before diagnosing anything.
 - **Deleting a league is impossible by design.** Every FK into `leagues` is ON
@@ -386,8 +405,17 @@ is 2.
 - **#165 — creating a league does not join it.** Has a **full implementation plan
   in a comment**, from three independent reviews: the five-step sequence, why
   steps 3 and 4 cannot be swapped, the batching trap that would put a seat
-  on-chain before consent, and a recommended sub-hour first slice. Start there.
-  #166 fixed the symptom (a nav offering eight doors that 404); the cause stands.
+  on-chain before consent, and a recommended sub-hour first slice. #166 fixed the
+  symptom (a nav offering eight doors that 404); the cause stands.
+
+  **The plan's first slice landed 2026-08-17** — see "The commissioner's four
+  steps" below. It makes the state legible and resumable; it does **not** make a
+  memberless league impossible. The next piece is the plan's own follow-up:
+  extract `JoinPanel`'s link-wallet block into a control that stands on its own,
+  and collect the commissioner's team name in the create form. Note the issue was
+  **closed by #166's PR body** and had to be reopened — `Closes #165` on a partial
+  fix, which is the third time this repo has swallowed an issue that way.
+
 - **#157** — provider stats that contradict themselves are ingested silently. Only
   field goals are cross-checked today. Two cheap checks would have caught both
   known cases without a season sweep or a second source.
@@ -2028,6 +2056,62 @@ does exactly that.
 The denormalised `league_scoring_rules` and `league_roster_slots` are **copies**, never
 references to a shared template — a template edit must never be able to reach a league
 that already exists. They carry the same immutability triggers.
+
+### The commissioner's four steps
+
+`apps/web/src/lib/setup.ts`, `components/CommissionerSetup.tsx`, on `/leagues/[id]`.
+The first slice of #165, landed 2026-08-17.
+
+**`createLeague` seats nobody, and that is not a flag somebody forgot.** Joining is a
+wallet signature over the rules hash; `joinLeague` needs a linked wallet and an anchored
+league, and a league is unanchored at the instant it is created. So the commissioner is a
+stranger to their own league until they walk the same steps every member walks — and
+because the league is usually PRIVATE, `leagueReadAccess` 404s them out of every tab in
+the meantime. #166 stopped the nav offering those doors. This says why they are shut.
+
+**The decision is in `lib/setup.ts`, not in the component.** `apps/web` cannot render a
+component in a test, so a rule written in `.tsx` is verified only by being run in
+production — the same reasoning that put `expectedTermsFromRules` in `@rostr/escrow` and
+the lobby's view model in `lib/lobby.ts`, and in both of those the defects review found
+were in the mapping rather than in the rule.
+
+**Anchor is step one here, and the issue's plan tabulates it second.** That table is right
+about the happy path — linking is the first wallet interaction — but linking is reachable
+only from `JoinPanel`, and `JoinPanel` renders a bare "not open yet" notice with no link
+control until the league is anchored. A checklist naming a step that has no button
+anywhere on the page is worse than no checklist. Anchoring is also the only step that
+blocks _other people_. Revisit the order when the link control is extracted.
+
+**Every input is a row, never a step counter.** All five come from state the page already
+loads, so the position survives a reload, a second tab, and the wallet popup in the middle
+of two of the four steps — which here is the ordinary case, not the exceptional one. A
+wizard inside `CreateLeagueForm` would hold its position in `useState` and strand a
+commissioner exactly when a popup stole focus, which is the failure `JoinPanel`'s
+`resumable` already exists to prevent.
+
+**`done` is each step's own condition, not "sits before the current one".** A commissioner
+can anchor without ever linking — `AnchorPanel` signs from the connected wallet and never
+consults `wallets` — and a list telling them they have not anchored, on the one step
+nobody can repeat, would be the screen contradicting the thing it reports on.
+
+**`AnchorPanel` now renders above `JoinPanel`.** It never renders once anchored, so this
+changes nothing for anybody else; while unanchored it stops the only control the
+commissioner can act on sitting _below_ the panel explaining that they need to act.
+
+**And `CreateLeagueForm` now compares the hash it previewed against the hash the server
+froze.** The whole promise of that screen is that they are the same, its own docstring
+said a divergence "should be visible", and nothing made it visible. They are built from
+separately supplied values — the mint and fee recipient come from server configuration and
+are only mirrored into `NEXT_PUBLIC_*` — so drift is a configuration mistake away. On a
+mismatch it stops, shows both hashes, disables the create button and hands over the link:
+the league already exists by then and cannot be amended, so this has to be loud **and**
+not lose it. `router.replace`, not `push`, so Back cannot return to a filled-in freeze
+step whose only button creates a second league.
+
+**What this does not do.** A commissioner can still abandon the league at any step, and
+after the frozen draft time migration `0028` refuses every `teams` INSERT — so a
+zero-team, undissolvable league is still reachable. The checklist says so, with the date.
+Making it impossible rather than merely legible is the next slice.
 
 ### Database
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,10 +388,17 @@ is 2.
     ForEach-Object { cmd /c rmdir "$($_.FullName)" }
   ```
 
-  It also **empties the workspace root's `node_modules`** on the way through, so
-  `pnpm typecheck` then fails with `'tsc' is not recognized` — which looks like a
-  missing toolchain and is the same interrupted install. Cost about twenty minutes
-  on 2026-08-17.
+  `cmd /c rmdir` rather than `Remove-Item -Recurse`: every `.ignored_*` is a
+  directory **symlink**, and `Remove-Item -Recurse` would follow it and delete the
+  store contents behind it. `rmdir` without `/s` refuses a real directory, which
+  is the right way round — but it also fails silently through `cmd /c`, so check
+  the count afterwards rather than assuming.
+
+  It also strips the **root workspace's own direct devDependency links** —
+  `typescript`, `vitest`, `eslint`, `prettier`, `typescript-eslint` — which is why
+  `pnpm typecheck` then fails with `'tsc' is not recognized`. The virtual store
+  under `.pnpm` is intact, so it looks like a missing toolchain and is the same
+  interrupted install. Cost about twenty minutes on 2026-08-17.
 
 - **Stale servers on 3000/3001/3002** made half of them answer and half not. Check
   which port is actually live before diagnosing anything.
@@ -412,9 +419,17 @@ is 2.
   steps" below. It makes the state legible and resumable; it does **not** make a
   memberless league impossible. The next piece is the plan's own follow-up:
   extract `JoinPanel`'s link-wallet block into a control that stands on its own,
-  and collect the commissioner's team name in the create form. Note the issue was
-  **closed by #166's PR body** and had to be reopened — `Closes #165` on a partial
-  fix, which is the third time this repo has swallowed an issue that way.
+  and collect the commissioner's team name in the create form.
+
+  **And note how it got closed, because the existing rule was followed and did not
+  save it.** #166 wrote `Refs #165`, exactly as the GitHub trap above instructs —
+  and, in its Scope section, the sentence _"This does not close #165."_ GitHub's
+  keyword parser has no notion of negation: it read `close #165`, linked the PR,
+  and closed the issue one second after the merge. So `Refs` plus a hand-close is
+  **necessary and not sufficient** — never put `close`/`fix`/`resolve` (in any
+  form) immediately before an issue number in a PR body **at all, even to deny
+  it**. Write "this does not resolve the cause in #165", or keep the number away
+  from the verb. Third issue swallowed, first by this mechanism.
 
 - **#157** — provider stats that contradict themselves are ingested silently. Only
   field goals are cross-checked today. Two cheap checks would have caught both
@@ -538,6 +553,13 @@ partial fix write `Refs #79` and close it by hand when the last part lands.
    unconditional refund, but it cannot be _distributed_. What closes the gap is
    `potDepositGate`, which shuts the stake button on mainnet until the committed IDL
    carries a settlement instruction. See "Deposit and refund" below.
+
+   **That is true of `DepositPanel` and false of `JoinPanel` — issue #168, found
+   2026-08-17.** The page passes `depositsOpen()` to the first and an ungated
+   `hasPot` to the second, and `JoinPanel` batches `deposit` into the join
+   transaction from that boolean alone. So the gate is not consulted on the path
+   every new member actually takes, and the sentence above describes the panel
+   almost nobody uses. Do not treat this as a structural barrier until #168 lands.
 
    The missing piece is the payout (#28, D6). PR #31 offered one and was closed on
    2026-08-14 — see the review above; the short version is that it declared a winner,
@@ -2072,8 +2094,8 @@ the meantime. #166 stopped the nav offering those doors. This says why they are 
 **The decision is in `lib/setup.ts`, not in the component.** `apps/web` cannot render a
 component in a test, so a rule written in `.tsx` is verified only by being run in
 production — the same reasoning that put `expectedTermsFromRules` in `@rostr/escrow` and
-the lobby's view model in `lib/lobby.ts`, and in both of those the defects review found
-were in the mapping rather than in the rule.
+the lobby's view model in `lib/lobby.ts`, and in the `@rostr/escrow` case both defects
+review found were in the mapping rather than in the rule.
 
 **Anchor is step one here, and the issue's plan tabulates it second.** That table is right
 about the happy path — linking is the first wallet interaction — but linking is reachable
@@ -2082,36 +2104,74 @@ control until the league is anchored. A checklist naming a step that has no butt
 anywhere on the page is worse than no checklist. Anchoring is also the only step that
 blocks _other people_. Revisit the order when the link control is extracted.
 
-**Every input is a row, never a step counter.** All five come from state the page already
+**Every input is a row, never a step counter.** All eight come from state the page already
 loads, so the position survives a reload, a second tab, and the wallet popup in the middle
-of two of the four steps — which here is the ordinary case, not the exceptional one. A
+of any of the four — every step signs something, two transactions and two messages, so
+leaving part-way through is the ordinary case here rather than the exceptional one. A
 wizard inside `CreateLeagueForm` would hold its position in `useState` and strand a
 commissioner exactly when a popup stole focus, which is the failure `JoinPanel`'s
 `resumable` already exists to prevent.
 
-**`done` is each step's own condition, not "sits before the current one".** A commissioner
-can anchor without ever linking — `AnchorPanel` signs from the connected wallet and never
-consults `wallets` — and a list telling them they have not anchored, on the one step
-nobody can repeat, would be the screen contradicting the thing it reports on.
+**`done` is each step's own condition, not "sits before the current one".** ANCHOR and
+LINK are independent in both directions: `AnchorPanel` signs from the connected wallet and
+never consults `wallets`, so anchoring can come first; and `wallets` is per-**user**, so a
+commissioner who linked one on any previous league arrives with LINK already satisfied —
+which is the ordinary case for a returning user. A list telling them they had not done
+what they just did would be the screen contradicting the thing it reports on.
+
+That per-user scope is also the one place the checklist is coarser than the control it
+points at. `JoinPanel` gates on whether the **connected** address is linked, so a
+commissioner who connects a second wallet sees LINK ticked and is still asked to verify.
+Narrowing it needs the connected address, which only the browser has.
+
+**A checklist has to know when it has run out of time**, and the first version did not.
+Three of the four steps need an open field, and **nothing in this app moves a league out
+of FORMING when its draft time passes** — so a step counter alone went on naming "take
+your seat" as the next action on a full league, a dissolved one, and one whose field
+`0028` had locked forever, directly above a `JoinPanel` saying "this league is not
+accepting members". Two panels, one screen, opposite answers. `blocker` reports the dead
+end instead, with the codes and their order mirroring `joinLeague`'s own refusals — state,
+then `requireOpenField`, then the seat count — so the screen cannot name a different reason
+than the server would. It is deliberately **never** set once `hasTeam` is true:
+`/join-onchain` grants the on-chain record against the existing membership row and consults
+none of those three, so a seated commissioner must still be sent to finish, and blocking
+there would strand exactly what `resumable` exists to prevent.
+
+`commissionerSetupStep` still answers the bare sequence and still says `SEAT` on a dead
+league — that is the correct answer to "which step is outstanding" and the wrong thing to
+put on a screen. Screens call `commissionerSetup`. A test asserts both answers side by
+side so nobody wires in the wrong one.
 
 **`AnchorPanel` now renders above `JoinPanel`.** It never renders once anchored, so this
 changes nothing for anybody else; while unanchored it stops the only control the
 commissioner can act on sitting _below_ the panel explaining that they need to act.
 
 **And `CreateLeagueForm` now compares the hash it previewed against the hash the server
-froze.** The whole promise of that screen is that they are the same, its own docstring
-said a divergence "should be visible", and nothing made it visible. They are built from
-separately supplied values — the mint and fee recipient come from server configuration and
-are only mirrored into `NEXT_PUBLIC_*` — so drift is a configuration mistake away. On a
-mismatch it stops, shows both hashes, disables the create button and hands over the link:
-the league already exists by then and cannot be amended, so this has to be loud **and**
-not lose it. `router.replace`, not `push`, so Back cannot return to a filled-in freeze
-step whose only button creates a second league.
+froze.** That file already noted a divergence _would_ be visible — as two hashes on two
+screens — which is only true of someone who thinks to compare them; nothing surfaced it at
+the moment it matters. Drift is a configuration mistake away: `FEE_RECIPIENT` is mirrored
+into `NEXT_PUBLIC_FEE_RECIPIENT`, two values set independently that must agree, and the
+mint is derived on both sides from `POT_MINTS` keyed by a cluster the browser reads from
+`NEXT_PUBLIC_SOLANA_CLUSTER` and **defaults to devnet when unset**, where the server's
+`declaredCluster()` would have thrown. A mainnet deployment with that browser variable
+unset previews a devnet mint against a mainnet freeze. Free leagues build `pot: null` on
+both sides and have no divergence surface, so it cannot fire on them.
+
+On a mismatch the form **stops being a form**: it shows both hashes and one link to the
+league, with no back button and no submit. The league exists by then and can never be
+amended, so this has to be loud **and** must not lose it — there is no "my leagues" list to
+find it in again, and an earlier draft that rendered the banner inside the freeze step left
+"back to the choices" live, landing the commissioner on a permanently disabled form with the
+explanation off screen. `router.replace`, not `push`, so the create page leaves the history
+stack and Back returns to wherever they came from rather than to a form that remounts empty
+and invites a second league.
 
 **What this does not do.** A commissioner can still abandon the league at any step, and
 after the frozen draft time migration `0028` refuses every `teams` INSERT — so a
-zero-team, undissolvable league is still reachable. The checklist says so, with the date.
-Making it impossible rather than merely legible is the next slice.
+zero-team, undissolvable league is still reachable. What changed is that the screen now
+says so before the deadline (with the date, and the timezone named, because it is rendered
+on the server's clock) and reports it plainly afterwards instead of asking for a seat that
+can no longer be taken. Making it impossible rather than merely legible is the next slice.
 
 ### Database
 

--- a/apps/web/src/app/(app)/leagues/[id]/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/page.tsx
@@ -12,9 +12,11 @@ import { RulesView } from "@/components/RulesView";
 import { JoinPanel } from "@/components/JoinPanel";
 import { AnchorPanel } from "@/components/AnchorPanel";
 import { DepositPanel } from "@/components/DepositPanel";
+import { CommissionerSetup } from "@/components/CommissionerSetup";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 import { depositsOpen } from "@/lib/pot";
+import { commissionerSetup } from "@/lib/setup";
 
 export default async function LeaguePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -58,6 +60,30 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
   const myWallet = user ? await memberWallet(client, id, user.id) : null;
   const resumable = myWallet !== null && (await getOnChainJoin(client, id, myWallet)) === null;
 
+  const anchored = chain?.anchoredAt !== null && chain?.anchoredAt !== undefined;
+  const isCommissioner = user !== null && commissioner?.commissioner_id === user.id;
+
+  /*
+    What the commissioner still owes their own league (#165).
+
+    Every input is already loaded above, and every one of them is a row rather
+    than a step counter — which is the point. The four steps each involve a
+    wallet popup, so leaving the page part-way through is the ordinary case, and
+    a position held in a component's state would be lost exactly when it was
+    needed. Resolved here, it survives a reload and a second tab.
+
+    `memberWallet` is the membership row and the team is written in the same
+    transaction, so it answers "has a seat"; `resumable` is already "has a seat
+    and no on-chain record", which is the fourth step still owed.
+  */
+  const setup = commissionerSetup({
+    isCommissioner,
+    hasLinkedWallet: wallets.length > 0,
+    anchored,
+    hasTeam: myWallet !== null,
+    onChainJoined: myWallet !== null && !resumable,
+  });
+
   // Whether the six tabs and the two buttons below lead anywhere for this
   // viewer. Derived from the same gate those destinations enforce, so the nav
   // and the 404 cannot disagree — see `leagueNavOpen`.
@@ -75,6 +101,22 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
         active=""
         navOpen={navOpen}
       />
+
+      {/*
+        First on the page, and only while something is owed.
+
+        A commissioner who has not finished is the person least able to guess
+        what to do next: their league is real, its rules are frozen, and every
+        tab 404s at them because they are not a member of it. Once the four
+        steps are done `setup.complete` is true and this disappears — a
+        permanently all-ticked list is noise on a screen people open weekly.
+      */}
+      {setup && !setup.complete ? (
+        <CommissionerSetup
+          setup={setup}
+          fieldLocksAt={new Date(stored.rules.draft.scheduledAt * 1000)}
+        />
+      ) : null}
 
       {/*
         The draft and the bracket are not tabs.
@@ -113,27 +155,19 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
       */}
       <RulesView rules={stored.rules} hash={stored.hash} />
 
-      <JoinPanel
-        leagueId={league.id}
-        leagueName={league.name}
-        rulesHash={stored.hash}
-        open={league.state === "FORMING" && taken < stored.rules.league.maxTeams}
-        signedIn={user !== null}
-        linkedWallets={wallets.map((wallet) => wallet.address)}
-        anchored={chain?.anchoredAt !== null && chain?.anchoredAt !== undefined}
-        isCommissioner={user !== null && commissioner?.commissioner_id === user.id}
-        hasPot={stored.rules.pot !== null}
-        tokenMint={stored.rules.pot?.tokenMint ?? null}
-        resumable={resumable}
-      />
-
       {/*
         Only the commissioner, and only while it is unanchored. Anchoring is
         signed by their own wallet, so this is the one place the flow needs a
-        human rather than a job — and until it happens nobody can join, which is
-        why it sits directly under the notice explaining that.
+        human rather than a job.
+
+        **Above `JoinPanel`, so the screen order is the flow order.** It used to
+        sit below, which put the one control the commissioner can act on
+        underneath a panel telling them nobody can join yet — including the
+        notice explaining that anchoring is theirs to do, with the button for it
+        further down the page. It never renders once anchored, so this reorder
+        changes nothing for anybody else.
       */}
-      {!chain?.anchoredAt && user !== null && commissioner?.commissioner_id === user.id && (
+      {!anchored && isCommissioner && (
         <AnchorPanel
           leagueId={league.id}
           rulesHash={stored.hash}
@@ -155,6 +189,20 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
           }
         />
       )}
+
+      <JoinPanel
+        leagueId={league.id}
+        leagueName={league.name}
+        rulesHash={stored.hash}
+        open={league.state === "FORMING" && taken < stored.rules.league.maxTeams}
+        signedIn={user !== null}
+        linkedWallets={wallets.map((wallet) => wallet.address)}
+        anchored={anchored}
+        isCommissioner={isCommissioner}
+        hasPot={stored.rules.pot !== null}
+        tokenMint={stored.rules.pot?.tokenMint ?? null}
+        resumable={resumable}
+      />
 
       {league.rules_uri && (
         <p className="text-xs text-nocturne-neutral-600">

--- a/apps/web/src/app/(app)/leagues/[id]/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/page.tsx
@@ -75,6 +75,13 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
     `memberWallet` is the membership row and the team is written in the same
     transaction, so it answers "has a seat"; `resumable` is already "has a seat
     and no on-chain record", which is the fourth step still owed.
+
+    The last three are what stop the list naming a step that can never be taken.
+    `leagueState` and `seatsFree` are the same two facts `open` below is built
+    from, and `fieldLocked` is the frozen draft time against the server's clock —
+    the instant migration `0028` starts refusing every `teams` INSERT. Nothing in
+    this app moves a league out of FORMING when that time passes, so without them
+    the checklist would go on asking for a seat forever.
   */
   const setup = commissionerSetup({
     isCommissioner,
@@ -82,6 +89,9 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
     anchored,
     hasTeam: myWallet !== null,
     onChainJoined: myWallet !== null && !resumable,
+    leagueState: league.state,
+    seatsFree: taken < stored.rules.league.maxTeams,
+    fieldLocked: Date.now() >= stored.rules.draft.scheduledAt * 1000,
   });
 
   // Whether the six tabs and the two buttons below lead anywhere for this
@@ -110,6 +120,10 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
         tab 404s at them because they are not a member of it. Once the four
         steps are done `setup.complete` is true and this disappears — a
         permanently all-ticked list is noise on a screen people open weekly.
+
+        It stays when the steps can no longer be taken, and says so instead. A
+        commissioner who never joined their own league is not less entitled to
+        be told once it is too late to fix.
       */}
       {setup && !setup.complete ? (
         <CommissionerSetup

--- a/apps/web/src/components/CommissionerSetup.tsx
+++ b/apps/web/src/components/CommissionerSetup.tsx
@@ -1,4 +1,4 @@
-import type { CommissionerSetupView, SetupStepKey } from "@/lib/setup";
+import type { CommissionerSetupView, SetupBlocker, SetupStepKey } from "@/lib/setup";
 
 /**
  * The commissioner's own checklist, on the league page.
@@ -9,17 +9,18 @@ import type { CommissionerSetupView, SetupStepKey } from "@/lib/setup";
  * league is not in it, every league-scoped tab 404s at them, and before this
  * nothing on any screen said why.
  *
- * **Presentation only.** Which step is owed is decided by `commissionerSetup` in
- * `lib/setup.ts`, where a test can reach it — `apps/web` cannot render a
- * component in a test, so a decision made in this file would be verified only by
- * being run in production. That is the same reasoning that put
- * `expectedTermsFromRules` in `@rostr/escrow` and the lobby's view model in
- * `lib/lobby.ts`, and in both cases the defects found in review were in the
- * mapping rather than in the rule.
+ * **Presentation only.** Which step is owed — and whether it can still be taken
+ * at all — is decided by `commissionerSetup` in `lib/setup.ts`, where a test can
+ * reach it. `apps/web` cannot render a component in a test, so a decision made in
+ * this file would be verified only by being run in production. That is the same
+ * reasoning that put `expectedTermsFromRules` in `@rostr/escrow` and the lobby's
+ * view model in `lib/lobby.ts`, and in the `@rostr/escrow` case both defects
+ * review found were in the mapping rather than in the rule.
  *
  * It points at controls rather than carrying any: `AnchorPanel` and `JoinPanel`
- * are directly below and each already knows how to do its own step. A second
- * button here would be a second implementation of the step it duplicates.
+ * are further down the same page, below the full rule set, and each already
+ * knows how to do its own step. A button here would be a second implementation
+ * of the step it duplicates.
  */
 
 const COPY: Record<SetupStepKey, { title: string; detail: string }> = {
@@ -30,7 +31,7 @@ const COPY: Record<SetupStepKey, { title: string; detail: string }> = {
       "rules are fixed, so nobody can join — not your members, and not you.",
   },
   LINK: {
-    title: "Prove your wallet is yours",
+    title: "Prove a wallet is yours",
     detail:
       "One signature over a message we issue. It moves no funds. Without it, linking a wallet " +
       "would be typing an address, and anyone could claim one.",
@@ -46,6 +47,33 @@ const COPY: Record<SetupStepKey, { title: string; detail: string }> = {
     detail:
       "One approval, which also stakes your buy-in if this league has a pot. Both or neither.",
   },
+};
+
+/**
+ * Formatted with the zone named, because the value is the **server's** clock.
+ *
+ * This is a server component and `toLocaleString()` runs in Node's locale — UTC
+ * on Vercel — while the commissioner picked the draft time in their own zone in
+ * a `datetime-local` field. Rendering an unlabelled wall-clock instant would be
+ * silently wrong for everyone outside that zone, and off by a day boundary for an
+ * evening draft. Naming the zone makes it correct rather than merely careful.
+ *
+ * `RulesView` renders this same instant the same unlabelled way, on this same
+ * page. That is worth fixing there too and is not this change's job; the two do
+ * not contradict each other, since one carries the zone and the other omits it.
+ */
+function withZone(at: Date): string {
+  return at.toLocaleString(undefined, {
+    dateStyle: "long",
+    timeStyle: "short",
+    timeZoneName: "short",
+  });
+}
+
+const BLOCKED: Record<SetupBlocker["code"], string> = {
+  LEAGUE_CLOSED: "it is no longer forming",
+  FIELD_LOCKED: "its draft time has passed and the field is locked",
+  LEAGUE_FULL: "every seat is taken",
 };
 
 export function CommissionerSetup({
@@ -64,6 +92,38 @@ export function CommissionerSetup({
    */
   fieldLocksAt: Date;
 }) {
+  /*
+    The dead end, reported rather than dressed up as a to-do.
+
+    Nothing in this app moves a league out of `FORMING` when its draft time
+    passes, so a checklist that only counted steps would keep naming "take your
+    seat" as the next action on a league nobody can join — beside a `JoinPanel`
+    saying the opposite. This is the state #165 warns about, arrived at.
+  */
+  if (setup.blocker) {
+    return (
+      <section className="space-y-4 rounded-lg border border-red-500/30 bg-red-500/[0.04] p-6">
+        <h2 className="text-[19px] font-medium tracking-[-0.018em]">
+          You are not a member of this league
+        </h2>
+        <p className="max-w-[640px] text-[14px] leading-[1.62] text-nocturne-neutral-400">
+          Creating a league does not join it — joining is a signature over the rules hash, and
+          there is no way to sign on your behalf. That signature can no longer be given here,
+          because {BLOCKED[setup.blocker.code]}
+          {setup.blocker.code === "LEAGUE_CLOSED"
+            ? ` (${setup.blocker.state.toLowerCase().replace("_", " ")})`
+            : ""}
+          .
+        </p>
+        <p className="max-w-[640px] text-[13px] leading-[1.6] text-nocturne-neutral-500">
+          The league&rsquo;s rules are frozen and its draft time cannot be moved, so this cannot
+          be undone from here. A league cannot be deleted either — there is no dissolve in the
+          product yet (#163). Start a new league rather than waiting on this one.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="space-y-5 rounded-lg border border-nocturne-accent/30 bg-nocturne-accent/[0.03] p-6">
       <div className="flex flex-wrap items-baseline justify-between gap-3">
@@ -73,11 +133,29 @@ export function CommissionerSetup({
         </span>
       </div>
 
+      {/*
+        Two intros, because one of them would be a lie half the time.
+
+        This said "It has no members yet — including you" unconditionally, which
+        is false on a league other people have already joined — and it rendered
+        four lines under a subtitle reading `12/12 teams`. Neither sentence
+        claims anything about anybody else's seats now.
+      */}
       <p className="max-w-[640px] text-[14px] leading-[1.62] text-nocturne-neutral-400">
-        The league exists and its rules are frozen. It has no members yet —{" "}
-        <strong className="font-medium text-nocturne-text">including you</strong>. Creating a
-        league does not join it, because joining is a signature over the rules hash, and there
-        is no way to sign on your behalf.
+        {setup.seated ? (
+          <>
+            Your seat is taken and your consent is recorded here. One step left, and it is the
+            one that puts your membership somewhere nobody &mdash; us included &mdash; can
+            quietly change it.
+          </>
+        ) : (
+          <>
+            The league exists and its rules are frozen.{" "}
+            <strong className="font-medium text-nocturne-text">You are not in it yet</strong>.
+            Creating a league does not join it, because joining is a signature over the rules
+            hash, and there is no way to sign on your behalf.
+          </>
+        )}
       </p>
 
       <ol className="space-y-3">
@@ -132,10 +210,18 @@ export function CommissionerSetup({
         })}
       </ol>
 
-      <p className="text-[12.5px] leading-[1.6] text-nocturne-neutral-600">
-        All of it has to be done before the draft, {fieldLocksAt.toLocaleString()}. The field
-        locks at that moment and nobody can join afterwards — including you, on your own league.
-      </p>
+      {/*
+        Only while a seat is still owed. A commissioner who has one is past the
+        deadline this warns about, and repeating it would read as a threat
+        against the one step the lock does not touch.
+      */}
+      {setup.seated ? null : (
+        <p className="text-[12.5px] leading-[1.6] text-nocturne-neutral-600">
+          The controls are below the rule set. All of it has to be done before the draft,{" "}
+          {withZone(fieldLocksAt)} — the field locks at that moment and nobody can join
+          afterwards, including you, on your own league.
+        </p>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/CommissionerSetup.tsx
+++ b/apps/web/src/components/CommissionerSetup.tsx
@@ -1,0 +1,141 @@
+import type { CommissionerSetupView, SetupStepKey } from "@/lib/setup";
+
+/**
+ * The commissioner's own checklist, on the league page.
+ *
+ * Creating a league seats nobody (#165): `createLeague` writes the rules and
+ * stops, because joining is a wallet signature over the rules hash and a league
+ * is unanchored at the instant it is created. So the person who just made this
+ * league is not in it, every league-scoped tab 404s at them, and before this
+ * nothing on any screen said why.
+ *
+ * **Presentation only.** Which step is owed is decided by `commissionerSetup` in
+ * `lib/setup.ts`, where a test can reach it — `apps/web` cannot render a
+ * component in a test, so a decision made in this file would be verified only by
+ * being run in production. That is the same reasoning that put
+ * `expectedTermsFromRules` in `@rostr/escrow` and the lobby's view model in
+ * `lib/lobby.ts`, and in both cases the defects found in review were in the
+ * mapping rather than in the rule.
+ *
+ * It points at controls rather than carrying any: `AnchorPanel` and `JoinPanel`
+ * are directly below and each already knows how to do its own step. A second
+ * button here would be a second implementation of the step it duplicates.
+ */
+
+const COPY: Record<SetupStepKey, { title: string; detail: string }> = {
+  ANCHOR: {
+    title: "Anchor the rules on-chain",
+    detail:
+      "Your wallet, one transaction. Until the hash is on-chain nobody can check that these " +
+      "rules are fixed, so nobody can join — not your members, and not you.",
+  },
+  LINK: {
+    title: "Prove your wallet is yours",
+    detail:
+      "One signature over a message we issue. It moves no funds. Without it, linking a wallet " +
+      "would be typing an address, and anyone could claim one.",
+  },
+  SEAT: {
+    title: "Sign the rules and take your seat",
+    detail:
+      "The same signature every other member gives, over the same hash. There is no flag that " +
+      "seats a commissioner without one — consent here is cryptographic or it is nothing.",
+  },
+  ONCHAIN: {
+    title: "Record your membership on-chain",
+    detail:
+      "One approval, which also stakes your buy-in if this league has a pot. Both or neither.",
+  },
+};
+
+export function CommissionerSetup({
+  setup,
+  fieldLocksAt,
+}: {
+  setup: CommissionerSetupView;
+  /**
+   * The scheduled draft, from the frozen rules — the instant the field locks.
+   *
+   * Said out loud because the failure it guards against is silent and permanent:
+   * migration `0028` refuses every `teams` INSERT from this moment, so a
+   * commissioner who stalls at any step above ends up locked out of their own
+   * league, with a draft that answers `NO_TEAMS` and no way to dissolve it
+   * (#163). Rules are immutable, so the date cannot be moved.
+   */
+  fieldLocksAt: Date;
+}) {
+  return (
+    <section className="space-y-5 rounded-lg border border-nocturne-accent/30 bg-nocturne-accent/[0.03] p-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="text-[19px] font-medium tracking-[-0.018em]">Finish setting up</h2>
+        <span className="text-[11px] uppercase tracking-[0.14em] text-nocturne-neutral-600">
+          {setup.remaining} of {setup.items.length} left
+        </span>
+      </div>
+
+      <p className="max-w-[640px] text-[14px] leading-[1.62] text-nocturne-neutral-400">
+        The league exists and its rules are frozen. It has no members yet —{" "}
+        <strong className="font-medium text-nocturne-text">including you</strong>. Creating a
+        league does not join it, because joining is a signature over the rules hash, and there
+        is no way to sign on your behalf.
+      </p>
+
+      <ol className="space-y-3">
+        {setup.items.map((item, index) => {
+          const copy = COPY[item.key];
+
+          return (
+            <li key={item.key} className="flex gap-3">
+              <span
+                aria-hidden
+                className={`mt-[3px] flex h-[19px] w-[19px] shrink-0 items-center justify-center rounded-full border text-[11px] ${
+                  item.done
+                    ? "border-nocturne-accent/50 text-nocturne-accent-300"
+                    : item.current
+                      ? "border-nocturne-accent text-nocturne-accent-200"
+                      : "border-nocturne-neutral-800 text-nocturne-neutral-600"
+                }`}
+              >
+                {item.done ? "✓" : index + 1}
+              </span>
+              <div>
+                <p
+                  className={`text-[14.5px] ${
+                    item.done
+                      ? "text-nocturne-neutral-600 line-through decoration-nocturne-neutral-700"
+                      : item.current
+                        ? "text-nocturne-text"
+                        : "text-nocturne-neutral-500"
+                  }`}
+                >
+                  {copy.title}
+                  {item.current ? (
+                    <span className="ml-2 text-[11px] uppercase tracking-[0.14em] text-nocturne-accent-300">
+                      next
+                    </span>
+                  ) : null}
+                </p>
+                {/*
+                  The reasoning is shown for the step being asked for and hidden
+                  for the rest. All four at once is a wall of text at the top of
+                  the screen; none at all makes four wallet interactions look
+                  like bureaucracy rather than the thing being bought.
+                */}
+                {item.current ? (
+                  <p className="mt-1 max-w-[560px] text-[13px] leading-[1.6] text-nocturne-neutral-500">
+                    {copy.detail}
+                  </p>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <p className="text-[12.5px] leading-[1.6] text-nocturne-neutral-600">
+        All of it has to be done before the draft, {fieldLocksAt.toLocaleString()}. The field
+        locks at that moment and nobody can join afterwards — including you, on your own league.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/CreateLeagueForm.tsx
+++ b/apps/web/src/components/CreateLeagueForm.tsx
@@ -322,17 +322,23 @@ export function CreateLeagueForm() {
         The one check this screen was missing.
 
         Everything above promises that the hash rendered in the freeze step is
-        the hash the server stores — the preview is built by the same
-        `buildNflPprRules` from the same inputs, and the comment at the top of
-        this file says the discrepancy "should be visible" if they ever
-        disagreed. Nothing made it visible. The two are built from separately
-        supplied values (the mint and the fee recipient come from server
-        configuration and are only *mirrored* into `NEXT_PUBLIC_*` here), so
-        drift is a configuration mistake away rather than hypothetical, and its
-        symptom is a commissioner who read and acknowledged one document while
-        their members sign another.
+        the hash the server stores. This file already noted that a divergence
+        *would* be visible — as two different hashes on two different screens —
+        and that is only true of someone who thinks to compare them. Nothing
+        surfaced it at the moment it matters.
 
-        Three lines, and the divergence stops the flow rather than being logged.
+        Drift is a configuration mistake away rather than hypothetical.
+        `FEE_RECIPIENT` is mirrored into `NEXT_PUBLIC_FEE_RECIPIENT`, two values
+        set independently that must agree; and the mint is derived on both sides
+        from `POT_MINTS`, keyed by a cluster the browser reads from
+        `NEXT_PUBLIC_SOLANA_CLUSTER` and **defaults to devnet when unset**, where
+        the server's `declaredCluster()` would have thrown. So an unset browser
+        variable on a mainnet deployment previews a devnet mint against a mainnet
+        freeze — and the symptom is a commissioner who read and acknowledged one
+        document while their members sign another.
+
+        Free leagues build `pot: null` on both sides and have no divergence
+        surface at all, so this cannot fire on them.
       */
       if (previewHash !== null && created.rulesHash !== previewHash) {
         setMismatch({
@@ -344,9 +350,11 @@ export function CreateLeagueForm() {
         return;
       }
 
-      // `replace`, not `push`. Back from the league would otherwise return to a
-      // filled-in freeze step whose only button creates a *second* league — and
-      // a league cannot be deleted, only dissolved.
+      // `replace`, not `push`, so the create page leaves the history stack.
+      // Back from a league should return to wherever the commissioner came from,
+      // not to the form that made it — a form that remounts empty (every piece
+      // of its state is `useState`, and this is a route change) and invites a
+      // second league, which cannot be deleted, only dissolved.
       router.replace(`/leagues/${created.id}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -366,6 +374,57 @@ export function CreateLeagueForm() {
   const potAvailable = POT_MINT !== null;
   const choicesSet =
     (name.trim() ? 1 : 0) + 6 + (withPot ? 2 : 0) + (potAvailable && !withPot ? 1 : 0);
+
+  /*
+    Once a league exists this screen has nothing left to offer, so it stops being
+    a form.
+
+    Rendering the banner *inside* the freeze step left "Back to the choices"
+    live: pressing it landed the commissioner on a configure step whose submit
+    button was permanently disabled, with the explanation no longer on screen and
+    nothing saying why. The only thing worth doing now is opening the league that
+    was created, so that is the only thing here.
+  */
+  if (mismatch) {
+    return (
+      <div className="mx-auto max-w-[860px]">
+        <h1 className="text-[38px] font-medium leading-[1.08] tracking-[-0.03em]">
+          The frozen rules are not the rules you read
+        </h1>
+        <p className="mt-4 max-w-[640px] text-[15.5px] leading-[1.6] text-nocturne-neutral-400">
+          The league was created — that cannot be undone, and its rules can never be amended —
+          but the hash the server stored differs from the one shown on the previous screen. So
+          this screen did not show you the document your members will sign. Read the stored rule
+          set before inviting anyone.
+        </p>
+        <p className="mt-4 max-w-[640px] text-[14px] leading-[1.6] text-nocturne-neutral-500">
+          This almost always means the browser and the server disagree about which chain this
+          deployment is on, or about the fee recipient. Both are build-time configuration and
+          neither can be fixed from here.
+        </p>
+
+        <dl className="mt-6 space-y-1 font-mono text-[11.5px] break-all text-nocturne-neutral-500">
+          <div>
+            <dt className="inline text-nocturne-neutral-600">shown to you </dt>
+            <dd className="inline">{mismatch.previewed}</dd>
+          </div>
+          <div>
+            <dt className="inline text-nocturne-neutral-600">frozen </dt>
+            <dd className="inline">{mismatch.frozen}</dd>
+          </div>
+        </dl>
+
+        {mismatch.id ? (
+          <a
+            href={`/leagues/${mismatch.id}`}
+            className="mt-8 inline-block rounded-[4px] border border-nocturne-accent px-[26px] py-3 text-[14.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
+          >
+            Open the league and read what was stored
+          </a>
+        ) : null}
+      </div>
+    );
+  }
 
   if (step === "freeze") {
     return (
@@ -434,38 +493,6 @@ export function CreateLeagueForm() {
           </span>
         </label>
 
-        {mismatch ? (
-          <div className="mt-6 space-y-3 rounded-lg border border-red-500/40 bg-red-500/5 p-5">
-            <p className="text-[15px] font-medium text-red-300">
-              The frozen rules are not the rules you just read.
-            </p>
-            <p className="max-w-[620px] text-[13.5px] leading-[1.6] text-nocturne-neutral-400">
-              The league was created — that cannot be undone, and its rules cannot be amended —
-              but the hash the server stored differs from the one shown above, so this screen
-              did not show you the document your members will sign. Do not invite anyone until
-              you have read the stored rule set on the league page.
-            </p>
-            <dl className="space-y-1 font-mono text-[11.5px] break-all text-nocturne-neutral-500">
-              <div>
-                <dt className="inline text-nocturne-neutral-600">shown here </dt>
-                <dd className="inline">{mismatch.previewed}</dd>
-              </div>
-              <div>
-                <dt className="inline text-nocturne-neutral-600">frozen </dt>
-                <dd className="inline">{mismatch.frozen}</dd>
-              </div>
-            </dl>
-            {mismatch.id ? (
-              <a
-                href={`/leagues/${mismatch.id}`}
-                className="inline-block rounded-[4px] border border-nocturne-neutral-800 px-4 py-2 text-[13.5px] text-nocturne-neutral-300 transition-colors hover:text-nocturne-text"
-              >
-                Open the league and read what was stored
-              </a>
-            ) : null}
-          </div>
-        ) : null}
-
         {problems.length > 0 ? (
           <ul className="mt-6 space-y-1 text-[13.5px] text-nocturne-accent-300">
             {problems.map((problem) => (
@@ -478,9 +505,7 @@ export function CreateLeagueForm() {
         <form onSubmit={(e) => void submit(e)} className="mt-8">
           <button
             type="submit"
-            // Shut once a league exists, mismatch or not: this button creates,
-            // and pressing it again would create a second one.
-            disabled={!acknowledged || submitting || !preview || mismatch !== null}
+            disabled={!acknowledged || submitting || !preview}
             className="rounded-[4px] border border-nocturne-accent px-[26px] py-3 text-[14.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10 disabled:cursor-not-allowed disabled:border-nocturne-neutral-800 disabled:text-nocturne-neutral-600"
           >
             {submitting ? "Freezing…" : "Freeze and create the league"}

--- a/apps/web/src/components/CreateLeagueForm.tsx
+++ b/apps/web/src/components/CreateLeagueForm.tsx
@@ -182,6 +182,21 @@ export function CreateLeagueForm() {
   const [problems, setProblems] = useState<readonly string[]>([]);
 
   /**
+   * The league was created and its hash is not the one previewed above.
+   *
+   * Held rather than thrown, because by the time this is knowable the league
+   * exists — the rules are frozen and cannot be corrected, only abandoned. So
+   * this has to be loud *and* still hand over the link: an error that navigated
+   * nowhere would leave a real league reachable only through browser history,
+   * and there is no "my leagues" list to find it in.
+   */
+  const [mismatch, setMismatch] = useState<{
+    id: string;
+    previewed: string;
+    frozen: string;
+  } | null>(null);
+
+  /**
    * Two steps, and the second is a ceremony rather than a page.
    *
    * The design splits creation into the choices and **the freeze** — read the
@@ -293,6 +308,7 @@ export function CreateLeagueForm() {
 
       const created = (await response.json()) as {
         id?: string;
+        rulesHash?: string;
         error?: string;
         problems?: string[];
       };
@@ -302,7 +318,36 @@ export function CreateLeagueForm() {
         throw new Error(created.error ?? "Could not create the league");
       }
 
-      router.push(`/leagues/${created.id}`);
+      /*
+        The one check this screen was missing.
+
+        Everything above promises that the hash rendered in the freeze step is
+        the hash the server stores — the preview is built by the same
+        `buildNflPprRules` from the same inputs, and the comment at the top of
+        this file says the discrepancy "should be visible" if they ever
+        disagreed. Nothing made it visible. The two are built from separately
+        supplied values (the mint and the fee recipient come from server
+        configuration and are only *mirrored* into `NEXT_PUBLIC_*` here), so
+        drift is a configuration mistake away rather than hypothetical, and its
+        symptom is a commissioner who read and acknowledged one document while
+        their members sign another.
+
+        Three lines, and the divergence stops the flow rather than being logged.
+      */
+      if (previewHash !== null && created.rulesHash !== previewHash) {
+        setMismatch({
+          id: created.id ?? "",
+          previewed: previewHash,
+          frozen: created.rulesHash ?? "none returned",
+        });
+        setSubmitting(false);
+        return;
+      }
+
+      // `replace`, not `push`. Back from the league would otherwise return to a
+      // filled-in freeze step whose only button creates a *second* league — and
+      // a league cannot be deleted, only dissolved.
+      router.replace(`/leagues/${created.id}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setSubmitting(false);
@@ -389,6 +434,38 @@ export function CreateLeagueForm() {
           </span>
         </label>
 
+        {mismatch ? (
+          <div className="mt-6 space-y-3 rounded-lg border border-red-500/40 bg-red-500/5 p-5">
+            <p className="text-[15px] font-medium text-red-300">
+              The frozen rules are not the rules you just read.
+            </p>
+            <p className="max-w-[620px] text-[13.5px] leading-[1.6] text-nocturne-neutral-400">
+              The league was created — that cannot be undone, and its rules cannot be amended —
+              but the hash the server stored differs from the one shown above, so this screen
+              did not show you the document your members will sign. Do not invite anyone until
+              you have read the stored rule set on the league page.
+            </p>
+            <dl className="space-y-1 font-mono text-[11.5px] break-all text-nocturne-neutral-500">
+              <div>
+                <dt className="inline text-nocturne-neutral-600">shown here </dt>
+                <dd className="inline">{mismatch.previewed}</dd>
+              </div>
+              <div>
+                <dt className="inline text-nocturne-neutral-600">frozen </dt>
+                <dd className="inline">{mismatch.frozen}</dd>
+              </div>
+            </dl>
+            {mismatch.id ? (
+              <a
+                href={`/leagues/${mismatch.id}`}
+                className="inline-block rounded-[4px] border border-nocturne-neutral-800 px-4 py-2 text-[13.5px] text-nocturne-neutral-300 transition-colors hover:text-nocturne-text"
+              >
+                Open the league and read what was stored
+              </a>
+            ) : null}
+          </div>
+        ) : null}
+
         {problems.length > 0 ? (
           <ul className="mt-6 space-y-1 text-[13.5px] text-nocturne-accent-300">
             {problems.map((problem) => (
@@ -401,7 +478,9 @@ export function CreateLeagueForm() {
         <form onSubmit={(e) => void submit(e)} className="mt-8">
           <button
             type="submit"
-            disabled={!acknowledged || submitting || !preview}
+            // Shut once a league exists, mismatch or not: this button creates,
+            // and pressing it again would create a second one.
+            disabled={!acknowledged || submitting || !preview || mismatch !== null}
             className="rounded-[4px] border border-nocturne-accent px-[26px] py-3 text-[14.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10 disabled:cursor-not-allowed disabled:border-nocturne-neutral-800 disabled:text-nocturne-neutral-600"
           >
             {submitting ? "Freezing…" : "Freeze and create the league"}

--- a/apps/web/src/lib/setup.test.ts
+++ b/apps/web/src/lib/setup.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  commissionerSetup,
+  commissionerSetupStep,
+  SETUP_ORDER,
+  type CommissionerSetupInput,
+} from "./setup";
+
+/** A commissioner who has just pressed "Freeze and create the league". */
+function fresh(overrides: Partial<CommissionerSetupInput> = {}): CommissionerSetupInput {
+  return {
+    isCommissioner: true,
+    hasLinkedWallet: false,
+    anchored: false,
+    hasTeam: false,
+    onChainJoined: false,
+    ...overrides,
+  };
+}
+
+/** The state at the end of the flow. */
+const seated: CommissionerSetupInput = {
+  isCommissioner: true,
+  hasLinkedWallet: true,
+  anchored: true,
+  hasTeam: true,
+  onChainJoined: true,
+};
+
+describe("commissionerSetupStep", () => {
+  it("is null for anyone who did not create the league", () => {
+    expect(commissionerSetupStep(fresh({ isCommissioner: false }))).toBeNull();
+    // Including a member who is fully seated: the checklist is the
+    // commissioner's own, and `JoinPanel` is what speaks to everybody else.
+    expect(commissionerSetupStep({ ...seated, isCommissioner: false })).toBeNull();
+  });
+
+  it("walks the four steps in order", () => {
+    expect(commissionerSetupStep(fresh())).toBe("ANCHOR");
+    expect(commissionerSetupStep(fresh({ anchored: true }))).toBe("LINK");
+    expect(commissionerSetupStep(fresh({ anchored: true, hasLinkedWallet: true }))).toBe(
+      "SEAT",
+    );
+    expect(
+      commissionerSetupStep(fresh({ anchored: true, hasLinkedWallet: true, hasTeam: true })),
+    ).toBe("ONCHAIN");
+    expect(commissionerSetupStep(seated)).toBe("DONE");
+  });
+
+  /**
+   * The one pair that can legitimately complete out of order.
+   *
+   * `AnchorPanel` signs a transaction from the connected wallet and never
+   * consults `wallets`, so a commissioner can anchor without ever linking. Every
+   * other ordering is enforced upstream — `joinLeague` refuses an unanchored
+   * league and an unlinked wallet, and `/join-onchain` derives its wallet from
+   * the membership row that step 3 writes.
+   */
+  it("asks for the link after an anchor signed by an unlinked wallet", () => {
+    expect(commissionerSetupStep(fresh({ anchored: true }))).toBe("LINK");
+  });
+
+  it("does not skip the anchor for a commissioner who linked a wallet first", () => {
+    expect(commissionerSetupStep(fresh({ hasLinkedWallet: true }))).toBe("ANCHOR");
+  });
+});
+
+describe("commissionerSetup", () => {
+  it("is null for anyone who did not create the league", () => {
+    expect(commissionerSetup(fresh({ isCommissioner: false }))).toBeNull();
+  });
+
+  it("marks exactly one step current until the last is done", () => {
+    for (const input of [
+      fresh(),
+      fresh({ anchored: true }),
+      fresh({ anchored: true, hasLinkedWallet: true }),
+      fresh({ anchored: true, hasLinkedWallet: true, hasTeam: true }),
+    ]) {
+      const view = commissionerSetup(input)!;
+      expect(view.items.filter((item) => item.current)).toHaveLength(1);
+      expect(view.complete).toBe(false);
+    }
+  });
+
+  it("marks nothing current once every step is done", () => {
+    const view = commissionerSetup(seated)!;
+    expect(view.items.every((item) => item.done)).toBe(true);
+    expect(view.items.some((item) => item.current)).toBe(false);
+    expect(view.complete).toBe(true);
+    expect(view.remaining).toBe(0);
+  });
+
+  /**
+   * `done` is each step's own condition, not "sits before the current one".
+   *
+   * A commissioner who anchored with an unlinked wallet must not be shown a list
+   * claiming they have not anchored — that is the screen contradicting the thing
+   * it is reporting on, and the anchor is the step nobody can repeat.
+   */
+  it("ticks a step completed out of order", () => {
+    const view = commissionerSetup(fresh({ anchored: true }))!;
+    const byKey = Object.fromEntries(view.items.map((item) => [item.key, item]));
+
+    expect(byKey["ANCHOR"]).toMatchObject({ done: true, current: false });
+    expect(byKey["LINK"]).toMatchObject({ done: false, current: true });
+    expect(view.remaining).toBe(3);
+  });
+
+  it("counts down as steps land", () => {
+    expect(commissionerSetup(fresh())!.remaining).toBe(4);
+    expect(commissionerSetup(fresh({ anchored: true }))!.remaining).toBe(3);
+    expect(
+      commissionerSetup(fresh({ anchored: true, hasLinkedWallet: true, hasTeam: true }))!
+        .remaining,
+    ).toBe(1);
+  });
+
+  it("reports every step, in the screen's order", () => {
+    expect(commissionerSetup(fresh())!.items.map((item) => item.key)).toEqual([...SETUP_ORDER]);
+  });
+});

--- a/apps/web/src/lib/setup.test.ts
+++ b/apps/web/src/lib/setup.test.ts
@@ -14,18 +14,20 @@ function fresh(overrides: Partial<CommissionerSetupInput> = {}): CommissionerSet
     anchored: false,
     hasTeam: false,
     onChainJoined: false,
+    leagueState: "FORMING",
+    seatsFree: true,
+    fieldLocked: false,
     ...overrides,
   };
 }
 
 /** The state at the end of the flow. */
-const seated: CommissionerSetupInput = {
-  isCommissioner: true,
+const seated: CommissionerSetupInput = fresh({
   hasLinkedWallet: true,
   anchored: true,
   hasTeam: true,
   onChainJoined: true,
-};
+});
 
 describe("commissionerSetupStep", () => {
   it("is null for anyone who did not create the league", () => {
@@ -48,13 +50,14 @@ describe("commissionerSetupStep", () => {
   });
 
   /**
-   * The one pair that can legitimately complete out of order.
+   * ANCHOR and LINK are independent in both directions.
    *
-   * `AnchorPanel` signs a transaction from the connected wallet and never
-   * consults `wallets`, so a commissioner can anchor without ever linking. Every
-   * other ordering is enforced upstream — `joinLeague` refuses an unanchored
-   * league and an unlinked wallet, and `/join-onchain` derives its wallet from
-   * the membership row that step 3 writes.
+   * `AnchorPanel` signs from the connected wallet and never consults `wallets`,
+   * so a commissioner can anchor without ever linking; and `wallets` is
+   * per-user, so one who linked on a previous league arrives with LINK already
+   * satisfied. Every other ordering is enforced upstream — `joinLeague` refuses
+   * an unanchored league and an unlinked wallet, and `/join-onchain` derives its
+   * wallet from the membership row that step 3 writes.
    */
   it("asks for the link after an anchor signed by an unlinked wallet", () => {
     expect(commissionerSetupStep(fresh({ anchored: true }))).toBe("LINK");
@@ -62,6 +65,25 @@ describe("commissionerSetupStep", () => {
 
   it("does not skip the anchor for a commissioner who linked a wallet first", () => {
     expect(commissionerSetupStep(fresh({ hasLinkedWallet: true }))).toBe("ANCHOR");
+  });
+
+  /**
+   * The trap this function is deliberately not protected against.
+   *
+   * It answers "which step is outstanding", which on a dead league is still
+   * `SEAT`. Putting that on a screen is what `commissionerSetup`'s `blocker`
+   * exists to stop, and the two answers are asserted side by side here so
+   * nobody wires the wrong one into a page.
+   */
+  it("still names a step on a league that can never be joined", () => {
+    const dissolved = fresh({
+      anchored: true,
+      hasLinkedWallet: true,
+      leagueState: "DISSOLVED",
+    });
+
+    expect(commissionerSetupStep(dissolved)).toBe("SEAT");
+    expect(commissionerSetup(dissolved)!.next).toBeNull();
   });
 });
 
@@ -79,7 +101,9 @@ describe("commissionerSetup", () => {
     ]) {
       const view = commissionerSetup(input)!;
       expect(view.items.filter((item) => item.current)).toHaveLength(1);
+      expect(view.next).not.toBeNull();
       expect(view.complete).toBe(false);
+      expect(view.blocker).toBeNull();
     }
   });
 
@@ -87,6 +111,7 @@ describe("commissionerSetup", () => {
     const view = commissionerSetup(seated)!;
     expect(view.items.every((item) => item.done)).toBe(true);
     expect(view.items.some((item) => item.current)).toBe(false);
+    expect(view.next).toBeNull();
     expect(view.complete).toBe(true);
     expect(view.remaining).toBe(0);
   });
@@ -118,5 +143,94 @@ describe("commissionerSetup", () => {
 
   it("reports every step, in the screen's order", () => {
     expect(commissionerSetup(fresh())!.items.map((item) => item.key)).toEqual([...SETUP_ORDER]);
+  });
+});
+
+/**
+ * The three states in which the remaining steps can never be taken.
+ *
+ * Each was a screen that said "Sign the rules and take your seat — next" beside
+ * a `JoinPanel` reading "This league is not accepting members". Nothing in this
+ * app moves a league out of `FORMING` when its draft time passes, so without
+ * these the checklist was monotone forever.
+ */
+describe("blockers", () => {
+  const readyToSeat = { anchored: true, hasLinkedWallet: true };
+
+  it("blocks on a league that has left FORMING", () => {
+    for (const state of ["DRAFTING", "IN_SEASON", "PLAYOFFS", "SETTLED", "DISSOLVED"]) {
+      const view = commissionerSetup(fresh({ ...readyToSeat, leagueState: state }))!;
+      expect(view.blocker).toEqual({ code: "LEAGUE_CLOSED", state });
+      expect(view.next).toBeNull();
+      expect(view.items.some((item) => item.current)).toBe(false);
+    }
+  });
+
+  it("blocks once the field has locked", () => {
+    const view = commissionerSetup(fresh({ ...readyToSeat, fieldLocked: true }))!;
+    expect(view.blocker).toEqual({ code: "FIELD_LOCKED" });
+    expect(view.next).toBeNull();
+  });
+
+  it("blocks on a full league", () => {
+    const view = commissionerSetup(fresh({ ...readyToSeat, seatsFree: false }))!;
+    expect(view.blocker).toEqual({ code: "LEAGUE_FULL" });
+    expect(view.next).toBeNull();
+  });
+
+  /**
+   * The order matches `joinLeague`'s own refusals: state, then
+   * `requireOpenField`, then the seat count checked inside its transaction. A
+   * screen naming a different reason than the server would is the two-sources
+   * problem this repo keeps paying for.
+   */
+  it("reports the reason the server would report first", () => {
+    const view = commissionerSetup(
+      fresh({ ...readyToSeat, leagueState: "DRAFTING", fieldLocked: true, seatsFree: false }),
+    )!;
+    expect(view.blocker).toEqual({ code: "LEAGUE_CLOSED", state: "DRAFTING" });
+  });
+
+  it("blocks an unanchored league too, rather than inviting a pointless anchor", () => {
+    // Nobody can join a locked field, so anchoring would buy nothing — not for
+    // the commissioner and not for anyone they invited.
+    const view = commissionerSetup(fresh({ leagueState: "DISSOLVED" }))!;
+    expect(view.blocker).toEqual({ code: "LEAGUE_CLOSED", state: "DISSOLVED" });
+    expect(view.next).toBeNull();
+    expect(view.remaining).toBe(4);
+  });
+
+  /**
+   * The exception, and the reason `seatBlocker` short-circuits on `hasTeam`.
+   *
+   * `/join-onchain` grants the on-chain record against the existing membership
+   * row and consults neither the state, the seat count nor the field lock. A
+   * commissioner who joined and then started the draft still owes that step and
+   * must still be sent to finish it — blocking here would strand a member
+   * holding a seat with no `Membership` account.
+   */
+  it("never blocks a seated commissioner who still owes the on-chain record", () => {
+    for (const overrides of [
+      { leagueState: "DRAFTING" },
+      { leagueState: "IN_SEASON" },
+      { fieldLocked: true },
+      { seatsFree: false },
+    ]) {
+      const view = commissionerSetup(fresh({ ...readyToSeat, hasTeam: true, ...overrides }))!;
+      expect(view.blocker).toBeNull();
+      expect(view.next).toBe("ONCHAIN");
+      expect(view.seated).toBe(true);
+    }
+  });
+
+  it("never blocks a commissioner who has finished", () => {
+    const view = commissionerSetup({ ...seated, leagueState: "IN_SEASON" })!;
+    expect(view.blocker).toBeNull();
+    expect(view.complete).toBe(true);
+  });
+
+  it("reports whether a seat is held, so the copy can stop saying nobody joined", () => {
+    expect(commissionerSetup(fresh())!.seated).toBe(false);
+    expect(commissionerSetup(fresh({ ...readyToSeat, hasTeam: true }))!.seated).toBe(true);
   });
 });

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -1,0 +1,134 @@
+/**
+ * What the commissioner still owes their own league.
+ *
+ * `createLeague` seats nobody (issue #165). Creating a league writes `leagues`,
+ * `league_rules` and `drafts` and stops there — no team, no membership — because
+ * joining is a wallet signature over the rules hash and a league is unanchored at
+ * the instant it is created, so `joinLeague` would refuse it. The commissioner is
+ * therefore a stranger to their own league until they walk the same four steps
+ * every other member walks, and until 2026-08-16 nothing on any screen said so.
+ *
+ * Pure, and deliberately so. `apps/web` cannot render a component in a test —
+ * both vitest projects are node-environment with no jsdom — so what the screen
+ * decides has to live where a test can reach it. `lib/lobby.ts` and `lib/pot.ts`
+ * are the pattern.
+ *
+ * **This is a checklist, not a wizard.** Every input is resolved server-side from
+ * rows that already exist, so the position survives a reload, a new tab, and the
+ * wallet popup in the middle of steps 1 and 4 — which is not an exceptional case
+ * here, it is the ordinary one. A wizard holding its position in `useState` would
+ * strand a commissioner at exactly the moment a popup stole focus, which is the
+ * failure `JoinPanel`'s `resumable` already exists to prevent.
+ */
+
+/** The four steps, in the order the screen offers them. See `SETUP_ORDER`. */
+export type SetupStepKey = "ANCHOR" | "LINK" | "SEAT" | "ONCHAIN";
+
+/** The next step, or `DONE` when the commissioner is fully seated. */
+export type SetupStep = SetupStepKey | "DONE";
+
+/**
+ * Anchor first, and this is **not** the order the issue's plan tabulates.
+ *
+ * That table lists linking the wallet as step 1 because it is the first wallet
+ * interaction in an uninterrupted run. But linking is reachable only from
+ * `JoinPanel`, and `JoinPanel` renders its "not open yet" notice — with no link
+ * control at all — until the league is anchored. So a checklist that pointed at
+ * LINK first would name a step that has no button anywhere on the page.
+ *
+ * Anchoring is also the only step that blocks *other people*: nobody can join an
+ * unanchored league, so a commissioner who stalls there has a league nobody else
+ * can enter either. Extracting the link control so it stands on its own is the
+ * next piece of #165, and when it lands this order is worth revisiting.
+ */
+export const SETUP_ORDER = ["ANCHOR", "LINK", "SEAT", "ONCHAIN"] as const;
+
+export interface CommissionerSetupInput {
+  /** Whether this viewer created the league. Nothing renders for anyone else. */
+  readonly isCommissioner: boolean;
+  /** At least one wallet proven by signature — `wallets`, not a typed address. */
+  readonly hasLinkedWallet: boolean;
+  /** The rules are on-chain. `joinLeague` refuses until they are. */
+  readonly anchored: boolean;
+  /** A `league_memberships` row, and so a team. Signed the rules hash. */
+  readonly hasTeam: boolean;
+  /** The `Membership` PDA exists and is recorded in `league_onchain_joins`. */
+  readonly onChainJoined: boolean;
+}
+
+export interface SetupItem {
+  readonly key: SetupStepKey;
+  /** Already satisfied — independently of position, so a checklist is honest. */
+  readonly done: boolean;
+  /** The one step to act on now. Exactly one item carries it, until `complete`. */
+  readonly current: boolean;
+}
+
+export interface CommissionerSetupView {
+  readonly step: SetupStep;
+  readonly items: readonly SetupItem[];
+  /** How many of the four are still owed. */
+  readonly remaining: number;
+  /** Nothing left. The caller renders nothing rather than an all-ticked list. */
+  readonly complete: boolean;
+}
+
+/**
+ * The next step the commissioner owes, or `null` if they are not the
+ * commissioner.
+ *
+ * Steps are checked in `SETUP_ORDER` and the first unsatisfied one wins. The
+ * states are nested by construction rather than by this function's say-so —
+ * `joinLeague` requires a linked wallet and an anchored league, and
+ * `/join-onchain` derives its wallet from the membership row — so the only pair
+ * that can legitimately complete out of order is anchoring before linking. That
+ * one can: anchoring signs a transaction from a connected wallet and never
+ * consults `wallets`.
+ */
+export function commissionerSetupStep(input: CommissionerSetupInput): SetupStep | null {
+  if (!input.isCommissioner) return null;
+  if (!input.anchored) return "ANCHOR";
+  if (!input.hasLinkedWallet) return "LINK";
+  if (!input.hasTeam) return "SEAT";
+  if (!input.onChainJoined) return "ONCHAIN";
+  return "DONE";
+}
+
+/** Whether one step's own condition is met, ignoring where it sits in the order. */
+function satisfied(input: CommissionerSetupInput, key: SetupStepKey): boolean {
+  switch (key) {
+    case "ANCHOR":
+      return input.anchored;
+    case "LINK":
+      return input.hasLinkedWallet;
+    case "SEAT":
+      return input.hasTeam;
+    case "ONCHAIN":
+      return input.onChainJoined;
+  }
+}
+
+/**
+ * The whole checklist, or `null` for anyone who is not the commissioner.
+ *
+ * `done` is each step's own condition and not "comes before the current one", so
+ * a commissioner who anchored before linking sees an anchored league ticked
+ * rather than a list claiming they have not done the thing they just did.
+ */
+export function commissionerSetup(input: CommissionerSetupInput): CommissionerSetupView | null {
+  const step = commissionerSetupStep(input);
+  if (step === null) return null;
+
+  const items = SETUP_ORDER.map((key): SetupItem => ({
+    key,
+    done: satisfied(input, key),
+    current: key === step,
+  }));
+
+  return {
+    step,
+    items,
+    remaining: items.filter((item) => !item.done).length,
+    complete: step === "DONE",
+  };
+}

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -1,12 +1,14 @@
 /**
  * What the commissioner still owes their own league.
  *
- * `createLeague` seats nobody (issue #165). Creating a league writes `leagues`,
- * `league_rules` and `drafts` and stops there — no team, no membership — because
- * joining is a wallet signature over the rules hash and a league is unanchored at
- * the instant it is created, so `joinLeague` would refuse it. The commissioner is
- * therefore a stranger to their own league until they walk the same four steps
- * every other member walks, and until 2026-08-16 nothing on any screen said so.
+ * `createLeague` seats nobody (issue #165). Creating a league writes the rules —
+ * `leagues`, `league_rules` and their two denormalised copies — and the route
+ * then schedules the draft in a second transaction. **No team, no membership**,
+ * because joining is a wallet signature over the rules hash and a league is
+ * unanchored at the instant it is created, so `joinLeague` would refuse it. The
+ * commissioner is therefore a stranger to their own league until they walk the
+ * same four steps every other member walks, and until 2026-08-17 nothing on any
+ * screen said so.
  *
  * Pure, and deliberately so. `apps/web` cannot render a component in a test —
  * both vitest projects are node-environment with no jsdom — so what the screen
@@ -15,17 +17,41 @@
  *
  * **This is a checklist, not a wizard.** Every input is resolved server-side from
  * rows that already exist, so the position survives a reload, a new tab, and the
- * wallet popup in the middle of steps 1 and 4 — which is not an exceptional case
- * here, it is the ordinary one. A wizard holding its position in `useState` would
- * strand a commissioner at exactly the moment a popup stole focus, which is the
- * failure `JoinPanel`'s `resumable` already exists to prevent.
+ * wallet popup in the middle of any of the four — every step signs something, two
+ * transactions and two messages, so leaving the page part-way through is the
+ * ordinary case here rather than the exceptional one. A wizard holding its
+ * position in `useState` would strand a commissioner at exactly the moment a
+ * popup stole focus, which is the failure `JoinPanel`'s `resumable` already
+ * exists to prevent.
+ *
+ * **And a checklist has to know when it has run out of time.** Three of the four
+ * steps are only reachable while the league still accepts members, and nothing
+ * in this app moves a league out of `FORMING` when its draft time passes — so
+ * without `blocker` below, this would go on naming "take your seat" as the next
+ * action on a full league, a dissolved one, and one whose field migration `0028`
+ * locked permanently. That is the state #165 exists to warn about, and a panel
+ * that reported it as an ordinary to-do would be the loudest possible way to get
+ * it wrong.
  */
 
 /** The four steps, in the order the screen offers them. See `SETUP_ORDER`. */
 export type SetupStepKey = "ANCHOR" | "LINK" | "SEAT" | "ONCHAIN";
 
-/** The next step, or `DONE` when the commissioner is fully seated. */
+/** The next step in the bare sequence, or `DONE`. See `commissionerSetupStep`. */
 export type SetupStep = SetupStepKey | "DONE";
+
+/**
+ * Why the outstanding steps can never be completed. `null` while they can.
+ *
+ * The codes and their order mirror `joinLeague`'s own refusals — state first,
+ * then `requireOpenField`, then the seat count checked inside its transaction —
+ * so the screen and the server cannot disagree about which reason comes first.
+ * Same shape and same reasoning as `DrawBlocker` in `lib/lobby.ts`.
+ */
+export type SetupBlocker =
+  | { readonly code: "LEAGUE_CLOSED"; readonly state: string }
+  | { readonly code: "FIELD_LOCKED" }
+  | { readonly code: "LEAGUE_FULL" };
 
 /**
  * Anchor first, and this is **not** the order the issue's plan tabulates.
@@ -46,7 +72,20 @@ export const SETUP_ORDER = ["ANCHOR", "LINK", "SEAT", "ONCHAIN"] as const;
 export interface CommissionerSetupInput {
   /** Whether this viewer created the league. Nothing renders for anyone else. */
   readonly isCommissioner: boolean;
-  /** At least one wallet proven by signature — `wallets`, not a typed address. */
+  /**
+   * This **user** has at least one wallet proven by signature — a `wallets` row,
+   * never a typed address.
+   *
+   * Per-user rather than per-league, and per-user rather than per-*connected
+   * wallet*, which is the one place this checklist is coarser than the control
+   * it points at: `JoinPanel` gates on whether the currently connected address
+   * is linked (`linked.includes(address)`), so a commissioner holding a wallet
+   * linked from an earlier league, who then connects a second one, sees LINK
+   * ticked and is still asked to verify. The tick is true at the level it
+   * claims — they have linked a wallet — and the panel below asks for what it
+   * actually needs. Narrowing it would mean knowing the connected address,
+   * which only the browser has, and this file is resolved on the server.
+   */
   readonly hasLinkedWallet: boolean;
   /** The rules are on-chain. `joinLeague` refuses until they are. */
   readonly anchored: boolean;
@@ -54,36 +93,64 @@ export interface CommissionerSetupInput {
   readonly hasTeam: boolean;
   /** The `Membership` PDA exists and is recorded in `league_onchain_joins`. */
   readonly onChainJoined: boolean;
+  /** `leagues.state`. Only `FORMING` accepts members. */
+  readonly leagueState: string;
+  /** `taken < maxTeams`. */
+  readonly seatsFree: boolean;
+  /**
+   * The frozen draft time has passed, so migration `0028` refuses every further
+   * `teams` INSERT. Computed by the caller against the server's clock.
+   */
+  readonly fieldLocked: boolean;
 }
 
 export interface SetupItem {
   readonly key: SetupStepKey;
   /** Already satisfied — independently of position, so a checklist is honest. */
   readonly done: boolean;
-  /** The one step to act on now. Exactly one item carries it, until `complete`. */
+  /** The one step to act on now. Nothing is current when `blocker` is set. */
   readonly current: boolean;
 }
 
 export interface CommissionerSetupView {
-  readonly step: SetupStep;
+  /**
+   * The step to act on now, or `null` when nothing is: either `complete`, or
+   * `blocker` says the rest can never be done.
+   */
+  readonly next: SetupStepKey | null;
   readonly items: readonly SetupItem[];
   /** How many of the four are still owed. */
   readonly remaining: number;
   /** Nothing left. The caller renders nothing rather than an all-ticked list. */
   readonly complete: boolean;
+  /** Set when the outstanding steps are unreachable. See `SetupBlocker`. */
+  readonly blocker: SetupBlocker | null;
+  /**
+   * The commissioner holds a seat, so only the on-chain record can still be
+   * owed — and that step needs no open field. Callers use it to avoid telling a
+   * seated commissioner they are not in their own league.
+   */
+  readonly seated: boolean;
 }
 
 /**
- * The next step the commissioner owes, or `null` if they are not the
- * commissioner.
+ * The next step in the bare sequence, or `null` if this is not the commissioner.
+ *
+ * **Knows nothing about `blocker`**, deliberately: it answers "which step is
+ * outstanding", not "which step can be done". On a dissolved or full league it
+ * still says `SEAT`, which is the correct answer to the question it is asked and
+ * the wrong thing to put on a screen. Screens call `commissionerSetup`.
  *
  * Steps are checked in `SETUP_ORDER` and the first unsatisfied one wins. The
- * states are nested by construction rather than by this function's say-so —
- * `joinLeague` requires a linked wallet and an anchored league, and
- * `/join-onchain` derives its wallet from the membership row — so the only pair
- * that can legitimately complete out of order is anchoring before linking. That
- * one can: anchoring signs a transaction from a connected wallet and never
- * consults `wallets`.
+ * states are otherwise nested by construction rather than by this function's
+ * say-so — `joinLeague` requires a linked wallet and an anchored league, and
+ * `/join-onchain` derives its wallet from the membership row — with exactly one
+ * exception: **ANCHOR and LINK are independent in both directions.** Anchoring
+ * signs a transaction from the connected wallet and never consults `wallets`, so
+ * it can be done first; and `wallets` is per-user, so a commissioner who linked
+ * one on any previous league arrives with LINK already satisfied and ANCHOR
+ * outstanding. That second case is the ordinary one for a returning user, and it
+ * is why `done` below is each step's own condition.
  */
 export function commissionerSetupStep(input: CommissionerSetupInput): SetupStep | null {
   if (!input.isCommissioner) return null;
@@ -109,26 +176,54 @@ function satisfied(input: CommissionerSetupInput, key: SetupStepKey): boolean {
 }
 
 /**
+ * Why the outstanding steps cannot be completed, or `null`.
+ *
+ * **Only ever set for a commissioner without a seat**, and that exception is the
+ * load-bearing half. Once `hasTeam` is true the only step left is the on-chain
+ * record, which `/join-onchain` grants against the existing membership row — it
+ * consults neither the league's state nor its seat count nor the field lock. So
+ * a commissioner who joined and then let the draft start must still be sent to
+ * finish it, and a blocker there would strand a member holding a seat with no
+ * `Membership` account, which is precisely what `resumable` exists to prevent.
+ */
+function seatBlocker(input: CommissionerSetupInput): SetupBlocker | null {
+  if (input.hasTeam) return null;
+  if (input.leagueState !== "FORMING") {
+    return { code: "LEAGUE_CLOSED", state: input.leagueState };
+  }
+  if (input.fieldLocked) return { code: "FIELD_LOCKED" };
+  if (!input.seatsFree) return { code: "LEAGUE_FULL" };
+  return null;
+}
+
+/**
  * The whole checklist, or `null` for anyone who is not the commissioner.
  *
  * `done` is each step's own condition and not "comes before the current one", so
- * a commissioner who anchored before linking sees an anchored league ticked
- * rather than a list claiming they have not done the thing they just did.
+ * a commissioner who anchored before linking — or who arrived with a wallet
+ * already linked from another league — sees what they actually did ticked rather
+ * than a list contradicting them.
  */
 export function commissionerSetup(input: CommissionerSetupInput): CommissionerSetupView | null {
   const step = commissionerSetupStep(input);
   if (step === null) return null;
 
+  const blocker = seatBlocker(input);
+  const complete = step === "DONE";
+  const next = complete || blocker !== null ? null : step;
+
   const items = SETUP_ORDER.map((key): SetupItem => ({
     key,
     done: satisfied(input, key),
-    current: key === step,
+    current: key === next,
   }));
 
   return {
-    step,
+    next,
     items,
     remaining: items.filter((item) => !item.done).length,
-    complete: step === "DONE",
+    complete,
+    blocker,
+    seated: input.hasTeam,
   };
 }


### PR DESCRIPTION
The first slice of the implementation plan on #165.

`createLeague` seats nobody. Joining is a wallet signature over the rules hash, `joinLeague` needs a linked wallet and an anchored league, and a league is unanchored the instant it is created — so the person who just made a league is a stranger to it. Since most leagues are PRIVATE, `leagueReadAccess` then 404s them out of every tab. #166 stopped the nav offering those doors; nothing said why they were shut, or what to do next.

## What this adds

- **`apps/web/src/lib/setup.ts`** — `commissionerSetupStep` / `commissionerSetup`, pure and unit-tested (10 tests). `apps/web` cannot render a component in a test, so what the screen decides lives where a test can reach it. `lib/lobby.ts` is the pattern.
- **`CommissionerSetup.tsx`** — presentation only, on `/leagues/[id]`, above everything, and gone once all four steps are done. It points at `AnchorPanel` and `JoinPanel` rather than carrying controls of its own; a button here would be a second implementation of the step it duplicates.
- **`AnchorPanel` above `JoinPanel`.** It never renders once anchored, so nobody else sees a change. While unanchored it stops the only control the commissioner can act on sitting *below* the panel explaining that they need to act.
- **`CreateLeagueForm` compares the previewed hash against the frozen one**, and `router.replace`s to the league.

## Two decisions worth reviewing

**Anchor is step one here, and the plan's table lists linking first.** The table is right about an uninterrupted run, but linking is reachable only from `JoinPanel`, and `JoinPanel` renders a bare "not open yet" notice — with no link control at all — until the league is anchored. A checklist asking for the link first would name a step that has no button anywhere on the page. Anchoring is also the only step that blocks *other people*. When the link control is extracted (the plan's next item) this order is worth revisiting; the reasoning is recorded on `SETUP_ORDER`.

**`done` is each step's own condition, not "sits before the current one".** A commissioner can anchor without ever linking — `AnchorPanel` signs from the connected wallet and never consults `wallets` — and a list claiming they had not anchored, on the one step nobody can repeat, would be the screen contradicting what it reports on. Tested.

## The hash check

`CreateLeagueForm`'s docstring already said a divergence between the previewed hash and the frozen one "should be visible". Nothing made it visible. The two are built from separately supplied values — the mint and fee recipient come from server configuration and are only mirrored into `NEXT_PUBLIC_*` — so drift is a configuration mistake away, and its symptom is a commissioner who read and acknowledged one document while their members sign another.

On a mismatch it stops, shows both hashes, shuts the create button and hands over a link to the league. The league already exists by then and its rules cannot be amended, so this has to be loud **and** must not lose it — there is no "my leagues" list to find it in again. `router.replace` rather than `push`, so Back cannot return to a filled-in freeze step whose only button creates a second league.

## What this does not do

It makes the state legible and resumable. It does **not** make a memberless league impossible: a commissioner can still stop at any step, and after the frozen draft time migration `0028` refuses every `teams` INSERT, leaving a zero-team league with no dissolve path (#163). The checklist says so, with the date. Closing that is the plan's next slice — extract `JoinPanel`'s link-wallet block into a control that stands on its own, and collect the commissioner's team name in the create form.

Also unchanged, and named in the plan's "things to handle": `ALREADY_JOINED` still reads as a 409 rather than as success, and `join/route.ts` still has no `STATUS` entry for `DRAFT_ALREADY_DRAWN` or `FIELD_LOCKED`.

## Verified

`pnpm test` 1359 passed, 2 skipped (was 1349). `pnpm typecheck`, `pnpm lint`, and `pnpm --filter @rostr/web build` all clean. **Not seen in a browser** — no jsdom in either vitest project, so the component itself is compiled and not rendered.

Refs #165