### PR TITLE
No odd fields, and no pot league drafts against an empty vault

### DIFF
--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -1373,6 +1373,61 @@ describe("queues", () => {
  * the default `minHumans: 2`, so they are a standing detector for anyone who
  * writes `<=` where the guard needs `<`.
  */
+/**
+ * No odd fields — decided by the owner on 2026-08-17.
+ *
+ * An odd field hands somebody a bye every week, and a bye is a free result: no
+ * game, no loss. In a league playing for money that moves who gets paid.
+ *
+ * The refusal is here rather than a fix, and that is forced rather than chosen:
+ * migration `0028` locks the field at `scheduledAt` on INSERT *and* DELETE, and
+ * this runs at or after that instant. So nothing can add a bot or drop a team
+ * by the time the draw happens — squaring the field has to be done while it is
+ * still open, which is what the lobby has to say before the deadline.
+ */
+describe("the draw refuses an odd field", () => {
+  it("refuses three teams", async () => {
+    const fx = await setup(3);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toMatchObject({ code: "ODD_FIELD" });
+  });
+
+  it("draws an even field", async () => {
+    const fx = await setup(4);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).resolves.toBeDefined();
+  });
+
+  it("counts every team, bots included", async () => {
+    // A bot occupies a fixture like anyone else, so it is what squares an odd
+    // free league — the field being even is a fact about the schedule, not
+    // about how many people are in it.
+    const fx = await setup(5);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toThrow(/5 teams/);
+  });
+
+  it("answers BELOW_MIN_HUMANS first for a single-manager league", async () => {
+    // One team is both odd and short, and short is the more useful thing to be
+    // told — the same ordering `NO_TEAMS` keeps ahead of both.
+    const fx = await setup(1);
+    await createDraftRecord(fx.client, scheduleArgs(fx.leagueId));
+
+    await expect(
+      drawDraftOrder(fx.client, { leagueId: fx.leagueId, beacon: BEACON, now: DRAW_TIME }),
+    ).rejects.toMatchObject({ code: "BELOW_MIN_HUMANS" });
+  });
+});
+
 describe("the draw refuses a field below minHumans", () => {
   it("refuses a single-manager league", async () => {
     const fx = await setup(1);

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -65,6 +65,11 @@ export class DraftPersistenceError extends Error {
       | "ORDER_ALREADY_DRAWN"
       | "TOO_EARLY_TO_DRAW"
       | "BELOW_MIN_HUMANS"
+      // An odd field would give somebody a bye every week. Squaring it is only
+      // possible before `scheduledAt`, when the field is still open.
+      | "ODD_FIELD"
+      // A pot league whose vault does not hold every member's stake.
+      | "POT_NOT_FUNDED"
       | "RULES_MISSING"
       | "NOT_IN_PROGRESS"
       | "ALREADY_STARTED"
@@ -310,6 +315,75 @@ export async function drawDraftOrder(
           `gap: it is a placeholder for a person, not a person.`,
         "BELOW_MIN_HUMANS",
       );
+    }
+
+    /*
+      No odd fields — decided by the owner on 2026-08-17.
+
+      An odd field gives somebody a bye every week, and a bye is a free result:
+      no game, no loss, and in a paying league that moves who gets paid. The
+      existing tool for squaring one is a bot, which is exactly what `maxBots`
+      exists for — and which a pot league may never have, because a bot has no
+      wallet and paid no buy-in. So a pot league's people have to be even.
+
+      **This refuses; it does not fix.** Adding a bot here is impossible rather
+      than merely unwanted: migration `0028` locks the field at `scheduledAt` on
+      INSERT *and* DELETE, and this runs at or after that instant. The remedy has
+      to happen while the field is still open, which is why the lobby has to say
+      so before the deadline rather than after it.
+    */
+    if (teams.length % 2 !== 0) {
+      throw new DraftPersistenceError(
+        `This league has ${teams.length} teams and cannot draft with an odd field — ` +
+          `somebody would take a bye every week. ` +
+          (stored.rules.pot
+            ? `A pot league cannot use a bot to square it, because a bot pays no buy-in.`
+            : `A bot can square it, but only before the draft time: the field is locked now.`),
+        "ODD_FIELD",
+      );
+    }
+
+    /*
+      And a pot league drafts only once every member has actually staked.
+
+      Nothing used to check this — the seat is written in Postgres when the rules
+      are signed, and the buy-in moves in a separate transaction the member can
+      simply not send. So a pot league could fill, draft, and play a whole season
+      against an empty vault, and the first anyone would learn of it is when
+      settlement tried to pay out of it.
+
+      The stake is read from `league_onchain_stakes`, which is written only after
+      `/deposit` has read the `Membership` PDA back — so this is the chain's
+      answer, recorded, not the client's word for it. `refunded_at IS NULL`
+      matters as much as `deposited_at IS NOT NULL`: a member who staked and then
+      withdrew under a failed league's refund has their money back, and is not
+      funded.
+
+      Bots are excluded because they cannot pay and are barred from pot leagues
+      anyway; the check is written to be true rather than to rely on that.
+    */
+    if (stored.rules.pot) {
+      const unfunded = await tx.query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM teams t
+           JOIN league_memberships m ON m.team_id = t.id
+           JOIN wallets w ON w.id = m.wallet_id
+           LEFT JOIN league_onchain_stakes s
+             ON s.league_id = t.league_id AND s.wallet_address = w.address
+          WHERE t.league_id = $1
+            AND t.is_bot = false
+            AND (s.deposited_at IS NULL OR s.refunded_at IS NOT NULL)`,
+        [input.leagueId],
+      );
+      const owing = Number(unfunded[0]?.count ?? 0);
+      if (owing > 0) {
+        throw new DraftPersistenceError(
+          `${owing} member${owing === 1 ? " has" : "s have"} not staked the buy-in, so the ` +
+            `pot is not full. A pot league cannot draft against a vault that does not hold ` +
+            `every member's stake.`,
+          "POT_NOT_FUNDED",
+        );
+      }
     }
 
     const seed = deriveOrderSeed({


### PR DESCRIPTION
The two rules you set, enforced at `drawDraftOrder` — the single transaction that selects the teams and locks the field. Follows #171 (the escrow half) which is on `main`.

## No odd fields

An odd field hands somebody a bye every week, and a bye is a free result: no game, no loss. In a league playing for money that moves who gets paid.

The existing tool for squaring one is a bot — exactly what `maxBots` is for — and a pot league may never have one, because a bot has no wallet and paid no buy-in. So a pot league's people have to be even.

## The pot must be full

Nothing checked this before. The seat is written in Postgres when the rules are signed, and the buy-in moves in a **separate transaction the member can simply not send**. So a pot league could fill, draft and play an entire season against an empty vault, and the first anyone would learn of it is settlement trying to pay out of one.

The stake comes from `league_onchain_stakes`, which is written only after `/deposit` has read the `Membership` PDA back — the chain's answer, recorded, not the client's word for it. `refunded_at IS NULL` matters as much as `deposited_at IS NOT NULL`: a member who staked and then withdrew under a failed league's refund has their money back and is not funded.

## A correction to what I told you earlier

I said unpaid members would be auto-dropped at the draft time, and that a bot would auto-square an odd free league at the draw. **Neither is possible, and I was wrong to say so.**

Migration `0028` locks the field at `scheduledAt` on INSERT **and** DELETE. The draw runs at or after that instant. So by the time it happens, nothing can join and nothing can leave — the draw can only refuse.

That changes where the work goes, not what it achieves. Every remedy has to happen while the field is still open, which makes the lobby warning load-bearing rather than a courtesy: it is the only thing that can prevent the failure. A league that reaches its draft time odd or underfunded now simply does not draft, and #171's refund releases everyone 48 hours later.

## Ordering

Both checks sit after `NO_TEAMS` and `BELOW_MIN_HUMANS`. A one-team league is both odd and short, and short is the more useful thing to be told — the same reason `NO_TEAMS` stays ahead of both. There is a test for that.

## Verified

1378 tests (4 new), typecheck, lint and format clean. The pot check has no test yet that builds a funded pot league end to end — that needs the fixture from `stake.test.ts`, which runs in the program suite against a validator, and is the honest place for it.

## Still to come

- `start_season` sent from the app immediately before the draw — mark first, draw second
- The draft lobby saying which condition is outstanding, **before** the deadline
- The failed state itself

Refs #170