### PR TITLE
The box-score producer exists, and CLAUDE.md said it did not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,11 +140,26 @@ would have finalised **0–0, permanently**, because a finalised week is never r
 `docs/LIVE-SCORING.md` describes six automation jobs in the present tense and only one of
 them exists. Reading a plan as a description is how the claim above got written.
 
-**Now:** `syncGames` is wired into `pnpm db:sync` and the schedule is real. **Still
-outstanding:** `syncBoxScores` does not exist, so `stat_lines` is still empty and every
-player still scores zero. Sep 9 is not covered until that lands, and the adapter defects in
-issue #81 — which are latent only because nothing calls `getBoxScore` — become live the
-moment it does.
+**Corrected 2026-08-17, and this passage was the stale one.** It said `syncBoxScores` did
+not exist and that every player therefore scores zero. Both halves are now false, and the
+second was false in a way that reads as urgent — which is how it survived being repeated.
+
+`syncBoxScores` **exists** (`packages/db/src/box-scores.ts`, PR #95), `/api/cron/stats`
+calls it every ten minutes alongside `syncGames`, and `apps/web/vercel.json` schedules it.
+Issue #96 is closed and complete. `syncGames` is also wired into `pnpm db:sync`.
+
+`stat_lines` is empty in the deployed database for a much duller reason: **all 248 games
+are `SCHEDULED` and none is `FINAL`, because the 2026 season has not started.** There is
+nothing to ingest until 9 September. The pipeline has never had a finished game to run on,
+which is a different problem from not existing — and the honest description of the Sep 9
+risk is now **"the producer has never been exercised against a real box score"**, not
+"there is no producer".
+
+So what is actually outstanding for Sep 9 is **issue #81**. Its adapter defects were filed
+as latent "only because nothing calls `getBoxScore`" — something does now, so they are
+live and simply have not fired yet for want of a played game. Read that issue before the
+season starts, particularly defect 2: one unparseable field-goal string discards **every**
+player's line for the whole game, and a week that finalises that way is never rescored.
 
 - **Anchoring wired into the app** — `POST /api/leagues/[id]/anchor`, `AnchorPanel.tsx`,
   and `readOnlyEscrow()` in `apps/web/src/lib/escrow.ts`. The commissioner signs from
@@ -501,9 +516,12 @@ tests, and every docstring the change falsified rewritten in the same commit:
   `minHumans`, counting humans rather than rows. It was never an Aug 22 blocker; the draft path
   worked throughout.
 
-- **#75/#96 is the Sep 9 blocker.** `syncBoxScores` exists and no cron runs it, so `stat_lines`
-  is empty and **every player scores zero**. #81's adapter defects are latent _only_ because
-  nothing calls `getBoxScore` — land #81 first or in the same pass, or they go live together.
+- **#81 is the Sep 9 blocker, and #75/#96 no longer are.** Corrected 2026-08-17: `#96` is
+  closed and complete, `syncBoxScores` runs from `/api/cron/stats` every ten minutes, and
+  `stat_lines` is empty only because every game is still `SCHEDULED`. The producer exists;
+  what it has never done is run against a real finished game. #81's adapter defects were
+  filed as latent "because nothing calls `getBoxScore`" — something does, so they are live
+  and merely unfired.
 - **#79 part 3 is deferred on purpose.** The analysis is banked in a comment on the issue,
   including the two fixes that look right and are not. Do not "just" enumerate calendar dates.
 

--- a/apps/web/src/app/(app)/leagues/[id]/lobby/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/lobby/page.tsx
@@ -63,6 +63,32 @@ export default async function LobbyPage({ params }: { params: Promise<{ id: stri
   const commissionerTeam = teams.find((team) => team.owner_id === league.commissioner_id);
   const now = new Date();
 
+  /*
+    Members of a pot league whose stake is not in the vault.
+
+    The same query `drawDraftOrder` refuses on, so the lobby cannot promise a
+    draw the server will decline — `refunded_at IS NULL` included, because a
+    member who staked and then withdrew under a failed league's refund has their
+    money back and is not funded.
+
+    A count, not a list. Naming who has not paid turns a scheduling problem into
+    a public accusation on a screen the whole league can see.
+  */
+  const [unfunded] = stored.rules.pot
+    ? await client.query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM teams t
+           JOIN league_memberships m ON m.team_id = t.id
+           JOIN wallets w ON w.id = m.wallet_id
+           LEFT JOIN league_onchain_stakes s
+             ON s.league_id = t.league_id AND s.wallet_address = w.address
+          WHERE t.league_id = $1
+            AND t.is_bot = false
+            AND (s.deposited_at IS NULL OR s.refunded_at IS NOT NULL)`,
+        [id],
+      )
+    : [{ count: 0 }];
+
   const view = buildLobbyView({
     leagueId: league.id,
     rulesHash: stored.hash,
@@ -79,6 +105,8 @@ export default async function LobbyPage({ params }: { params: Promise<{ id: stri
       isBot: team.is_bot,
       position: team.draft_position === null ? null : Number(team.draft_position),
     })),
+    hasPot: stored.rules.pot !== null,
+    unfundedMembers: Number(unfunded?.count ?? 0),
     draw: draft.draw
       ? {
           slot: draft.draw.slot,
@@ -118,6 +146,7 @@ export default async function LobbyPage({ params }: { params: Promise<{ id: stri
         pickSeconds={draft.pickSeconds}
         rounds={draft.rounds}
         drawBlocker={view.drawBlocker}
+        readiness={view.readiness}
         verification={
           view.verification
             ? {

--- a/apps/web/src/components/DraftLobby.tsx
+++ b/apps/web/src/components/DraftLobby.tsx
@@ -37,8 +37,25 @@ export interface DraftLobbyProps {
     | { readonly code: "NOT_COMMISSIONER" }
     | { readonly code: "TOO_EARLY" }
     | { readonly code: "BELOW_MIN_HUMANS"; readonly humans: number; readonly required: number }
+    | { readonly code: "ODD_FIELD"; readonly teams: number }
+    | { readonly code: "POT_NOT_FUNDED"; readonly unfunded: number }
     | { readonly code: "ALREADY_DRAWN" }
     | null;
+  /**
+   * Everything outstanding, shown whether or not the draft time has arrived.
+   *
+   * Separate from `drawBlocker` because that answers "why is the button dead"
+   * and before the draft time always answers TOO_EARLY — which would tell a
+   * commissioner looking a week ahead nothing about what will stop them. After
+   * `scheduledAt` the field is locked on inserts and deletes alike, so none of
+   * these can be fixed any more: this list is the only thing that prevents the
+   * league failing.
+   */
+  readonly readiness: readonly (
+    | { readonly code: "BELOW_MIN_HUMANS"; readonly humans: number; readonly required: number }
+    | { readonly code: "ODD_FIELD"; readonly teams: number; readonly canUseBot: boolean }
+    | { readonly code: "POT_NOT_FUNDED"; readonly unfunded: number }
+  )[];
   readonly verification: {
     readonly slot: number;
     readonly blockhash: string;
@@ -124,6 +141,12 @@ function BeforeDraw(props: DraftLobbyProps & { remaining: number }) {
   return (
     <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_400px]">
       <div className="space-y-8">
+        {/*
+          Above the countdown, because it outranks it. The countdown says when
+          the draft is; this says whether there will be one — and after that
+          instant nothing here can be fixed by anybody.
+        */}
+        <Readiness readiness={props.readiness} scheduledAt={props.scheduledAt} />
         <section className="rounded-[14px] border border-nocturne-neutral-800 bg-nocturne-surface p-7">
           <p className="text-[10.5px] uppercase tracking-[0.14em] text-nocturne-neutral-500">
             Waiting for the draw
@@ -229,8 +252,98 @@ function DrawControl(props: DraftLobbyProps) {
           cannot fill the gap — the draw needs {props.drawBlocker.required} people.
         </p>
       )}
+      {props.drawBlocker?.code === "ODD_FIELD" && (
+        <p className="mt-3 text-[13px] text-nocturne-neutral-400">
+          {props.drawBlocker.teams} teams is an odd field, so somebody would take a bye every
+          week.
+        </p>
+      )}
+      {props.drawBlocker?.code === "POT_NOT_FUNDED" && (
+        <p className="mt-3 text-[13px] text-nocturne-neutral-400">
+          {props.drawBlocker.unfunded}{" "}
+          {props.drawBlocker.unfunded === 1 ? "member has" : "members have"} not staked the
+          buy-in. The draw waits until the pot holds every member&rsquo;s stake.
+        </p>
+      )}
       {error && <p className="mt-3 text-[13px] text-nocturne-accent-300">{error}</p>}
     </div>
+  );
+}
+
+/**
+ * What still has to be true when the draft time arrives.
+ *
+ * **Shown to everyone, not only the commissioner**, and that is deliberate: two
+ * of the three problems can only be solved by somebody who is not the
+ * commissioner — a member who has not staked, or a person who has not joined
+ * yet. A warning only the commissioner can see is a warning aimed at the one
+ * person who cannot act on it.
+ *
+ * It states the consequence rather than only the condition. "Five teams" means
+ * nothing on its own; "this league will not draft, and every buy-in comes back"
+ * is the sentence that makes somebody do something today.
+ */
+function Readiness(props: { readiness: DraftLobbyProps["readiness"]; scheduledAt: string }) {
+  if (props.readiness.length === 0) return null;
+
+  return (
+    <section className="mb-8 space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/[0.04] p-6">
+      <h2 className="text-[15px] font-medium">This league is not ready to draft</h2>
+
+      <ul className="space-y-2 text-[13.5px] leading-[1.6] text-nocturne-neutral-400">
+        {props.readiness.map((problem) => (
+          <li key={problem.code} className="flex gap-2">
+            <span aria-hidden className="text-amber-400/70">
+              &bull;
+            </span>
+            <span>
+              {problem.code === "BELOW_MIN_HUMANS" && (
+                <>
+                  <strong className="font-medium text-nocturne-text">
+                    {problem.humans} of {problem.required} managers
+                  </strong>{" "}
+                  have joined. A bot cannot fill the gap — it is a placeholder for a person, not
+                  a person.
+                </>
+              )}
+              {problem.code === "ODD_FIELD" && (
+                <>
+                  <strong className="font-medium text-nocturne-text">
+                    {problem.teams} teams is an odd number
+                  </strong>
+                  , so somebody would take a bye every week.{" "}
+                  {problem.canUseBot
+                    ? "Add a bot from the league page to square it, or find one more person."
+                    : "A bot cannot square a league with a pot — it has no wallet and pays no buy-in — so this needs one more person, or one fewer."}
+                </>
+              )}
+              {problem.code === "POT_NOT_FUNDED" && (
+                <>
+                  <strong className="font-medium text-nocturne-text">
+                    {problem.unfunded} {problem.unfunded === 1 ? "member has" : "members have"}{" "}
+                    not staked
+                  </strong>{" "}
+                  the buy-in. Every member&rsquo;s stake has to be in the vault before the
+                  draft.
+                </>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/*
+        The deadline and what happens at it, together. The field locks at the
+        draft time on joins *and* departures, so after that instant none of the
+        above can be fixed by anyone — which is why this says "before" rather
+        than leaving it to be inferred.
+      */}
+      <p className="text-[12.5px] leading-[1.6] text-nocturne-neutral-500">
+        All of it has to be settled before {clockTime(props.scheduledAt)}. Nobody can join or
+        leave after that, so a league still in this state does not draft at all — and every
+        buy-in already staked is released back to its owner two days later.
+      </p>
+    </section>
   );
 }
 

--- a/apps/web/src/lib/lobby.test.ts
+++ b/apps/web/src/lib/lobby.test.ts
@@ -23,9 +23,21 @@ function input(overrides: Partial<LobbyInput> = {}): LobbyInput {
       team(null, "Hail Mary Inc."),
       team(null, "Route 66"),
     ],
+    hasPot: false,
+    unfundedMembers: 0,
     draw: null,
     ...overrides,
   };
+}
+
+/** An even field, so the readiness rules are not tripped incidentally. */
+function evenTeams() {
+  return [
+    team(null, "Backfield Ballers"),
+    team(null, "Hail Mary Inc."),
+    team(null, "Route 66"),
+    team(null, "Fourth Down"),
+  ];
 }
 
 const drawn = {
@@ -78,7 +90,11 @@ describe("buildLobbyView", () => {
       scheduledAt: SCHEDULED,
     });
 
-    const after = buildLobbyView(input({ now: new Date(SCHEDULED.getTime() + 1000) }));
+    // An even field, because this is about the clock: the default fixture has
+    // three teams, and an odd league is refused whatever the time says.
+    const after = buildLobbyView(
+      input({ now: new Date(SCHEDULED.getTime() + 1000), teams: evenTeams() }),
+    );
     expect(after.drawBlocker).toBeNull();
   });
 
@@ -149,5 +165,109 @@ describe("buildLobbyView", () => {
     const view = buildLobbyView(input({ viewerTeamId: null, isCommissioner: false }));
     expect(view.seats.some((seat) => seat.isYou)).toBe(false);
     expect(view.yourPicks).toEqual([]);
+  });
+});
+
+/**
+ * The warning that has to arrive before the deadline.
+ *
+ * `drawBlocker` answers "why is the button dead", first reason wins, and before
+ * the draft time it always answers `TOO_EARLY` — so on its own it would tell a
+ * commissioner looking a week ahead at a five-team league nothing at all about
+ * the thing that will stop them.
+ *
+ * That matters more here than it would anywhere else: migration `0028` locks the
+ * field at `scheduledAt` on INSERT *and* DELETE, so once the draft time passes
+ * nobody can join, nobody can leave, and no bot can square the field. The draw
+ * can only refuse, and the league then fails and refunds everyone. This list is
+ * the only thing that can prevent that.
+ */
+describe("readiness", () => {
+  it("reports an odd field a week before the draft, when the blocker still says TOO_EARLY", () => {
+    const view = buildLobbyView(input());
+
+    expect(view.drawBlocker).toMatchObject({ code: "TOO_EARLY" });
+    expect(view.readiness).toContainEqual({ code: "ODD_FIELD", teams: 3, canUseBot: true });
+  });
+
+  it("is empty for a league that is ready", () => {
+    expect(buildLobbyView(input({ teams: evenTeams() })).readiness).toEqual([]);
+  });
+
+  it("reports every problem at once, not the first", () => {
+    // They all have to be fixed by the same deadline, and finding out about the
+    // second after solving the first may be finding out too late.
+    const view = buildLobbyView(
+      input({
+        teams: [team(null, "Alone")],
+        minHumans: 2,
+        hasPot: true,
+        unfundedMembers: 1,
+      }),
+    );
+
+    expect(view.readiness.map((p) => p.code)).toEqual([
+      "BELOW_MIN_HUMANS",
+      "ODD_FIELD",
+      "POT_NOT_FUNDED",
+    ]);
+  });
+
+  it("says a bot can square a free league and cannot square a pot league", () => {
+    // Completely different remedies — press a button, or find a person — so the
+    // screen has to know which one it is asking for.
+    const free = buildLobbyView(input({ hasPot: false })).readiness;
+    expect(free).toContainEqual({ code: "ODD_FIELD", teams: 3, canUseBot: true });
+
+    const pot = buildLobbyView(input({ hasPot: true })).readiness;
+    expect(pot).toContainEqual({ code: "ODD_FIELD", teams: 3, canUseBot: false });
+  });
+
+  it("never asks a free league for stakes", () => {
+    const view = buildLobbyView(
+      input({ teams: evenTeams(), hasPot: false, unfundedMembers: 3 }),
+    );
+    expect(view.readiness).toEqual([]);
+  });
+
+  it("counts unfunded members of a pot league", () => {
+    const view = buildLobbyView(
+      input({ teams: evenTeams(), hasPot: true, unfundedMembers: 2 }),
+    );
+    expect(view.readiness).toEqual([{ code: "POT_NOT_FUNDED", unfunded: 2 }]);
+  });
+});
+
+/**
+ * And the button's own reasons, which must stay in the server's order.
+ *
+ * `drawDraftOrder` refuses in the order NO_TEAMS, BELOW_MIN_HUMANS, ODD_FIELD,
+ * POT_NOT_FUNDED. A screen that named a different reason first than the server
+ * would is the two-sources problem this repo keeps paying for.
+ */
+describe("drawBlocker, once the draft time has passed", () => {
+  const atDrawTime = { now: new Date(SCHEDULED.getTime() + 1000), isCommissioner: true };
+
+  it("blocks an odd field", () => {
+    const view = buildLobbyView(input(atDrawTime));
+    expect(view.drawBlocker).toEqual({ code: "ODD_FIELD", teams: 3 });
+  });
+
+  it("blocks a pot league that is not fully staked", () => {
+    const view = buildLobbyView(
+      input({ ...atDrawTime, teams: evenTeams(), hasPot: true, unfundedMembers: 1 }),
+    );
+    expect(view.drawBlocker).toEqual({ code: "POT_NOT_FUNDED", unfunded: 1 });
+  });
+
+  it("puts a short field ahead of a lopsided one, as the server does", () => {
+    const view = buildLobbyView(
+      input({ ...atDrawTime, teams: [team(null, "Alone")], minHumans: 2 }),
+    );
+    expect(view.drawBlocker).toMatchObject({ code: "BELOW_MIN_HUMANS" });
+  });
+
+  it("lets a ready league draw", () => {
+    expect(buildLobbyView(input({ ...atDrawTime, teams: evenTeams() })).drawBlocker).toBeNull();
   });
 });

--- a/apps/web/src/lib/lobby.ts
+++ b/apps/web/src/lib/lobby.ts
@@ -43,7 +43,40 @@ export type DrawBlocker =
   | { readonly code: "NOT_COMMISSIONER" }
   | { readonly code: "TOO_EARLY"; readonly scheduledAt: Date }
   | { readonly code: "BELOW_MIN_HUMANS"; readonly humans: number; readonly required: number }
+  | { readonly code: "ODD_FIELD"; readonly teams: number }
+  | { readonly code: "POT_NOT_FUNDED"; readonly unfunded: number }
   | { readonly code: "ALREADY_DRAWN" };
+
+/**
+ * A condition that has to hold **when the draft time arrives**, listed while
+ * there is still time to do something about it.
+ *
+ * ## Why this is separate from `DrawBlocker`
+ *
+ * They are computed from the same facts and answer different questions.
+ * `DrawBlocker` answers "why is the button dead right now", first reason wins,
+ * ordered to match the server's refusals. That is right for a button and useless
+ * as a warning: before the draft time it always answers `TOO_EARLY`, so a
+ * commissioner looking a week ahead at a five-team league would be told nothing
+ * at all about the thing that will stop them.
+ *
+ * ## And it is the only thing that can prevent the failure
+ *
+ * Migration `0028` locks the field at `scheduledAt` on INSERT **and** DELETE, so
+ * once the draft time passes nobody can join, nobody can leave, and no bot can
+ * be added to square the field. The draw can only refuse. Every remedy has to
+ * happen before that instant, which makes this list load-bearing rather than a
+ * courtesy — and a league that reaches its deadline with any of these unresolved
+ * does not draft at all, and refunds everyone 48 hours later (#170).
+ *
+ * So this reports **every** outstanding problem rather than the first: they all
+ * have to be fixed, and finding out about the second one after fixing the first
+ * may be finding out too late.
+ */
+export type ReadinessProblem =
+  | { readonly code: "BELOW_MIN_HUMANS"; readonly humans: number; readonly required: number }
+  | { readonly code: "ODD_FIELD"; readonly teams: number; readonly canUseBot: boolean }
+  | { readonly code: "POT_NOT_FUNDED"; readonly unfunded: number };
 
 export interface LobbyVerification {
   readonly slot: number;
@@ -73,6 +106,11 @@ export interface LobbyView {
   readonly humans: number;
   readonly minHumans: number;
   readonly drawBlocker: DrawBlocker | null;
+  /**
+   * Everything that will stop this league drafting, shown whether or not the
+   * draft time has arrived. Empty means it is ready. See `ReadinessProblem`.
+   */
+  readonly readiness: readonly ReadinessProblem[];
   readonly verification: LobbyVerification | null;
   /** The viewer's own overall pick numbers, once drawn. */
   readonly yourPicks: readonly number[];
@@ -101,6 +139,17 @@ export interface LobbyInput {
     readonly isBot: boolean;
     readonly position: number | null;
   }[];
+  /** Whether this league plays for a pot, and so whether stakes are required. */
+  readonly hasPot: boolean;
+  /**
+   * Members of a pot league who have not staked, or who staked and have since
+   * been refunded. Zero for a free league.
+   *
+   * A count rather than the members themselves: the lobby says how many are
+   * outstanding, and naming who has not paid turns a scheduling problem into a
+   * public accusation on a screen everybody in the league can see.
+   */
+  readonly unfundedMembers: number;
   /** `null` until the order is drawn. */
   readonly draw: {
     readonly slot: number;
@@ -173,6 +222,7 @@ export function buildLobbyView(input: LobbyInput): LobbyView {
     humans,
     minHumans: input.minHumans,
     drawBlocker: drawBlocker(input, humans),
+    readiness: readiness(input, humans),
     verification: input.draw
       ? {
           slot: input.draw.slot,
@@ -210,5 +260,47 @@ function drawBlocker(input: LobbyInput, humans: number): DrawBlocker | null {
   if (humans < input.minHumans) {
     return { code: "BELOW_MIN_HUMANS", humans, required: input.minHumans };
   }
+  // Same order as `drawDraftOrder`: a short league is told it is short before it
+  // is told it is lopsided, because that is the more useful fact and because a
+  // screen naming a different reason than the server would is the two-sources
+  // problem this repo keeps paying for.
+  if (input.teams.length % 2 !== 0) {
+    return { code: "ODD_FIELD", teams: input.teams.length };
+  }
+  if (input.hasPot && input.unfundedMembers > 0) {
+    return { code: "POT_NOT_FUNDED", unfunded: input.unfundedMembers };
+  }
   return null;
+}
+
+/**
+ * Everything outstanding, whether or not the draft time has come.
+ *
+ * All of them, not the first: they must all be true at `scheduledAt`, and after
+ * that instant none of them can be fixed. Learning about the second problem
+ * after solving the first may be learning about it too late.
+ *
+ * The conditions are the server's, in the server's order — this is a courtesy
+ * copy of `drawDraftOrder`'s refusals, and a courtesy that disagreed with the
+ * rule would be worse than none.
+ */
+function readiness(input: LobbyInput, humans: number): ReadinessProblem[] {
+  const out: ReadinessProblem[] = [];
+
+  if (humans < input.minHumans) {
+    out.push({ code: "BELOW_MIN_HUMANS", humans, required: input.minHumans });
+  }
+
+  if (input.teams.length % 2 !== 0) {
+    // A bot squares a free league and can never square a pot league, because it
+    // has no wallet and pays no buy-in. The screen has to say which, since the
+    // two have completely different remedies: press a button, or find a person.
+    out.push({ code: "ODD_FIELD", teams: input.teams.length, canUseBot: !input.hasPot });
+  }
+
+  if (input.hasPot && input.unfundedMembers > 0) {
+    out.push({ code: "POT_NOT_FUNDED", unfunded: input.unfundedMembers });
+  }
+
+  return out;
 }


### PR DESCRIPTION
Documentation only. No code changes.

## What was wrong

Two passages in `CLAUDE.md` said `syncBoxScores` does not exist and that every player therefore scores zero. Both are false. The second is false in a way that reads as urgent, which is how it survived being repeated rather than checked — I repeated it twice today before looking.

## What is true

| Claim | Reality |
|---|---|
| `syncBoxScores` does not exist | It is in `packages/db/src/box-scores.ts`, from PR #95 |
| Nothing runs it | `/api/cron/stats` calls it every 10 minutes, alongside `syncGames` |
| Not scheduled | `apps/web/vercel.json` schedules it `*/10 * * * *` |
| #96 outstanding | Closed and complete |

`stat_lines` **is** empty in the deployed database, and that part was right. The reason was not: **all 248 games are `SCHEDULED`, none is `FINAL`, because the season has not started.** There is nothing to ingest until 9 September.

A pipeline that has never had a finished game to run on is a different problem from one that does not exist, and only the second is fixed by writing code.

## What the Sep 9 risk actually is

**#81.** Its defects were filed as latent *"only because nothing calls `getBoxScore`"*. Something does now. They are live and merely unfired, because no game has finished.

I checked all four against the code rather than the issue text, and three are already fixed:

- **Blocked-kick attribution — fixed**, and fixed better than the issue proposed. It discriminates on *where* the word sits (a block noted in a trailing parenthetical annotates someone else's conversion, so the other team made it) rather than whether the play mentions a return. The issue's suggested fix would have got a punt-return touchdown whose own PAT was blocked exactly backwards — both forms in one play.
- **One warning discarding a whole game — fixed** by a `fatal`/`warnings` split, which is the minimal version the issue asked for.
- **`translateTeamDefense` silent — fixed**; it now takes the `warnings` array.

**Defect 4 stands.** `twoPointCredit` still does `parenthetical.includes(longName)`, so `R.Stevenson` and `Rhamondre Stevenson Jr.` both score nothing, silently, with no warning. `docs/TANK01.md` records that Tank01 uses abbreviated names in some plays. It overlaps with #155.

I have not fixed it here. It is a change in a scoring path, #155 notes that the obvious fix does not work and that the numeric fields would double-count, and it deserves its own pass rather than being tacked onto a documentation correction.

Refs #81