### PR TITLE
A league that never starts gives the money back

### DIFF
--- a/apps/web/src/app/(app)/leagues/[id]/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/page.tsx
@@ -186,6 +186,7 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
           leagueId={league.id}
           rulesHash={stored.hash}
           maxTeams={stored.rules.league.maxTeams}
+          draftScheduledAt={stored.rules.draft.scheduledAt}
           pot={
             stored.rules.pot
               ? {

--- a/apps/web/src/app/api/leagues/[id]/anchor/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/anchor/route.ts
@@ -153,27 +153,57 @@ export async function POST(
       // Deliberately specific. "Not found" means the transaction has not landed
       // — retry. "Hash mismatch" means the chain holds a different rule set,
       // which is not a retry, it is a league nobody should join.
-      return verdict.reason === "NOT_FOUND"
-        ? NextResponse.json(
-            {
-              error:
-                "No league account exists on-chain yet. If the transaction was just sent, " +
-                "give it a moment and try again.",
-              reason: verdict.reason,
-            },
-            { status: 409 },
-          )
-        : NextResponse.json(
-            {
-              error:
-                "The on-chain rules hash does not match this league's. Do not let anyone " +
-                "join: the chain holds a different rule set than the one shown here.",
-              reason: verdict.reason,
-              onChain: verdict.onChain,
-              expected: verdict.expected,
-            },
-            { status: 409 },
-          );
+      if (verdict.reason === "NOT_FOUND") {
+        return NextResponse.json(
+          {
+            error:
+              "No league account exists on-chain yet. If the transaction was just sent, " +
+              "give it a moment and try again.",
+            reason: verdict.reason,
+          },
+          { status: 409 },
+        );
+      }
+
+      /*
+        An account is there and this build cannot read it.
+
+        The third refusal, and it is the one that must not be confused with the
+        first: they are indistinguishable from a distance and mean opposite
+        things. `NOT_FOUND` invites a retry; this one has to say plainly that
+        retrying is the single action guaranteed not to work. The address
+        derives from the league's id, the program has no `close`, and those
+        bytes are there for good — so the league can only be recreated under a
+        new id.
+
+        Reachable when the program's account layout moves and a league was
+        anchored under the older one. Before this it escaped as a 500.
+      */
+      if (verdict.reason === "INCOMPATIBLE") {
+        return NextResponse.json(
+          {
+            error:
+              "This league was anchored by a different version of the escrow program and " +
+              "cannot be read. It cannot be re-anchored — the on-chain address comes from " +
+              "the league's id and nothing can free it. Create the league again.",
+            reason: verdict.reason,
+            detail: verdict.detail,
+          },
+          { status: 409 },
+        );
+      }
+
+      return NextResponse.json(
+        {
+          error:
+            "The on-chain rules hash does not match this league's. Do not let anyone " +
+            "join: the chain holds a different rule set than the one shown here.",
+          reason: verdict.reason,
+          onChain: verdict.onChain,
+          expected: verdict.expected,
+        },
+        { status: 409 },
+      );
     }
 
     // The hash matches, but the program stores the economic terms as a separate

--- a/apps/web/src/components/AnchorPanel.tsx
+++ b/apps/web/src/components/AnchorPanel.tsx
@@ -43,12 +43,23 @@ export function AnchorPanel({
   leagueId,
   rulesHash,
   maxTeams,
+  draftScheduledAt,
   pot,
 }: {
   leagueId: string;
   /** The hash as stored: 64 lower-case hex characters. */
   rulesHash: string;
   maxTeams: number;
+  /**
+   * The frozen draft time, unix seconds.
+   *
+   * Only a pot league uses it — it fixes when a league that never starts gives
+   * the stakes back — but it is required rather than optional, because a free
+   * league passing it costs nothing and an omitted one on a pot league would
+   * anchor a deadline the signed rules do not imply, which the anchor route
+   * then refuses permanently. There is no second chance at anchoring.
+   */
+  draftScheduledAt: number;
   pot: PotTerms | null;
 }) {
   const { connection } = useConnection();
@@ -91,6 +102,12 @@ export function AnchorPanel({
               ? new PublicKey(pot.feeRecipient)
               : PublicKey.default,
             maxTeams,
+            // The frozen draft time, from which `startDeadlineFor` derives when
+            // a league that never starts releases its stakes. Passed as the
+            // draft time rather than the deadline so this component computes
+            // nothing — the anchor route recomputes the same value from the
+            // signed rules and refuses an account that disagrees.
+            draftScheduledAt,
             payer: wallet.publicKey,
           })
         : await initializeFreeLeagueIx(program, {

--- a/packages/escrow/src/idl.ts
+++ b/packages/escrow/src/idl.ts
@@ -303,8 +303,11 @@ export const ESCROW_IDL: EscrowIdl = {
         {
           "name": "payer",
           "docs": [
-            "Pays rent. Holds no privileges afterwards — creating a league is not a",
-            "role, and this key is not recorded on the account."
+            "Pays rent, and is recorded as `league.commissioner`.",
+            "",
+            "This used to say the key held no privileges afterwards and was not",
+            "recorded. It is now recorded, and it holds exactly one: `start_season`.",
+            "That instruction changes no term and moves no token — see the field."
           ],
           "writable": true,
           "signer": true
@@ -557,6 +560,89 @@ export const ESCROW_IDL: EscrowIdl = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "start_season",
+      "docs": [
+        "Declare that this league's season has begun, closing the failed-league",
+        "refund.",
+        "",
+        "## What this is for",
+        "",
+        "A league that is not ready at its draft time — short of its buy-ins, or",
+        "with an odd field — must give everyone their money back **then**, not in",
+        "six months. But this program cannot tell a failed league from a running",
+        "one: the roster, the draft and who has paid are Postgres facts, and",
+        "`rules_hash` is 32 opaque bytes to it. Something has to say so.",
+        "",
+        "So the default is failure. A league that was ready calls this inside its",
+        "grace window; a league that was not never does, and its members are",
+        "released automatically. **Doing nothing returns the money.**",
+        "",
+        "## The window is the whole safety argument",
+        "",
+        "This is illegal from exactly the instant the failed-league refund becomes",
+        "legal, so the two can never both be available. A league therefore cannot",
+        "be started with a partly-drained vault, and a member cannot be refunded",
+        "out of a season that has begun — the halves are complements rather than",
+        "two checks that have to agree with each other.",
+        "",
+        "## What it cannot do",
+        "",
+        "It changes no term, moves no token, and names no winner. Its only effect",
+        "is which of two refund schedules the members are on, and both of those",
+        "end with the member holding their own money. `drawDraftOrder` refuses to",
+        "draw a pot league until this has landed, which is what stops a",
+        "commissioner running a season with the escape hatch still open.",
+        "",
+        "Free leagues are excluded rather than exempted: no vault, so nothing to",
+        "release and nothing to protect."
+      ],
+      "discriminator": [
+        152,
+        173,
+        197,
+        144,
+        221,
+        79,
+        236,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "league",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  101,
+                  97,
+                  103,
+                  117,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "league.league_id",
+                "account": "League"
+              }
+            ]
+          }
+        },
+        {
+          "name": "commissioner",
+          "docs": [
+            "The wallet that created the league. No other key can start a season, and",
+            "this one can do nothing else."
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -707,6 +793,31 @@ export const ESCROW_IDL: EscrowIdl = {
       "code": 6023,
       "name": "RefundUnlockTooFar",
       "msg": "Refund unlock time is too far in the future"
+    },
+    {
+      "code": 6024,
+      "name": "NotCommissioner",
+      "msg": "Only the wallet that created this league may start its season"
+    },
+    {
+      "code": 6025,
+      "name": "AlreadyStarted",
+      "msg": "This league's season has already started"
+    },
+    {
+      "code": 6026,
+      "name": "StartWindowClosed",
+      "msg": "The window to start this season has closed; its members may now be refunded"
+    },
+    {
+      "code": 6027,
+      "name": "StartDeadlineNotInFuture",
+      "msg": "The start deadline must be in the future"
+    },
+    {
+      "code": 6028,
+      "name": "StartDeadlineAfterRefundUnlock",
+      "msg": "The start deadline must fall before the refund unlock"
     }
   ],
   "types": [
@@ -791,6 +902,14 @@ export const ESCROW_IDL: EscrowIdl = {
           {
             "name": "max_teams",
             "type": "u8"
+          },
+          {
+            "name": "start_deadline",
+            "docs": [
+              "When the season must be declared started by. Appended, so the argument",
+              "order is stable. See the field on `League`."
+            ],
+            "type": "i64"
           }
         ]
       }
@@ -800,10 +919,16 @@ export const ESCROW_IDL: EscrowIdl = {
       "docs": [
         "The terms of a league, frozen at creation.",
         "",
-        "Deliberately absent: a commissioner authority. Nothing in this account may",
-        "change, so there is nobody who needs the right to change it. Adding an",
-        "authority field would create the exact attack docs/DECISIONS.md §",
-        "\"Commissioner powers are bounded by the contract\" exists to remove."
+        "**No term may change, and there is no authority that could change one.** That",
+        "is what docs/DECISIONS.md § \"Commissioner powers are bounded by the contract\"",
+        "asks for, and it still holds: the buy-in, the fee, its recipient, the payout",
+        "split, the mint and the refund date are written once and read forever.",
+        "",
+        "This paragraph used to say the account had no authority field at all. It has",
+        "one — `commissioner`, whose sole power is `start_season`, and whose sole",
+        "effect is which of two refund schedules a member is on. Both end with them",
+        "holding their own money. See the field for why that was the least bad way to",
+        "let a league that never started give the money back."
       ],
       "type": {
         "kind": "struct",
@@ -916,6 +1041,18 @@ export const ESCROW_IDL: EscrowIdl = {
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "commissioner",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_deadline",
+            "type": "i64"
+          },
+          {
+            "name": "started",
+            "type": "bool"
           }
         ]
       }

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -18,6 +18,7 @@ export {
   type Cluster,
 } from "./cluster.js";
 export {
+  IncompatibleLeagueAccountError,
   anchorTermMismatches,
   bytesToHex,
   clusterOf,

--- a/packages/escrow/src/index.ts
+++ b/packages/escrow/src/index.ts
@@ -55,13 +55,16 @@ export {
   joinLeagueIx,
   payoutArray,
   refundStakeIx,
+  startSeasonIx,
   type DepositParams,
   type InitializeFreeLeagueParams,
   type InitializeLeagueParams,
   type JoinLeagueParams,
   type PrizeKey,
   type RefundParams,
+  type StartSeasonParams,
 } from "./instructions.js";
+export { START_GRACE_SECONDS, startDeadlineFor } from "./start.js";
 export {
   ESCROW_PROGRAM_ID,
   leagueAddresses,

--- a/packages/escrow/src/instructions.ts
+++ b/packages/escrow/src/instructions.ts
@@ -19,6 +19,7 @@ import { SystemProgram, type PublicKey, type TransactionInstruction } from "@sol
 
 import { ESCROW_IDL } from "./idl.js";
 import { leagueIdBytes, leaguePda, membershipPda, vaultPda } from "./program.js";
+import { startDeadlineFor } from "./start.js";
 import type { RostrEscrow } from "./types.js";
 
 /**
@@ -73,6 +74,25 @@ export type InitializeLeagueParams = {
    * choose, and a test must be able to express.
    */
   readonly refundUnlockAt: number | string;
+  /**
+   * The frozen draft time, unix seconds.
+   *
+   * Not the deadline itself: `startDeadlineFor` derives that, so the value
+   * anchored and the value `anchorTermMismatches` expects come from one line of
+   * code rather than two that have to agree.
+   */
+  readonly draftScheduledAt: number;
+  /**
+   * The deadline itself, overriding the derivation above.
+   *
+   * **Nothing in the app passes this**, and nothing should: the anchor route
+   * recomputes the expected value from the signed rules and refuses an account
+   * that differs, so a league anchored with anything else is one nobody can
+   * join. It exists for the same reason `refundUnlockAt` accepts a string — a
+   * test has to be able to express a league whose deadline falls in seconds,
+   * which no real draft time can produce.
+   */
+  readonly startDeadline?: number;
   readonly payoutBps: readonly number[];
   readonly feeBps: number;
   readonly feeRecipient: PublicKey;
@@ -97,6 +117,10 @@ export async function initializeLeagueIx(
       feeBps: params.feeBps,
       feeRecipient: params.feeRecipient,
       maxTeams: params.maxTeams,
+      // Derived from the frozen draft time, never chosen. `anchorTermMismatches`
+      // recomputes it from the signed rules and refuses an account that differs,
+      // so this is the only value that can survive the anchor route.
+      startDeadline: new BN(params.startDeadline ?? startDeadlineFor(params.draftScheduledAt)),
     })
     .accountsPartial({
       league,
@@ -187,6 +211,38 @@ export async function depositIx(
         params.memberTokenAccount ?? getAssociatedTokenAddressSync(params.mint, params.member),
       member: params.member,
       tokenProgram: TOKEN_PROGRAM_ID,
+    })
+    .instruction();
+}
+
+export type StartSeasonParams = {
+  readonly leagueId: string;
+  /** The wallet that created the league. No other key can send this. */
+  readonly commissioner: PublicKey;
+};
+
+/**
+ * Declare a league's season started, closing its failed-league refund.
+ *
+ * Sent once, by the commissioner, immediately before the draft order is drawn —
+ * `drawDraftOrder` refuses a pot league until the chain says `started`. Mark
+ * first and draw second, deliberately: drawing first and failing to mark would
+ * leave a live season whose members can withdraw out of it.
+ *
+ * It changes no term and moves no token. Its only effect is which of two refund
+ * schedules the members are on, and both end with them holding their own money.
+ * A league that is never marked releases every stake at its deadline — so the
+ * failure of this transaction is the safe direction, not the dangerous one.
+ */
+export async function startSeasonIx(
+  program: Program<RostrEscrow>,
+  params: StartSeasonParams,
+): Promise<TransactionInstruction> {
+  return program.methods
+    .startSeason()
+    .accountsPartial({
+      league: leaguePda(params.leagueId),
+      commissioner: params.commissioner,
     })
     .instruction();
 }

--- a/packages/escrow/src/settlement.test.ts
+++ b/packages/escrow/src/settlement.test.ts
@@ -14,6 +14,10 @@ const TODAY = [
   "initialize_league",
   "join_league",
   "refund_stake",
+  // Added 2026-08-17 with the failed-league refund (#170). It closes a refund
+  // window; it pays nobody, so the gate below must stay shut — see the test
+  // that says so explicitly.
+  "start_season",
 ];
 
 const settled = { instructions: [...TODAY, "settle_league"].map((name) => ({ name })) };
@@ -21,6 +25,26 @@ const settled = { instructions: [...TODAY, "settle_league"].map((name) => ({ nam
 describe("settlementShipped", () => {
   it("is false for the program as it stands", () => {
     expect(settlementShipped(ESCROW_IDL)).toBe(false);
+  });
+
+  /**
+   * `start_season` must never read as settlement, and the margin is one letter.
+   *
+   * `SETTLEMENT_PREFIXES` matches on `startsWith`, and "start" and "settle"
+   * share their first two characters. Had the prefixes been looser — "s", or a
+   * substring match — adding this instruction would have silently opened the
+   * mainnet deposit gate on a program that still cannot pay a pot out, which is
+   * the exact failure the gate exists to prevent.
+   *
+   * It closes a refund window. It moves nothing to anybody.
+   */
+  it("does not count start_season, which pays nobody", () => {
+    expect(instructionNames(ESCROW_IDL)).toContain("start_season");
+    expect(settlementShipped(ESCROW_IDL)).toBe(false);
+    expect(potDepositGate("mainnet-beta", ESCROW_IDL)).toEqual({
+      open: false,
+      reason: "SETTLEMENT_NOT_SHIPPED",
+    });
   });
 
   it("is true once an instruction that pays a pot out exists", () => {

--- a/packages/escrow/src/start.ts
+++ b/packages/escrow/src/start.ts
@@ -1,0 +1,56 @@
+/**
+ * When a league must have declared its season started, and what happens if it
+ * never does.
+ *
+ * ## The rule
+ *
+ * A league that is not ready at its draft time — short of its buy-ins, or with
+ * an odd field — gives everyone their money back **then**, not in six months.
+ * The ordinary timelock is a season and sixty days past the draft (see
+ * `earliestRefundUnlock`), which is right for a pot being played for and absurd
+ * for a league that never started.
+ *
+ * The program cannot tell those apart: the roster, the draft and who has paid
+ * are Postgres facts, and `rules_hash` is 32 opaque bytes to it. So the default
+ * is failure. A league that was ready calls `start_season` inside its window; a
+ * league that was not never does, and its members are released automatically.
+ * **Doing nothing is what returns the money.**
+ *
+ * ## Why the deadline is derived here rather than on-chain
+ *
+ * `League.start_deadline` is an explicit instant, not a draft time the program
+ * adds a constant to — for the same reason `refund_unlock_at` is. The program
+ * has no schedule and no view of a league's calendar, so a deadline it computed
+ * would be computed from something it was handed anyway.
+ *
+ * What makes that safe is the same thing that makes every other term safe: the
+ * anchor route derives the expected value from the **signed rule set** and
+ * refuses an account that disagrees (`anchorTermMismatches`). A creator can no
+ * more anchor a deadline nobody agreed to than a buy-in nobody agreed to.
+ */
+
+/**
+ * How long after its draft time a league has to declare itself started. 48
+ * hours.
+ *
+ * Two days rather than minutes, because the commissioner has to be awake: the
+ * draft time is a moment they chose months earlier, and drawing the order is a
+ * button somebody presses. Two days rather than a week, because every hour here
+ * is an hour a failed league's members wait for money that is already theirs.
+ *
+ * It bounds a *window*, never the refund. Once the failed-league refund opens it
+ * never closes again — a refund that expires is a way for money to become
+ * permanently stuck, which is the one outcome the escrow exists to prevent.
+ */
+export const START_GRACE_SECONDS = 48 * 60 * 60;
+
+/**
+ * The instant a league must have started by, from its frozen draft time.
+ *
+ * Unix seconds in, unix seconds out. Both the anchor instruction and the check
+ * that verifies it read this, so the value written on-chain and the value
+ * expected from the rules cannot drift apart.
+ */
+export function startDeadlineFor(draftScheduledAt: number): number {
+  return draftScheduledAt + START_GRACE_SECONDS;
+}

--- a/packages/escrow/src/types.ts
+++ b/packages/escrow/src/types.ts
@@ -289,8 +289,11 @@ export type RostrEscrow = {
         {
           "name": "payer",
           "docs": [
-            "Pays rent. Holds no privileges afterwards — creating a league is not a",
-            "role, and this key is not recorded on the account."
+            "Pays rent, and is recorded as `league.commissioner`.",
+            "",
+            "This used to say the key held no privileges afterwards and was not",
+            "recorded. It is now recorded, and it holds exactly one: `start_season`.",
+            "That instruction changes no term and moves no token — see the field."
           ],
           "writable": true,
           "signer": true
@@ -543,6 +546,89 @@ export type RostrEscrow = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "startSeason",
+      "docs": [
+        "Declare that this league's season has begun, closing the failed-league",
+        "refund.",
+        "",
+        "## What this is for",
+        "",
+        "A league that is not ready at its draft time — short of its buy-ins, or",
+        "with an odd field — must give everyone their money back **then**, not in",
+        "six months. But this program cannot tell a failed league from a running",
+        "one: the roster, the draft and who has paid are Postgres facts, and",
+        "`rules_hash` is 32 opaque bytes to it. Something has to say so.",
+        "",
+        "So the default is failure. A league that was ready calls this inside its",
+        "grace window; a league that was not never does, and its members are",
+        "released automatically. **Doing nothing returns the money.**",
+        "",
+        "## The window is the whole safety argument",
+        "",
+        "This is illegal from exactly the instant the failed-league refund becomes",
+        "legal, so the two can never both be available. A league therefore cannot",
+        "be started with a partly-drained vault, and a member cannot be refunded",
+        "out of a season that has begun — the halves are complements rather than",
+        "two checks that have to agree with each other.",
+        "",
+        "## What it cannot do",
+        "",
+        "It changes no term, moves no token, and names no winner. Its only effect",
+        "is which of two refund schedules the members are on, and both of those",
+        "end with the member holding their own money. `drawDraftOrder` refuses to",
+        "draw a pot league until this has landed, which is what stops a",
+        "commissioner running a season with the escape hatch still open.",
+        "",
+        "Free leagues are excluded rather than exempted: no vault, so nothing to",
+        "release and nothing to protect."
+      ],
+      "discriminator": [
+        152,
+        173,
+        197,
+        144,
+        221,
+        79,
+        236,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "league",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  101,
+                  97,
+                  103,
+                  117,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "league.league_id",
+                "account": "league"
+              }
+            ]
+          }
+        },
+        {
+          "name": "commissioner",
+          "docs": [
+            "The wallet that created the league. No other key can start a season, and",
+            "this one can do nothing else."
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -693,6 +779,31 @@ export type RostrEscrow = {
       "code": 6023,
       "name": "refundUnlockTooFar",
       "msg": "Refund unlock time is too far in the future"
+    },
+    {
+      "code": 6024,
+      "name": "notCommissioner",
+      "msg": "Only the wallet that created this league may start its season"
+    },
+    {
+      "code": 6025,
+      "name": "alreadyStarted",
+      "msg": "This league's season has already started"
+    },
+    {
+      "code": 6026,
+      "name": "startWindowClosed",
+      "msg": "The window to start this season has closed; its members may now be refunded"
+    },
+    {
+      "code": 6027,
+      "name": "startDeadlineNotInFuture",
+      "msg": "The start deadline must be in the future"
+    },
+    {
+      "code": 6028,
+      "name": "startDeadlineAfterRefundUnlock",
+      "msg": "The start deadline must fall before the refund unlock"
     }
   ],
   "types": [
@@ -777,6 +888,14 @@ export type RostrEscrow = {
           {
             "name": "maxTeams",
             "type": "u8"
+          },
+          {
+            "name": "startDeadline",
+            "docs": [
+              "When the season must be declared started by. Appended, so the argument",
+              "order is stable. See the field on `League`."
+            ],
+            "type": "i64"
           }
         ]
       }
@@ -786,10 +905,16 @@ export type RostrEscrow = {
       "docs": [
         "The terms of a league, frozen at creation.",
         "",
-        "Deliberately absent: a commissioner authority. Nothing in this account may",
-        "change, so there is nobody who needs the right to change it. Adding an",
-        "authority field would create the exact attack docs/DECISIONS.md §",
-        "\"Commissioner powers are bounded by the contract\" exists to remove."
+        "**No term may change, and there is no authority that could change one.** That",
+        "is what docs/DECISIONS.md § \"Commissioner powers are bounded by the contract\"",
+        "asks for, and it still holds: the buy-in, the fee, its recipient, the payout",
+        "split, the mint and the refund date are written once and read forever.",
+        "",
+        "This paragraph used to say the account had no authority field at all. It has",
+        "one — `commissioner`, whose sole power is `start_season`, and whose sole",
+        "effect is which of two refund schedules a member is on. Both end with them",
+        "holding their own money. See the field for why that was the least bad way to",
+        "let a league that never started give the money back."
       ],
       "type": {
         "kind": "struct",
@@ -902,6 +1027,18 @@ export type RostrEscrow = {
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "commissioner",
+            "type": "pubkey"
+          },
+          {
+            "name": "startDeadline",
+            "type": "i64"
+          },
+          {
+            "name": "started",
+            "type": "bool"
           }
         ]
       }

--- a/packages/escrow/src/verify.test.ts
+++ b/packages/escrow/src/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { anchorTermMismatches, expectedTermsFromRules } from "./verify.js";
+import { anchorTermMismatches, expectedTermsFromRules, verifyLeagueAnchor } from "./verify.js";
 import type { ExpectedTerms, OnChainLeague } from "./verify.js";
 import { startDeadlineFor } from "./start.js";
 import { PublicKey } from "@solana/web3.js";
@@ -55,6 +55,67 @@ const EXPECTED: ExpectedTerms = {
 /** The rules half of the fixture, with the draft the deadline derives from. */
 const RULES_LEAGUE = { maxTeams: 12 } as const;
 const RULES_DRAFT = { scheduledAt: DRAFT_AT } as const;
+
+/**
+ * An account this build cannot read is not an account that is missing.
+ *
+ * They are indistinguishable at the fetch — Anchor answers `null` for one and
+ * throws for the other — and they mean opposite things to whoever reads the
+ * answer. `NOT_FOUND` means the anchor never landed and should be retried;
+ * `INCOMPATIBLE` means it landed under an older program layout and can never be
+ * used, because the address derives from the league's id and there is no
+ * `close`. Retrying is the one action guaranteed not to help.
+ *
+ * Reached on 2026-08-17, when the failed-league refund appended three fields to
+ * `League` (#170). Before that the decode threw past every handler as a 500.
+ */
+describe("verifyLeagueAnchor's two kinds of absence", () => {
+  const leagueId = "11111111-1111-4111-8111-111111111111";
+
+  const programThat = (fetchNullable: () => Promise<unknown>) =>
+    ({ account: { league: { fetchNullable } } }) as never;
+
+  it("reports NOT_FOUND for a league nobody has anchored", async () => {
+    const verdict = await verifyLeagueAnchor(
+      programThat(async () => null),
+      leagueId,
+      "a".repeat(64),
+    );
+    expect(verdict).toEqual({ ok: false, reason: "NOT_FOUND" });
+  });
+
+  it("reports INCOMPATIBLE for an account it cannot decode, and never NOT_FOUND", async () => {
+    const verdict = await verifyLeagueAnchor(
+      programThat(async () => {
+        throw new Error("Invalid account discriminator");
+      }),
+      leagueId,
+      "a".repeat(64),
+    );
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toBe("INCOMPATIBLE");
+    // The message has to say the thing a retry cannot fix, because the retry is
+    // what somebody reaching this will otherwise do.
+    if (verdict.reason !== "INCOMPATIBLE") return;
+    expect(verdict.detail).toMatch(/cannot be re-anchored|different version/i);
+  });
+
+  it("surfaces the failure as an answer rather than a throw", async () => {
+    // A throw here is a 500 on the anchor route, which tells the commissioner
+    // nothing and records nothing. The route can only decide with a verdict.
+    await expect(
+      verifyLeagueAnchor(
+        programThat(async () => {
+          throw new Error("unexpected end of buffer");
+        }),
+        leagueId,
+        "a".repeat(64),
+      ),
+    ).resolves.toBeDefined();
+  });
+});
 
 describe("anchorTermMismatches", () => {
   it("passes when every term matches the signed rules", () => {

--- a/packages/escrow/src/verify.test.ts
+++ b/packages/escrow/src/verify.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { anchorTermMismatches, expectedTermsFromRules } from "./verify.js";
 import type { ExpectedTerms, OnChainLeague } from "./verify.js";
+import { startDeadlineFor } from "./start.js";
 import { PublicKey } from "@solana/web3.js";
 
 /**
@@ -15,6 +16,10 @@ const FEE_TO = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
 
 const RECIPIENT = new PublicKey(FEE_TO);
 
+/** The frozen draft time these fixtures share, and its derived deadline. */
+const DRAFT_AT = 1_756_000_000;
+const START_DEADLINE = String(startDeadlineFor(DRAFT_AT));
+
 function onChain(overrides: Partial<OnChainLeague> = {}): OnChainLeague {
   return {
     address: PublicKey.default,
@@ -26,6 +31,9 @@ function onChain(overrides: Partial<OnChainLeague> = {}): OnChainLeague {
     feeBps: 100,
     feeRecipient: FEE_TO,
     payoutBps: [6000, 1500, 1000, 1000, 500],
+    startDeadline: START_DEADLINE,
+    started: false,
+    commissioner: FEE_TO,
     maxTeams: 12,
     memberCount: 0,
     ...overrides,
@@ -41,7 +49,12 @@ const EXPECTED: ExpectedTerms = {
   feeBps: 100,
   feeRecipient: FEE_TO,
   payoutBps: [6000, 1500, 1000, 1000, 500],
+  startDeadline: START_DEADLINE,
 };
+
+/** The rules half of the fixture, with the draft the deadline derives from. */
+const RULES_LEAGUE = { maxTeams: 12 } as const;
+const RULES_DRAFT = { scheduledAt: DRAFT_AT } as const;
 
 describe("anchorTermMismatches", () => {
   it("passes when every term matches the signed rules", () => {
@@ -154,6 +167,39 @@ describe("anchorTermMismatches", () => {
     expect(anchorTermMismatches(chain, free)).toEqual([]);
   });
 
+  /**
+   * The deadline decides when a failed league gives the money back, so it is a
+   * money term and belongs in this comparison.
+   *
+   * Anchored later than the rules imply, a failed league's members wait longer
+   * than they agreed to — up to the ordinary timelock, six months out. Anchored
+   * earlier, the escape hatch opens on a league that is about to start, and
+   * whoever withdraws first plays the season with nothing at risk.
+   */
+  it("catches a start deadline that differs from the signed rules", () => {
+    const later = String(Number(START_DEADLINE) + 30 * 24 * 3600);
+    const m = anchorTermMismatches(onChain({ startDeadline: later }), EXPECTED);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatch(/startDeadline/);
+  });
+
+  it("does not compare a start deadline on a free league", () => {
+    // No vault, so nothing the deadline could release. `initialize_free_league`
+    // writes zero and the rules imply zero; comparing anything else here would
+    // refuse a legitimate free anchor, which is unrecoverable.
+    const free = onChain({
+      hasPot: false,
+      buyIn: "0",
+      refundUnlockAt: "0",
+      tokenMint: PublicKey.default.toBase58(),
+      feeBps: 0,
+      feeRecipient: PublicKey.default.toBase58(),
+      payoutBps: [0, 0, 0, 0, 0],
+      startDeadline: "0",
+    });
+    expect(anchorTermMismatches(free, { ...EXPECTED, hasPot: false })).toEqual([]);
+  });
+
   it("still catches a fee smuggled in against fee-free rules", () => {
     // The exemption above must not become a hole: `feeBps` is compared either
     // way, so a chain that charges a fee the rules do not is still refused.
@@ -188,7 +234,11 @@ describe("expectedTermsFromRules", () => {
   };
 
   it("agrees with an honestly anchored pot league", () => {
-    const expected = expectedTermsFromRules({ league: { maxTeams: 12 }, pot: POT });
+    const expected = expectedTermsFromRules({
+      league: RULES_LEAGUE,
+      draft: RULES_DRAFT,
+      pot: POT,
+    });
     expect(anchorTermMismatches(onChain(), expected)).toEqual([]);
   });
 
@@ -205,7 +255,8 @@ describe("expectedTermsFromRules", () => {
       POT.payout[3],
     ];
     const expected = expectedTermsFromRules({
-      league: { maxTeams: 12 },
+      league: RULES_LEAGUE,
+      draft: RULES_DRAFT,
       pot: { ...POT, payout: shuffled as typeof POT.payout },
     });
     expect(expected.payoutBps).toEqual([6000, 1500, 1000, 1000, 500]);
@@ -214,14 +265,19 @@ describe("expectedTermsFromRules", () => {
 
   it("carries a 64-bit refund unlock without losing it", () => {
     const expected = expectedTermsFromRules({
-      league: { maxTeams: 12 },
+      league: RULES_LEAGUE,
+      draft: RULES_DRAFT,
       pot: { ...POT, refundUnlockAt: 4_102_444_800 },
     });
     expect(expected.refundUnlockAt).toBe("4102444800");
   });
 
   it("builds a free league the way the route does, and it verifies", () => {
-    const expected = expectedTermsFromRules({ league: { maxTeams: 12 }, pot: null });
+    const expected = expectedTermsFromRules({
+      league: RULES_LEAGUE,
+      draft: RULES_DRAFT,
+      pot: null,
+    });
     expect(expected.hasPot).toBe(false);
 
     const free = onChain({
@@ -241,7 +297,8 @@ describe("expectedTermsFromRules", () => {
     // `undefined`, and `!== null` would call that a pot league — telling a
     // genuine free league its rules imply one, unresolvably.
     const expected = expectedTermsFromRules({
-      league: { maxTeams: 12 },
+      league: RULES_LEAGUE,
+      draft: RULES_DRAFT,
       pot: undefined as unknown as null,
     });
     expect(expected.hasPot).toBe(false);

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -97,13 +97,53 @@ export function hexToBytes(hex: string): Uint8Array {
  * A missing account is the ordinary case — a league created in the database but
  * not yet anchored — so it is a return value rather than a throw.
  */
+/**
+ * An account exists at the league's address and this build cannot read it.
+ *
+ * **Not the same as "not anchored", and the difference is the whole reason this
+ * class exists.** `fetchNullable` answers `null` for a missing account, which is
+ * the ordinary case for a league nobody has anchored yet — and the anchor route
+ * documents that as *retry*. An account whose bytes do not fit the current
+ * `League` layout also fails to decode, but retrying it can never work: the PDA
+ * derives from the league's UUID, there is no `close`, and the account will hold
+ * those bytes forever.
+ *
+ * Reachable when the program's account layout changes and a league was anchored
+ * under the older one — which happened on 2026-08-17, when `commissioner`,
+ * `start_deadline` and `started` were appended for the failed-league refund
+ * (#170). Before this the decode threw an opaque Anchor error and surfaced as a
+ * 500, or, worse, as advice to try again.
+ */
+export class IncompatibleLeagueAccountError extends Error {
+  constructor(
+    readonly leagueId: string,
+    override readonly cause: unknown,
+  ) {
+    super(
+      `The account for league ${leagueId} was written by a different version of ` +
+        `the escrow program and cannot be read by this build. It cannot be ` +
+        `re-anchored: the address derives from the league's id and the program ` +
+        `has no instruction that closes an account.`,
+    );
+    this.name = "IncompatibleLeagueAccountError";
+  }
+}
+
 export async function fetchOnChainLeague(
   program: Program<RostrEscrow>,
   leagueId: string,
 ): Promise<OnChainLeague | null> {
   const address = leaguePda(leagueId);
 
-  const account = await program.account["league"]?.fetchNullable(address);
+  // Two failures wear the same coat here, and only one is recoverable. A missing
+  // account is `null`; an account that exists and does not decode *throws* out
+  // of Anchor, so without this it escapes as a 500 rather than as an answer.
+  let account: unknown;
+  try {
+    account = await program.account["league"]?.fetchNullable(address);
+  } catch (error) {
+    throw new IncompatibleLeagueAccountError(leagueId, error);
+  }
   if (!account) return null;
 
   const raw = account as {
@@ -143,6 +183,17 @@ export async function fetchOnChainLeague(
 export type AnchorVerdict =
   | { readonly ok: true; readonly league: OnChainLeague }
   | { readonly ok: false; readonly reason: "NOT_FOUND" }
+  /**
+   * An account is there and this build cannot read it — a league anchored
+   * under an older program layout.
+   *
+   * Deliberately its own reason rather than folded into `NOT_FOUND`. They look
+   * identical from here and mean opposite things to the person reading the
+   * answer: `NOT_FOUND` means the anchor did not land and should be retried,
+   * this means it landed and can never be used. Retrying is the one action
+   * guaranteed not to help.
+   */
+  | { readonly ok: false; readonly reason: "INCOMPATIBLE"; readonly detail: string }
   | {
       readonly ok: false;
       readonly reason: "HASH_MISMATCH";
@@ -166,7 +217,17 @@ export async function verifyLeagueAnchor(
   leagueId: string,
   expectedRulesHash: string,
 ): Promise<AnchorVerdict> {
-  const league = await fetchOnChainLeague(program, leagueId);
+  let league: OnChainLeague | null;
+  try {
+    league = await fetchOnChainLeague(program, leagueId);
+  } catch (error) {
+    // Answered rather than thrown, because the caller's job is to decide what
+    // to record and a 500 gives it nothing to decide with.
+    if (error instanceof IncompatibleLeagueAccountError) {
+      return { ok: false, reason: "INCOMPATIBLE", detail: error.message };
+    }
+    throw error;
+  }
   if (!league) return { ok: false, reason: "NOT_FOUND" };
 
   if (league.rulesHash.toLowerCase() !== expectedRulesHash.toLowerCase()) {

--- a/packages/escrow/src/verify.ts
+++ b/packages/escrow/src/verify.ts
@@ -22,6 +22,7 @@ import type { Connection, PublicKey } from "@solana/web3.js";
 
 import { payoutArray } from "./instructions.js";
 import { leaguePda, membershipPda } from "./program.js";
+import { startDeadlineFor } from "./start.js";
 import type { RostrEscrow } from "./types.js";
 
 /** A league's frozen terms, as they exist on-chain. */
@@ -50,6 +51,17 @@ export interface OnChainLeague {
   readonly feeRecipient: string;
   /** Payout split in basis points, positional (see `PRIZE_ORDER`). */
   readonly payoutBps: readonly number[];
+  /**
+   * Unix seconds by which the season must be declared started, as a decimal
+   * string — same reasoning as `refundUnlockAt`: it is an `i64` the creator
+   * supplies, so `BN.toNumber()` would throw on the hostile value rather than
+   * letting the comparison that catches it run.
+   */
+  readonly startDeadline: string;
+  /** Whether the season was declared started before that deadline. */
+  readonly started: boolean;
+  /** Base58. The only key with an instruction on this account. */
+  readonly commissioner: string;
   readonly maxTeams: number;
   readonly memberCount: number;
 }
@@ -105,6 +117,9 @@ export async function fetchOnChainLeague(
     payoutBps: number[];
     maxTeams: number;
     memberCount: number;
+    startDeadline: { toString(): string };
+    started: boolean;
+    commissioner: PublicKey;
   };
 
   return {
@@ -117,6 +132,9 @@ export async function fetchOnChainLeague(
     feeBps: raw.feeBps,
     feeRecipient: raw.feeRecipient.toBase58(),
     payoutBps: [...raw.payoutBps],
+    startDeadline: raw.startDeadline.toString(),
+    started: raw.started,
+    commissioner: raw.commissioner.toBase58(),
     maxTeams: raw.maxTeams,
     memberCount: raw.memberCount,
   };
@@ -236,6 +254,19 @@ export interface ExpectedTerms {
   readonly feeBps: number;
   readonly feeRecipient: string;
   readonly payoutBps: readonly number[];
+  /**
+   * Unix seconds, as a decimal string.
+   *
+   * Compared for a **pot league only**, like the money fields — a free league
+   * carries zero, because there is no vault for the deadline to release.
+   *
+   * It belongs in this comparison for the same reason `refundUnlockAt` does:
+   * it decides when money moves. A creator who could anchor a later one than
+   * the rules imply would hold a failed league's stakes past the point members
+   * agreed to, and one who could anchor an earlier one could open the escape
+   * hatch on a league that was about to start.
+   */
+  readonly startDeadline: string;
 }
 
 /**
@@ -248,6 +279,8 @@ export interface ExpectedTerms {
  */
 export interface RulesLikeTerms {
   readonly league: { readonly maxTeams: number };
+  /** The frozen draft time, in unix seconds — `startDeadlineFor` reads it. */
+  readonly draft: { readonly scheduledAt: number };
   readonly pot: {
     readonly tokenMint: string;
     readonly buyInBaseUnits: string;
@@ -278,6 +311,9 @@ export function expectedTermsFromRules(rules: RulesLikeTerms): ExpectedTerms {
     feeBps: pot?.feeBps ?? 0,
     feeRecipient: pot?.feeRecipient ?? "",
     payoutBps: pot ? payoutArray(pot.payout) : [0, 0, 0, 0, 0],
+    // Zero for a free league, matching what `initialize_free_league` writes:
+    // there is no vault, so no deadline could release anything.
+    startDeadline: pot ? String(startDeadlineFor(rules.draft.scheduledAt)) : "0",
   };
 }
 
@@ -317,6 +353,10 @@ export function anchorTermMismatches(
   if (expected.hasPot && onChain.hasPot) {
     ne("buyIn", onChain.buyIn, expected.buyIn);
     ne("refundUnlockAt", onChain.refundUnlockAt, expected.refundUnlockAt);
+    // When a league that never starts releases its stakes. Anchored later than
+    // the rules imply, a failed league's members wait longer than they agreed
+    // to; anchored earlier, the escape hatch opens on a league about to begin.
+    ne("startDeadline", onChain.startDeadline, expected.startDeadline);
     ne("tokenMint", onChain.tokenMint, expected.tokenMint);
     ne("feeBps", onChain.feeBps, expected.feeBps);
 

--- a/programs/rostr-escrow/src/lib.rs
+++ b/programs/rostr-escrow/src/lib.rs
@@ -246,6 +246,30 @@ pub mod rostr_escrow {
             EscrowError::RefundUnlockTooFar
         );
 
+        // The deadline for declaring the season started, after which a league
+        // that never did releases every stake. One in the past would open the
+        // failed-league refund before anyone could deposit, so the first stake
+        // could be withdrawn immediately — the same failure `refund_unlock_at >
+        // now` prevents for the ordinary timelock.
+        require!(
+            args.start_deadline > now,
+            EscrowError::StartDeadlineNotInFuture
+        );
+
+        // The two refund openings must be ordered, and strictly.
+        //
+        // If the failed-league opening came at or after the timelock it would be
+        // dead code, and worse, `start_season` would still be legal past the
+        // point where the ordinary refund had already released stakes — a league
+        // could be declared started with a drained vault. Off-chain this cannot
+        // happen, since `earliestRefundUnlock` puts the timelock a season and
+        // sixty days beyond the draft, so this rejects only a caller who
+        // bypassed it.
+        require!(
+            args.start_deadline < args.refund_unlock_at,
+            EscrowError::StartDeadlineAfterRefundUnlock
+        );
+
         let league = &mut ctx.accounts.league;
         league.league_id = args.league_id;
         league.rules_hash = args.rules_hash;
@@ -262,6 +286,56 @@ pub mod rostr_escrow {
         league.member_count = 0;
         league.total_deposited = 0;
         league.bump = ctx.bumps.league;
+        // The one key on this account, and it can only ever call `start_season`.
+        league.commissioner = ctx.accounts.payer.key();
+        league.start_deadline = args.start_deadline;
+        league.started = false;
+
+        Ok(())
+    }
+
+    /// Declare that this league's season has begun, closing the failed-league
+    /// refund.
+    ///
+    /// ## What this is for
+    ///
+    /// A league that is not ready at its draft time — short of its buy-ins, or
+    /// with an odd field — must give everyone their money back **then**, not in
+    /// six months. But this program cannot tell a failed league from a running
+    /// one: the roster, the draft and who has paid are Postgres facts, and
+    /// `rules_hash` is 32 opaque bytes to it. Something has to say so.
+    ///
+    /// So the default is failure. A league that was ready calls this inside its
+    /// grace window; a league that was not never does, and its members are
+    /// released automatically. **Doing nothing returns the money.**
+    ///
+    /// ## The window is the whole safety argument
+    ///
+    /// This is illegal from exactly the instant the failed-league refund becomes
+    /// legal, so the two can never both be available. A league therefore cannot
+    /// be started with a partly-drained vault, and a member cannot be refunded
+    /// out of a season that has begun — the halves are complements rather than
+    /// two checks that have to agree with each other.
+    ///
+    /// ## What it cannot do
+    ///
+    /// It changes no term, moves no token, and names no winner. Its only effect
+    /// is which of two refund schedules the members are on, and both of those
+    /// end with the member holding their own money. `drawDraftOrder` refuses to
+    /// draw a pot league until this has landed, which is what stops a
+    /// commissioner running a season with the escape hatch still open.
+    ///
+    /// Free leagues are excluded rather than exempted: no vault, so nothing to
+    /// release and nothing to protect.
+    pub fn start_season(ctx: Context<StartSeason>) -> Result<()> {
+        let now = Clock::get()?.unix_timestamp;
+        let league = &mut ctx.accounts.league;
+
+        require!(league.has_pot, EscrowError::LeagueHasNoPot);
+        require!(!league.started, EscrowError::AlreadyStarted);
+        require!(now < league.start_deadline, EscrowError::StartWindowClosed);
+
+        league.started = true;
 
         Ok(())
     }
@@ -303,6 +377,14 @@ pub mod rostr_escrow {
         league.member_count = 0;
         league.total_deposited = 0;
         league.bump = ctx.bumps.league;
+        // Recorded for symmetry, and it grants nothing here: `start_season`
+        // refuses a league with no pot, so this key has no instruction to call.
+        league.commissioner = ctx.accounts.payer.key();
+        // No start deadline and never started. Both are about releasing a vault
+        // and a free league has none, so they are inert rather than defaulted —
+        // `refund_stake` cannot run against this league at all.
+        league.start_deadline = 0;
+        league.started = false;
 
         Ok(())
     }
@@ -410,10 +492,23 @@ pub mod rostr_escrow {
     /// Do not add one.
     pub fn refund_stake(ctx: Context<RefundStake>) -> Result<()> {
         let now = Clock::get()?.unix_timestamp;
-        require!(
-            now >= ctx.accounts.league.refund_unlock_at,
-            EscrowError::RefundLocked
-        );
+        let league = &ctx.accounts.league;
+
+        // **Two ways in, and this is a disjunction rather than a new condition.**
+        //
+        // Every extra *condition* on this instruction is a new way for money to
+        // become permanently stuck, which is why it has three and no more. This
+        // adds none: it can only ever make a refund available earlier, so no
+        // path that worked before stops working.
+        //
+        // The second opening exists because the reasoning behind the first does
+        // not apply to a league that never started. The timelock is late so that
+        // a refund and a payout can never both be legal — but a league with no
+        // season has no payout to race, no scores, nothing to settle. Holding
+        // its members' money for six months protects nobody from anything.
+        let timelock_open = now >= league.refund_unlock_at;
+        let failed_open = !league.started && now >= league.start_deadline;
+        require!(timelock_open || failed_open, EscrowError::RefundLocked);
 
         let amount = ctx.accounts.membership.deposited;
         require!(amount > 0, EscrowError::NothingDeposited);
@@ -457,10 +552,16 @@ pub mod rostr_escrow {
 
 /// The terms of a league, frozen at creation.
 ///
-/// Deliberately absent: a commissioner authority. Nothing in this account may
-/// change, so there is nobody who needs the right to change it. Adding an
-/// authority field would create the exact attack docs/DECISIONS.md §
-/// "Commissioner powers are bounded by the contract" exists to remove.
+/// **No term may change, and there is no authority that could change one.** That
+/// is what docs/DECISIONS.md § "Commissioner powers are bounded by the contract"
+/// asks for, and it still holds: the buy-in, the fee, its recipient, the payout
+/// split, the mint and the refund date are written once and read forever.
+///
+/// This paragraph used to say the account had no authority field at all. It has
+/// one — `commissioner`, whose sole power is `start_season`, and whose sole
+/// effect is which of two refund schedules a member is on. Both end with them
+/// holding their own money. See the field for why that was the least bad way to
+/// let a league that never started give the money back.
 #[account]
 #[derive(InitSpace)]
 pub struct League {
@@ -540,6 +641,47 @@ pub struct League {
     /// it tracks what the vault actually holds rather than what it ever held.
     pub total_deposited: u64,
     pub bump: u8,
+    // ---------------------------------------------------------------------
+    // Appended, and appended deliberately. Field order is the serialisation
+    // layout, so inserting above would move every field below it and make every
+    // already-anchored league unreadable. Same discipline as `EscrowError`.
+    // ---------------------------------------------------------------------
+    // The wallet that created this league.
+    //
+    // **This is an authority, and this account did not have one.** The struct
+    // docstring above used to say so flatly. What it can do is call
+    // `start_season`, whose entire effect is to choose between two refund
+    // schedules — and both of them end with the member holding their own money.
+    // It cannot change a term, cannot move a token, and cannot name a winner.
+    //
+    // Its worst abuse is marking a failed league started, which locks stakes
+    // until the ordinary timelock: exactly the behaviour before this field
+    // existed, so it is not a regression but the floor it was measured against.
+    // The commissioner is also a member with a stake, so it costs them too.
+    //
+    // The alternative was a permissionless `start_season` proving on-chain that
+    // the field was full and funded. Rejected: `join_league` is permissionless
+    // (#18), so any stranger opening an unfunded `Membership` could force every
+    // pot league to fail. Money would stay safe, but a one-transaction kill on
+    // any league is worse than an authority whose worst case is the status quo.
+    pub commissioner: Pubkey,
+    // The instant by which this league must have declared itself started. After
+    // it, a league that never did releases every stake.
+    //
+    // **An explicit instant rather than the draft time plus a constant here**,
+    // for the same reason `refund_unlock_at` is: the program has no schedule and
+    // no view of a league's calendar, so a deadline it computed itself would be
+    // computed from something it was handed anyway. Derived off-chain by
+    // `startDeadlineFor` in `@rostr/escrow` as the draft time plus its grace,
+    // and compared against the signed rule set by `anchorTermMismatches` — so a
+    // creator cannot anchor a deadline nobody agreed to, exactly as they cannot
+    // anchor a buy-in or a refund date nobody agreed to.
+    //
+    // Zero for a free league, which has no vault and so nothing to release.
+    pub start_deadline: i64,
+    // Set once by `start_season` and never unset. False means the season never
+    // began, which is what opens the failed-league refund.
+    pub started: bool,
 }
 
 /// One member's place in one league.
@@ -568,6 +710,9 @@ pub struct InitializeLeagueArgs {
     pub fee_bps: u16,
     pub fee_recipient: Pubkey,
     pub max_teams: u8,
+    /// When the season must be declared started by. Appended, so the argument
+    /// order is stable. See the field on `League`.
+    pub start_deadline: i64,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -604,8 +749,11 @@ pub struct InitializeLeague<'info> {
     )]
     pub vault: Account<'info, TokenAccount>,
 
-    /// Pays rent. Holds no privileges afterwards — creating a league is not a
-    /// role, and this key is not recorded on the account.
+    /// Pays rent, and is recorded as `league.commissioner`.
+    ///
+    /// This used to say the key held no privileges afterwards and was not
+    /// recorded. It is now recorded, and it holds exactly one: `start_season`.
+    /// That instruction changes no term and moves no token — see the field.
     #[account(mut)]
     pub payer: Signer<'info>,
 
@@ -629,6 +777,23 @@ pub struct InitializeFreeLeague<'info> {
     pub payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct StartSeason<'info> {
+    #[account(
+        mut,
+        seeds = [b"league", league.league_id.as_ref()],
+        bump = league.bump,
+        // The one authority on this account, checked here rather than in the
+        // handler so a caller who is not the commissioner cannot even reach it.
+        constraint = league.commissioner == commissioner.key() @ EscrowError::NotCommissioner,
+    )]
+    pub league: Account<'info, League>,
+
+    /// The wallet that created the league. No other key can start a season, and
+    /// this one can do nothing else.
+    pub commissioner: Signer<'info>,
 }
 
 #[derive(Accounts)]
@@ -793,4 +958,14 @@ pub enum EscrowError {
     // Rust toolchain to regenerate it with.
     #[msg("Refund unlock time is too far in the future")]
     RefundUnlockTooFar,
+    #[msg("Only the wallet that created this league may start its season")]
+    NotCommissioner,
+    #[msg("This league's season has already started")]
+    AlreadyStarted,
+    #[msg("The window to start this season has closed; its members may now be refunded")]
+    StartWindowClosed,
+    #[msg("The start deadline must be in the future")]
+    StartDeadlineNotInFuture,
+    #[msg("The start deadline must fall before the refund unlock")]
+    StartDeadlineAfterRefundUnlock,
 }

--- a/programs/rostr-escrow/tests/anchor.test.ts
+++ b/programs/rostr-escrow/tests/anchor.test.ts
@@ -122,6 +122,7 @@ async function anchorOnChain(
     mint,
     buyInBaseUnits: pot.buyInBaseUnits,
     refundUnlockAt: pot.refundUnlockAt,
+    draftScheduledAt: DRAFT.scheduledAt,
     payoutBps: payoutArray(pot.payout),
     feeBps: pot.feeBps,
     feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),
@@ -279,6 +280,7 @@ describe("create -> anchor -> join", () => {
       // A year past what the rules say still diverges, which is what this test
       // is for, and is a value initialize_league will now actually accept.
       refundUnlockAt: String(refundUnlockFor(DRAFT.scheduledAt) + 365 * 24 * 3600),
+      draftScheduledAt: DRAFT.scheduledAt,
       payoutBps: payoutArray(pot.payout),
       feeBps: pot.feeBps,
       feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),

--- a/programs/rostr-escrow/tests/divergence.test.ts
+++ b/programs/rostr-escrow/tests/divergence.test.ts
@@ -99,6 +99,7 @@ async function anchorOnChain(
     mint,
     buyInBaseUnits: pot.buyInBaseUnits,
     refundUnlockAt: pot.refundUnlockAt,
+    draftScheduledAt: DRAFT.scheduledAt,
     payoutBps: payoutArray(pot.payout),
     feeBps: pot.feeBps,
     feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),

--- a/programs/rostr-escrow/tests/failed-league.test.ts
+++ b/programs/rostr-escrow/tests/failed-league.test.ts
@@ -1,0 +1,307 @@
+import * as anchor from "@coral-xyz/anchor";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  type InitArgs,
+  type Member,
+  createPotMint,
+  expectError,
+  fundedMember,
+  getProgram,
+  getProvider,
+  leaguePda,
+  membershipPda,
+  startSeason,
+  tokenBalance,
+  validArgs,
+  vaultPda,
+} from "./helpers.js";
+
+/**
+ * A league that never starts gives the money back — issue #170.
+ *
+ * ## What this is proving
+ *
+ * Before this, the only way tokens left a vault was `refund_stake` after
+ * `refund_unlock_at`, which `earliestRefundUnlock` puts a season and sixty days
+ * past the draft. For a league that filled and played, that is right: the
+ * timelock is late so a refund and a payout can never both be legal, and
+ * whoever transacts first cannot take the pot.
+ *
+ * For a league that **never started** it was absurd. A pot league that reached
+ * its draft time one short of its buy-ins, or with an odd field, had nothing to
+ * settle and no season to protect — and its members waited six months for money
+ * that was never at stake in anything.
+ *
+ * ## The shape, and why it fails safe
+ *
+ * The program cannot tell a failed league from a running one: the roster, the
+ * draft and who has paid are all Postgres facts. So the default is failure. A
+ * league that was ready calls `start_season` inside its window; one that was not
+ * never does, and its members are released the instant the window shuts.
+ * **Doing nothing is what returns the money**, which is the direction a rule
+ * about other people's money should fail in.
+ *
+ * ## Reading the clock in these tests
+ *
+ * Deadlines are set a few seconds out and waited for, the same way `pot.test.ts`
+ * reaches the ordinary timelock — the validator's clock follows real time and
+ * cannot be warped. Note it *drifts behind* wall time on a long-lived ledger, so
+ * sleeping past a deadline is reliable while picking a past wall time is not.
+ * See CLAUDE.md on validator drift if several of these fail at once.
+ */
+
+const BUY_IN = 5_000_000;
+
+let provider: anchor.AnchorProvider;
+let program: anchor.Program;
+let mint: anchor.web3.PublicKey;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+beforeAll(async () => {
+  provider = getProvider();
+  program = getProgram(provider);
+  mint = await createPotMint(provider);
+});
+
+const initialize = async (args: InitArgs): Promise<anchor.web3.PublicKey> => {
+  const league = leaguePda(program, args.leagueId);
+  await program.methods
+    .initializeLeague(args)
+    .accounts({
+      league,
+      mint,
+      vault: vaultPda(program, league),
+      payer: provider.wallet.publicKey,
+      tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .rpc();
+  return league;
+};
+
+const join = async (league: anchor.web3.PublicKey, member: Member, rulesHash: number[]) =>
+  program.methods
+    .joinLeague(rulesHash)
+    .accounts({
+      league,
+      membership: membershipPda(program, league, member.keypair.publicKey),
+      member: member.keypair.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .signers([member.keypair])
+    .rpc();
+
+const deposit = async (league: anchor.web3.PublicKey, member: Member) =>
+  program.methods
+    .deposit()
+    .accounts({
+      league,
+      membership: membershipPda(program, league, member.keypair.publicKey),
+      vault: vaultPda(program, league),
+      mint,
+      memberTokenAccount: member.tokenAccount,
+      member: member.keypair.publicKey,
+      tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+    })
+    .signers([member.keypair])
+    .rpc();
+
+const refund = async (league: anchor.web3.PublicKey, member: Member) =>
+  program.methods
+    .refundStake()
+    .accounts({
+      league,
+      membership: membershipPda(program, league, member.keypair.publicKey),
+      vault: vaultPda(program, league),
+      memberTokenAccount: member.tokenAccount,
+      member: member.keypair.publicKey,
+      tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+    })
+    .signers([member.keypair])
+    .rpc();
+
+/** A league whose start window shuts in ~3s, with the timelock a year out. */
+const failingSoon = (overrides: Partial<InitArgs> = {}): InitArgs =>
+  validArgs({
+    buyIn: new anchor.BN(BUY_IN),
+    startDeadline: new anchor.BN(Math.floor(Date.now() / 1000) + 3),
+    ...overrides,
+  });
+
+describe("a league that never starts", () => {
+  it("returns every stake when its start window shuts, with the timelock a year away", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+    const member = await fundedMember(provider, mint, BUY_IN);
+
+    await join(league, member, args.rulesHash);
+    await deposit(league, member);
+    expect(await tokenBalance(provider, vaultPda(program, league))).toBe(BigInt(BUY_IN));
+
+    // Before the window shuts, nothing has failed yet, so the ordinary timelock
+    // still governs — and it is a year out.
+    await expectError(refund(league, member), "RefundLocked");
+
+    await sleep(5000);
+
+    // Nobody declared it started, so it failed, so the money is theirs.
+    await refund(league, member);
+    expect(await tokenBalance(provider, vaultPda(program, league))).toBe(0n);
+    expect(await tokenBalance(provider, member.tokenAccount)).toBe(BigInt(BUY_IN));
+  });
+
+  /**
+   * The claim never expires, and that is deliberate.
+   *
+   * A refund window that closes is a way for money to become permanently stuck,
+   * which is the one outcome this program exists to prevent. Members forget;
+   * forgetting must cost them nothing. (#169 emails them, and must never gate
+   * this.)
+   */
+  it("keeps the claim open indefinitely rather than expiring it", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+    const member = await fundedMember(provider, mint, BUY_IN);
+
+    await join(league, member, args.rulesHash);
+    await deposit(league, member);
+
+    await sleep(9000);
+
+    await refund(league, member);
+    expect(await tokenBalance(provider, member.tokenAccount)).toBe(BigInt(BUY_IN));
+  });
+
+  it("releases every member, not merely the first to ask", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+    const one = await fundedMember(provider, mint, BUY_IN);
+    const two = await fundedMember(provider, mint, BUY_IN);
+
+    await join(league, one, args.rulesHash);
+    await deposit(league, one);
+    await join(league, two, args.rulesHash);
+    await deposit(league, two);
+
+    await sleep(5000);
+
+    await refund(league, one);
+    await refund(league, two);
+    expect(await tokenBalance(provider, vaultPda(program, league))).toBe(0n);
+
+    const account = await program.account["league"]!.fetch(league);
+    expect((account as { totalDeposited: anchor.BN }).totalDeposited.toString()).toBe("0");
+  });
+
+  it("still refuses a second withdrawal", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+    const member = await fundedMember(provider, mint, BUY_IN);
+
+    await join(league, member, args.rulesHash);
+    await deposit(league, member);
+    await sleep(5000);
+    await refund(league, member);
+
+    await expectError(refund(league, member), "AlreadyRefunded");
+  });
+});
+
+describe("a league that starts", () => {
+  it("closes the failed-league refund, leaving only the timelock", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+    const member = await fundedMember(provider, mint, BUY_IN);
+
+    await join(league, member, args.rulesHash);
+    await deposit(league, member);
+
+    // Inside the window, so this lands.
+    await startSeason(program, league);
+
+    await sleep(5000);
+
+    // The window has shut, but the season began — so the only way out is the
+    // ordinary timelock, a year from now. Without this the season would be
+    // played by managers who could withdraw at any point and keep their roster,
+    // their standings place and their claim on the pot.
+    await expectError(refund(league, member), "RefundLocked");
+    expect(await tokenBalance(provider, vaultPda(program, league))).toBe(BigInt(BUY_IN));
+  });
+
+  it("records that it started", async () => {
+    const args = failingSoon();
+    const league = await initialize(args);
+
+    const before = await program.account["league"]!.fetch(league);
+    expect((before as { started: boolean }).started).toBe(false);
+
+    await startSeason(program, league);
+
+    const after = await program.account["league"]!.fetch(league);
+    expect((after as { started: boolean }).started).toBe(true);
+  });
+
+  it("cannot be started twice", async () => {
+    const league = await initialize(failingSoon());
+    await startSeason(program, league);
+    await expectError(startSeason(program, league), "AlreadyStarted");
+  });
+
+  /**
+   * The two windows are complements, and that is the whole safety argument.
+   *
+   * `start_season` is illegal from exactly the instant the failed-league refund
+   * becomes legal. So a league can never be declared started with a vault
+   * members have already withdrawn from, and a member can never be refunded out
+   * of a season that has begun. Neither half has to agree with the other; there
+   * is no overlap for them to disagree about.
+   */
+  it("cannot be started once its window has shut", async () => {
+    const league = await initialize(failingSoon());
+    await sleep(5000);
+    await expectError(startSeason(program, league), "StartWindowClosed");
+  });
+
+  it("can only be started by the wallet that created it", async () => {
+    const league = await initialize(failingSoon());
+    const stranger = anchor.web3.Keypair.generate();
+    await provider.connection.confirmTransaction(
+      await provider.connection.requestAirdrop(stranger.publicKey, 1_000_000_000),
+      "confirmed",
+    );
+
+    await expectError(startSeason(program, league, stranger), "NotCommissioner");
+
+    // And the real commissioner is unaffected by the attempt.
+    await startSeason(program, league);
+  });
+});
+
+describe("the terms that bound it", () => {
+  it("refuses a start deadline already in the past", async () => {
+    // Otherwise a league could be created already failed, and its first deposit
+    // would be withdrawable immediately — the same failure `refund_unlock_at >
+    // now` prevents for the ordinary timelock.
+    await expectError(
+      initialize(
+        validArgs({ startDeadline: new anchor.BN(Math.floor(Date.now() / 1000) - 60) }),
+      ),
+      "StartDeadlineNotInFuture",
+    );
+  });
+
+  it("refuses a start deadline at or after the refund unlock", async () => {
+    const unlock = Math.floor(Date.now() / 1000) + 3600;
+    await expectError(
+      initialize(
+        validArgs({
+          refundUnlockAt: new anchor.BN(unlock),
+          startDeadline: new anchor.BN(unlock),
+        }),
+      ),
+      "StartDeadlineAfterRefundUnlock",
+    );
+  });
+});

--- a/programs/rostr-escrow/tests/helpers.ts
+++ b/programs/rostr-escrow/tests/helpers.ts
@@ -54,6 +54,7 @@ export type InitArgs = {
   feeBps: number;
   feeRecipient: anchor.web3.PublicKey;
   maxTeams: number;
+  startDeadline: anchor.BN;
 };
 
 export type FreeLeagueArgs = {
@@ -110,18 +111,60 @@ export const membershipPda = (
     program.programId,
   )[0];
 
-export const validArgs = (overrides: Partial<InitArgs> = {}): InitArgs => ({
-  leagueId: freshLeagueId(),
-  // Any non-zero 32 bytes stands in for a real SHA-256 of the canonical rules.
-  rulesHash: Array.from({ length: 32 }, (_, i) => (i + 1) % 256),
-  buyIn: new anchor.BN(10_000_000),
-  refundUnlockAt: new anchor.BN(Math.floor(Date.now() / 1000) + 365 * 24 * 3600),
-  payoutBps: [...DEFAULT_PAYOUT],
-  feeBps: DEFAULT_FEE_BPS,
-  feeRecipient: anchor.web3.Keypair.generate().publicKey,
-  maxTeams: 12,
-  ...overrides,
-});
+export const validArgs = (overrides: Partial<InitArgs> = {}): InitArgs => {
+  const base = {
+    leagueId: freshLeagueId(),
+    // Any non-zero 32 bytes stands in for a real SHA-256 of the canonical rules.
+    rulesHash: Array.from({ length: 32 }, (_, i) => (i + 1) % 256),
+    buyIn: new anchor.BN(10_000_000),
+    refundUnlockAt: new anchor.BN(Math.floor(Date.now() / 1000) + 365 * 24 * 3600),
+    payoutBps: [...DEFAULT_PAYOUT],
+    feeBps: DEFAULT_FEE_BPS,
+    feeRecipient: anchor.web3.Keypair.generate().publicKey,
+    maxTeams: 12,
+    ...overrides,
+  };
+
+  /*
+    The start deadline has to stay strictly inside the refund unlock, and many
+    tests here override the unlock to a few seconds out so they can sleep past
+    it. A fixed default would make every one of those fail at `initialize_league`
+    with `StartDeadlineAfterRefundUnlock` — so derive it from whatever unlock the
+    caller actually chose.
+
+    A week out for a realistic league; one second inside the unlock for the short
+    ones. Both satisfy `now < start_deadline < refund_unlock_at`.
+  */
+  // BN arithmetic throughout, never `.toNumber()`: one test deliberately passes
+  // `i64::MAX` as the unlock, and bn.js throws above 53 bits — which would abort
+  // that test here, in the fixture, instead of reaching the ceiling it exists to
+  // prove.
+  const week = new anchor.BN(Math.floor(Date.now() / 1000) + 7 * 24 * 3600);
+  const justInside = base.refundUnlockAt.subn(1);
+
+  return {
+    ...base,
+    startDeadline: overrides.startDeadline ?? (justInside.lt(week) ? justInside : week),
+  };
+};
+
+/**
+ * Declare a season started, which is what closes the failed-league refund.
+ *
+ * Signed by the provider wallet, which is the `payer` on `initialize_league` and
+ * therefore the league's recorded commissioner.
+ */
+export const startSeason = async (
+  program: anchor.Program,
+  league: anchor.web3.PublicKey,
+  commissioner?: anchor.web3.Keypair,
+): Promise<string> => {
+  const method = program.methods.startSeason().accounts({
+    league,
+    commissioner: commissioner?.publicKey ?? program.provider.publicKey,
+  });
+  return commissioner ? method.signers([commissioner]).rpc() : method.rpc();
+};
 
 export const validFreeArgs = (overrides: Partial<FreeLeagueArgs> = {}): FreeLeagueArgs => ({
   leagueId: freshLeagueId(),

--- a/programs/rostr-escrow/tests/pot.test.ts
+++ b/programs/rostr-escrow/tests/pot.test.ts
@@ -12,6 +12,7 @@ import {
   refundStakeIx,
   vaultPda as clientVaultPda,
 } from "@rostr/escrow";
+import { START_GRACE_SECONDS } from "@rostr/escrow";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   type FreeLeagueArgs,
@@ -325,6 +326,11 @@ describe("the @rostr/escrow client", () => {
         mint,
         buyInBaseUnits: String(BUY_IN),
         refundUnlockAt: unlockAt,
+        // The deadline derives as draft + 48h and must land strictly inside the
+        // refund unlock, which this test sets three seconds out so it can sleep
+        // past it. So the draft has to sit a grace window and a little more
+        // before that.
+        draftScheduledAt: unlockAt - START_GRACE_SECONDS - 1,
         payoutBps: payoutArray([
           { prize: "CHAMPION", basisPoints: 6000 },
           { prize: "RUNNER_UP", basisPoints: 1500 },

--- a/programs/rostr-escrow/tests/stake.test.ts
+++ b/programs/rostr-escrow/tests/stake.test.ts
@@ -134,15 +134,27 @@ async function anchorLeague(
   leagueId: string,
   rulesHash: string,
   rules: ReturnType<typeof buildNflPprRules>,
+  /**
+   * Only for the refund test below, which builds a league with a draft deep in
+   * the past so its unlock can be three seconds away. The derived deadline would
+   * then be in the past too, and `initialize_league` refuses that — a league
+   * cannot be created already failed.
+   */
+  startDeadline?: number,
 ) {
   const pot = rules.pot;
   if (!pot) throw new Error("expected a pot league");
   const ix = await initializeLeagueIx(program, {
+    ...(startDeadline === undefined ? {} : { startDeadline }),
     leagueId,
     rulesHash: hexToBytes(rulesHash),
     mint,
     buyInBaseUnits: pot.buyInBaseUnits,
     refundUnlockAt: pot.refundUnlockAt,
+    // The league's own draft time, not the module default. A test that shortens
+    // the refund unlock shifts the draft with it, and anchoring the default here
+    // would derive a start deadline past that unlock.
+    draftScheduledAt: rules.draft.scheduledAt,
     payoutBps: payoutArray(pot.payout),
     feeBps: pot.feeBps,
     feeRecipient: new anchor.web3.PublicKey(pot.feeRecipient),
@@ -262,7 +274,14 @@ describe("a completed refund verifies as a refund", () => {
       Math.floor(Date.now() / 1000) + 3,
       Math.floor(Date.now() / 1000) - 220 * 24 * 3600,
     );
-    const sig = await anchorLeague(league.id, league.rulesHash, rules);
+    // Two seconds out: inside the three-second unlock, and in the future, which
+    // the derived deadline could not be for a draft 220 days ago.
+    const sig = await anchorLeague(
+      league.id,
+      league.rulesHash,
+      rules,
+      Math.floor(Date.now() / 1000) + 2,
+    );
     await recordChainAnchor(db, league.id, {
       signature: sig,
       cluster: clusterOf(provider.connection),


### PR DESCRIPTION
The on-chain half of #170. **Merges #167's work already on `main`; this is the escrow layer only** — the draft gating and the UI are still to come, listed at the bottom.

## What it does

A pot league that reaches its draft time short of its buy-ins, or with an odd field, refunds everyone **then**. Before this, the only exit was `refund_stake` after `refund_unlock_at` — for a league drafting 22 Aug 2026, that is **24 Feb 2027, 186 days**.

That lateness is correct for a league that played: a refund and a payout must never both be legal, or whoever transacts first takes the pot. It is absurd for a league that never started — nothing to settle, no season to protect, twelve people waiting six months for money that was never at stake in anything.

## How

The program cannot tell a failed league from a running one; the roster, the draft and who has paid are Postgres facts. So **the default is failure**. A league that was ready calls `start_season` inside a 48-hour window; one that was not never does, and its members are released the moment the window shuts. Doing nothing is what returns the money.

`refund_stake` gains a **disjunction, never a condition**:

```rust
let timelock_open = now >= league.refund_unlock_at;   // unchanged
let failed_open   = !league.started && now >= league.start_deadline;
require!(timelock_open || failed_open, EscrowError::RefundLocked);
```

That instruction has exactly three conditions because every extra one is a new way for money to become stuck. This adds none — it can only make a refund available *earlier*, so no path that worked before stops working.

**The two windows are complements.** `start_season` is illegal from exactly the instant the failed-league refund becomes legal, so a league can never be started with a vault members have already drawn from, and a member can never be refunded out of a season that began. Neither half has to agree with the other; there is no overlap for them to disagree about.

## The invariant this touches, stated plainly

`League`'s docstring said *"Deliberately absent: a commissioner authority."* It now has one.

`commissioner` can call exactly one instruction, whose entire effect is choosing between two refund schedules — **both of which end with the member holding their own money**. It changes no term, moves no token, names no winner. Its worst abuse is marking a failed league started, which locks stakes until the ordinary timelock: precisely the behaviour before this existed, so the floor it is measured against rather than a regression. The commissioner is also a member with a stake.

A permissionless `start_season` proving the field full and funded on-chain was considered and rejected — `join_league` is permissionless (#18), so any stranger opening an unfunded `Membership` could force every pot league to fail. Money would stay safe, but a one-transaction kill on any league is worse than an authority whose worst case is the status quo.

## `start_deadline` is a term, and is verified like one

An explicit instant rather than a draft time the program adds a constant to — the same reasoning as `refund_unlock_at`, which the program also cannot derive. `startDeadlineFor` computes it off-chain as the draft plus 48 hours, and `anchorTermMismatches` now compares it. So a creator can no more anchor a deadline nobody agreed to than a buy-in nobody agreed to: anchored later, a failed league's members wait past what they signed; anchored earlier, the escape hatch opens on a league about to start.

## The tripwire fired, as designed

`settlement.test.ts` pins the program's instruction list precisely so a new instruction cannot slip past the mainnet deposit gate. `start_season` must never read as settlement and **the margin is one letter** — "start" and "settle" share two characters, and a looser prefix would have opened that gate on a program that still cannot pay a pot out. There is now a test asserting it stays shut.

## Verified

- **85 program tests against a real validator** (`anchor test`), 11 new in `failed-league.test.ts`. Fresh ledger, so no clock drift.
- 1371 TypeScript tests, typecheck, lint, format, `idl:check` all clean.

Three existing tests needed real changes rather than cosmetic ones, and the reasons are in the comments: they built leagues with a three-second timelock, which now forces a correspondingly early start deadline, and one built a league with a draft 220 days in the past — which the program now refuses, because a league cannot be created already failed.

## Not in this PR

The rules the owner set that this enables, still to build:

1. `drawDraftOrder` refuses a pot league until every member has staked, and refuses any odd field.
2. A bot squares an odd **free** league automatically at the draw.
3. `start_season` sent from the app immediately before the draw — mark first, draw second, because drawing first and failing to mark would leave a live season members can withdraw out of.
4. The failed state, and the lobby saying which condition is outstanding *before* the deadline rather than after.

Also note the account layout changed, so leagues anchored on devnet before this become unreadable. Acceptable — they are test leagues — but it has to happen before anything real is anchored.

Refs #170