### PR TITLE
fix(stats): four scoring defects in the Tank01 translation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,12 @@ Two-point conversions were compared separately, because Sleeper splits them acro
 `pass_2pt`, `rush_2pt` and `rec_2pt`. **Tua Tagovailoa 1/1 and Julian Hill 1/1** — #175
 confirmed against an independent source on the game that exposed the bug.
 
-**What is still not established.** ESPN is the third source and has not been checked for
-these games, so by the standing rule above these numbers are corroborated rather than
-confirmed. And 91 comparisons across two games is not a season: #160 is the issue for
+**And ESPN, the third source, agrees too** — 91 of 91, joined on `espnID`, which Tank01
+carries alongside `sleeperBotID`. Extracted by column _label_ rather than position, so a
+column moving in their payload cannot silently shift a stat into the wrong key. That
+satisfies the standing three-source rule for these two games.
+
+**What is still not established.** And 91 comparisons across two games is not a season: #160 is the issue for
 making this a permanent check rather than a thing somebody did once. Nothing here tests
 D/ST, kicking or return touchdowns, none of which occurred in the two games sampled.
 

--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -127,23 +127,32 @@ scoring zero.
 
 ## Scoring plays: the only source for three of our rules
 
-There are exactly **three** `scoreType` values across 96 games spanning the whole
-2025 season: `TD`, `FG`, `SF`. See [Recheck](#recheck).
+`TD`, `FG` and `SF` are the three that carry meaning for us, and they were the
+only three seen across the 96 games sampled in [Recheck](#recheck).
+
+> **Corrected 2026-08-17.** This section said "there are exactly **three**
+> `scoreType` values" and that was a claim about a sample, not about the feed. A
+> sweep of the **full** 2025 season also found `2PTC` and a `null`. Nothing in
+> the adapter enumerates the set — every use is an equality test against one of
+> the three — so an unfamiliar value is inert rather than a crash. Do not write a
+> `switch` over this field.
 
 Extra points, two-point conversions, and blocked kicks are **not score types**.
 They appear in the trailing parenthetical of a touchdown's `score` text.
 
 Every observed form:
 
-| Text                                                                   | Meaning                 |
-| ---------------------------------------------------------------------- | ----------------------- |
-| `(Brandon Aubrey Kick)`                                                | Extra point made        |
-| `(Harrison Butker PAT Failed)`                                         | Extra point missed      |
-| `(Joshua Karty PAT blocked)`                                           | Extra point **blocked** |
-| `(Rhamondre Stevenson Run for Two-Point Conversion)`                   | Two-point **good**      |
-| `(Tua Tagovailoa Pass to Julian Hill for Two-Point Conversion)`        | Two-point **good**      |
-| `(Two-Point Pass Conversion Failed)`                                   | Two-point **failed**    |
-| `Blocked Kick Recovered by Jordan Davis (PHI) … 61 Yd Touchown Return` | Blocked kick returned   |
+| Text                                                                   | Meaning                  |
+| ---------------------------------------------------------------------- | ------------------------ |
+| `(Brandon Aubrey Kick)`                                                | Extra point made         |
+| `(Harrison Butker PAT Failed)`                                         | Extra point missed       |
+| `(Joshua Karty PAT blocked)`                                           | Extra point **blocked**  |
+| `(Rhamondre Stevenson Run for Two-Point Conversion)`                   | Two-point **good**       |
+| `(Tua Tagovailoa Pass to Julian Hill for Two-Point Conversion)`        | Two-point **good**       |
+| `(Two-Point Pass Conversion Failed)`                                   | Two-point **failed**     |
+| `Blocked Kick Recovered by Jordan Davis (PHI) … 61 Yd Touchown Return` | Blocked kick returned    |
+| `Marshawn Kneeland Blocked Punt Recovery in End Zone`                  | Blocked punt, recovered  |
+| `Defensive Holding in Endzone for Safety`                              | Safety, `scoreType` `SF` |
 
 Three consequences:
 
@@ -158,6 +167,116 @@ would award two points for a conversion that did not happen.
 
 **Tank01's text contains typos.** `"61 Yd Touchown Return"` is verbatim. Match
 stable tokens, never whole phrases.
+
+---
+
+## `teamStats` — the second team-level block
+
+Established 2026-08-17, after a full-season comparison against Sleeper turned up
+four defects in the D/ST and player translation. **This block was read nowhere
+until then**, and three of the four fixes come out of it. Same `home` / `away`
+shape as `DST`, same string-typed values (`blockedFG: "1"`, not `1`).
+
+| Field                        | What it is                                          |
+| ---------------------------- | --------------------------------------------------- |
+| `blockedFG`                  | Field goals **this team blocked**                   |
+| `blockedPunt`                | Punts this team blocked                             |
+| `blockedXP`                  | Extra points this team blocked                      |
+| `defensiveOrSpecialTeamsTds` | Def + ST touchdowns — **double-counted, see below** |
+| `safeties`                   | Safeties this team scored                           |
+
+### Blocked kicks are credited to the blocking team
+
+The fact that had to be nailed down before these could be used at all, because
+getting it backwards is a four-point swing between two rosters.
+
+**Proven on `20250907_ARI@NO` (2025 week 1).** Arizona's kicker had a field goal
+blocked. **New Orleans**' `teamStats.blockedFG` reads `"1"`; Arizona's reads
+`"0"`. Captured as `packages/stats/src/tank01/__fixtures__/box-score-blocked-fg.json`.
+
+That game is also why this matters: **no scoring play in it mentions a block at
+all**, so the play-text path — the only source before this — scored New Orleans
+zero. **27 of the 44 blocked kicks in the 2025 season never led to a score**, 54
+points invisible.
+
+**The counters include a block that scored.** Proven on `20251103_ARI@DAL`, where
+Marshawn Kneeland recovered a blocked punt in the end zone for a touchdown and
+Dallas reads `blockedPunt: "1"`. So the numeric counters and the text path are
+combined by taking the **larger**, never by adding — adding pays twice.
+
+### `defensiveOrSpecialTeamsTds` double-counts, and is a check rather than a source
+
+`20250928_CAR@NE` has **exactly one** defensive or special-teams touchdown in it,
+Marcus Jones's 87-yard punt return. New England's `defensiveOrSpecialTeamsTds`
+reads **`"2"`**: `DST.defTD` (1) plus the special-teams score (1).
+
+Which is the whole of the `def_td` defect. **`DST.defTD` is the sum of the
+players' own `Defense.defTD`** — Marcus Jones is the only player in that game
+carrying one, and it is `"1"` — and **ESPN files a punt or kickoff return by a
+_defensive_ player there too.** So a unit whose returner happened to be a
+defender was paid twice for one touchdown. Six times in 2025, 36 points.
+
+Subtracting gives Tank01's own independent count of the special-teams half, which
+is a usable cross-check on our pattern matching and is wired up as one. It is what
+would have caught `"Marshawn Kneeland Blocked Punt Recovery in End Zone"` sitting
+unrecognised for a season, without a sweep. Refs #157, #158.
+
+### `DST.safeties` — what was actually observed
+
+A full-season sweep reported `DST.safeties` as `"0"` for every game including two
+with a genuine safety, and this document was going to record that. **It does not
+reproduce.** `20250921_ARI@SF` — the sweep's own example, "Defensive Holding in
+Endzone for Safety" — returns `DST.away.safeties: "1"` for Arizona today, and the
+adapter has always scored that correctly.
+
+What _is_ established from that game:
+
+- `scoreType` is **`"SF"`**, and `team` is the **defense that scored it** —
+  Arizona's away score moves 13 → 15 on the play.
+- `teamStats.safeties` agrees with `DST.safeties` (`"1"` / `"1"`).
+
+So a safety has two independent readings, and the adapter takes the larger of the
+two and **warns on any disagreement** rather than picking a winner between a
+measurement it cannot reproduce and one it can. About a dozen safeties a season,
+2 points each.
+
+### Individual `Defense.*` fields are not fantasy stats
+
+`Defense.defTD`, `Defense.sacks`, `Defense.defensiveInterceptions` and
+`Defense.fumblesRecovered` were mapped to `def_td`, `def_sack`, `def_int` and
+`def_fum_rec` **for every player**. There is no IDP slot in this product, so the
+only roster spot those keys reach is the D/ST — which is scored from the `DST`
+block. A per-player row keyed the same way is a duplicate, not an unused row.
+
+And Tank01 files things under `Defense` that are not defensive plays. A player who
+fumbles and falls on his own ball carries `Defense.fumblesRecovered: "1"`. From
+`20251103_ARI@DAL`, verbatim:
+
+```
+Jacoby Brissett  (QB, ARI)  fumbles "1"  fumblesRecovered "1"  fumblesLost "0"
+George Pickens   (WR, DAL)  fumbles "2"  fumblesRecovered "1"  fumblesLost "0"
+Javonte Williams (RB, DAL)  fumbles "1"  fumblesRecovered "1"  fumblesLost "1"
+```
+
+All three were paid 2 points each. **185 player-weeks of the 2025 season, 384
+points.** `Defense.defTD` did the same to Tyler Lockett, a wide receiver, for
+"Tyler Lockett 0 Yd Fumble Recovery" in week 5.
+
+**`Defense.fumblesLost` stays mapped.** That one really is the offensive player's
+own stat.
+
+### `"Recovery"` is not a synonym for `"Return"`
+
+The trap in repairing the blocked-kick wordings above. **Every** fumble-return
+touchdown in the 2025 season is worded `"Fumble Recovery"`, not `"Fumble
+Return"` — so adding a bare `recover` alternative to the special-teams pattern
+turns **14 defensive touchdowns** into return touchdowns as well, paying each of
+them under two rules in two roster spots. The pattern is anchored on `blocked`
+instead, and there is a test pinning the negative case.
+
+Still unrecognised on purpose: `"George Holani Recovered Kickoff in End Zone for a
+Touchdown"` (#158). Not a blocked kick, scorer is a running back, and whether ESPN
+pays it as a return touchdown or an offensive fumble recovery is not established.
 
 ---
 
@@ -369,9 +488,13 @@ obtainable:
 - ✅ Extra points — `Kicking.xpMade`
 - ✅ Field goals by distance — parsed from scoring plays
 - ✅ Two-point conversions — parsed from scoring plays
-- ✅ Blocked kicks — parsed from scoring plays
-- ✅ Defensive points allowed, sacks, interceptions, fumble recoveries,
-  safeties, defensive touchdowns — the `DST` block
+- ✅ Blocked kicks — **`teamStats`**, floored by the scoring text
+- ✅ Defensive points allowed, yards allowed, sacks, interceptions, fumble
+  recoveries — the `DST` block
+- ✅ Safeties — `DST.safeties`, floored by the `SF` scoring plays
+- ✅ Defensive and special teams touchdowns — `DST.defTD` plus the special teams
+  scores it does not already contain. **Not a single field**; see
+  [`teamStats`](#teamstats--the-second-team-level-block) for why.
 
 Outstanding questions, none blocking:
 

--- a/packages/stats/src/tank01/__fixtures__/box-score-blocked-fg.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-blocked-fg.json
@@ -1,0 +1,2597 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "ARI",
+      "teamID": "1",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "1",
+      "ydsAllowed": "315",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "13",
+      "safeties": "0"
+    },
+    "home": {
+      "teamAbv": "NO",
+      "teamID": "23",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "5",
+      "ydsAllowed": "276",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "20",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Terry Brown, Scott Novak, Mike Morton, Tony Josselyn, Mark Stewart, Don Willard, Brian Sakowski",
+  "arena": "Caesars Superdome",
+  "arenaCapacity": "73,000",
+  "attendance": "70,006",
+  "away": "ARI",
+  "awayPts": "20",
+  "awayResult": "W",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20250907",
+  "gameLocation": "New Orleans, LA",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 1",
+  "home": "NO",
+  "homePts": "13",
+  "homeResult": "L",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "3",
+      "Q2": "14",
+      "Q3": "3",
+      "Q4": "0",
+      "teamID": "1",
+      "currentlyInPossession": "False",
+      "totalPts": "20",
+      "teamAbv": "ARI"
+    },
+    "home": {
+      "Q1": "0",
+      "Q2": "10",
+      "Q3": "0",
+      "Q4": "3",
+      "teamID": "23",
+      "currentlyInPossession": "False",
+      "totalPts": "13",
+      "teamAbv": "NO"
+    }
+  },
+  "network": "CBS",
+  "playerStats": {
+    "11284": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "33",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.44"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "11284",
+      "longName": "Calais Campbell"
+    },
+    "13971": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.74"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "2",
+        "qbHits": "2",
+        "defensiveInterceptions": "0",
+        "sacks": "1.5",
+        "passDeflections": "1"
+      },
+      "playerID": "13971",
+      "longName": "Cameron Jordan"
+    },
+    "14958": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "9",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "2",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "14958",
+      "longName": "Demario Davis"
+    },
+    "15035": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15035",
+      "longName": "Kelvin Beachum"
+    },
+    "15241": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15241",
+      "longName": "Aaron Brewer"
+    },
+    "16731": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "12",
+        "targets": "4",
+        "recYds": "26",
+        "recAvg": "8.7"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.76",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "57",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "16731",
+      "longName": "Brandin Cooks"
+    },
+    "2575788": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "2575788",
+      "longName": "Zach Wood"
+    },
+    "2979860": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "25",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.33"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "2979860",
+      "longName": "Dalvin Tomlinson"
+    },
+    "2980097": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "22",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.33"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "2980097",
+      "longName": "Jonathan Bullard"
+    },
+    "3045147": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "3.3",
+        "rushYds": "39",
+        "carries": "12",
+        "longRush": "12",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "4",
+        "recTD": "1",
+        "longRec": "5",
+        "targets": "4",
+        "recYds": "5",
+        "recAvg": "1.3"
+      },
+      "scoringPlays": [
+        {
+          "score": "James Conner 4 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "10",
+          "awayScore": "17",
+          "teamID": "1",
+          "scoreDetails": "10 plays, 71 yards, 4:30",
+          "scoreType": "TD",
+          "scoreTime": "0:28",
+          "team": "ARI",
+          "playerIDs": ["3917315", "3045147", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.65",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "43",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3045147",
+      "longName": "James Conner"
+    },
+    "3054850": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "4.1",
+        "rushYds": "45",
+        "carries": "11",
+        "longRush": "18",
+        "rushTD": "1"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "7",
+        "targets": "2",
+        "recYds": "12",
+        "recAvg": "6.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Alvin Kamara 18 Yd Rush (Blake Grupe Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "3",
+          "teamID": "23",
+          "scoreDetails": "10 plays, 75 yards, 5:43",
+          "scoreType": "TD",
+          "scoreTime": "14:20",
+          "team": "NO",
+          "playerIDs": ["3054850", "4259619"]
+        }
+      ],
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.79",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "3054850",
+      "longName": "Alvin Kamara"
+    },
+    "3059722": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "4",
+        "targets": "1",
+        "recYds": "4",
+        "recAvg": "4.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.47",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "31",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3059722",
+      "longName": "Zay Jones"
+    },
+    "3115383": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "39",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.59"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3115383",
+      "longName": "Davon Godchaux"
+    },
+    "3116449": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3116449",
+      "longName": "L.J. Collier"
+    },
+    "3122797": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "4",
+        "stSnapPct": "0.15",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3122797",
+      "longName": "Isaac Yiadom"
+    },
+    "3127287": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "75",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "10",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "3127287",
+      "longName": "Budda Baker"
+    },
+    "3128412": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3128412",
+      "longName": "Evan Brown"
+    },
+    "3693166": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.63"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3693166",
+      "longName": "Josh Sweat"
+    },
+    "3886633": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3886633",
+      "longName": "Hjalte Froholdt"
+    },
+    "3886834": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.67",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "3886834",
+      "longName": "Ugo Amadi"
+    },
+    "3917142": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "19",
+        "stSnapPct": "0.70",
+        "offSnap": "0",
+        "defSnapPct": "0.37"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "3917142",
+      "longName": "Akeem Davis-Gaither"
+    },
+    "3917315": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "5.4",
+        "rushYds": "38",
+        "carries": "7",
+        "longRush": "13",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "48.2",
+        "rtg": "108.8",
+        "sacked": "5-33",
+        "passAttempts": "29",
+        "passAvg": "5.6",
+        "passTD": "2",
+        "passYds": "163",
+        "int": "0",
+        "passCompletions": "21"
+      },
+      "scoringPlays": [
+        {
+          "score": "Marvin Harrison Jr. 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "7 plays, 65 yards, 4:15",
+          "scoreType": "TD",
+          "scoreTime": "10:05",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4432708", "4363538"]
+        },
+        {
+          "score": "James Conner 4 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "10",
+          "awayScore": "17",
+          "teamID": "1",
+          "scoreDetails": "10 plays, 71 yards, 4:30",
+          "scoreType": "TD",
+          "scoreTime": "0:28",
+          "team": "ARI",
+          "playerIDs": ["3917315", "3045147", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3917315",
+      "longName": "Kyler Murray"
+    },
+    "3917331": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "75",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "3917331",
+      "longName": "Erik McCoy"
+    },
+    "3918310": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "57",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.86"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1.5",
+        "passDeflections": "2"
+      },
+      "playerID": "3918310",
+      "longName": "Carl Granderson"
+    },
+    "3929645": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "8",
+        "recTD": "0",
+        "longRec": "21",
+        "targets": "11",
+        "recYds": "76",
+        "recAvg": "9.5"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.99",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "74",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "3929645",
+      "longName": "Juwan Johnson"
+    },
+    "3931399": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3931399",
+      "longName": "Justin Reid"
+    },
+    "4032473": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "6",
+        "recTD": "0",
+        "longRec": "17",
+        "targets": "9",
+        "recYds": "33",
+        "recAvg": "5.5"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.85",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.15",
+        "offSnap": "64",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntReturns": "2",
+        "puntReturnYds": "18",
+        "puntReturnAvg": "9.0",
+        "puntReturnLong": "11",
+        "puntReturnTD": "0"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4032473",
+      "longName": "Rashid Shaheed"
+    },
+    "4032481": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "13",
+        "stSnap": "7",
+        "stSnapPct": "0.26",
+        "offSnap": "0",
+        "defSnapPct": "0.20"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4032481",
+      "longName": "Jonah Williams"
+    },
+    "4034862": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.24",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "18",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4034862",
+      "longName": "Jack Stoll"
+    },
+    "4035048": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4035048",
+      "longName": "Luke Fortner"
+    },
+    "4035661": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4035661",
+      "longName": "Julian Blackmon"
+    },
+    "4035693": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.63",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "40",
+        "kickReturnAvg": "20.0",
+        "kickReturnLong": "22"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4035693",
+      "longName": "Velus Jones Jr."
+    },
+    "4037235": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "-2",
+        "targets": "1",
+        "recYds": "-2",
+        "recAvg": "-2.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.15",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "10",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "44",
+        "kickReturnAvg": "22.0",
+        "kickReturnLong": "22"
+      },
+      "Punting": {
+        "puntReturns": "3",
+        "puntReturnYds": "30",
+        "puntReturnAvg": "10.0",
+        "puntReturnLong": "23",
+        "puntReturnTD": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4037235",
+      "longName": "Greg Dortch"
+    },
+    "4040726": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4040726",
+      "longName": "Jonah Williams"
+    },
+    "4040945": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "75",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4040945",
+      "longName": "Dillon Radunz"
+    },
+    "4040983": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "75",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4040983",
+      "longName": "Mack Wilson Sr."
+    },
+    "4043089": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "75",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4043089",
+      "longName": "Jalen Thompson"
+    },
+    "4045180": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "188",
+        "punts": "4",
+        "puntAvg": "47.0",
+        "puntsin20": "1",
+        "puntTouchBacks": "0",
+        "puntLong": "60"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4045180",
+      "longName": "Blake Gillikin"
+    },
+    "4076951": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "44",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.67"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4076951",
+      "longName": "Nathan Shepherd"
+    },
+    "4240475": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "21",
+        "stSnap": "18",
+        "stSnapPct": "0.67",
+        "offSnap": "0",
+        "defSnapPct": "0.32"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240475",
+      "longName": "Chris Rumph II"
+    },
+    "4240824": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.37",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4240824",
+      "longName": "Joey Blount"
+    },
+    "4241987": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "40",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.53"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4241987",
+      "longName": "Baron Browning"
+    },
+    "4241993": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "60",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.91"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "9",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "7",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4241993",
+      "longName": "Pete Werner"
+    },
+    "4244606": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "37",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4244606",
+      "longName": "Zaven Collins"
+    },
+    "4258199": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "75",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4258199",
+      "longName": "Cesar Ruiz"
+    },
+    "4259324": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.05",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.44",
+        "offSnap": "3",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4259324",
+      "longName": "Travis Vokolek"
+    },
+    "4259619": {
+      "gameID": "20250907_ARI@NO",
+      "scoringPlays": [
+        {
+          "score": "Alvin Kamara 18 Yd Rush (Blake Grupe Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "3",
+          "teamID": "23",
+          "scoreDetails": "10 plays, 75 yards, 5:43",
+          "scoreType": "TD",
+          "scoreTime": "14:20",
+          "team": "NO",
+          "playerIDs": ["3054850", "4259619"]
+        },
+        {
+          "score": "Blake Grupe 36 Yd Field Goal",
+          "scorePeriod": "Q2",
+          "homeScore": "10",
+          "awayScore": "10",
+          "teamID": "23",
+          "scoreDetails": "10 plays, 37 yards, 5:07",
+          "scoreType": "FG",
+          "scoreTime": "4:58",
+          "team": "NO",
+          "playerIDs": ["4259619"]
+        },
+        {
+          "score": "Blake Grupe 28 Yd Field Goal",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "20",
+          "teamID": "23",
+          "scoreDetails": "9 plays, 54 yards, 1:52",
+          "scoreType": "FG",
+          "scoreTime": "2:42",
+          "team": "NO",
+          "playerIDs": ["4259619"]
+        }
+      ],
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "36",
+        "fgMade": "2",
+        "fgAttempts": "3",
+        "xpMade": "1",
+        "fgPct": "66.7",
+        "kickingPts": "7",
+        "xpAttempts": "1",
+        "fgMissed": "1",
+        "xpMissed": "0"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4259619",
+      "longName": "Blake Grupe"
+    },
+    "4360761": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "4",
+        "recYds": "5",
+        "recAvg": "5.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.67",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "44",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4360761",
+      "longName": "Michael Wilson"
+    },
+    "4361194": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "22",
+        "stSnapPct": "0.81",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4361194",
+      "longName": "Isaiah Stalbird"
+    },
+    "4361307": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "6",
+        "recTD": "0",
+        "longRec": "25",
+        "targets": "9",
+        "recYds": "61",
+        "recAvg": "10.2"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.97",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "64",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4361307",
+      "longName": "Trey McBride"
+    },
+    "4361370": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "7",
+        "recTD": "0",
+        "longRec": "13",
+        "targets": "13",
+        "recYds": "54",
+        "recAvg": "7.7"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.85",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "64",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4361370",
+      "longName": "Chris Olave"
+    },
+    "4361421": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "11",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.15"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4361421",
+      "longName": "PJ Mustipher"
+    },
+    "4362225": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "34",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.45"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362225",
+      "longName": "Dante Stills"
+    },
+    "4362478": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.59",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "29",
+        "kickReturnAvg": "29.0",
+        "kickReturnLong": "29"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362478",
+      "longName": "Emari Demercado"
+    },
+    "4363538": {
+      "gameID": "20250907_ARI@NO",
+      "scoringPlays": [
+        {
+          "score": "Chad Ryland 42 Yd Field Goal",
+          "scorePeriod": "Q1",
+          "homeScore": "0",
+          "awayScore": "3",
+          "teamID": "1",
+          "scoreDetails": "11 plays, 42 yards, 5:31",
+          "scoreType": "FG",
+          "scoreTime": "5:03",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        },
+        {
+          "score": "Marvin Harrison Jr. 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "7 plays, 65 yards, 4:15",
+          "scoreType": "TD",
+          "scoreTime": "10:05",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4432708", "4363538"]
+        },
+        {
+          "score": "James Conner 4 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "10",
+          "awayScore": "17",
+          "teamID": "1",
+          "scoreDetails": "10 plays, 71 yards, 4:30",
+          "scoreType": "TD",
+          "scoreTime": "0:28",
+          "team": "ARI",
+          "playerIDs": ["3917315", "3045147", "4363538"]
+        },
+        {
+          "score": "Chad Ryland 50 Yd Field Goal",
+          "scorePeriod": "Q3",
+          "homeScore": "10",
+          "awayScore": "20",
+          "teamID": "1",
+          "scoreDetails": "6 plays, 49 yards, 3:11",
+          "scoreType": "FG",
+          "scoreTime": "9:16",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.37",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "50",
+        "fgMade": "2",
+        "fgAttempts": "3",
+        "xpMade": "2",
+        "fgPct": "66.7",
+        "kickingPts": "8",
+        "xpAttempts": "2",
+        "fgMissed": "1",
+        "xpMissed": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4363538",
+      "longName": "Chad Ryland"
+    },
+    "4367199": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4367199",
+      "longName": "Jon Gaines II"
+    },
+    "4369835": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.55"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4369835",
+      "longName": "Alontae Taylor"
+    },
+    "4426339": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "7.3",
+        "rushYds": "29",
+        "carries": "4",
+        "longRush": "12",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "57.5",
+        "rtg": "70.4",
+        "sacked": "1-6",
+        "passAttempts": "46",
+        "passAvg": "4.7",
+        "passTD": "0",
+        "passYds": "214",
+        "int": "0",
+        "passCompletions": "27"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "75",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4426339",
+      "longName": "Spencer Rattler"
+    },
+    "4426844": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "3",
+        "targets": "2",
+        "recYds": "3",
+        "recAvg": "3.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.30",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.37",
+        "offSnap": "20",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426844",
+      "longName": "Elijah Higgins"
+    },
+    "4428350": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "13",
+        "stSnapPct": "0.48",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4428350",
+      "longName": "Quincy Riley"
+    },
+    "4428633": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "50",
+        "stSnap": "14",
+        "stSnapPct": "0.52",
+        "offSnap": "0",
+        "defSnapPct": "0.67"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "2"
+      },
+      "playerID": "4428633",
+      "longName": "Dadrion Taylor-Demerson"
+    },
+    "4428811": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4428811",
+      "longName": "Xavier Weaver"
+    },
+    "4428988": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.71"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428988",
+      "longName": "Bryan Bresee"
+    },
+    "4428991": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4428991",
+      "longName": "Paris Johnson Jr."
+    },
+    "4428996": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "10",
+        "stSnapPct": "0.37",
+        "offSnap": "0",
+        "defSnapPct": "0.37"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428996",
+      "longName": "Jordan Burch"
+    },
+    "4429071": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.37",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4429071",
+      "longName": "Cody Simon"
+    },
+    "4429073": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "7",
+        "stSnap": "4",
+        "stSnapPct": "0.15",
+        "offSnap": "0",
+        "defSnapPct": "0.11"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4429073",
+      "longName": "Fadil Diggs"
+    },
+    "4429275": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "8.6",
+        "rushYds": "69",
+        "carries": "8",
+        "longRush": "52",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "6",
+        "targets": "1",
+        "recYds": "6",
+        "recAvg": "6.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.33",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "22",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4429275",
+      "longName": "Trey Benson"
+    },
+    "4429782": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4429782",
+      "longName": "Josh Fryar"
+    },
+    "4430379": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.43",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "32",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4430379",
+      "longName": "Asim Richards"
+    },
+    "4430821": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "22",
+        "stSnapPct": "0.81",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4430821",
+      "longName": "Kitan Crawford"
+    },
+    "4432668": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "15",
+        "stSnapPct": "0.56",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4432668",
+      "longName": "Denzel Burke"
+    },
+    "4432708": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "45",
+        "targets": "6",
+        "recYds": "71",
+        "recAvg": "14.2"
+      },
+      "scoringPlays": [
+        {
+          "score": "Marvin Harrison Jr. 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "7 plays, 65 yards, 4:15",
+          "scoreType": "TD",
+          "scoreTime": "10:05",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4432708", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.89",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4432708",
+      "longName": "Marvin Harrison Jr."
+    },
+    "4432731": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.01",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4432731",
+      "longName": "Moliki Matavao"
+    },
+    "4433975": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4433975",
+      "longName": "Kool-Aid McKinstry"
+    },
+    "4566088": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.63",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4566088",
+      "longName": "Jaylan Ford"
+    },
+    "4567219": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "20",
+        "stSnapPct": "0.74",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4567219",
+      "longName": "Owen Pappoe"
+    },
+    "4568506": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "75",
+        "stSnap": "8",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4568506",
+      "longName": "Garrett Williams"
+    },
+    "4569480": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "42",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.56"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4569480",
+      "longName": "Darius Robinson"
+    },
+    "4569559": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "13",
+        "targets": "2",
+        "recYds": "13",
+        "recAvg": "13.0"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.23",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "17",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4569559",
+      "longName": "Devaughn Vele"
+    },
+    "4570033": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.33",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "202",
+        "punts": "4",
+        "puntAvg": "50.5",
+        "puntsin20": "2",
+        "puntTouchBacks": "0",
+        "puntLong": "54"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4570033",
+      "longName": "Kai Kroeger"
+    },
+    "4573697": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4573697",
+      "longName": "Mason Tipton"
+    },
+    "4599739": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "4.8",
+        "rushYds": "24",
+        "carries": "5",
+        "longRush": "10",
+        "rushTD": "0"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.15",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "3",
+        "kickReturnTD": "0",
+        "kickReturnYds": "88",
+        "kickReturnAvg": "29.3",
+        "kickReturnLong": "43"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4599739",
+      "longName": "Kendre Miller"
+    },
+    "4606711": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.61",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "46",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4606711",
+      "longName": "Taliese Fuaga"
+    },
+    "4682652": {
+      "gameID": "20250907_ARI@NO",
+      "Rushing": {
+        "rushAvg": "4.5",
+        "rushYds": "9",
+        "carries": "2",
+        "longRush": "5",
+        "rushTD": "0"
+      },
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.09",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.15",
+        "offSnap": "7",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4682652",
+      "longName": "Devin Neal"
+    },
+    "4683215": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.63",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4683215",
+      "longName": "Danny Stutsman"
+    },
+    "4683813": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "1",
+        "stSnap": "22",
+        "stSnapPct": "0.81",
+        "offSnap": "0",
+        "defSnapPct": "0.02"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4683813",
+      "longName": "Jonas Sanker"
+    },
+    "4685260": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "75",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4685260",
+      "longName": "Kelvin Banks Jr."
+    },
+    "4685408": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "45",
+        "stSnap": "4",
+        "stSnapPct": "0.15",
+        "offSnap": "0",
+        "defSnapPct": "0.60"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "3"
+      },
+      "playerID": "4685408",
+      "longName": "Will Johnson"
+    },
+    "4696043": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "13",
+        "stSnapPct": "0.48",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4696043",
+      "longName": "Rejzohn Wright"
+    },
+    "4696700": {
+      "gameID": "20250907_ARI@NO",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "10",
+        "targets": "1",
+        "recYds": "10",
+        "recAvg": "10.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.52",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.44",
+        "offSnap": "34",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4696700",
+      "longName": "Tip Reiman"
+    },
+    "4696902": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "23",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NO",
+      "teamAbv": "NO",
+      "playerID": "4696902",
+      "longName": "Torricelli Simpkins III"
+    },
+    "4698113": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "75",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4698113",
+      "longName": "Max Melton"
+    },
+    "5084939": {
+      "gameID": "20250907_ARI@NO",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.19",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "5084939",
+      "longName": "Isaiah Adams"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Chad Ryland 42 Yd Field Goal",
+      "scorePeriod": "Q1",
+      "homeScore": "0",
+      "awayScore": "3",
+      "teamID": "1",
+      "scoreDetails": "11 plays, 42 yards, 5:31",
+      "scoreType": "FG",
+      "scoreTime": "5:03",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Alvin Kamara 18 Yd Rush (Blake Grupe Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "7",
+      "awayScore": "3",
+      "teamID": "23",
+      "scoreDetails": "10 plays, 75 yards, 5:43",
+      "scoreType": "TD",
+      "scoreTime": "14:20",
+      "team": "NO",
+      "playerIDs": ["3054850", "4259619"]
+    },
+    {
+      "score": "Marvin Harrison Jr. 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "7",
+      "awayScore": "10",
+      "teamID": "1",
+      "scoreDetails": "7 plays, 65 yards, 4:15",
+      "scoreType": "TD",
+      "scoreTime": "10:05",
+      "team": "ARI",
+      "playerIDs": ["3917315", "4432708", "4363538"]
+    },
+    {
+      "score": "Blake Grupe 36 Yd Field Goal",
+      "scorePeriod": "Q2",
+      "homeScore": "10",
+      "awayScore": "10",
+      "teamID": "23",
+      "scoreDetails": "10 plays, 37 yards, 5:07",
+      "scoreType": "FG",
+      "scoreTime": "4:58",
+      "team": "NO",
+      "playerIDs": ["4259619"]
+    },
+    {
+      "score": "James Conner 4 Yd pass from Kyler Murray (Chad Ryland Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "10",
+      "awayScore": "17",
+      "teamID": "1",
+      "scoreDetails": "10 plays, 71 yards, 4:30",
+      "scoreType": "TD",
+      "scoreTime": "0:28",
+      "team": "ARI",
+      "playerIDs": ["3917315", "3045147", "4363538"]
+    },
+    {
+      "score": "Chad Ryland 50 Yd Field Goal",
+      "scorePeriod": "Q3",
+      "homeScore": "10",
+      "awayScore": "20",
+      "teamID": "1",
+      "scoreDetails": "6 plays, 49 yards, 3:11",
+      "scoreType": "FG",
+      "scoreTime": "9:16",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Blake Grupe 28 Yd Field Goal",
+      "scorePeriod": "Q4",
+      "homeScore": "13",
+      "awayScore": "20",
+      "teamID": "23",
+      "scoreDetails": "9 plays, 54 yards, 1:52",
+      "scoreType": "FG",
+      "scoreTime": "2:42",
+      "team": "NO",
+      "playerIDs": ["4259619"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "1",
+  "teamIDHome": "23",
+  "teamStats": {
+    "away": {
+      "totalYards": "276",
+      "rushingAttempts": "27",
+      "rushingYards": "146",
+      "fumblesLost": "0",
+      "penalties": "9-54",
+      "totalPlays": "61",
+      "possession": "33:46",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "21-29",
+      "passingFirstDowns": "11",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "5-33",
+      "thirdDownEfficiency": "6-13",
+      "blockedPunt": "0",
+      "yardsPerPlay": "4.5",
+      "redZoneScoredAndAttempted": "2-3",
+      "teamID": "1",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "9",
+      "rushingFirstDowns": "5",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "19",
+      "passTD": "2",
+      "team": "ARI",
+      "blockedXP": "0",
+      "teamAbv": "ARI",
+      "firstDownsFromPenalties": "3",
+      "fourthDownEfficiency": "0-0",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "130",
+      "yardsPerRush": "5.4",
+      "snapCounts": {
+        "totalSpecialTeams": "27",
+        "totalOffensive": "66",
+        "totalDefensive": "75"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "3.8"
+    },
+    "home": {
+      "totalYards": "315",
+      "rushingAttempts": "22",
+      "rushingYards": "107",
+      "fumblesLost": "0",
+      "penalties": "13-89",
+      "totalPlays": "69",
+      "possession": "26:14",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "27-46",
+      "passingFirstDowns": "12",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "1-6",
+      "thirdDownEfficiency": "5-14",
+      "blockedPunt": "0",
+      "yardsPerPlay": "4.6",
+      "redZoneScoredAndAttempted": "1-4",
+      "teamID": "23",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "10",
+      "rushingFirstDowns": "5",
+      "blockedFG": "1",
+      "rushTD": "1",
+      "twoPointConversions": "0",
+      "firstDowns": "21",
+      "passTD": "0",
+      "team": "NO",
+      "blockedXP": "0",
+      "teamAbv": "NO",
+      "firstDownsFromPenalties": "4",
+      "fourthDownEfficiency": "1-2",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "208",
+      "yardsPerRush": "4.9",
+      "snapCounts": {
+        "totalSpecialTeams": "27",
+        "totalOffensive": "75",
+        "totalDefensive": "66"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "4.4"
+    }
+  },
+  "gameID": "20250907_ARI@NO",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/__fixtures__/box-score-blocked-punt-td.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-blocked-punt-td.json
@@ -1,0 +1,2754 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "ARI",
+      "teamID": "1",
+      "defTD": "0",
+      "defensiveInterceptions": "1",
+      "sacks": "5",
+      "ydsAllowed": "333",
+      "fumblesRecovered": "2",
+      "ptsAllowed": "17",
+      "safeties": "0"
+    },
+    "home": {
+      "teamAbv": "DAL",
+      "teamID": "9",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "5",
+      "ydsAllowed": "340",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "27",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Trawick Boger, Adrian Hill, Greg Steed, Roy Ellison, Julian Mapp, Clay Reynard, Mike Carr",
+  "arena": "AT&T Stadium",
+  "arenaCapacity": "100,000",
+  "attendance": "92,211",
+  "away": "ARI",
+  "awayPts": "27",
+  "awayResult": "W",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20251103",
+  "gameLocation": "Arlington, TX",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 9",
+  "home": "DAL",
+  "homePts": "17",
+  "homeResult": "L",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "3",
+      "Q2": "14",
+      "Q3": "10",
+      "Q4": "0",
+      "teamID": "1",
+      "currentlyInPossession": "False",
+      "totalPts": "27",
+      "teamAbv": "ARI"
+    },
+    "home": {
+      "Q1": "0",
+      "Q2": "7",
+      "Q3": "3",
+      "Q4": "7",
+      "teamID": "9",
+      "currentlyInPossession": "False",
+      "totalPts": "17",
+      "teamAbv": "DAL"
+    }
+  },
+  "network": "ABC",
+  "playerStats": {
+    "11284": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "9",
+        "stSnapPct": "0.39",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "2",
+        "qbHits": "3",
+        "defensiveInterceptions": "0",
+        "sacks": "2",
+        "passDeflections": "0"
+      },
+      "playerID": "11284",
+      "longName": "Calais Campbell"
+    },
+    "14950": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "41",
+        "punts": "1",
+        "puntAvg": "41.0",
+        "puntsin20": "0",
+        "puntTouchBacks": "0",
+        "puntLong": "41"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "14950",
+      "longName": "Bryan Anger"
+    },
+    "15035": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.36",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "24",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15035",
+      "longName": "Kelvin Beachum"
+    },
+    "15241": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15241",
+      "longName": "Aaron Brewer"
+    },
+    "16734": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "2",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "1"
+      },
+      "playerID": "16734",
+      "longName": "Jadeveon Clowney"
+    },
+    "16863": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "87",
+        "punts": "2",
+        "puntAvg": "43.5",
+        "puntsin20": "0",
+        "puntTouchBacks": "0",
+        "puntLong": "47"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "16863",
+      "longName": "Pat O'Donnell"
+    },
+    "17474": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.83",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "17474",
+      "longName": "C.J. Goodwin"
+    },
+    "2577417": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "8.5",
+        "rushYds": "34",
+        "carries": "4",
+        "longRush": "14",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "35.4",
+        "rtg": "77.9",
+        "sacked": "5-40",
+        "passAttempts": "39",
+        "passAvg": "6.4",
+        "passTD": "1",
+        "passYds": "250",
+        "int": "1",
+        "passCompletions": "24"
+      },
+      "scoringPlays": [
+        {
+          "score": "Ryan Flournoy 5 Yd pass from Dak Prescott (Brandon Aubrey Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "17",
+          "awayScore": "27",
+          "teamID": "9",
+          "scoreDetails": "7 plays, 78 yards, 2:01",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "DAL",
+          "playerIDs": ["2577417", "5083754", "3953687"]
+        }
+      ],
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "2577417",
+      "longName": "Dak Prescott"
+    },
+    "2578570": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "0.8",
+        "rushYds": "4",
+        "carries": "5",
+        "longRush": "4",
+        "rushTD": "1"
+      },
+      "Passing": {
+        "qbr": "52.4",
+        "rtg": "115.1",
+        "sacked": "5-40",
+        "passAttempts": "31",
+        "passAvg": "8.4",
+        "passTD": "2",
+        "passYds": "261",
+        "int": "0",
+        "passCompletions": "21"
+      },
+      "scoringPlays": [
+        {
+          "score": "Marvin Harrison Jr. 4 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "0",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "8 plays, 47 yards, 4:45",
+          "scoreType": "TD",
+          "scoreTime": "12:17",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4432708", "4363538"]
+        },
+        {
+          "score": "Jacoby Brissett 1 Yd Rush (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "17",
+          "teamID": "1",
+          "scoreDetails": "11 plays, 74 yards, 3:09",
+          "scoreType": "TD",
+          "scoreTime": "0:49",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4363538"]
+        },
+        {
+          "score": "Trey McBride 12 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "7",
+          "awayScore": "24",
+          "teamID": "1",
+          "scoreDetails": "3 plays, 74 yards, 2:12",
+          "scoreType": "TD",
+          "scoreTime": "12:48",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4361307", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "1",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "2578570",
+      "longName": "Jacoby Brissett"
+    },
+    "2979860": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.42"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "2979860",
+      "longName": "Dalvin Tomlinson"
+    },
+    "2980100": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "7",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.10"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "2980100",
+      "longName": "Dante Fowler Jr."
+    },
+    "3042516": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3042516",
+      "longName": "Will Hernandez"
+    },
+    "3052357": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "3052357",
+      "longName": "Trent Sieg"
+    },
+    "3059722": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.52",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "35",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3059722",
+      "longName": "Zay Jones"
+    },
+    "3117258": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "26",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3117258",
+      "longName": "Solomon Thomas"
+    },
+    "3122752": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "51",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.76"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "2",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "3122752",
+      "longName": "Kenny Clark"
+    },
+    "3127287": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "67",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "7",
+        "fumblesLost": "0",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "fumbles": "0",
+        "fumblesRecovered": "1",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3127287",
+      "longName": "Budda Baker"
+    },
+    "3128412": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3128412",
+      "longName": "Evan Brown"
+    },
+    "3676833": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "3.0",
+        "rushYds": "3",
+        "carries": "1",
+        "longRush": "3",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "6",
+        "targets": "3",
+        "recYds": "10",
+        "recAvg": "5.0"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.19",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.39",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "6",
+        "kickReturnTD": "0",
+        "kickReturnYds": "151",
+        "kickReturnAvg": "25.2",
+        "kickReturnLong": "36"
+      },
+      "Punting": {
+        "puntReturns": "1",
+        "puntReturnYds": "6",
+        "puntReturnAvg": "6.0",
+        "puntReturnLong": "6",
+        "puntReturnTD": "0"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3676833",
+      "longName": "KaVontae Turpin"
+    },
+    "3693166": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "45",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.67"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "2",
+        "qbHits": "5",
+        "defensiveInterceptions": "0",
+        "sacks": "2",
+        "passDeflections": "1"
+      },
+      "playerID": "3693166",
+      "longName": "Josh Sweat"
+    },
+    "3886633": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3886633",
+      "longName": "Hjalte Froholdt"
+    },
+    "3914151": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.13",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3914151",
+      "longName": "Josiah Deguara"
+    },
+    "3915834": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.72",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "48",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "3915834",
+      "longName": "Terence Steele"
+    },
+    "3917142": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "48",
+        "stSnap": "9",
+        "stSnapPct": "0.39",
+        "offSnap": "0",
+        "defSnapPct": "0.72"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "7",
+        "fumblesLost": "0",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "fumbles": "0",
+        "fumblesRecovered": "1",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3917142",
+      "longName": "Akeem Davis-Gaither"
+    },
+    "3953687": {
+      "gameID": "20251103_ARI@DAL",
+      "scoringPlays": [
+        {
+          "score": "Marshawn Kneeland Blocked Punt Recovery in End Zone (Brandon Aubrey Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "10",
+          "teamID": "9",
+          "scoreDetails": "5 plays, 12 yards, 2:32",
+          "scoreType": "TD",
+          "scoreTime": "3:58",
+          "team": "DAL",
+          "playerIDs": ["3953687"]
+        },
+        {
+          "score": "Brandon Aubrey 26 Yd Field Goal",
+          "scorePeriod": "Q3",
+          "homeScore": "10",
+          "awayScore": "24",
+          "teamID": "9",
+          "scoreDetails": "12 plays, 65 yards, 5:33",
+          "scoreType": "FG",
+          "scoreTime": "7:15",
+          "team": "DAL",
+          "playerIDs": ["3953687"]
+        },
+        {
+          "score": "Ryan Flournoy 5 Yd pass from Dak Prescott (Brandon Aubrey Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "17",
+          "awayScore": "27",
+          "teamID": "9",
+          "scoreDetails": "7 plays, 78 yards, 2:01",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "DAL",
+          "playerIDs": ["2577417", "5083754", "3953687"]
+        }
+      ],
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "26",
+        "fgMade": "1",
+        "fgAttempts": "2",
+        "xpMade": "2",
+        "fgPct": "50.0",
+        "kickingPts": "5",
+        "xpAttempts": "2",
+        "fgMissed": "1",
+        "xpMissed": "0"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "3953687",
+      "longName": "Brandon Aubrey"
+    },
+    "4035840": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "51",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.76"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "4",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4035840",
+      "longName": "Osa Odighizuwa"
+    },
+    "4037235": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "9.0",
+        "rushYds": "9",
+        "carries": "1",
+        "longRush": "9",
+        "rushTD": "0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.21",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.26",
+        "offSnap": "14",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "4",
+        "kickReturnTD": "0",
+        "kickReturnYds": "102",
+        "kickReturnAvg": "25.5",
+        "kickReturnLong": "35"
+      },
+      "Punting": {
+        "puntReturns": "1",
+        "puntReturnYds": "5",
+        "puntReturnAvg": "5.0",
+        "puntReturnLong": "5",
+        "puntReturnTD": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4037235",
+      "longName": "Greg Dortch"
+    },
+    "4040726": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4040726",
+      "longName": "Jonah Williams"
+    },
+    "4040983": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "50",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.75"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4040983",
+      "longName": "Mack Wilson Sr."
+    },
+    "4043089": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.97"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4043089",
+      "longName": "Jalen Thompson"
+    },
+    "4240603": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "3.0",
+        "rushYds": "3",
+        "carries": "1",
+        "longRush": "3",
+        "rushTD": "0"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.07",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "5",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4240603",
+      "longName": "Malik Davis"
+    },
+    "4240608": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "17",
+        "stSnap": "7",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.25"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240608",
+      "longName": "James Houston"
+    },
+    "4241087": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4241087",
+      "longName": "Brock Hoffman"
+    },
+    "4241389": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "7",
+        "recTD": "0",
+        "longRec": "33",
+        "targets": "12",
+        "recYds": "85",
+        "recAvg": "12.1"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4241389",
+      "longName": "CeeDee Lamb"
+    },
+    "4241394": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "67",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241394",
+      "longName": "Kenneth Murray Jr."
+    },
+    "4241921": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.97"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241921",
+      "longName": "Markquese Bell"
+    },
+    "4241987": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "40",
+        "stSnap": "2",
+        "stSnapPct": "0.09",
+        "offSnap": "0",
+        "defSnapPct": "0.60"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241987",
+      "longName": "Baron Browning"
+    },
+    "4242355": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "0",
+        "longRec": "23",
+        "targets": "7",
+        "recYds": "50",
+        "recAvg": "10.0"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.90",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "fumblesLost": "1",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "1",
+        "fumblesRecovered": "0"
+      },
+      "playerID": "4242355",
+      "longName": "Jake Ferguson"
+    },
+    "4242442": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.48",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4242442",
+      "longName": "Princeton Fant"
+    },
+    "4244606": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "7",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.43"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4244606",
+      "longName": "Zaven Collins"
+    },
+    "4248911": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.97"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "14",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4248911",
+      "longName": "DaRon Bland"
+    },
+    "4249417": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.10",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "7",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4249417",
+      "longName": "Jalen Tolbert"
+    },
+    "4360590": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "62",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.93"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360590",
+      "longName": "Juanyeh Thomas"
+    },
+    "4360739": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.03",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "2",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360739",
+      "longName": "Simi Fehoko"
+    },
+    "4360761": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "50",
+        "targets": "4",
+        "recYds": "61",
+        "recAvg": "20.3"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.72",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "48",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4360761",
+      "longName": "Michael Wilson"
+    },
+    "4360967": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.13",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.48",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360967",
+      "longName": "Brevyn Spann-Ford"
+    },
+    "4361307": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "19",
+        "targets": "9",
+        "recYds": "55",
+        "recAvg": "11.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Trey McBride 12 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "7",
+          "awayScore": "24",
+          "teamID": "1",
+          "scoreDetails": "3 plays, 74 yards, 2:12",
+          "scoreType": "TD",
+          "scoreTime": "12:48",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4361307", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4361307",
+      "longName": "Trey McBride"
+    },
+    "4361421": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "6",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.09"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4361421",
+      "longName": "PJ Mustipher"
+    },
+    "4361579": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "5.5",
+        "rushYds": "83",
+        "carries": "15",
+        "longRush": "19",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "0",
+        "targets": "1",
+        "recYds": "0",
+        "recAvg": "0.0"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.87",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "58",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "fumblesLost": "1",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "1",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "4361579",
+      "longName": "Javonte Williams"
+    },
+    "4362225": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "18",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.27"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362225",
+      "longName": "Dante Stills"
+    },
+    "4362478": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "5.6",
+        "rushYds": "79",
+        "carries": "14",
+        "longRush": "19",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "-1",
+        "targets": "1",
+        "recYds": "-1",
+        "recAvg": "-1.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.40",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "27",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4362478",
+      "longName": "Emari Demercado"
+    },
+    "4362636": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.83",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4362636",
+      "longName": "Damone Clark"
+    },
+    "4363538": {
+      "gameID": "20251103_ARI@DAL",
+      "scoringPlays": [
+        {
+          "score": "Chad Ryland 48 Yd Field Goal",
+          "scorePeriod": "Q1",
+          "homeScore": "0",
+          "awayScore": "3",
+          "teamID": "1",
+          "scoreDetails": "15 plays, 60 yards, 6:54",
+          "scoreType": "FG",
+          "scoreTime": "3:38",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        },
+        {
+          "score": "Marvin Harrison Jr. 4 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "0",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "8 plays, 47 yards, 4:45",
+          "scoreType": "TD",
+          "scoreTime": "12:17",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4432708", "4363538"]
+        },
+        {
+          "score": "Jacoby Brissett 1 Yd Rush (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "7",
+          "awayScore": "17",
+          "teamID": "1",
+          "scoreDetails": "11 plays, 74 yards, 3:09",
+          "scoreType": "TD",
+          "scoreTime": "0:49",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4363538"]
+        },
+        {
+          "score": "Trey McBride 12 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "7",
+          "awayScore": "24",
+          "teamID": "1",
+          "scoreDetails": "3 plays, 74 yards, 2:12",
+          "scoreType": "TD",
+          "scoreTime": "12:48",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4361307", "4363538"]
+        },
+        {
+          "score": "Chad Ryland 34 Yd Field Goal",
+          "scorePeriod": "Q3",
+          "homeScore": "10",
+          "awayScore": "27",
+          "teamID": "1",
+          "scoreDetails": "9 plays, 45 yards, 4:44",
+          "scoreType": "FG",
+          "scoreTime": "2:31",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.48",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "48",
+        "fgMade": "2",
+        "fgAttempts": "2",
+        "xpMade": "3",
+        "fgPct": "100.0",
+        "kickingPts": "9",
+        "xpAttempts": "3",
+        "fgMissed": "0",
+        "xpMissed": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4363538",
+      "longName": "Chad Ryland"
+    },
+    "4367199": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.01",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4367199",
+      "longName": "Jon Gaines II"
+    },
+    "4372096": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "14",
+        "targets": "2",
+        "recYds": "14",
+        "recAvg": "14.0"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.19",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.48",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4372096",
+      "longName": "Luke Schoonmaker"
+    },
+    "4383396": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.07",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.48",
+        "offSnap": "5",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4383396",
+      "longName": "Hunter Luepke"
+    },
+    "4426354": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "6",
+        "recTD": "0",
+        "longRec": "19",
+        "targets": "9",
+        "recYds": "79",
+        "recAvg": "13.2"
+      },
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.91",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "61",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "2",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "4426354",
+      "longName": "George Pickens"
+    },
+    "4426513": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "7",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.10"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426513",
+      "longName": "Trikweze Bridges"
+    },
+    "4426663": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4426663",
+      "longName": "Cooper Beebe"
+    },
+    "4426844": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "16",
+        "targets": "3",
+        "recYds": "30",
+        "recAvg": "10.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.40",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "27",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426844",
+      "longName": "Elijah Higgins"
+    },
+    "4426923": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "15",
+        "stSnapPct": "0.65",
+        "offSnap": "0",
+        "defSnapPct": "0.04"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426923",
+      "longName": "Kei'Trel Clark"
+    },
+    "4427728": {
+      "gameID": "20251103_ARI@DAL",
+      "Rushing": {
+        "rushAvg": "3.0",
+        "rushYds": "27",
+        "carries": "9",
+        "longRush": "17",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "12",
+        "targets": "2",
+        "recYds": "20",
+        "recAvg": "10.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.57",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "38",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4427728",
+      "longName": "Bam Knight"
+    },
+    "4427816": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "11",
+        "stSnap": "15",
+        "stSnapPct": "0.65",
+        "offSnap": "0",
+        "defSnapPct": "0.16"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4427816",
+      "longName": "Marist Liufau"
+    },
+    "4428584": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "26",
+        "stSnap": "3",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4428584",
+      "longName": "Reddy Steward"
+    },
+    "4428633": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "8",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "0",
+        "defSnapPct": "0.12"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428633",
+      "longName": "Dadrion Taylor-Demerson"
+    },
+    "4428656": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.28",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "19",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4428656",
+      "longName": "Nate Thomas"
+    },
+    "4428811": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.04",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.13",
+        "offSnap": "3",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4428811",
+      "longName": "Xavier Weaver"
+    },
+    "4428991": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4428991",
+      "longName": "Paris Johnson Jr."
+    },
+    "4428996": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "26",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428996",
+      "longName": "Jordan Burch"
+    },
+    "4429071": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "18",
+        "stSnapPct": "0.78",
+        "offSnap": "0",
+        "defSnapPct": "0.30"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4429071",
+      "longName": "Cody Simon"
+    },
+    "4429996": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "17",
+        "stSnap": "3",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.25"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4429996",
+      "longName": "Marshawn Kneeland"
+    },
+    "4430821": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.78",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4430821",
+      "longName": "Kitan Crawford"
+    },
+    "4431006": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "0",
+        "defSnapPct": "0.42"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4431006",
+      "longName": "Caelen Carson"
+    },
+    "4431603": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.30"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4431603",
+      "longName": "Jay Toia"
+    },
+    "4432668": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "39",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.58"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "1",
+        "defensiveInterceptionsYards": "0",
+        "interceptionTDs": "0",
+        "sacks": "0",
+        "passDeflections": "2"
+      },
+      "playerID": "4432668",
+      "longName": "Denzel Burke"
+    },
+    "4432708": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "7",
+        "recTD": "1",
+        "longRec": "20",
+        "targets": "10",
+        "recYds": "96",
+        "recAvg": "13.7"
+      },
+      "scoringPlays": [
+        {
+          "score": "Marvin Harrison Jr. 4 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "0",
+          "awayScore": "10",
+          "teamID": "1",
+          "scoreDetails": "8 plays, 47 yards, 4:45",
+          "scoreType": "TD",
+          "scoreTime": "12:17",
+          "team": "ARI",
+          "playerIDs": ["2578570", "4432708", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.72",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "48",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4432708",
+      "longName": "Marvin Harrison Jr."
+    },
+    "4567219": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.78",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4567219",
+      "longName": "Owen Pappoe"
+    },
+    "4567242": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "8",
+        "stSnapPct": "0.35",
+        "offSnap": "0",
+        "defSnapPct": "0.36"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4567242",
+      "longName": "Sam Williams"
+    },
+    "4567399": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "41",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.61"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4567399",
+      "longName": "Kaiir Elam"
+    },
+    "4568506": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "54",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.81"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4568506",
+      "longName": "Garrett Williams"
+    },
+    "4568652": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4568652",
+      "longName": "Tyler Smith"
+    },
+    "4569480": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.36"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4569480",
+      "longName": "Darius Robinson"
+    },
+    "4609048": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4609048",
+      "longName": "Tyler Guyton"
+    },
+    "4683848": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "51",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.76"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4683848",
+      "longName": "Donovan Ezeiruaku"
+    },
+    "4685120": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4685120",
+      "longName": "T.J. Bass"
+    },
+    "4685263": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.17",
+        "offSnap": "67",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "playerID": "4685263",
+      "longName": "Tyler Booker"
+    },
+    "4685400": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "58",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.87"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4685400",
+      "longName": "Shemar James"
+    },
+    "4685408": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.99"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "5",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4685408",
+      "longName": "Will Johnson"
+    },
+    "4685503": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "37",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.55"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "2",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "1"
+      },
+      "playerID": "4685503",
+      "longName": "Walter Nolen III"
+    },
+    "4685841": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "5",
+        "stSnap": "9",
+        "stSnapPct": "0.39",
+        "offSnap": "0",
+        "defSnapPct": "0.07"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4685841",
+      "longName": "Zion Childress"
+    },
+    "4698113": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "26",
+        "stSnap": "3",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4698113",
+      "longName": "Max Melton"
+    },
+    "5083754": {
+      "gameID": "20251103_ARI@DAL",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "1",
+        "longRec": "7",
+        "targets": "2",
+        "recYds": "12",
+        "recAvg": "6.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Ryan Flournoy 5 Yd pass from Dak Prescott (Brandon Aubrey Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "17",
+          "awayScore": "27",
+          "teamID": "9",
+          "scoreDetails": "7 plays, 78 yards, 2:01",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "DAL",
+          "playerIDs": ["2577417", "5083754", "3953687"]
+        }
+      ],
+      "teamID": "9",
+      "snapCounts": {
+        "offSnapPct": "0.67",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.61",
+        "offSnap": "45",
+        "defSnapPct": "0.00"
+      },
+      "team": "DAL",
+      "teamAbv": "DAL",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "5083754",
+      "longName": "Ryan Flournoy"
+    },
+    "5084939": {
+      "gameID": "20251103_ARI@DAL",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.22",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "5084939",
+      "longName": "Isaiah Adams"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Chad Ryland 48 Yd Field Goal",
+      "scorePeriod": "Q1",
+      "homeScore": "0",
+      "awayScore": "3",
+      "teamID": "1",
+      "scoreDetails": "15 plays, 60 yards, 6:54",
+      "scoreType": "FG",
+      "scoreTime": "3:38",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Marvin Harrison Jr. 4 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "0",
+      "awayScore": "10",
+      "teamID": "1",
+      "scoreDetails": "8 plays, 47 yards, 4:45",
+      "scoreType": "TD",
+      "scoreTime": "12:17",
+      "team": "ARI",
+      "playerIDs": ["2578570", "4432708", "4363538"]
+    },
+    {
+      "score": "Marshawn Kneeland Blocked Punt Recovery in End Zone (Brandon Aubrey Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "7",
+      "awayScore": "10",
+      "teamID": "9",
+      "scoreDetails": "5 plays, 12 yards, 2:32",
+      "scoreType": "TD",
+      "scoreTime": "3:58",
+      "team": "DAL",
+      "playerIDs": ["3953687"]
+    },
+    {
+      "score": "Jacoby Brissett 1 Yd Rush (Chad Ryland Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "7",
+      "awayScore": "17",
+      "teamID": "1",
+      "scoreDetails": "11 plays, 74 yards, 3:09",
+      "scoreType": "TD",
+      "scoreTime": "0:49",
+      "team": "ARI",
+      "playerIDs": ["2578570", "4363538"]
+    },
+    {
+      "score": "Trey McBride 12 Yd pass from Jacoby Brissett (Chad Ryland Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "7",
+      "awayScore": "24",
+      "teamID": "1",
+      "scoreDetails": "3 plays, 74 yards, 2:12",
+      "scoreType": "TD",
+      "scoreTime": "12:48",
+      "team": "ARI",
+      "playerIDs": ["2578570", "4361307", "4363538"]
+    },
+    {
+      "score": "Brandon Aubrey 26 Yd Field Goal",
+      "scorePeriod": "Q3",
+      "homeScore": "10",
+      "awayScore": "24",
+      "teamID": "9",
+      "scoreDetails": "12 plays, 65 yards, 5:33",
+      "scoreType": "FG",
+      "scoreTime": "7:15",
+      "team": "DAL",
+      "playerIDs": ["3953687"]
+    },
+    {
+      "score": "Chad Ryland 34 Yd Field Goal",
+      "scorePeriod": "Q3",
+      "homeScore": "10",
+      "awayScore": "27",
+      "teamID": "1",
+      "scoreDetails": "9 plays, 45 yards, 4:44",
+      "scoreType": "FG",
+      "scoreTime": "2:31",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Ryan Flournoy 5 Yd pass from Dak Prescott (Brandon Aubrey Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "17",
+      "awayScore": "27",
+      "teamID": "9",
+      "scoreDetails": "7 plays, 78 yards, 2:01",
+      "scoreType": "TD",
+      "scoreTime": "10:51",
+      "team": "DAL",
+      "playerIDs": ["2577417", "5083754", "3953687"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "1",
+  "teamIDHome": "9",
+  "teamStats": {
+    "away": {
+      "totalYards": "340",
+      "rushingAttempts": "29",
+      "rushingYards": "119",
+      "fumblesLost": "0",
+      "penalties": "2-10",
+      "totalPlays": "65",
+      "possession": "33:20",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "21-31",
+      "passingFirstDowns": "14",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "5-40",
+      "thirdDownEfficiency": "7-13",
+      "blockedPunt": "0",
+      "yardsPerPlay": "5.2",
+      "redZoneScoredAndAttempted": "3-4",
+      "teamID": "1",
+      "defensiveInterceptions": "1",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "10",
+      "rushingFirstDowns": "8",
+      "blockedFG": "0",
+      "rushTD": "1",
+      "twoPointConversions": "0",
+      "firstDowns": "23",
+      "passTD": "2",
+      "team": "ARI",
+      "blockedXP": "0",
+      "teamAbv": "ARI",
+      "firstDownsFromPenalties": "1",
+      "fourthDownEfficiency": "0-1",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "221",
+      "yardsPerRush": "4.1",
+      "snapCounts": {
+        "totalSpecialTeams": "23",
+        "totalOffensive": "67",
+        "totalDefensive": "67"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "6.1"
+    },
+    "home": {
+      "totalYards": "333",
+      "rushingAttempts": "21",
+      "rushingYards": "123",
+      "fumblesLost": "2",
+      "penalties": "6-55",
+      "totalPlays": "65",
+      "possession": "26:40",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "24-39",
+      "passingFirstDowns": "14",
+      "interceptionsThrown": "1",
+      "sacksAndYardsLost": "5-40",
+      "thirdDownEfficiency": "5-12",
+      "blockedPunt": "1",
+      "yardsPerPlay": "5.1",
+      "redZoneScoredAndAttempted": "1-3",
+      "teamID": "9",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "1",
+      "totalDrives": "9",
+      "rushingFirstDowns": "8",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "22",
+      "passTD": "1",
+      "team": "DAL",
+      "blockedXP": "0",
+      "teamAbv": "DAL",
+      "firstDownsFromPenalties": "0",
+      "fourthDownEfficiency": "0-3",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "210",
+      "yardsPerRush": "5.9",
+      "snapCounts": {
+        "totalSpecialTeams": "23",
+        "totalOffensive": "67",
+        "totalDefensive": "67"
+      },
+      "turnovers": "3",
+      "yardsPerPass": "4.8"
+    }
+  },
+  "gameID": "20251103_ARI@DAL",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/__fixtures__/box-score-def-st-overlap.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-def-st-overlap.json
@@ -1,0 +1,2890 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "CAR",
+      "teamID": "5",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "1",
+      "ydsAllowed": "307",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "36",
+      "safeties": "0"
+    },
+    "home": {
+      "teamAbv": "NE",
+      "teamID": "22",
+      "defTD": "1",
+      "defensiveInterceptions": "0",
+      "sacks": "1",
+      "ydsAllowed": "326",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "13",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Greg Meyer, Bill Vinovich, Jimmy Buchanan, Aaron Santi, Tripp Sutter, Dale Keller, Scott Walker",
+  "arena": "Gillette Stadium",
+  "arenaCapacity": "64,628",
+  "attendance": "64,628",
+  "away": "CAR",
+  "awayPts": "13",
+  "awayResult": "L",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20250928",
+  "gameLocation": "Foxborough, MA",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 4",
+  "home": "NE",
+  "homePts": "42",
+  "homeResult": "W",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "6",
+      "Q2": "0",
+      "Q3": "0",
+      "Q4": "7",
+      "teamID": "5",
+      "currentlyInPossession": "False",
+      "totalPts": "13",
+      "teamAbv": "CAR"
+    },
+    "home": {
+      "Q1": "7",
+      "Q2": "21",
+      "Q3": "7",
+      "Q4": "7",
+      "teamID": "22",
+      "currentlyInPossession": "False",
+      "totalPts": "42",
+      "teamAbv": "NE"
+    }
+  },
+  "network": "FOX",
+  "playerStats": {
+    "11759": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.29",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "11759",
+      "longName": "JJ Jansen"
+    },
+    "14012": {
+      "gameID": "20250928_CAR@NE",
+      "Passing": {
+        "qbr": "100.0",
+        "rtg": "146.5",
+        "sacked": "0-0",
+        "passAttempts": "6",
+        "passAvg": "9.7",
+        "passTD": "1",
+        "passYds": "58",
+        "int": "0",
+        "passCompletions": "5"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mitchell Evans 2 Yd pass from Andy Dalton (Ryan Fitzgerald Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "13",
+          "teamID": "5",
+          "scoreDetails": "13 plays, 91 yards, 6:45",
+          "scoreType": "TD",
+          "scoreTime": "1:56",
+          "team": "CAR",
+          "playerIDs": ["14012", "4683243", "4568263"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.19",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "14012",
+      "longName": "Andy Dalton"
+    },
+    "15928": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.29",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "231",
+        "punts": "5",
+        "puntAvg": "46.2",
+        "puntsin20": "1",
+        "puntTouchBacks": "1",
+        "puntLong": "55"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "15928",
+      "longName": "Sam Martin"
+    },
+    "16771": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "43",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "16771",
+      "longName": "Morgan Moses"
+    },
+    "2973051": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "69",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "2973051",
+      "longName": "Taylor Moton"
+    },
+    "2976212": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "6",
+        "recTD": "0",
+        "longRec": "33",
+        "targets": "7",
+        "recYds": "101",
+        "recAvg": "16.8"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.63",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "31",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "2976212",
+      "longName": "Stefon Diggs"
+    },
+    "2991662": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "1",
+        "longRec": "4",
+        "targets": "1",
+        "recYds": "4",
+        "recAvg": "4.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mack Hollins 4 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "7 plays, 41 yards, 3:10",
+          "scoreType": "TD",
+          "scoreTime": "14:13",
+          "team": "NE",
+          "playerIDs": ["4431452", "2991662", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.49",
+        "defSnap": "1",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "24",
+        "defSnapPct": "0.01"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "2991662",
+      "longName": "Mack Hollins"
+    },
+    "3043275": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "24",
+        "targets": "1",
+        "recYds": "24",
+        "recAvg": "24.0"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.65",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "32",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "3043275",
+      "longName": "Austin Hooper"
+    },
+    "3044720": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "-0.7",
+        "rushYds": "-2",
+        "carries": "3",
+        "longRush": "0",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "1.0",
+        "rtg": "39.6",
+        "sacked": "0-0",
+        "passAttempts": "1",
+        "passAvg": "0.0",
+        "passTD": "0",
+        "passYds": "0",
+        "int": "0",
+        "passCompletions": "0"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.12",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "6",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "3044720",
+      "longName": "Joshua Dobbs"
+    },
+    "3046439": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "1",
+        "longRec": "31",
+        "targets": "2",
+        "recYds": "39",
+        "recAvg": "19.5"
+      },
+      "scoringPlays": [
+        {
+          "score": "Hunter Henry 31 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "35",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "8 plays, 78 yards, 4:43",
+          "scoreType": "TD",
+          "scoreTime": "10:17",
+          "team": "NE",
+          "playerIDs": ["4431452", "3046439", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.76",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "37",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "3046439",
+      "longName": "Hunter Henry"
+    },
+    "3054857": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "0",
+        "defSnapPct": "0.59"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3054857",
+      "longName": "A'Shawn Robinson"
+    },
+    "3116179": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.96"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3116179",
+      "longName": "Nick Scott"
+    },
+    "3116729": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "49",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "3116729",
+      "longName": "Garrett Bradbury"
+    },
+    "3122793": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.71"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "0",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3122793",
+      "longName": "Harold Landry III"
+    },
+    "3122906": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.57",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3122906",
+      "longName": "Darius Harris"
+    },
+    "3129446": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "51",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "0",
+        "defSnapPct": "0.74"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "10",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3129446",
+      "longName": "Robert Spillane"
+    },
+    "3135321": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "2",
+        "recYds": "10",
+        "recAvg": "5.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.49",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "34",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntReturns": "1",
+        "puntReturnYds": "13",
+        "puntReturnAvg": "13.0",
+        "puntReturnLong": "13",
+        "puntReturnTD": "0"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3135321",
+      "longName": "Hunter Renfrow"
+    },
+    "3858276": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "39",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3858276",
+      "longName": "Jaylinn Hawkins"
+    },
+    "3871880": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3871880",
+      "longName": "Yosh Nijman"
+    },
+    "3909013": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3909013",
+      "longName": "Christian Rozeboom"
+    },
+    "3916923": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.71"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "3916923",
+      "longName": "Carlton Davis III"
+    },
+    "3917853": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "3917853",
+      "longName": "Mike Jackson"
+    },
+    "3925350": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "17",
+        "stSnapPct": "0.61",
+        "offSnap": "0",
+        "defSnapPct": "0.29"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3925350",
+      "longName": "Anfernee Jennings"
+    },
+    "4035495": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "37",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.76"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4035495",
+      "longName": "Derrick Brown"
+    },
+    "4037239": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "10",
+        "stSnap": "7",
+        "stSnapPct": "0.25",
+        "offSnap": "0",
+        "defSnapPct": "0.20"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4037239",
+      "longName": "Boogie Basham"
+    },
+    "4038815": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "3.6",
+        "rushYds": "32",
+        "carries": "9",
+        "longRush": "10",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "-2",
+        "targets": "1",
+        "recYds": "-2",
+        "recAvg": "-2.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.39",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.25",
+        "offSnap": "27",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "4",
+        "kickReturnTD": "0",
+        "kickReturnYds": "100",
+        "kickReturnAvg": "25.0",
+        "kickReturnLong": "30"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4038815",
+      "longName": "Rico Dowdle"
+    },
+    "4040778": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.33",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "23",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4040778",
+      "longName": "Brandon Walton"
+    },
+    "4046545": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "49",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4046545",
+      "longName": "Mike Onwenu"
+    },
+    "4047941": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "22",
+        "stSnapPct": "0.79",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4047941",
+      "longName": "Brenden Schooler"
+    },
+    "4058925": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "5",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.63"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4058925",
+      "longName": "Tershawn Wharton"
+    },
+    "4212909": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "12.0",
+        "rushYds": "12",
+        "carries": "1",
+        "longRush": "12",
+        "rushTD": "0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.01",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4212909",
+      "longName": "David Moore"
+    },
+    "4239699": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "40",
+        "stSnap": "4",
+        "stSnapPct": "0.14",
+        "offSnap": "0",
+        "defSnapPct": "0.58"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4239699",
+      "longName": "Milton Williams"
+    },
+    "4240042": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "16",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.23"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240042",
+      "longName": "Cory Durden"
+    },
+    "4240545": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "205",
+        "punts": "4",
+        "puntAvg": "51.3",
+        "puntsin20": "2",
+        "puntTouchBacks": "0",
+        "puntLong": "59"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4240545",
+      "longName": "Bryce Baringer"
+    },
+    "4240554": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.16",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "8",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4240554",
+      "longName": "Vederian Lowe"
+    },
+    "4240623": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "5",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240623",
+      "longName": "DJ Johnson"
+    },
+    "4240800": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4240800",
+      "longName": "Brenden Jaimes"
+    },
+    "4241416": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "4.9",
+        "rushYds": "49",
+        "carries": "10",
+        "longRush": "11",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "14",
+        "targets": "3",
+        "recYds": "20",
+        "recAvg": "6.7"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.51",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "35",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4241416",
+      "longName": "Chuba Hubbard"
+    },
+    "4241720": {
+      "gameID": "20250928_CAR@NE",
+      "scoringPlays": [
+        {
+          "score": "Marcus Jones 87 Yd Punt Return (Andy Borregales Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "6 plays, 34 yards, 3:42",
+          "scoreType": "TD",
+          "scoreTime": "5:34",
+          "team": "NE",
+          "playerIDs": ["4241720", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "5",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.55"
+      },
+      "Punting": {
+        "puntReturns": "3",
+        "puntReturnYds": "167",
+        "puntReturnAvg": "55.7",
+        "puntReturnLong": "87",
+        "puntReturnTD": "1"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "1",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241720",
+      "longName": "Marcus Jones"
+    },
+    "4242205": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "34",
+        "stSnap": "9",
+        "stSnapPct": "0.32",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4242205",
+      "longName": "K'Lavon Chaisson"
+    },
+    "4243493": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "42",
+        "stSnap": "12",
+        "stSnapPct": "0.43",
+        "offSnap": "0",
+        "defSnapPct": "0.61"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4243493",
+      "longName": "Keion White"
+    },
+    "4244607": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.39",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4244607",
+      "longName": "Akayleb Evans"
+    },
+    "4245273": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "39",
+        "stSnap": "20",
+        "stSnapPct": "0.71",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "9",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4245273",
+      "longName": "Christian Elliss"
+    },
+    "4248899": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "16",
+        "stSnap": "17",
+        "stSnapPct": "0.61",
+        "offSnap": "0",
+        "defSnapPct": "0.23"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4248899",
+      "longName": "Marte Mapu"
+    },
+    "4249739": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "22",
+        "stSnapPct": "0.79",
+        "offSnap": "0",
+        "defSnapPct": "0.45"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "12",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "8",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4249739",
+      "longName": "Jack Gibbens"
+    },
+    "4256062": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.43",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "30",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4256062",
+      "longName": "Brady Christensen"
+    },
+    "4256074": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "27",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.39"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "0",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4256074",
+      "longName": "Khyiris Tonga"
+    },
+    "4256224": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "25",
+        "stSnapPct": "0.89",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4256224",
+      "longName": "Claudin Cherelus"
+    },
+    "4360294": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "4.5",
+        "rushYds": "27",
+        "carries": "6",
+        "longRush": "21",
+        "rushTD": "1"
+      },
+      "scoringPlays": [
+        {
+          "score": "Antonio Gibson 1 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "28",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "4 plays, 14 yards, 2:05",
+          "scoreType": "TD",
+          "scoreTime": "1:57",
+          "team": "NE",
+          "playerIDs": ["4360294", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.18",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "28",
+        "kickReturnAvg": "28.0",
+        "kickReturnLong": "28"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4360294",
+      "longName": "Antonio Gibson"
+    },
+    "4360763": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "24",
+        "targets": "4",
+        "recYds": "36",
+        "recAvg": "12.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.81",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "56",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "1",
+        "fumblesRecovered": "0"
+      },
+      "playerID": "4360763",
+      "longName": "Brycen Tremayne"
+    },
+    "4361100": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.22",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.29",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4361100",
+      "longName": "Jack Westover"
+    },
+    "4361788": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "69",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4361788",
+      "longName": "Cade Mays"
+    },
+    "4361988": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "9",
+        "targets": "2",
+        "recYds": "17",
+        "recAvg": "8.5"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.25",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.43",
+        "offSnap": "17",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4361988",
+      "longName": "James Mitchell"
+    },
+    "4362487": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "46",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.94"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362487",
+      "longName": "Tre'von Moehrig"
+    },
+    "4362647": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "69",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4362647",
+      "longName": "Damien Lewis"
+    },
+    "4362847": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "46",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.94"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362847",
+      "longName": "Jaycee Horn"
+    },
+    "4362890": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "49",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4362890",
+      "longName": "Ben Brown"
+    },
+    "4368113": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "21",
+        "stSnap": "14",
+        "stSnapPct": "0.50",
+        "offSnap": "0",
+        "defSnapPct": "0.30"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4368113",
+      "longName": "Charles Woods"
+    },
+    "4372030": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.52"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "0",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "2",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4372030",
+      "longName": "Christian Barmore"
+    },
+    "4372518": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "18",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.37"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4372518",
+      "longName": "Bobby Brown III"
+    },
+    "4372780": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "15",
+        "targets": "8",
+        "recYds": "42",
+        "recAvg": "8.4"
+      },
+      "scoringPlays": [
+        {
+          "score": "Tommy Tremble 7 Yd pass from Bryce Young (Ryan Fitzgerald PAT Failed)",
+          "scorePeriod": "Q1",
+          "homeScore": "0",
+          "awayScore": "6",
+          "teamID": "5",
+          "scoreDetails": "7 plays, 76 yards, 4:09",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "CAR",
+          "playerIDs": ["4685720", "4372780", "4568263"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.75",
+        "defSnap": "0",
+        "stSnap": "2",
+        "stSnapPct": "0.07",
+        "offSnap": "52",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4372780",
+      "longName": "Tommy Tremble"
+    },
+    "4401811": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "35",
+        "stSnap": "12",
+        "stSnapPct": "0.43",
+        "offSnap": "0",
+        "defSnapPct": "0.51"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4401811",
+      "longName": "Kyle Dugger"
+    },
+    "4426599": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.29"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426599",
+      "longName": "Alex Austin"
+    },
+    "4426926": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "25",
+        "stSnapPct": "0.89",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4426926",
+      "longName": "Demani Richardson"
+    },
+    "4427095": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.16",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "8",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4427095",
+      "longName": "DeMario Douglas"
+    },
+    "4427132": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "69",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4427132",
+      "longName": "Ikem Ekwonu"
+    },
+    "4428125": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.68",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4428125",
+      "longName": "Maema Njongmeta"
+    },
+    "4428232": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "18",
+        "stSnap": "22",
+        "stSnapPct": "0.79",
+        "offSnap": "0",
+        "defSnapPct": "0.26"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428232",
+      "longName": "Dell Pettus"
+    },
+    "4428930": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "68",
+        "stSnap": "10",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.99"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "2",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4428930",
+      "longName": "Craig Woodson"
+    },
+    "4429022": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "18",
+        "targets": "3",
+        "recYds": "18",
+        "recAvg": "18.0"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.69",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "34",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4429022",
+      "longName": "Kayshon Boutte"
+    },
+    "4429110": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "15",
+        "stSnap": "13",
+        "stSnapPct": "0.46",
+        "offSnap": "0",
+        "defSnapPct": "0.31"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4429110",
+      "longName": "Lathan Ransom"
+    },
+    "4429166": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "12",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.24"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4429166",
+      "longName": "Princely Umanmielen"
+    },
+    "4431426": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "16",
+        "stSnapPct": "0.57",
+        "offSnap": "0",
+        "defSnapPct": "0.06"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4431426",
+      "longName": "Corey Thornton"
+    },
+    "4431452": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "3.7",
+        "rushYds": "11",
+        "carries": "3",
+        "longRush": "5",
+        "rushTD": "1"
+      },
+      "Passing": {
+        "qbr": "93.3",
+        "rtg": "155.6",
+        "sacked": "1-0",
+        "passAttempts": "17",
+        "passAvg": "11.9",
+        "passTD": "2",
+        "passYds": "203",
+        "int": "0",
+        "passCompletions": "14"
+      },
+      "scoringPlays": [
+        {
+          "score": "Drake Maye 5 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "14",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "6 plays, 80 yards, 3:02",
+          "scoreType": "TD",
+          "scoreTime": "14:54",
+          "team": "NE",
+          "playerIDs": ["4431452", "4569923"]
+        },
+        {
+          "score": "Hunter Henry 31 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "35",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "8 plays, 78 yards, 4:43",
+          "scoreType": "TD",
+          "scoreTime": "10:17",
+          "team": "NE",
+          "playerIDs": ["4431452", "3046439", "4569923"]
+        },
+        {
+          "score": "Mack Hollins 4 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "7 plays, 41 yards, 3:10",
+          "scoreType": "TD",
+          "scoreTime": "14:13",
+          "team": "NE",
+          "playerIDs": ["4431452", "2991662", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "43",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4431452",
+      "longName": "Drake Maye"
+    },
+    "4432710": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "4.6",
+        "rushYds": "32",
+        "carries": "7",
+        "longRush": "11",
+        "rushTD": "1"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "9",
+        "targets": "2",
+        "recYds": "14",
+        "recAvg": "7.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "TreVeyon Henderson 5 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "21",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "8 plays, 55 yards, 4:07",
+          "scoreType": "TD",
+          "scoreTime": "5:48",
+          "team": "NE",
+          "playerIDs": ["4432710", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.31",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.11",
+        "offSnap": "15",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "20",
+        "kickReturnAvg": "20.0",
+        "kickReturnLong": "20"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4432710",
+      "longName": "TreVeyon Henderson"
+    },
+    "4565293": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.12",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "6",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4565293",
+      "longName": "Marcus Bryant"
+    },
+    "4568263": {
+      "gameID": "20250928_CAR@NE",
+      "scoringPlays": [
+        {
+          "score": "Tommy Tremble 7 Yd pass from Bryce Young (Ryan Fitzgerald PAT Failed)",
+          "scorePeriod": "Q1",
+          "homeScore": "0",
+          "awayScore": "6",
+          "teamID": "5",
+          "scoreDetails": "7 plays, 76 yards, 4:09",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "CAR",
+          "playerIDs": ["4685720", "4372780", "4568263"]
+        },
+        {
+          "score": "Mitchell Evans 2 Yd pass from Andy Dalton (Ryan Fitzgerald Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "13",
+          "teamID": "5",
+          "scoreDetails": "13 plays, 91 yards, 6:45",
+          "scoreType": "TD",
+          "scoreTime": "1:56",
+          "team": "CAR",
+          "playerIDs": ["14012", "4683243", "4568263"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "0",
+        "fgMade": "0",
+        "fgAttempts": "1",
+        "xpMade": "1",
+        "fgPct": "0.0",
+        "kickingPts": "1",
+        "xpAttempts": "2",
+        "fgMissed": "1",
+        "xpMissed": "1"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4568263",
+      "longName": "Ryan Fitzgerald"
+    },
+    "4569173": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "4.2",
+        "rushYds": "38",
+        "carries": "9",
+        "longRush": "22",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "3",
+        "targets": "1",
+        "recYds": "3",
+        "recAvg": "3.0"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.57",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "28",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4569173",
+      "longName": "Rhamondre Stevenson"
+    },
+    "4569372": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.13",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4569372",
+      "longName": "Dalevon Campbell"
+    },
+    "4569923": {
+      "gameID": "20250928_CAR@NE",
+      "scoringPlays": [
+        {
+          "score": "Marcus Jones 87 Yd Punt Return (Andy Borregales Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "6 plays, 34 yards, 3:42",
+          "scoreType": "TD",
+          "scoreTime": "5:34",
+          "team": "NE",
+          "playerIDs": ["4241720", "4569923"]
+        },
+        {
+          "score": "Drake Maye 5 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "14",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "6 plays, 80 yards, 3:02",
+          "scoreType": "TD",
+          "scoreTime": "14:54",
+          "team": "NE",
+          "playerIDs": ["4431452", "4569923"]
+        },
+        {
+          "score": "TreVeyon Henderson 5 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "21",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "8 plays, 55 yards, 4:07",
+          "scoreType": "TD",
+          "scoreTime": "5:48",
+          "team": "NE",
+          "playerIDs": ["4432710", "4569923"]
+        },
+        {
+          "score": "Antonio Gibson 1 Yd Rush (Andy Borregales Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "28",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "4 plays, 14 yards, 2:05",
+          "scoreType": "TD",
+          "scoreTime": "1:57",
+          "team": "NE",
+          "playerIDs": ["4360294", "4569923"]
+        },
+        {
+          "score": "Hunter Henry 31 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "35",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "8 plays, 78 yards, 4:43",
+          "scoreType": "TD",
+          "scoreTime": "10:17",
+          "team": "NE",
+          "playerIDs": ["4431452", "3046439", "4569923"]
+        },
+        {
+          "score": "Mack Hollins 4 Yd pass from Drake Maye (Andy Borregales Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "6",
+          "teamID": "22",
+          "scoreDetails": "7 plays, 41 yards, 3:10",
+          "scoreType": "TD",
+          "scoreTime": "14:13",
+          "team": "NE",
+          "playerIDs": ["4431452", "2991662", "4569923"]
+        }
+      ],
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "13",
+        "stSnapPct": "0.46",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "0",
+        "fgMade": "0",
+        "fgAttempts": "0",
+        "xpMade": "6",
+        "fgPct": "0.0",
+        "kickingPts": "6",
+        "xpAttempts": "6",
+        "fgMissed": "0",
+        "xpMissed": "0"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4569923",
+      "longName": "Andy Borregales"
+    },
+    "4611993": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.29"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4611993",
+      "longName": "Joshua Farmer"
+    },
+    "4613202": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "-2.0",
+        "rushYds": "-2",
+        "carries": "1",
+        "longRush": "-2",
+        "rushTD": "0"
+      },
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.29",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "14",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4613202",
+      "longName": "Kyle Williams"
+    },
+    "4683243": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "1",
+        "longRec": "16",
+        "targets": "4",
+        "recYds": "23",
+        "recAvg": "7.7"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mitchell Evans 2 Yd pass from Andy Dalton (Ryan Fitzgerald Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "42",
+          "awayScore": "13",
+          "teamID": "5",
+          "scoreDetails": "13 plays, 91 yards, 6:45",
+          "scoreType": "TD",
+          "scoreTime": "1:56",
+          "team": "CAR",
+          "playerIDs": ["14012", "4683243", "4568263"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.54",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.29",
+        "offSnap": "37",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4683243",
+      "longName": "Mitchell Evans"
+    },
+    "4683815": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "46",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.94"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4683815",
+      "longName": "Trevin Wallace"
+    },
+    "4685298": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "43",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4685298",
+      "longName": "Will Campbell"
+    },
+    "4685350": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "4.7",
+        "rushYds": "33",
+        "carries": "7",
+        "longRush": "22",
+        "rushTD": "0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.16",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.39",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "39",
+        "kickReturnAvg": "19.5",
+        "kickReturnLong": "21"
+      },
+      "Punting": {
+        "puntReturns": "2",
+        "puntReturnYds": "6",
+        "puntReturnAvg": "3.0",
+        "puntReturnLong": "8",
+        "puntReturnTD": "0"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4685350",
+      "longName": "Trevor Etienne"
+    },
+    "4685472": {
+      "gameID": "20250928_CAR@NE",
+      "Receiving": {
+        "receptions": "4",
+        "recTD": "0",
+        "longRec": "22",
+        "targets": "8",
+        "recYds": "62",
+        "recAvg": "15.5"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.94",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4685472",
+      "longName": "Tetairoa McMillan"
+    },
+    "4685720": {
+      "gameID": "20250928_CAR@NE",
+      "Rushing": {
+        "rushAvg": "3.0",
+        "rushYds": "3",
+        "carries": "1",
+        "longRush": "3",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "44.6",
+        "rtg": "84.0",
+        "sacked": "1-11",
+        "passAttempts": "30",
+        "passAvg": "5.0",
+        "passTD": "1",
+        "passYds": "150",
+        "int": "0",
+        "passCompletions": "18"
+      },
+      "scoringPlays": [
+        {
+          "score": "Tommy Tremble 7 Yd pass from Bryce Young (Ryan Fitzgerald PAT Failed)",
+          "scorePeriod": "Q1",
+          "homeScore": "0",
+          "awayScore": "6",
+          "teamID": "5",
+          "scoreDetails": "7 plays, 76 yards, 4:09",
+          "scoreType": "TD",
+          "scoreTime": "10:51",
+          "team": "CAR",
+          "playerIDs": ["4685720", "4372780", "4568263"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.81",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "56",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4685720",
+      "longName": "Bryce Young"
+    },
+    "4686772": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.71"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4686772",
+      "longName": "Christian Gonzalez"
+    },
+    "4687513": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "9",
+        "stSnap": "4",
+        "stSnapPct": "0.14",
+        "offSnap": "0",
+        "defSnapPct": "0.18"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4687513",
+      "longName": "Cam Jackson"
+    },
+    "4695254": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "22",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "NE",
+      "teamAbv": "NE",
+      "playerID": "4695254",
+      "longName": "Julian Ashby"
+    },
+    "4697636": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "8",
+        "stSnapPct": "0.29",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4697636",
+      "longName": "Chau Smith-Wade"
+    },
+    "4710661": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.25",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "17",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4710661",
+      "longName": "Chandler Zavala"
+    },
+    "4714157": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "25",
+        "stSnapPct": "0.89",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4714157",
+      "longName": "Thomas Incoom"
+    },
+    "4833355": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "44",
+        "stSnap": "6",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.90"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4833355",
+      "longName": "Nic Scourton"
+    },
+    "4880613": {
+      "gameID": "20250928_CAR@NE",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.68",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4880613",
+      "longName": "Bam Martin-Scott"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Tommy Tremble 7 Yd pass from Bryce Young (Ryan Fitzgerald PAT Failed)",
+      "scorePeriod": "Q1",
+      "homeScore": "0",
+      "awayScore": "6",
+      "teamID": "5",
+      "scoreDetails": "7 plays, 76 yards, 4:09",
+      "scoreType": "TD",
+      "scoreTime": "10:51",
+      "team": "CAR",
+      "playerIDs": ["4685720", "4372780", "4568263"]
+    },
+    {
+      "score": "Marcus Jones 87 Yd Punt Return (Andy Borregales Kick)",
+      "scorePeriod": "Q1",
+      "homeScore": "7",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "6 plays, 34 yards, 3:42",
+      "scoreType": "TD",
+      "scoreTime": "5:34",
+      "team": "NE",
+      "playerIDs": ["4241720", "4569923"]
+    },
+    {
+      "score": "Drake Maye 5 Yd Rush (Andy Borregales Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "14",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "6 plays, 80 yards, 3:02",
+      "scoreType": "TD",
+      "scoreTime": "14:54",
+      "team": "NE",
+      "playerIDs": ["4431452", "4569923"]
+    },
+    {
+      "score": "TreVeyon Henderson 5 Yd Rush (Andy Borregales Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "21",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "8 plays, 55 yards, 4:07",
+      "scoreType": "TD",
+      "scoreTime": "5:48",
+      "team": "NE",
+      "playerIDs": ["4432710", "4569923"]
+    },
+    {
+      "score": "Antonio Gibson 1 Yd Rush (Andy Borregales Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "28",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "4 plays, 14 yards, 2:05",
+      "scoreType": "TD",
+      "scoreTime": "1:57",
+      "team": "NE",
+      "playerIDs": ["4360294", "4569923"]
+    },
+    {
+      "score": "Hunter Henry 31 Yd pass from Drake Maye (Andy Borregales Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "35",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "8 plays, 78 yards, 4:43",
+      "scoreType": "TD",
+      "scoreTime": "10:17",
+      "team": "NE",
+      "playerIDs": ["4431452", "3046439", "4569923"]
+    },
+    {
+      "score": "Mack Hollins 4 Yd pass from Drake Maye (Andy Borregales Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "42",
+      "awayScore": "6",
+      "teamID": "22",
+      "scoreDetails": "7 plays, 41 yards, 3:10",
+      "scoreType": "TD",
+      "scoreTime": "14:13",
+      "team": "NE",
+      "playerIDs": ["4431452", "2991662", "4569923"]
+    },
+    {
+      "score": "Mitchell Evans 2 Yd pass from Andy Dalton (Ryan Fitzgerald Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "42",
+      "awayScore": "13",
+      "teamID": "5",
+      "scoreDetails": "13 plays, 91 yards, 6:45",
+      "scoreType": "TD",
+      "scoreTime": "1:56",
+      "team": "CAR",
+      "playerIDs": ["14012", "4683243", "4568263"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "5",
+  "teamIDHome": "22",
+  "teamStats": {
+    "away": {
+      "totalYards": "326",
+      "rushingAttempts": "28",
+      "rushingYards": "129",
+      "fumblesLost": "0",
+      "penalties": "5-29",
+      "totalPlays": "65",
+      "possession": "35:14",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "23-36",
+      "passingFirstDowns": "11",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "1-11",
+      "thirdDownEfficiency": "5-14",
+      "blockedPunt": "0",
+      "yardsPerPlay": "5.0",
+      "redZoneScoredAndAttempted": "2-2",
+      "teamID": "5",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "11",
+      "rushingFirstDowns": "8",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "21",
+      "passTD": "2",
+      "team": "CAR",
+      "blockedXP": "0",
+      "teamAbv": "CAR",
+      "firstDownsFromPenalties": "2",
+      "fourthDownEfficiency": "1-3",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "197",
+      "yardsPerRush": "4.6",
+      "snapCounts": {
+        "totalSpecialTeams": "28",
+        "totalOffensive": "69",
+        "totalDefensive": "49"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "5.3"
+    },
+    "home": {
+      "totalYards": "307",
+      "rushingAttempts": "29",
+      "rushingYards": "104",
+      "fumblesLost": "0",
+      "penalties": "7-54",
+      "totalPlays": "48",
+      "possession": "24:46",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "14-18",
+      "passingFirstDowns": "8",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "1-0",
+      "thirdDownEfficiency": "3-9",
+      "blockedPunt": "0",
+      "yardsPerPlay": "6.4",
+      "redZoneScoredAndAttempted": "4-4",
+      "teamID": "22",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "2",
+      "totalDrives": "10",
+      "rushingFirstDowns": "7",
+      "blockedFG": "0",
+      "rushTD": "3",
+      "twoPointConversions": "0",
+      "firstDowns": "16",
+      "passTD": "2",
+      "team": "NE",
+      "blockedXP": "0",
+      "teamAbv": "NE",
+      "firstDownsFromPenalties": "1",
+      "fourthDownEfficiency": "1-1",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "203",
+      "yardsPerRush": "3.6",
+      "snapCounts": {
+        "totalSpecialTeams": "28",
+        "totalOffensive": "49",
+        "totalDefensive": "69"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "10.7"
+    }
+  },
+  "gameID": "20250928_CAR@NE",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/__fixtures__/box-score-safety.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-safety.json
@@ -1,0 +1,2702 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "ARI",
+      "teamID": "1",
+      "defTD": "0",
+      "defensiveInterceptions": "1",
+      "sacks": "1",
+      "ydsAllowed": "355",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "16",
+      "safeties": "1"
+    },
+    "home": {
+      "teamAbv": "SF",
+      "teamID": "28",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "1",
+      "ydsAllowed": "260",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "15",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Allen Baynes, John Hussey, Carl Johnson, Max Causey, Matt Edwards, Anthony Flemming, Duane Heydt",
+  "arena": "Levi's Stadium",
+  "arenaCapacity": "68,500",
+  "attendance": "70,414",
+  "away": "ARI",
+  "awayPts": "15",
+  "awayResult": "L",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20250921",
+  "gameLocation": "Santa Clara, CA",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 3",
+  "home": "SF",
+  "homePts": "16",
+  "homeResult": "W",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "0",
+      "Q2": "3",
+      "Q3": "3",
+      "Q4": "9",
+      "teamID": "1",
+      "currentlyInPossession": "False",
+      "totalPts": "15",
+      "teamAbv": "ARI"
+    },
+    "home": {
+      "Q1": "0",
+      "Q2": "6",
+      "Q3": "0",
+      "Q4": "10",
+      "teamID": "28",
+      "currentlyInPossession": "False",
+      "totalPts": "16",
+      "teamAbv": "SF"
+    }
+  },
+  "network": "FOX",
+  "playerStats": {
+    "11284": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "32",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "3",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "11284",
+      "longName": "Calais Campbell"
+    },
+    "12701": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.28",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "128",
+        "punts": "3",
+        "puntAvg": "42.7",
+        "puntsin20": "2",
+        "puntTouchBacks": "0",
+        "puntLong": "48"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "12701",
+      "longName": "Thomas Morstead"
+    },
+    "13241": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "13241",
+      "longName": "Trent Williams"
+    },
+    "13729": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.28",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "13729",
+      "longName": "Jon Weeks"
+    },
+    "15035": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15035",
+      "longName": "Kelvin Beachum"
+    },
+    "15241": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "15241",
+      "longName": "Aaron Brewer"
+    },
+    "16002": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "1",
+        "longRec": "1",
+        "targets": "1",
+        "recYds": "1",
+        "recAvg": "1.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Kyle Juszczyk 1 Yd pass from Mac Jones (Eddy Pineiro Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "6",
+          "teamID": "28",
+          "scoreDetails": "6 plays, 48 yards, 3:09",
+          "scoreType": "TD",
+          "scoreTime": "10:50",
+          "team": "SF",
+          "playerIDs": ["4241464", "16002", "4034949"]
+        }
+      ],
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.34",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.12",
+        "offSnap": "22",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "16002",
+      "longName": "Kyle Juszczyk"
+    },
+    "2577185": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "2577185",
+      "longName": "Jake Brendel"
+    },
+    "2979860": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "35",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.54"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "2979860",
+      "longName": "Dalvin Tomlinson"
+    },
+    "3045147": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "2.4",
+        "rushYds": "22",
+        "carries": "9",
+        "longRush": "9",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "10",
+        "targets": "4",
+        "recYds": "15",
+        "recAvg": "5.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.30",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "20",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "1",
+        "fumblesRecovered": "0"
+      },
+      "playerID": "3045147",
+      "longName": "James Conner"
+    },
+    "3045523": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "4",
+        "recTD": "0",
+        "longRec": "11",
+        "targets": "6",
+        "recYds": "38",
+        "recAvg": "9.5"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.72",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3045523",
+      "longName": "Kendrick Bourne"
+    },
+    "3051738": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "9",
+        "targets": "1",
+        "recYds": "9",
+        "recAvg": "9.0"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.26",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "17",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3051738",
+      "longName": "Marquez Valdes-Scantling"
+    },
+    "3057524": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.76",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3057524",
+      "longName": "Siran Neal"
+    },
+    "3059722": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "18",
+        "targets": "3",
+        "recYds": "25",
+        "recAvg": "12.5"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.50",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "33",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3059722",
+      "longName": "Zay Jones"
+    },
+    "3115928": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.02",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.28",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3115928",
+      "longName": "Malik Turner"
+    },
+    "3116097": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "12",
+        "stSnap": "21",
+        "stSnapPct": "0.84",
+        "offSnap": "0",
+        "defSnapPct": "0.18"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3116097",
+      "longName": "Luke Gifford"
+    },
+    "3117251": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "3.1",
+        "rushYds": "52",
+        "carries": "17",
+        "longRush": "15",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "10",
+        "recTD": "0",
+        "longRec": "20",
+        "targets": "15",
+        "recYds": "88",
+        "recAvg": "8.8"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.91",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3117251",
+      "longName": "Christian McCaffrey"
+    },
+    "3127287": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3127287",
+      "longName": "Budda Baker"
+    },
+    "3128412": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3128412",
+      "longName": "Evan Brown"
+    },
+    "3138826": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "6",
+        "stSnapPct": "0.24",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "11",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "2"
+      },
+      "playerID": "3138826",
+      "longName": "Fred Warner"
+    },
+    "3693166": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "27",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.42"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "2",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "3693166",
+      "longName": "Josh Sweat"
+    },
+    "3886633": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "0",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "3886633",
+      "longName": "Hjalte Froholdt"
+    },
+    "3916075": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3916075",
+      "longName": "Colton McKivitz"
+    },
+    "3917142": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "52",
+        "stSnap": "14",
+        "stSnapPct": "0.56",
+        "offSnap": "0",
+        "defSnapPct": "0.80"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3917142",
+      "longName": "Akeem Davis-Gaither"
+    },
+    "3917315": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "6.2",
+        "rushYds": "37",
+        "carries": "6",
+        "longRush": "9",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "52.0",
+        "rtg": "82.9",
+        "sacked": "1-5",
+        "passAttempts": "35",
+        "passAvg": "4.5",
+        "passTD": "1",
+        "passYds": "159",
+        "int": "0",
+        "passCompletions": "22"
+      },
+      "scoringPlays": [
+        {
+          "score": "Trey McBride 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "13",
+          "teamID": "1",
+          "scoreDetails": "4 plays, 65 yards, 2:13",
+          "scoreType": "TD",
+          "scoreTime": "8:37",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4361307", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "3917315",
+      "longName": "Kyler Murray"
+    },
+    "3920814": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "3920814",
+      "longName": "Austen Pleasants"
+    },
+    "4034949": {
+      "gameID": "20250921_ARI@SF",
+      "scoringPlays": [
+        {
+          "score": "Eddy Pineiro 38 Yd Field Goal",
+          "scorePeriod": "Q2",
+          "homeScore": "3",
+          "awayScore": "3",
+          "teamID": "28",
+          "scoreDetails": "9 plays, 49 yards, 4:23",
+          "scoreType": "FG",
+          "scoreTime": "4:22",
+          "team": "SF",
+          "playerIDs": ["4034949"]
+        },
+        {
+          "score": "Eddy Pineiro 51 Yd Field Goal",
+          "scorePeriod": "Q2",
+          "homeScore": "6",
+          "awayScore": "3",
+          "teamID": "28",
+          "scoreDetails": "11 plays, 53 yards, 1:51",
+          "scoreType": "FG",
+          "scoreTime": "0:17",
+          "team": "SF",
+          "playerIDs": ["4034949"]
+        },
+        {
+          "score": "Kyle Juszczyk 1 Yd pass from Mac Jones (Eddy Pineiro Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "6",
+          "teamID": "28",
+          "scoreDetails": "6 plays, 48 yards, 3:09",
+          "scoreType": "TD",
+          "scoreTime": "10:50",
+          "team": "SF",
+          "playerIDs": ["4241464", "16002", "4034949"]
+        },
+        {
+          "score": "Eddy Pineiro 35 Yd Field Goal",
+          "scorePeriod": "Q4",
+          "homeScore": "16",
+          "awayScore": "15",
+          "teamID": "28",
+          "scoreDetails": "10 plays, 63 yards, 1:46",
+          "scoreType": "FG",
+          "scoreTime": "0:00",
+          "team": "SF",
+          "playerIDs": ["4034949"]
+        }
+      ],
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "51",
+        "fgMade": "3",
+        "fgAttempts": "3",
+        "xpMade": "1",
+        "fgPct": "100.0",
+        "kickingPts": "10",
+        "xpAttempts": "1",
+        "fgMissed": "0",
+        "xpMissed": "0"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4034949",
+      "longName": "Eddy Pineiro"
+    },
+    "4035870": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4035870",
+      "longName": "Jake Curhan"
+    },
+    "4037235": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "5.0",
+        "rushYds": "5",
+        "carries": "1",
+        "longRush": "5",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "2",
+        "targets": "2",
+        "recYds": "3",
+        "recAvg": "1.5"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.24",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.32",
+        "offSnap": "16",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "58",
+        "kickReturnAvg": "29.0",
+        "kickReturnLong": "33"
+      },
+      "Punting": {
+        "puntReturns": "1",
+        "puntReturnYds": "8",
+        "puntReturnAvg": "8.0",
+        "puntReturnLong": "8",
+        "puntReturnTD": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4037235",
+      "longName": "Greg Dortch"
+    },
+    "4039052": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "32",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.48"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4039052",
+      "longName": "Jordan Elliott"
+    },
+    "4039375": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "2",
+        "stSnapPct": "0.08",
+        "offSnap": "0",
+        "defSnapPct": "0.55"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "2",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "1"
+      },
+      "playerID": "4039375",
+      "longName": "Bryce Huff"
+    },
+    "4040605": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "14",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.21"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4040605",
+      "longName": "Nick Bosa"
+    },
+    "4040612": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.46",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.32",
+        "offSnap": "30",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4040612",
+      "longName": "Luke Farrell"
+    },
+    "4040726": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4040726",
+      "longName": "Jonah Williams"
+    },
+    "4040983": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "12",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "2"
+      },
+      "playerID": "4040983",
+      "longName": "Mack Wilson Sr."
+    },
+    "4043089": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4043089",
+      "longName": "Jalen Thompson"
+    },
+    "4044138": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4044138",
+      "longName": "Matt Hennessy"
+    },
+    "4044448": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4044448",
+      "longName": "Curtis Robinson"
+    },
+    "4045180": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "258",
+        "punts": "5",
+        "puntAvg": "51.6",
+        "puntsin20": "2",
+        "puntTouchBacks": "1",
+        "puntLong": "55"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4045180",
+      "longName": "Blake Gillikin"
+    },
+    "4047846": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.48",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4047846",
+      "longName": "Chase Lucas"
+    },
+    "4240706": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240706",
+      "longName": "Jason Pinnock"
+    },
+    "4241464": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "-1.0",
+        "rushYds": "-1",
+        "carries": "1",
+        "longRush": "-1",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "62.9",
+        "rtg": "83.8",
+        "sacked": "1-2",
+        "passAttempts": "41",
+        "passAvg": "6.9",
+        "passTD": "1",
+        "passYds": "284",
+        "int": "1",
+        "passCompletions": "27"
+      },
+      "scoringPlays": [
+        {
+          "score": "Kyle Juszczyk 1 Yd pass from Mac Jones (Eddy Pineiro Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "6",
+          "teamID": "28",
+          "scoreDetails": "6 plays, 48 yards, 3:09",
+          "scoreType": "TD",
+          "scoreTime": "10:50",
+          "team": "SF",
+          "playerIDs": ["4241464", "16002", "4034949"]
+        }
+      ],
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4241464",
+      "longName": "Mac Jones"
+    },
+    "4241474": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "11.0",
+        "rushYds": "22",
+        "carries": "2",
+        "longRush": "19",
+        "rushTD": "0"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.09",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "6",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4241474",
+      "longName": "Brian Robinson Jr."
+    },
+    "4241987": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "30",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.46"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241987",
+      "longName": "Baron Browning"
+    },
+    "4242488": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "64",
+        "stSnap": "2",
+        "stSnapPct": "0.08",
+        "offSnap": "0",
+        "defSnapPct": "0.97"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4242488",
+      "longName": "Deommodore Lenoir"
+    },
+    "4243541": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.47"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4243541",
+      "longName": "Kalia Davis"
+    },
+    "4244606": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "0.45"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4244606",
+      "longName": "Zaven Collins"
+    },
+    "4259147": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "11",
+        "targets": "3",
+        "recYds": "21",
+        "recAvg": "10.5"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.69",
+        "defSnap": "0",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "45",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4259147",
+      "longName": "Jake Tonges"
+    },
+    "4259324": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4259324",
+      "longName": "Travis Vokolek"
+    },
+    "4259594": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "22",
+        "stSnap": "2",
+        "stSnapPct": "0.08",
+        "offSnap": "0",
+        "defSnapPct": "0.33"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4259594",
+      "longName": "Yetur Gross-Matos"
+    },
+    "4261606": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.40",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4261606",
+      "longName": "Darren Hall"
+    },
+    "4360203": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4360203",
+      "longName": "Elijah Jones"
+    },
+    "4360290": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.02",
+        "defSnap": "0",
+        "stSnap": "11",
+        "stSnapPct": "0.44",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360290",
+      "longName": "Brayden Willis"
+    },
+    "4360739": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.64",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360739",
+      "longName": "Simi Fehoko"
+    },
+    "4360761": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "2",
+        "recYds": "5",
+        "recAvg": "5.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.74",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "49",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4360761",
+      "longName": "Michael Wilson"
+    },
+    "4361307": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "17",
+        "targets": "8",
+        "recYds": "43",
+        "recAvg": "8.6"
+      },
+      "scoringPlays": [
+        {
+          "score": "Trey McBride 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "13",
+          "teamID": "1",
+          "scoreDetails": "4 plays, 65 yards, 2:13",
+          "scoreType": "TD",
+          "scoreTime": "8:37",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4361307", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.88",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "58",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4361307",
+      "longName": "Trey McBride"
+    },
+    "4361421": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "20",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.31"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4361421",
+      "longName": "PJ Mustipher"
+    },
+    "4362225": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.55"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362225",
+      "longName": "Dante Stills"
+    },
+    "4362478": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "0.0",
+        "rushYds": "0",
+        "carries": "2",
+        "longRush": "1",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "0",
+        "recTD": "0",
+        "longRec": "0",
+        "targets": "1",
+        "recYds": "0",
+        "recAvg": "0.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.11",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.48",
+        "offSnap": "7",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "57",
+        "kickReturnAvg": "28.5",
+        "kickReturnLong": "36"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4362478",
+      "longName": "Emari Demercado"
+    },
+    "4363538": {
+      "gameID": "20250921_ARI@SF",
+      "scoringPlays": [
+        {
+          "score": "Chad Ryland 34 Yd Field Goal",
+          "scorePeriod": "Q2",
+          "homeScore": "0",
+          "awayScore": "3",
+          "teamID": "1",
+          "scoreDetails": "12 plays, 49 yards, 6:09",
+          "scoreType": "FG",
+          "scoreTime": "8:45",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        },
+        {
+          "score": "Chad Ryland 28 Yd Field Goal",
+          "scorePeriod": "Q3",
+          "homeScore": "6",
+          "awayScore": "6",
+          "teamID": "1",
+          "scoreDetails": "15 plays, 77 yards, 6:35",
+          "scoreType": "FG",
+          "scoreTime": "6:37",
+          "team": "ARI",
+          "playerIDs": ["4363538"]
+        },
+        {
+          "score": "Trey McBride 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "13",
+          "awayScore": "13",
+          "teamID": "1",
+          "scoreDetails": "4 plays, 65 yards, 2:13",
+          "scoreType": "TD",
+          "scoreTime": "8:37",
+          "team": "ARI",
+          "playerIDs": ["3917315", "4361307", "4363538"]
+        }
+      ],
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.32",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "34",
+        "fgMade": "2",
+        "fgAttempts": "3",
+        "xpMade": "1",
+        "fgPct": "66.7",
+        "kickingPts": "7",
+        "xpAttempts": "1",
+        "fgMissed": "1",
+        "xpMissed": "0"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4363538",
+      "longName": "Chad Ryland"
+    },
+    "4367199": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.03",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "2",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4367199",
+      "longName": "Jon Gaines II"
+    },
+    "4372378": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "8",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.12"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4372378",
+      "longName": "Anthony Goodlow"
+    },
+    "4372561": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "19",
+        "kickReturnAvg": "19.0",
+        "kickReturnLong": "19"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4372561",
+      "longName": "Isaac Guerendo"
+    },
+    "4426698": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426698",
+      "longName": "Tatum Bethune"
+    },
+    "4426844": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "7",
+        "targets": "1",
+        "recYds": "7",
+        "recAvg": "7.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.15",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.64",
+        "offSnap": "10",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4426844",
+      "longName": "Elijah Higgins"
+    },
+    "4426923": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "6",
+        "stSnapPct": "0.24",
+        "offSnap": "0",
+        "defSnapPct": "0.48"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426923",
+      "longName": "Kei'Trel Clark"
+    },
+    "4427325": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "57",
+        "stSnap": "2",
+        "stSnapPct": "0.08",
+        "offSnap": "0",
+        "defSnapPct": "0.86"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4427325",
+      "longName": "Renardo Green"
+    },
+    "4428209": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "8",
+        "recTD": "0",
+        "longRec": "34",
+        "targets": "11",
+        "recYds": "117",
+        "recAvg": "14.6"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.97",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "63",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4428209",
+      "longName": "Ricky Pearsall"
+    },
+    "4428633": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "40",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.62"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "1",
+        "defensiveInterceptionsYards": "18",
+        "interceptionTDs": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4428633",
+      "longName": "Dadrion Taylor-Demerson"
+    },
+    "4428914": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "2",
+        "stSnapPct": "0.08",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4428914",
+      "longName": "Dee Winters"
+    },
+    "4428996": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "7",
+        "stSnapPct": "0.28",
+        "offSnap": "0",
+        "defSnapPct": "0.58"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428996",
+      "longName": "Jordan Burch"
+    },
+    "4429071": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "2",
+        "stSnap": "20",
+        "stSnapPct": "0.80",
+        "offSnap": "0",
+        "defSnapPct": "0.03"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4429071",
+      "longName": "Cody Simon"
+    },
+    "4429275": {
+      "gameID": "20250921_ARI@SF",
+      "Rushing": {
+        "rushAvg": "4.2",
+        "rushYds": "42",
+        "carries": "10",
+        "longRush": "29",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "4",
+        "recYds": "9",
+        "recAvg": "3.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.61",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "40",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4429275",
+      "longName": "Trey Benson"
+    },
+    "4429782": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.14",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4429782",
+      "longName": "Josh Fryar"
+    },
+    "4430191": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "10",
+        "targets": "1",
+        "recYds": "10",
+        "recAvg": "10.0"
+      },
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.52",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "34",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "2",
+        "kickReturnTD": "0",
+        "kickReturnYds": "61",
+        "kickReturnAvg": "30.5",
+        "kickReturnLong": "31"
+      },
+      "Punting": {
+        "puntReturns": "3",
+        "puntReturnYds": "26",
+        "puntReturnAvg": "8.7",
+        "puntReturnLong": "14",
+        "puntReturnTD": "0"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4430191",
+      "longName": "Skyy Moore"
+    },
+    "4430821": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "6",
+        "stSnap": "20",
+        "stSnapPct": "0.80",
+        "offSnap": "0",
+        "defSnapPct": "0.09"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4430821",
+      "longName": "Kitan Crawford"
+    },
+    "4430835": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.47"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4430835",
+      "longName": "Alfred Collins"
+    },
+    "4431523": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4431523",
+      "longName": "Connor Colby"
+    },
+    "4432668": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "33",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.51"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4432668",
+      "longName": "Denzel Burke"
+    },
+    "4432708": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "32",
+        "targets": "6",
+        "recYds": "44",
+        "recAvg": "14.7"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.80",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "53",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4432708",
+      "longName": "Marvin Harrison Jr."
+    },
+    "4565200": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "32",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.48"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4565200",
+      "longName": "Upton Stout"
+    },
+    "4567219": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.64",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4567219",
+      "longName": "Owen Pappoe"
+    },
+    "4569480": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "37",
+        "stSnap": "5",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4569480",
+      "longName": "Darius Robinson"
+    },
+    "4569497": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "42",
+        "stSnap": "8",
+        "stSnapPct": "0.32",
+        "offSnap": "0",
+        "defSnapPct": "0.64"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4569497",
+      "longName": "Sam Okuayinonu"
+    },
+    "4685623": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "43",
+        "stSnap": "3",
+        "stSnapPct": "0.12",
+        "offSnap": "0",
+        "defSnapPct": "0.65"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4685623",
+      "longName": "Mykel Williams"
+    },
+    "4685978": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "7",
+        "stSnap": "15",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.11"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4685978",
+      "longName": "Darrell Luter Jr."
+    },
+    "4686308": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "14",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.21"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4686308",
+      "longName": "CJ West"
+    },
+    "4693337": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "9",
+        "stSnapPct": "0.36",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4693337",
+      "longName": "Marques Sigle"
+    },
+    "4693644": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "25",
+        "stSnap": "13",
+        "stSnapPct": "0.52",
+        "offSnap": "0",
+        "defSnapPct": "0.38"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4693644",
+      "longName": "Ji'Ayir Brown"
+    },
+    "4696700": {
+      "gameID": "20250921_ARI@SF",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "6",
+        "targets": "3",
+        "recYds": "8",
+        "recAvg": "4.0"
+      },
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.50",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.56",
+        "offSnap": "33",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "4696700",
+      "longName": "Tip Reiman"
+    },
+    "4698113": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "64",
+        "stSnap": "1",
+        "stSnapPct": "0.04",
+        "offSnap": "0",
+        "defSnapPct": "0.98"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4698113",
+      "longName": "Max Melton"
+    },
+    "4879480": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "4879480",
+      "longName": "Drew Moss"
+    },
+    "5084939": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "1",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "ARI",
+      "teamAbv": "ARI",
+      "playerID": "5084939",
+      "longName": "Isaiah Adams"
+    },
+    "5092959": {
+      "gameID": "20250921_ARI@SF",
+      "teamID": "28",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.16",
+        "offSnap": "65",
+        "defSnapPct": "0.00"
+      },
+      "team": "SF",
+      "teamAbv": "SF",
+      "playerID": "5092959",
+      "longName": "Dominick Puni"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Chad Ryland 34 Yd Field Goal",
+      "scorePeriod": "Q2",
+      "homeScore": "0",
+      "awayScore": "3",
+      "teamID": "1",
+      "scoreDetails": "12 plays, 49 yards, 6:09",
+      "scoreType": "FG",
+      "scoreTime": "8:45",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Eddy Pineiro 38 Yd Field Goal",
+      "scorePeriod": "Q2",
+      "homeScore": "3",
+      "awayScore": "3",
+      "teamID": "28",
+      "scoreDetails": "9 plays, 49 yards, 4:23",
+      "scoreType": "FG",
+      "scoreTime": "4:22",
+      "team": "SF",
+      "playerIDs": ["4034949"]
+    },
+    {
+      "score": "Eddy Pineiro 51 Yd Field Goal",
+      "scorePeriod": "Q2",
+      "homeScore": "6",
+      "awayScore": "3",
+      "teamID": "28",
+      "scoreDetails": "11 plays, 53 yards, 1:51",
+      "scoreType": "FG",
+      "scoreTime": "0:17",
+      "team": "SF",
+      "playerIDs": ["4034949"]
+    },
+    {
+      "score": "Chad Ryland 28 Yd Field Goal",
+      "scorePeriod": "Q3",
+      "homeScore": "6",
+      "awayScore": "6",
+      "teamID": "1",
+      "scoreDetails": "15 plays, 77 yards, 6:35",
+      "scoreType": "FG",
+      "scoreTime": "6:37",
+      "team": "ARI",
+      "playerIDs": ["4363538"]
+    },
+    {
+      "score": "Kyle Juszczyk 1 Yd pass from Mac Jones (Eddy Pineiro Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "13",
+      "awayScore": "6",
+      "teamID": "28",
+      "scoreDetails": "6 plays, 48 yards, 3:09",
+      "scoreType": "TD",
+      "scoreTime": "10:50",
+      "team": "SF",
+      "playerIDs": ["4241464", "16002", "4034949"]
+    },
+    {
+      "score": "Trey McBride 1 Yd pass from Kyler Murray (Chad Ryland Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "13",
+      "awayScore": "13",
+      "teamID": "1",
+      "scoreDetails": "4 plays, 65 yards, 2:13",
+      "scoreType": "TD",
+      "scoreTime": "8:37",
+      "team": "ARI",
+      "playerIDs": ["3917315", "4361307", "4363538"]
+    },
+    {
+      "score": "Defensive Holding in Endzone for Safety",
+      "scorePeriod": "Q4",
+      "homeScore": "13",
+      "awayScore": "15",
+      "teamID": "1",
+      "scoreDetails": "1 play, -6 yards, 0:14",
+      "scoreType": "SF",
+      "scoreTime": "3:15",
+      "team": "ARI",
+      "playerIDs": []
+    },
+    {
+      "score": "Eddy Pineiro 35 Yd Field Goal",
+      "scorePeriod": "Q4",
+      "homeScore": "16",
+      "awayScore": "15",
+      "teamID": "28",
+      "scoreDetails": "10 plays, 63 yards, 1:46",
+      "scoreType": "FG",
+      "scoreTime": "0:00",
+      "team": "SF",
+      "playerIDs": ["4034949"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "1",
+  "teamIDHome": "28",
+  "teamStats": {
+    "away": {
+      "totalYards": "260",
+      "rushingAttempts": "28",
+      "rushingYards": "106",
+      "fumblesLost": "0",
+      "penalties": "5-30",
+      "totalPlays": "64",
+      "possession": "34:39",
+      "safeties": "1",
+      "passCompletionsAndAttempts": "22-35",
+      "passingFirstDowns": "8",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "1-5",
+      "thirdDownEfficiency": "5-15",
+      "blockedPunt": "0",
+      "yardsPerPlay": "4.1",
+      "redZoneScoredAndAttempted": "1-3",
+      "teamID": "1",
+      "defensiveInterceptions": "1",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "10",
+      "rushingFirstDowns": "7",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "16",
+      "passTD": "1",
+      "team": "ARI",
+      "blockedXP": "0",
+      "teamAbv": "ARI",
+      "firstDownsFromPenalties": "1",
+      "fourthDownEfficiency": "2-2",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "154",
+      "yardsPerRush": "3.8",
+      "snapCounts": {
+        "totalSpecialTeams": "25",
+        "totalOffensive": "66",
+        "totalDefensive": "65"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "4.3"
+    },
+    "home": {
+      "totalYards": "355",
+      "rushingAttempts": "20",
+      "rushingYards": "73",
+      "fumblesLost": "0",
+      "penalties": "5-69",
+      "totalPlays": "62",
+      "possession": "25:21",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "27-41",
+      "passingFirstDowns": "14",
+      "interceptionsThrown": "1",
+      "sacksAndYardsLost": "1-2",
+      "thirdDownEfficiency": "2-10",
+      "blockedPunt": "0",
+      "yardsPerPlay": "5.7",
+      "redZoneScoredAndAttempted": "1-4",
+      "teamID": "28",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "10",
+      "rushingFirstDowns": "4",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "19",
+      "passTD": "1",
+      "team": "SF",
+      "blockedXP": "0",
+      "teamAbv": "SF",
+      "firstDownsFromPenalties": "1",
+      "fourthDownEfficiency": "1-2",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "282",
+      "yardsPerRush": "3.7",
+      "snapCounts": {
+        "totalSpecialTeams": "25",
+        "totalOffensive": "65",
+        "totalDefensive": "66"
+      },
+      "turnovers": "1",
+      "yardsPerPass": "6.7"
+    }
+  },
+  "gameID": "20250921_ARI@SF",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -4,6 +4,10 @@ import type { StatLine } from "@rostr/core";
 import { translateBoxScore } from "./box-score.js";
 import rawBoxScore from "./__fixtures__/box-score.json" with { type: "json" };
 import rawReturnGame from "./__fixtures__/box-score-return-td.json" with { type: "json" };
+import rawBlockedFgGame from "./__fixtures__/box-score-blocked-fg.json" with { type: "json" };
+import rawSafetyGame from "./__fixtures__/box-score-safety.json" with { type: "json" };
+import rawBlockedPuntTdGame from "./__fixtures__/box-score-blocked-punt-td.json" with { type: "json" };
+import rawOverlapGame from "./__fixtures__/box-score-def-st-overlap.json" with { type: "json" };
 
 /**
  * Tests run against a **real captured box score** — Cowboys at Eagles, the 2025
@@ -612,5 +616,359 @@ describe("two-point conversions", () => {
     );
 
     expect(translated.warnings.join(" ")).toMatch(/reports 2 two-point conversion/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Four defects found by scoring the whole 2025 season against Sleeper and then
+// checking every disagreement against the play text and the box score itself.
+// Sleeper found them; the evidence below is what decided them. Each fixture is a
+// real captured `getNFLBoxScore` response.
+// ---------------------------------------------------------------------------
+
+const blockedFgGame = translateBoxScore(rawBlockedFgGame);
+const safetyGame = translateBoxScore(rawSafetyGame);
+const blockedPuntTdGame = translateBoxScore(rawBlockedPuntTdGame);
+const overlapGame = translateBoxScore(rawOverlapGame);
+
+const unitOf = (
+  translated: ReturnType<typeof translateBoxScore>,
+  teamAbv: string,
+): Map<string, number> =>
+  new Map((translated.teamDefense.get(teamAbv) ?? []).map((l) => [l.statKey, l.value]));
+
+const playerOf = (
+  translated: ReturnType<typeof translateBoxScore>,
+  playerID: string,
+): Map<string, number> =>
+  new Map((translated.players.get(playerID) ?? []).map((l) => [l.statKey, l.value]));
+
+const defenceBlock = (
+  raw: { playerStats: Record<string, unknown> },
+  playerID: string,
+): Record<string, string> =>
+  ((raw.playerStats[playerID] as { Defense?: Record<string, string> } | undefined)?.Defense ??
+    {}) as Record<string, string>;
+
+/**
+ * A quarterback falling on his own fumble is not a defensive play.
+ *
+ * `TANK01_STAT_MAP` mapped `Defense.fumblesRecovered` for **every** player, and
+ * Tank01 files a player recovering his own fumble there. 185 player-weeks of the
+ * 2025 season, 384 points, paid to somebody's quarterback, running back or
+ * receiver.
+ *
+ * The whole class went rather than the one field: `NFL_SLOT_TYPES` has no IDP
+ * slot, so no per-player defensive stat can reach a roster spot except by being
+ * mistaken for the D/ST's.
+ */
+describe("per-player defensive stats are not scored", () => {
+  const BRISSETT = "2578570"; // QB, ARI
+  const PICKENS = "4426354"; // WR, DAL
+  const JAVONTE = "4361579"; // RB, DAL
+  const MARCUS_JONES = "4241720"; // CB, NE
+
+  it("does not pay a quarterback for recovering his own fumble", () => {
+    // Verbatim from the fixture: he fumbled once and recovered one, and lost
+    // none — so the recovery is his own ball.
+    expect(defenceBlock(rawBlockedPuntTdGame, BRISSETT)["fumbles"]).toBe("1");
+    expect(defenceBlock(rawBlockedPuntTdGame, BRISSETT)["fumblesRecovered"]).toBe("1");
+    expect(defenceBlock(rawBlockedPuntTdGame, BRISSETT)["fumblesLost"]).toBe("0");
+
+    expect(playerOf(blockedPuntTdGame, BRISSETT).get("def_fum_rec")).toBeUndefined();
+  });
+
+  it("does not pay a receiver or a running back for the same thing", () => {
+    expect(defenceBlock(rawBlockedPuntTdGame, PICKENS)["fumblesRecovered"]).toBe("1");
+    expect(defenceBlock(rawBlockedPuntTdGame, JAVONTE)["fumblesRecovered"]).toBe("1");
+
+    expect(playerOf(blockedPuntTdGame, PICKENS).get("def_fum_rec")).toBeUndefined();
+    expect(playerOf(blockedPuntTdGame, JAVONTE).get("def_fum_rec")).toBeUndefined();
+  });
+
+  it("still charges the fumble that was actually lost", () => {
+    // `Defense.fumblesLost` is the one field under `Defense` that belongs to the
+    // offensive player, and it stays mapped. Dropping the whole category would
+    // have been the mirror-image error, and this is what stops it.
+    expect(playerOf(blockedPuntTdGame, JAVONTE).get("fum_lost")).toBe(1);
+  });
+
+  it("does not pay an individual defender for a touchdown", () => {
+    // Marcus Jones carries `Defense.defTD: "1"` for his punt return, and the old
+    // map turned that into a 6-point `def_td` on his own row — the same thing
+    // that paid Tyler Lockett, a wide receiver, 6 points for "Tyler Lockett 0 Yd
+    // Fumble Recovery" in week 5.
+    expect(defenceBlock(rawOverlapGame, MARCUS_JONES)["defTD"]).toBe("1");
+
+    expect(playerOf(overlapGame, MARCUS_JONES).get("def_td")).toBeUndefined();
+  });
+
+  it("emits no unit-only stat key on any player row, in any real game", () => {
+    // The sweep, so a re-introduced mapping fails here rather than in a payout.
+    const unitOnly = ["def_td", "def_sack", "def_int", "def_fum_rec", "def_safety"];
+    const games = [box, returnGame, blockedFgGame, safetyGame, blockedPuntTdGame, overlapGame];
+
+    for (const translated of games) {
+      for (const [playerID, lines] of translated.players) {
+        for (const line of lines) {
+          expect(unitOnly, `${playerID} produced ${line.statKey}`).not.toContain(line.statKey);
+        }
+      }
+    }
+  });
+});
+
+/**
+ * Blocked kicks, from the numbers rather than from the prose.
+ *
+ * The text path can only ever see a block that led to a score. **27 of the 44
+ * blocked kicks in 2025 did not**, which is 54 points nobody was paid.
+ */
+describe("blocked kicks come from teamStats", () => {
+  it("credits a block no scoring play mentions", () => {
+    // 2025 week 1, `20250907_ARI@NO`. New Orleans blocked an Arizona field goal,
+    // it went nowhere, and the scoring summary is silent about it.
+    expect(rawBlockedFgGame.scoringPlays.filter((p) => /block/i.test(p.score))).toEqual([]);
+
+    expect(unitOf(blockedFgGame, "NO").get("def_blk_kick")).toBe(1);
+  });
+
+  it("credits the team that made the block, not the team that got blocked", () => {
+    // The fact that had to be established before these fields could be used at
+    // all — the mirror of the trap `blockingTeamOf` exists for. Arizona's kick
+    // was blocked; Arizona's own counter reads 0 and New Orleans' reads 1.
+    expect(rawBlockedFgGame.teamStats.home.teamAbv).toBe("NO");
+    expect(rawBlockedFgGame.teamStats.home.blockedFG).toBe("1");
+    expect(rawBlockedFgGame.teamStats.away.blockedFG).toBe("0");
+
+    expect(unitOf(blockedFgGame, "ARI").get("def_blk_kick")).toBeUndefined();
+  });
+
+  it("counts a block that also scored exactly once", () => {
+    // The reason the two sources are combined with `max` and not `+`. Marshawn
+    // Kneeland recovered a blocked punt in the end zone for a touchdown, so the
+    // numeric counter and the scoring text both see it; adding them would pay
+    // Dallas twice for one block.
+    expect(rawBlockedPuntTdGame.teamStats.home.blockedPunt).toBe("1");
+
+    expect(unitOf(blockedPuntTdGame, "DAL").get("def_blk_kick")).toBe(1);
+  });
+
+  it("falls back to the scoring text when teamStats is absent, and says nothing", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20" },
+        away: { teamAbv: "DAL", ptsAllowed: "24" },
+      },
+      scoringPlays: [
+        { score: "Blake Corum 1 Yd Rush (Joshua Karty PAT blocked)", team: "DAL" },
+      ],
+    });
+
+    expect(unitOf(translated, "PHI").get("def_blk_kick")).toBe(1);
+    expect(translated.warnings.join(" ")).not.toMatch(/blocked kick/);
+  });
+
+  it("keeps the larger count and warns when the text sees a block the numbers do not", () => {
+    // The only direction worth reporting. The reverse is the ordinary case, 27
+    // times a season, and warning about it would drown the signal.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20" },
+        away: { teamAbv: "DAL", ptsAllowed: "24" },
+      },
+      teamStats: {
+        home: { teamAbv: "PHI", blockedFG: "0", blockedPunt: "0", blockedXP: "0" },
+        away: { teamAbv: "DAL", blockedFG: "0", blockedPunt: "0", blockedXP: "0" },
+      },
+      scoringPlays: [
+        { score: "Blake Corum 1 Yd Rush (Joshua Karty PAT blocked)", team: "DAL" },
+      ],
+    });
+
+    expect(unitOf(translated, "PHI").get("def_blk_kick")).toBe(1);
+    expect(translated.warnings.join(" ")).toMatch(/PHI: teamStats reports 0 blocked kick/);
+  });
+});
+
+/**
+ * One touchdown pays the unit once.
+ *
+ * Both halves below are load-bearing and pull in opposite directions: removing
+ * the special-teams term outright would have cost more points than the
+ * double-count it fixes.
+ */
+describe("the D/ST is paid once per defensive or special teams touchdown", () => {
+  it("does not pay twice when the returner is a defensive player", () => {
+    // 2025 week 4, `20250928_CAR@NE`. There is exactly one defensive or special
+    // teams touchdown in the whole game — Marcus Jones's 87-yard punt return —
+    // and New England scored 2 for it, because Jones is a cornerback and ESPN
+    // files his return under `defensiveTouchdowns` as well.
+    expect(rawOverlapGame.DST.home.defTD).toBe("1");
+    expect(rawOverlapGame.scoringPlays.filter((p) => /Return/i.test(p.score)).length).toBe(1);
+
+    expect(unitOf(overlapGame, "NE").get("def_td")).toBe(1);
+    expect(unitOf(overlapGame, "CAR").get("def_td")).toBeUndefined();
+  });
+
+  it("still pays the returner his own six on that same play", () => {
+    // The pair that is *not* a double-count: different roster spots, usually
+    // different managers. Losing this half would be the larger bug.
+    expect(playerOf(overlapGame, "4241720").get("ret_td")).toBe(1);
+  });
+
+  it("still pays the unit when the returner is not a defensive player", () => {
+    // `20251218_LAR@SEA`: Rashid Shaheed is a receiver, so Seattle's `DST.defTD`
+    // reads "0" and the scoring text is the only evidence the unit scored at all.
+    expect(rawReturnGame.DST.home.defTD).toBe("0");
+
+    expect(unitOf(returnGame, "SEA").get("def_td")).toBe(1);
+  });
+
+  it("pays a blocked punt recovered in the end zone", () => {
+    // `20251103_ARI@DAL`, verbatim: "Marshawn Kneeland Blocked Punt Recovery in
+    // End Zone". No "return" anywhere in it, so the old pattern read nothing —
+    // and Dallas's `DST.defTD` is "0", so no other path made it up. Refs #158.
+    expect(rawBlockedPuntTdGame.DST.home.defTD).toBe("0");
+
+    expect(unitOf(blockedPuntTdGame, "DAL").get("def_td")).toBe(1);
+    expect(unitOf(blockedPuntTdGame, "ARI").get("def_td")).toBeUndefined();
+  });
+
+  /**
+   * The negative case, and the reason the new pattern is anchored on "blocked".
+   *
+   * Every fumble-return touchdown in the 2025 season is worded "Fumble
+   * Recovery", not "Fumble Return". A bare `recover` alternative in the
+   * special-teams pattern therefore turns **14 defensive touchdowns** into a
+   * `ret_td` on a player *and* a second `def_td` on the unit — one play paid
+   * three times across two roster spots.
+   */
+  it("does not read a fumble recovery touchdown as a special teams score", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: { p: { playerID: "p", longName: "Zack Baun", team: "PHI" } },
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20", defTD: "1" },
+        away: { teamAbv: "DAL", ptsAllowed: "24" },
+      },
+      scoringPlays: [
+        {
+          score: "Zack Baun 12 Yd Fumble Recovery (Jake Elliott Kick)",
+          scoreType: "TD",
+          team: "PHI",
+          playerIDs: ["p"],
+        },
+      ],
+    });
+
+    // One touchdown, one credit — the one `DST.defTD` already reports.
+    expect(unitOf(translated, "PHI").get("def_td")).toBe(1);
+    expect(playerOf(translated, "p").get("ret_td")).toBeUndefined();
+  });
+
+  it("warns when Tank01's own count disagrees with the plays we recognised", () => {
+    // `defensiveOrSpecialTeamsTds` minus `DST.defTD` is Tank01's independent
+    // count of the special-teams half. This is the check that would have found
+    // the Kneeland wording without a season-long sweep. Refs #157, #158.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20", defTD: "0" },
+        away: { teamAbv: "DAL", ptsAllowed: "24" },
+      },
+      teamStats: {
+        home: { teamAbv: "PHI", defensiveOrSpecialTeamsTds: "1" },
+        away: { teamAbv: "DAL", defensiveOrSpecialTeamsTds: "0" },
+      },
+      scoringPlays: [],
+    });
+
+    expect(translated.warnings.join(" ")).toMatch(
+      /PHI: teamStats implies 1 special teams touchdown/,
+    );
+  });
+});
+
+/**
+ * Safeties.
+ *
+ * A safety always scores, so it always reaches `scoringPlays` — which makes the
+ * play list an independent second reading of a category worth 2 points and
+ * reported about a dozen times a season.
+ */
+describe("safeties", () => {
+  it("reads a safety, and does not count it twice", () => {
+    // 2025 week 3, `20250921_ARI@SF`. The away score moves 13 -> 15 on
+    // "Defensive Holding in Endzone for Safety" with `team: "ARI"`, which is what
+    // proves `play.team` on an `SF` play names the defense that scored it rather
+    // than the offense that conceded it.
+    const safety = rawSafetyGame.scoringPlays.find((p) => p.scoreType === "SF");
+    expect(safety?.team).toBe("ARI");
+    expect(safety?.score).toBe("Defensive Holding in Endzone for Safety");
+    expect(safety?.awayScore).toBe("15");
+
+    expect(unitOf(safetyGame, "ARI").get("def_safety")).toBe(1);
+    expect(unitOf(safetyGame, "SF").get("def_safety")).toBeUndefined();
+  });
+
+  it("agrees with the DST block on that game, and says nothing", () => {
+    // Recorded because a full-season sweep reported `DST.safeties` as "0" for
+    // this exact game. It is "1". The two sources agree here, so neither is
+    // discarded and no warning is raised. See docs/TANK01.md.
+    expect(rawSafetyGame.DST.away.safeties).toBe("1");
+
+    expect(safetyGame.warnings.join(" ")).not.toMatch(/safety/);
+  });
+
+  it("credits a safety the DST block does not report, and warns", () => {
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20", safeties: "0" },
+        away: { teamAbv: "DAL", ptsAllowed: "24", safeties: "0" },
+      },
+      scoringPlays: [
+        { score: "Defensive Holding in Endzone for Safety", scoreType: "SF", team: "PHI" },
+      ],
+    });
+
+    expect(unitOf(translated, "PHI").get("def_safety")).toBe(1);
+    expect(translated.warnings.join(" ")).toMatch(/PHI: DST.safeties is 0 but 1 safety/);
+  });
+});
+
+describe("the newly captured games reconcile", () => {
+  it.each([
+    ["20250907_ARI@NO", () => blockedFgGame],
+    ["20250921_ARI@SF", () => safetyGame],
+    ["20251103_ARI@DAL", () => blockedPuntTdGame],
+    ["20250928_CAR@NE", () => overlapGame],
+  ])("%s reads cleanly", (gameRef, get) => {
+    const translated = get();
+
+    expect(translated.gameRef).toBe(gameRef);
+    expect(translated.fatal).toEqual([]);
+    // Zero warnings is the claim worth making: every cross-check added here
+    // agrees with the provider on four independently captured responses.
+    expect(translated.warnings).toEqual([]);
+    expect(translated.players.size).toBeGreaterThan(50);
+  });
+
+  it("scores every player and every unit in them without throwing", () => {
+    for (const translated of [blockedFgGame, safetyGame, blockedPuntTdGame, overlapGame]) {
+      for (const lines of translated.players.values()) {
+        expect(() => scorePlayer(lines, RULES)).not.toThrow();
+      }
+      for (const lines of translated.teamDefense.values()) {
+        expect(() => scorePlayer(lines, RULES)).not.toThrow();
+      }
+    }
   });
 });

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -26,11 +26,14 @@ import {
   isBlockedKick,
   isSpecialTeamsReturnTouchdown,
   isSuccessfulTwoPointConversion,
+  mainClause,
   parseFieldGoalYards,
   parseStatValue,
   scoredInMainClause,
   TANK01_DST_MAP,
   TANK01_STAT_MAP,
+  TANK01_TEAM_BLOCKED_KICK_FIELDS,
+  TANK01_TEAM_DEF_ST_TD_FIELD,
 } from "./stat-map.js";
 
 interface ScoringPlay {
@@ -364,16 +367,6 @@ function translatePlayerWithConversions(
 }
 
 /**
- * Team defense stat lines.
- *
- * `ptsAllowed` is emitted **even when zero**, because the scoring engine treats
- * an absent stat as "did not play" and a shutout would otherwise silently
- * forfeit its bonus.
- *
- * Blocked kicks are credited to the team that *blocked* one, which is the
- * opponent of the team whose kick it was.
- */
-/**
  * Which team blocked the kick in this scoring play.
  *
  * `play.team` is the team that **scored** the play, and a blocked kick reaches
@@ -423,13 +416,111 @@ function blockingTeamOf(play: ScoringPlay, teamAbvs: readonly string[]): string 
   return scoringTeam;
 }
 
+/**
+ * The `teamStats` block, indexed by team rather than by side.
+ *
+ * `DST.home` and `teamStats.home` name the same team in every captured game, so
+ * matching on the side would work. It matches on `teamAbv` anyway, because a
+ * defensive stat credited to the wrong team is a swing between two rosters and
+ * this file has already made that mistake twice — see `blockingTeamOf`.
+ */
+function teamStatsByAbv(raw: unknown): Map<string, Record<string, unknown>> {
+  const block = (raw ?? {}) as Record<string, unknown>;
+  const byAbv = new Map<string, Record<string, unknown>>();
+
+  for (const side of ["home", "away"] as const) {
+    const unit = block[side] as Record<string, unknown> | undefined;
+    if (!unit || typeof unit !== "object") continue;
+
+    const teamAbv = String(unit["teamAbv"] ?? "");
+    if (teamAbv) byAbv.set(teamAbv, unit);
+  }
+
+  return byAbv;
+}
+
+/**
+ * Blocked kicks this team made, summed from the three `teamStats` counters.
+ *
+ * `null` when the block carries none of the three fields at all — which is not a
+ * zero, it is "this response does not have them", and the caller falls back to
+ * the scoring text rather than reporting no blocks.
+ */
+function blockedKicksFromTeamStats(unit: Record<string, unknown> | undefined): number | null {
+  if (!unit) return null;
+
+  let total: number | null = null;
+
+  for (const field of TANK01_TEAM_BLOCKED_KICK_FIELDS) {
+    if (unit[field] === undefined) continue;
+
+    const parsed = parseStatValue(unit[field]);
+    if (parsed === null) continue;
+
+    total = (total ?? 0) + parsed;
+  }
+
+  return total;
+}
+
+/**
+ * The name forms of every player on this team credited with a defensive
+ * touchdown in this game.
+ *
+ * This reads `Defense.defTD`, which {@link TANK01_STAT_MAP} deliberately no
+ * longer maps to a stat key. Reading a field and paying a roster spot for it are
+ * different things: nothing can start an individual defender, so the per-player
+ * value is not a score — but it is exactly the evidence needed to tell whether a
+ * special-teams touchdown is *already inside* `DST.defTD`.
+ *
+ * Proven on `20250928_CAR@NE`: Marcus Jones is the only player in the game with
+ * `Defense.defTD` (`"1"`), and New England's `DST.defTD` is `"1"`. The team
+ * figure is the sum of the player figures.
+ */
+function defensiveTouchdownScorers(
+  playerStats: Record<string, RawPlayer>,
+  teamAbv: string,
+): readonly (readonly string[])[] {
+  const scorers: (readonly string[])[] = [];
+
+  for (const player of Object.values(playerStats)) {
+    const team = String(player.team ?? player.teamAbv ?? "");
+    if (team !== teamAbv || !player.longName) continue;
+
+    const defence = player["Defense"] as Record<string, unknown> | undefined;
+    if ((parseStatValue(defence?.["defTD"]) ?? 0) > 0) scorers.push(nameForms(player.longName));
+  }
+
+  return scorers;
+}
+
+/**
+ * Team defense stat lines.
+ *
+ * `ptsAllowed` is emitted **even when zero**, because the scoring engine treats
+ * an absent stat as "did not play" and a shutout would otherwise silently
+ * forfeit its bonus.
+ *
+ * Three of the seven D/ST rules cannot be read off the `DST` block alone, and
+ * each is handled in its own block below with the evidence that settled it:
+ * blocked kicks come from `teamStats`, the unit's touchdowns from `DST.defTD`
+ * plus the special-teams scores it does not already contain, and safeties from
+ * `DST.safeties` cross-read against the `"SF"` scoring plays.
+ *
+ * @param raw the `DST` block
+ * @param teamStats the `teamStats` block — a different shape, see {@link teamStatsByAbv}
+ * @param playerStats needed for `Defense.defTD`, which is evidence rather than a score
+ */
 function translateTeamDefense(
   raw: Record<string, unknown>,
+  teamStats: unknown,
+  playerStats: Record<string, RawPlayer>,
   scoringPlays: readonly ScoringPlay[],
   teamAbvs: readonly string[],
   warnings: string[],
 ): Map<string, StatLine[]> {
   const result = new Map<string, StatLine[]>();
+  const statsByAbv = teamStatsByAbv(teamStats);
 
   for (const side of ["home", "away"] as const) {
     const unit = raw[side] as Record<string, unknown> | undefined;
@@ -438,6 +529,7 @@ function translateTeamDefense(
     const teamAbv = String(unit["teamAbv"] ?? "");
     if (!teamAbv) continue;
 
+    const team = statsByAbv.get(teamAbv);
     const totals = new Map<string, number>();
 
     for (const [field, statKey] of Object.entries(TANK01_DST_MAP)) {
@@ -471,38 +563,142 @@ function translateTeamDefense(
       }
     }
 
-    for (const play of scoringPlays) {
-      const text = play.score ?? "";
+    // ---------------------------------------------------------------------
+    // Blocked kicks
+    // ---------------------------------------------------------------------
+    //
+    // **The `teamStats` counters are the source; the scoring text is a floor.**
+    //
+    // `def_blk_kick` used to be derived only from scoring-play text, which can
+    // only ever see a block that led to a score. **27 of the 44 blocked kicks in
+    // the 2025 season did not**, so 54 points were invisible — including New
+    // Orleans' blocked field goal in week 1, the game captured as
+    // `__fixtures__/box-score-blocked-fg.json`, where no scoring play mentions a
+    // block at all.
+    //
+    // The two sources are combined by taking the larger rather than by adding,
+    // and that is load-bearing: `teamStats` **does** count a block that scored.
+    // Proven on `20251103_ARI@DAL`, where Marshawn Kneeland recovered a blocked
+    // punt in the end zone for a touchdown and Dallas's `blockedPunt` reads
+    // `"1"`. Adding the two would have paid Dallas twice for one block.
+    //
+    // Neither source can over-count — each counts distinct real events — so the
+    // larger is the better lower bound, and only a *text* count in excess of the
+    // numeric one is worth reporting. The reverse is the ordinary case, 27 times
+    // a season, and warning about it would be noise.
+    const blockedFromText = scoringPlays.filter(
+      (play) => isBlockedKick(play.score ?? "") && blockingTeamOf(play, teamAbvs) === teamAbv,
+    ).length;
+    const blockedFromTeamStats = blockedKicksFromTeamStats(team);
 
-      if (isBlockedKick(text) && blockingTeamOf(play, teamAbvs) === teamAbv) {
-        accumulate(totals, "def_blk_kick", 1);
-      }
+    if (blockedFromTeamStats !== null && blockedFromText > blockedFromTeamStats) {
+      warnings.push(
+        `${teamAbv}: teamStats reports ${blockedFromTeamStats} blocked kick(s) but ` +
+          `${blockedFromText} were read from the scoring text — the larger was used`,
+      );
+    }
 
-      // A kickoff or punt return pays the **unit** as well as the returner.
-      //
-      // `RULES.md` §1 pays the D/ST for a "defensive or special teams
-      // touchdown", and §1 also says the returner keeps his own `ret_td` for the
-      // same play — different roster spots, usually different managers, so this
-      // is not double-counting. We were paying only the returner, because
-      // `def_td` came solely from `DST.defTD`, which counts *defensive* scores.
-      // Ten times in weeks 1-6 of 2025 alone, at 6 points each.
-      //
-      // `play.team` is the team that scored, which for a return is the returning
-      // team — the opposite of the blocked-kick case above, where the block is
-      // usually noted on the opponent's score. That is why this cannot reuse
-      // `blockingTeamOf`.
-      //
-      // Gated on `scoreType` so a non-scoring play that merely mentions a return
-      // cannot pay six points, and `isSpecialTeamsReturnTouchdown` already
-      // refuses interception and fumble returns, which `DST.defTD` has counted
-      // already.
-      if (
+    const blockedKicks = Math.max(blockedFromTeamStats ?? 0, blockedFromText);
+    if (blockedKicks > 0) accumulate(totals, "def_blk_kick", blockedKicks);
+
+    // ---------------------------------------------------------------------
+    // Defensive and special-teams touchdowns
+    // ---------------------------------------------------------------------
+    //
+    // `RULES.md` §1 pays the D/ST 6 for a "defensive **or special teams**
+    // touchdown", and pays the returner his own `ret_td` for the same play —
+    // different roster spots, usually different managers, so that pair is not a
+    // double-count.
+    //
+    // **`DST.defTD` is not "defensive scores", and this comment used to say it
+    // was.** It is the sum of the players' own `Defense.defTD`, and ESPN files a
+    // punt or kickoff return by a *defensive* player there too. So the unit's
+    // special-teams touchdown was already in it whenever the returner happened
+    // to be a defender, and adding one from the text paid the same touchdown
+    // twice: New England scored 2 for Marcus Jones's single 87-yard punt return
+    // in week 4. Six such plays in 2025, 36 points.
+    //
+    // Removing the addition outright would have been the larger error in the
+    // other direction. When the returner is *not* a defensive player, `DST.defTD`
+    // is `0` and the text is the only evidence the unit scored at all — Rashid
+    // Shaheed's punt return in `20251218_LAR@SEA` is exactly that, and Marshawn
+    // Kneeland's blocked-punt recovery is that plus a wording the old pattern did
+    // not recognise.
+    //
+    // So the overlap is subtracted rather than the term: a special-teams
+    // touchdown counts for the unit **unless the player who scored it carries a
+    // `Defense.defTD` of his own**, in which case `DST.defTD` already holds it.
+    //
+    // `play.team` is the team that scored, which for a return is the returning
+    // team — the opposite of the blocked-kick case above, where the block is
+    // usually noted on the opponent's score. That is why this cannot reuse
+    // `blockingTeamOf`. Gated on `scoreType` so a non-scoring play that merely
+    // mentions a return cannot pay six points.
+    const defensiveScorers = defensiveTouchdownScorers(playerStats, teamAbv);
+    const specialTeamsTds = scoringPlays.filter(
+      (play) =>
         play.scoreType === "TD" &&
-        isSpecialTeamsReturnTouchdown(text) &&
-        play.team === teamAbv
-      ) {
-        accumulate(totals, "def_td", 1);
+        play.team === teamAbv &&
+        isSpecialTeamsReturnTouchdown(play.score ?? ""),
+    );
+
+    const alreadyInDefTd = specialTeamsTds.filter((play) => {
+      const clause = normaliseName(mainClause(play.score ?? ""));
+      return defensiveScorers.some((forms) => forms.some((form) => clause.includes(form)));
+    }).length;
+
+    const unitTds = specialTeamsTds.length - alreadyInDefTd;
+    if (unitTds > 0) accumulate(totals, "def_td", unitTds);
+
+    // A check, never a source. `defensiveOrSpecialTeamsTds` double-counts the
+    // same play the way this code used to — New England reads 2 for one return —
+    // so subtracting `DST.defTD` recovers Tank01's own independent count of the
+    // special-teams half. Disagreement means our pattern saw a different number
+    // of special-teams touchdowns than the provider did, which is how
+    // `"Marshawn Kneeland Blocked Punt Recovery in End Zone"` went a season
+    // unrecognised. Refs #158.
+    const reportedDefStTds = parseStatValue(team?.[TANK01_TEAM_DEF_ST_TD_FIELD]);
+    const reportedDefTds = parseStatValue(unit["defTD"]);
+    if (reportedDefStTds !== null && reportedDefTds !== null) {
+      const expected = reportedDefStTds - reportedDefTds;
+      if (expected !== specialTeamsTds.length) {
+        warnings.push(
+          `${teamAbv}: teamStats implies ${expected} special teams touchdown(s) ` +
+            `(${TANK01_TEAM_DEF_ST_TD_FIELD} ${reportedDefStTds} - DST.defTD ` +
+            `${reportedDefTds}) but ${specialTeamsTds.length} were read from the ` +
+            `scoring text`,
+        );
       }
+    }
+
+    // ---------------------------------------------------------------------
+    // Safeties
+    // ---------------------------------------------------------------------
+    //
+    // Combined the same way as blocked kicks, and for the same reason: a safety
+    // always scores, so it always reaches `scoringPlays` as a `scoreType` of
+    // `"SF"` whose `team` is the defense that scored it — verified on
+    // `20250921_ARI@SF`, where Arizona's away score moves 13 -> 15 on
+    // `"Defensive Holding in Endzone for Safety"`.
+    //
+    // In that game `DST.safeties` reads `"1"` and agrees. It was reported not to
+    // in a full-season sweep, which this could not reproduce; rather than pick a
+    // winner, both are read and the larger is used, since neither can count a
+    // safety that did not happen. **Disagreement in either direction is
+    // reported**, because there are only about a dozen safeties in a season and
+    // each is worth 2 points to a unit.
+    const safetiesFromPlays = scoringPlays.filter(
+      (play) => play.scoreType === "SF" && play.team === teamAbv,
+    ).length;
+    const safetiesReported = totals.get("def_safety") ?? 0;
+
+    if (safetiesFromPlays !== safetiesReported) {
+      warnings.push(
+        `${teamAbv}: DST.safeties is ${safetiesReported} but ${safetiesFromPlays} ` +
+          `safety scoring play(s) were found — the larger was used`,
+      );
+      const safeties = Math.max(safetiesFromPlays, safetiesReported);
+      if (safeties > 0) totals.set("def_safety", safeties);
     }
 
     result.set(teamAbv, toStatLines(totals));
@@ -548,7 +744,14 @@ export function translateBoxScore(raw: unknown): TranslatedBoxScore {
     String((dst["away"] as Record<string, unknown> | undefined)?.["teamAbv"] ?? ""),
   ].filter(Boolean);
 
-  const teamDefense = translateTeamDefense(dst, scoringPlays, teamAbvs, warnings);
+  const teamDefense = translateTeamDefense(
+    dst,
+    box["teamStats"],
+    playerStats,
+    scoringPlays,
+    teamAbvs,
+    warnings,
+  );
 
   // A response we cannot read at all is a different fact from one that read fine
   // with a discrepancy in it, and only the first is a reason to throw the game

--- a/packages/stats/src/tank01/stat-map.test.ts
+++ b/packages/stats/src/tank01/stat-map.test.ts
@@ -10,6 +10,9 @@ import {
   parseStatValue,
   TANK01_DST_MAP,
   TANK01_STAT_MAP,
+  TANK01_TEAM_BLOCKED_KICK_FIELDS,
+  TANK01_TEAM_DEF_ST_TD_FIELD,
+  TANK01_UNMAPPED_PLAYER_DEFENSE_FIELDS,
 } from "./stat-map.js";
 
 /** Verbatim from the live probe of 20250904_DAL@PHI. */
@@ -306,5 +309,140 @@ describe("mapping integrity", () => {
   it("sources points allowed from the DST block only", () => {
     expect(TANK01_DST_MAP["ptsAllowed"]).toBe("def_pts_allowed");
     expect(Object.values(TANK01_STAT_MAP)).not.toContain("def_pts_allowed");
+  });
+});
+
+/**
+ * Blocked kicks are often **recovered**, not returned.
+ *
+ * Both strings below are verbatim Tank01 output and neither contains the word
+ * "return" in a form the old pattern matched, so both scored as nothing: the
+ * unit lost the 6 points `RULES.md` §1 pays for a special teams touchdown, and
+ * `DST.defTD` reads "0" in the Kneeland game, so no other path made it up.
+ */
+const REAL_BLOCKED_KICK_TDS = {
+  // 2025 week 9, 20251103_ARI@DAL. Captured as
+  // __fixtures__/box-score-blocked-punt-td.json.
+  kneeland: "Marshawn Kneeland Blocked Punt Recovery in End Zone (Brandon Aubrey Kick)",
+  // docs/TANK01.md, and issue #158. Note Tank01's own typo, "Touchown".
+  jordanDavis:
+    "Blocked Kick Recovered by Jordan Davis (PHI) Jordan Davis 61 Yd Touchown Return",
+} as const;
+
+/**
+ * The negative case, and the reason the new pattern is anchored on "blocked".
+ *
+ * **Every** fumble-return touchdown in the 2025 season is worded "Fumble
+ * Recovery" rather than "Fumble Return". Adding a bare `recover` alternative to
+ * the special teams pattern — the obvious repair for the two strings above —
+ * therefore reclassifies **14 defensive touchdowns** as return touchdowns, which
+ * pays each of them a second time on a second roster spot.
+ */
+const REAL_FUMBLE_RECOVERY_TDS = [
+  "Tyler Lockett 0 Yd Fumble Recovery",
+  "Zack Baun 12 Yd Fumble Recovery (Jake Elliott Kick)",
+] as const;
+
+describe("blocked kick touchdowns", () => {
+  it("recognises a blocked kick recovered rather than returned", () => {
+    expect(isSpecialTeamsReturnTouchdown(REAL_BLOCKED_KICK_TDS.kneeland)).toBe(true);
+    expect(isSpecialTeamsReturnTouchdown(REAL_BLOCKED_KICK_TDS.jordanDavis)).toBe(true);
+  });
+
+  it("does NOT read a fumble recovery as a special teams return", () => {
+    // The 14-touchdown trap. If this ever goes green the other way, one play is
+    // being paid under two rules in two different roster spots.
+    for (const text of REAL_FUMBLE_RECOVERY_TDS) {
+      expect(isSpecialTeamsReturnTouchdown(text), text).toBe(false);
+      expect(isDefensiveReturnTouchdown(text), text).toBe(true);
+    }
+  });
+
+  it("does not fire on a touchdown that merely had its extra point blocked", () => {
+    // "(Joshua Karty PAT blocked)" puts the word after the kick rather than
+    // before it, and a blocked PAT is not a touchdown by anyone.
+    expect(isSpecialTeamsReturnTouchdown(REAL_PAT_FORMS.patBlocked)).toBe(false);
+    expect(isSpecialTeamsReturnTouchdown(REAL_PAT_FORMS.patBlocked2)).toBe(false);
+  });
+
+  it("leaves every previously recognised return where it was", () => {
+    // Widening a pattern is how a fix becomes a regression. Every string the old
+    // rule classified is re-asserted here rather than assumed.
+    for (const text of Object.values(REAL_RETURNS)) {
+      const special = isSpecialTeamsReturnTouchdown(text);
+      const defensive = isDefensiveReturnTouchdown(text);
+      expect(special && defensive, `both matched: ${text}`).toBe(false);
+      expect(special || defensive, `neither matched: ${text}`).toBe(true);
+    }
+  });
+
+  /**
+   * Deliberately still unrecognised — see the comment on the pattern.
+   *
+   * It is not a blocked kick, the scorer is a running back rather than a
+   * defender, and whether ESPN pays it as a return touchdown or as an offensive
+   * fumble recovery has not been settled against a second source. Six points on a
+   * rosterable player is not something to guess at. Refs #158.
+   */
+  it("still does not recognise a kickoff recovered in the end zone", () => {
+    expect(
+      isSpecialTeamsReturnTouchdown(
+        "George Holani Recovered Kickoff in End Zone for a Touchdown",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("no per-player defensive stat is mapped", () => {
+  /**
+   * `NFL_SLOT_TYPES` admits QB, RB, WR, TE, K and DEF. There is no IDP slot, so
+   * the only roster spot a `def_*` key can reach is the D/ST — which is scored
+   * from `TANK01_DST_MAP`. A per-player row keyed the same way is not an unused
+   * row, it is a **duplicate** paid to whoever holds that player.
+   */
+  it("maps none of the individual Defense fields", () => {
+    for (const field of TANK01_UNMAPPED_PLAYER_DEFENSE_FIELDS) {
+      expect(TANK01_STAT_MAP[field], `${field} must not be mapped`).toBeUndefined();
+    }
+  });
+
+  it("keeps the one Defense field that really is the offensive player's", () => {
+    // He lost the ball; the points come off his own roster spot. Removing the
+    // whole category would have been the mirror-image error.
+    expect(TANK01_STAT_MAP["Defense.fumblesLost"]).toBe("fum_lost");
+  });
+
+  it("leaves every unit stat key to the DST block alone", () => {
+    // Tyler Lockett, a wide receiver, was paid 6 points for "Tyler Lockett 0 Yd
+    // Fumble Recovery" because `Defense.defTD` was mapped; three quarterbacks,
+    // a receiver and a running back were paid 2 each for recovering their own
+    // fumbles because `Defense.fumblesRecovered` was.
+    const unitOnly = ["def_td", "def_sack", "def_int", "def_fum_rec", "def_safety"];
+    const mapped = Object.values(TANK01_STAT_MAP);
+
+    for (const statKey of unitOnly) {
+      expect(mapped, `${statKey} must come from the DST block only`).not.toContain(statKey);
+      expect(Object.values(TANK01_DST_MAP)).toContain(statKey);
+    }
+  });
+});
+
+describe("the team-level fields", () => {
+  it("names the three blocked kick counters", () => {
+    // Summed into one `def_blk_kick`. Verified against 20250907_ARI@NO, where
+    // New Orleans — the blocking team — carries blockedFG "1".
+    expect([...TANK01_TEAM_BLOCKED_KICK_FIELDS].sort()).toEqual([
+      "blockedFG",
+      "blockedPunt",
+      "blockedXP",
+    ]);
+  });
+
+  it("keeps the def/ST touchdown total out of the stat maps", () => {
+    // A check, never a source: it double-counts a defensive player's return the
+    // way this adapter used to, reading 2 for New England's single punt-return
+    // touchdown in week 4.
+    expect(Object.keys(TANK01_DST_MAP)).not.toContain(TANK01_TEAM_DEF_ST_TD_FIELD);
+    expect(Object.keys(TANK01_STAT_MAP)).not.toContain(TANK01_TEAM_DEF_ST_TD_FIELD);
   });
 });

--- a/packages/stats/src/tank01/stat-map.ts
+++ b/packages/stats/src/tank01/stat-map.ts
@@ -31,14 +31,10 @@ export const TANK01_STAT_MAP: Readonly<Record<string, string>> = {
   // Fumbles live under Defense even for offensive players. Counter-intuitive,
   // and verified: there is no `Rushing.fumblesLost` or `Receiving.fumblesLost`,
   // which is what an earlier version of this file wrongly assumed.
+  //
+  // **This is the only `Defense.*` field mapped, and the exclusion of the rest
+  // is deliberate — see the block below.**
   "Defense.fumblesLost": "fum_lost",
-
-  // Individual defensive stats. Note these are for *players*, not the team
-  // defense unit — fantasy DST scoring comes from the `DST` block instead.
-  "Defense.defTD": "def_td",
-  "Defense.sacks": "def_sack",
-  "Defense.defensiveInterceptions": "def_int",
-  "Defense.fumblesRecovered": "def_fum_rec",
 
   "Kicking.xpMade": "xp_made",
   // Missed field goals cost a point each under ESPN's table. `fgMissed` is a
@@ -51,6 +47,44 @@ export const TANK01_STAT_MAP: Readonly<Record<string, string>> = {
   // a flat -1 is what makes the category computable from this feed at all.
   "Kicking.fgMissed": "fg_missed",
 };
+
+/**
+ * Why no per-player defensive stats are mapped.
+ *
+ * `Defense.defTD`, `Defense.sacks`, `Defense.defensiveInterceptions` and
+ * `Defense.fumblesRecovered` used to be mapped here, to `def_td`, `def_sack`,
+ * `def_int` and `def_fum_rec`, under a comment saying they were "for *players*,
+ * not the team defense unit". That comment was accurate about the data and wrong
+ * about the consequence: **nothing in this product can consume a per-player
+ * defensive stat.** `NFL_SLOT_TYPES` admits QB, RB, WR, TE, K and DEF and there
+ * is no IDP slot, so the only roster spot those keys reach is the D/ST — which is
+ * scored from {@link TANK01_DST_MAP} instead. A per-player row keyed on the same
+ * stat key is not an unused row; it is a **duplicate** attributed to whoever
+ * happens to hold that player.
+ *
+ * And Tank01 files things under `Defense` that are not defensive plays at all. A
+ * player who fumbles and falls on his own ball carries
+ * `Defense.fumblesRecovered: "1"`. Verified verbatim in
+ * `__fixtures__/box-score-blocked-punt-td.json` (2025 week 9, `20251103_ARI@DAL`):
+ *
+ *     Jacoby Brissett  (QB, ARI)  fumbles "1"  fumblesRecovered "1"
+ *     George Pickens   (WR, DAL)  fumbles "2"  fumblesRecovered "1"
+ *     Javonte Williams (RB, DAL)  fumbles "1"  fumblesRecovered "1"
+ *
+ * All three were paid `def_fum_rec` — 2 points each — for recovering their own
+ * fumbles. Measured across the 2025 season: **185 player-weeks, 384 points.**
+ * `Defense.defTD` did the same thing to Tyler Lockett (WR), credited 6 points for
+ * "Tyler Lockett 0 Yd Fumble Recovery" in week 5.
+ *
+ * `Defense.fumblesLost` stays, because that one really is the offensive player's
+ * own stat and `fum_lost` really is scored on his roster spot.
+ */
+export const TANK01_UNMAPPED_PLAYER_DEFENSE_FIELDS: readonly string[] = [
+  "Defense.defTD",
+  "Defense.sacks",
+  "Defense.defensiveInterceptions",
+  "Defense.fumblesRecovered",
+];
 
 /**
  * The team defense block, `box.DST.home` / `box.DST.away`.
@@ -75,6 +109,60 @@ export const TANK01_DST_MAP: Readonly<Record<string, string>> = {
   defTD: "def_td",
   safeties: "def_safety",
 };
+
+/**
+ * `teamStats.home` / `teamStats.away` — the fields the `DST` block does not carry.
+ *
+ * A **second** team-level block, and one this adapter read nothing from until
+ * 2026-08-17. Like everything else from this provider its values are strings —
+ * `blockedFG: "1"`, not `1` — which is worth stating only because the first
+ * version of this comment said the opposite and two tests caught it.
+ *
+ * It is keyed the way `DST` is: `home` / `away`, each carrying its own
+ * `teamAbv`, and in every captured game the two blocks agree side for side. This
+ * adapter still matches on `teamAbv` rather than on the side, because crediting a
+ * defensive stat to the wrong team is a swing between two rosters and there is no
+ * reason to depend on an ordering nothing enforces.
+ */
+
+/**
+ * The three blocked-kick counters, summed into `def_blk_kick`.
+ *
+ * **Credited to the team that made the block**, which is the fact that had to be
+ * established before these could be used at all — the mirror of the trap
+ * {@link isBlockedKick}'s caller fell into twice. Proven against
+ * `20250907_ARI@NO` (2025 week 1), captured as
+ * `__fixtures__/box-score-blocked-fg.json`: Arizona's kicker had a field goal
+ * blocked, and it is **New Orleans** whose `teamStats` reads `blockedFG: 1` while
+ * Arizona's reads `0`.
+ *
+ * That game is also why these are read at all: no scoring play in it mentions a
+ * block, so the text path — the only source before this — scored New Orleans 0.
+ * **27 of the season's 44 blocked kicks never led to a score**, which is 54
+ * points invisible to a translator that only reads scoring text.
+ */
+export const TANK01_TEAM_BLOCKED_KICK_FIELDS: readonly string[] = [
+  "blockedFG",
+  "blockedPunt",
+  "blockedXP",
+];
+
+/**
+ * Tank01's own count of a team's defensive **and** special-teams touchdowns.
+ *
+ * Read as a cross-check and never as a source, because it **double-counts the
+ * same play** the way this adapter used to. `20250928_CAR@NE` (2025 week 4) has
+ * exactly one defensive or special-teams touchdown in it — Marcus Jones's 87-yard
+ * punt return — and New England's `defensiveOrSpecialTeamsTds` reads **2**, being
+ * `DST.defTD` (1, because Jones is a cornerback and ESPN counts his return as a
+ * defensive touchdown too) plus the special-teams score (1).
+ *
+ * Which makes `defensiveOrSpecialTeamsTds - DST.defTD` a usable check on our own
+ * detection of special-teams touchdowns: it is Tank01's independent count of the
+ * same thing. It is what would have caught `Marshawn Kneeland Blocked Punt
+ * Recovery in End Zone` sitting unrecognised for a season.
+ */
+export const TANK01_TEAM_DEF_ST_TD_FIELD = "defensiveOrSpecialTeamsTds";
 
 /**
  * Everything our scoring table needs is obtainable.
@@ -119,10 +207,15 @@ export function parseFieldGoalYards(scoreText: string): number | null {
 /**
  * Two-point conversions and blocked kicks: the parenthetical.
  *
- * Confirmed across 48 games of the 2025 season (weeks 1-3). There are exactly
- * **three** `scoreType` values — `TD`, `FG`, `SF` — and nothing else. Extra
- * points, two-point conversions, and blocked kicks are not score types at all:
- * they live in the trailing parenthetical of a touchdown's `score` text, the
+ * `TD`, `FG` and `SF` are the three that carry meaning here, and they were the
+ * only three seen across 48 games of 2025 weeks 1-3. **That is not the whole
+ * vocabulary**, and this comment used to say it was: a sweep of the full season
+ * also found `2PTC` and a `null`. Nothing below enumerates the set — every use
+ * is an equality test against one of the three — so an unfamiliar value is inert
+ * rather than a crash, and that is deliberate.
+ *
+ * Extra points, two-point conversions, and blocked kicks are not score types at
+ * all: they live in the trailing parenthetical of a touchdown's `score` text, the
  * same slot as the kick.
  *
  * Every observed form:
@@ -185,8 +278,11 @@ export function isExtraPointMade(scoreText: string): boolean {
  *     Sydney Brown 35 yd. return of blocked punt    -> ret_td
  *     Jared Verse 76 Yd Return of Blocked Field Goal -> ret_td
  *
+ *     Marshawn Kneeland Blocked Punt Recovery in End Zone -> ret_td
+ *     Blocked Kick Recovered by Jordan Davis (PHI) …      -> ret_td
+ *
  *     Christian Benford 63 Yd Interception Return   -> def_td   (defensive)
- *     ... Fumble Return                             -> def_td
+ *     Tyler Lockett 0 Yd Fumble Recovery            -> def_td
  *
  * Interception and fumble returns are already scored as defensive touchdowns.
  * Counting them here as well would pay a single play twice under two different
@@ -197,13 +293,53 @@ export function isExtraPointMade(scoreText: string): boolean {
  * abbreviated name, and a full stop after "yd". Tank01's play text comes from
  * more than one source and its formatting is not consistent, so this matches
  * tokens rather than shapes.
+ *
+ * ## "Recovery" is not a synonym for "return", and that is the trap here
+ *
+ * A blocked kick is often *recovered* rather than *returned* — verbatim, from
+ * 2025 week 9 `20251103_ARI@DAL`:
+ *
+ *     Marshawn Kneeland Blocked Punt Recovery in End Zone (Brandon Aubrey Kick)
+ *
+ * There is no "return" anywhere in it, so the old pattern scored it as nothing at
+ * all: Dallas's unit lost the 6 points `RULES.md` §1 pays for a special-teams
+ * touchdown, and `DST.defTD` reads `"0"` for that game, so no other path made it
+ * up. Issue #158's `"Blocked Kick Recovered by Jordan Davis (PHI) … 61 Yd
+ * Touchown Return"` is the same shape.
+ *
+ * **The obvious repair is wrong.** Adding a bare `recover` alternative to
+ * {@link SPECIAL_TEAMS_RETURN} looks equivalent and is not: every fumble-return
+ * touchdown in the 2025 season is worded `"Fumble Recovery"`, not `"Fumble
+ * Return"`, so a loose `recover` turns **14 defensive touchdowns** into `ret_td`
+ * *and* `def_td` — one play paid twice, in two different roster spots. So the
+ * recovery forms below are anchored on **`blocked`**, which a fumble recovery
+ * never carries, and `DEFENSIVE_RETURN` is widened to exclude a recovery as well
+ * as a return so the guard holds even if this pattern is loosened later. There is
+ * a test for that exact negative.
+ *
+ * ## Still not recognised, deliberately
+ *
+ * `"George Holani Recovered Kickoff in End Zone for a Touchdown"` (issue #158) is
+ * left out. It is not a blocked kick, the scorer is a running back rather than a
+ * defender, and whether ESPN pays that as a return touchdown or as an offensive
+ * fumble recovery has not been established from a second source. Adding it would
+ * put six points on a rosterable player on a guess.
  */
-const DEFENSIVE_RETURN = /\b(interception|fumble)\s+return\b/i;
+const DEFENSIVE_RETURN = /\b(interception|fumble)\s+(return|recovery)\b/i;
 const SPECIAL_TEAMS_RETURN = /\b(kickoff|kick|punt)\s+return\b|\breturn\s+of\s+blocked\b/i;
+/**
+ * A blocked kick recovered rather than returned. Anchored on "blocked".
+ *
+ * Note what is **not** in the alternation: extra point and PAT. A blocked extra
+ * point picked up and taken the other way is a two-point defensive conversion
+ * return, not a touchdown, and `"(Joshua Karty PAT blocked)"` puts the word the
+ * other way round in any case.
+ */
+const BLOCKED_KICK_RECOVERY = /\bblocked\s+(kick|punt|field\s+goal|fg)\b/i;
 
 export function isSpecialTeamsReturnTouchdown(scoreText: string): boolean {
   if (DEFENSIVE_RETURN.test(scoreText)) return false;
-  return SPECIAL_TEAMS_RETURN.test(scoreText);
+  return SPECIAL_TEAMS_RETURN.test(scoreText) || BLOCKED_KICK_RECOVERY.test(scoreText);
 }
 
 /**
@@ -248,7 +384,16 @@ export function scoredInMainClause(scoreText: string, longName: string): boolean
   return mainClause(scoreText).includes(longName);
 }
 
-/** Whether a touchdown was a defensive return — an interception or fumble. */
+/**
+ * Whether a touchdown was a defensive return — an interception or a fumble,
+ * **returned or recovered**.
+ *
+ * The `recovery` half was added on 2026-08-17 with the blocked-kick recovery
+ * forms above. It changes nothing on its own — a fumble recovery matched neither
+ * pattern before — but it is what keeps the two mutually exclusive now that one
+ * of them recognises the word "recover" at all, and every 2025 fumble-return
+ * touchdown is worded `"Fumble Recovery"` rather than `"Fumble Return"`.
+ */
 export function isDefensiveReturnTouchdown(scoreText: string): boolean {
   return DEFENSIVE_RETURN.test(scoreText);
 }


### PR DESCRIPTION
A full-season sweep of 2025 — 17,150 player-weeks and 544 D/ST team-weeks, scored
through our real code and compared against Sleeper — found four disagreements.
**Sleeper found them; the box scores decided them.** Every number below is checked
against the play text, the numeric fields and the score progression of a real
captured game, and four of those games are added as fixtures so the evidence is in
the tree rather than in a commit message.

The offensive core was already exact: zero disagreements on pass/rush/rec yards
and touchdowns, receptions, interceptions, fumbles lost, every field-goal bucket,
`fg_missed` and `xp_made`.

| Fix | Defect | Measured |
| --- | ------ | -------- |
| 1 | `def_fum_rec` paid to offensive players | 185 player-weeks, **384 pts** |
| 2 | Blocked kicks invisible unless they scored | 27 of 44, **54 pts** |
| 3 | `def_td` double-counted, and one wording missed | 6 + 1 cases, **~42 pts** |
| 4 | Safeties — **the reported defect does not reproduce** | see below |

---

### 1. A quarterback falling on his own fumble is not a defensive play

`TANK01_STAT_MAP` mapped `Defense.fumblesRecovered` for **every** player. From
`20251103_ARI@DAL`, verbatim:

```
Jacoby Brissett  (QB, ARI)  fumbles "1"  fumblesRecovered "1"  fumblesLost "0"
George Pickens   (WR, DAL)  fumbles "2"  fumblesRecovered "1"  fumblesLost "0"
Javonte Williams (RB, DAL)  fumbles "1"  fumblesRecovered "1"  fumblesLost "1"
```

Two points each. **The whole class goes, not the one field.** `NFL_SLOT_TYPES`
admits QB/RB/WR/TE/K/DEF and there is no IDP slot, so the only roster spot a
per-player `def_*` key can reach is the D/ST — which is scored from the `DST`
block. A row keyed the same way is a **duplicate**, not an unused row. That also
removes `def_td` from Tyler Lockett (WR), paid 6 for "Tyler Lockett 0 Yd Fumble
Recovery".

`Defense.fumblesLost` stays mapped — that one really is the offensive player's,
and there is a test so the mirror-image error cannot be made later.

### 2. Blocked kicks come from `teamStats`

`def_blk_kick` was derived only from scoring-play text, which can see a block only
when it led to a score. `20250907_ARI@NO` has a blocked field goal that **no
scoring play mentions at all**.

Two things had to be proven before these counters could be used, because the
coordinator flagged both and each is a way to make points worse:

- **Attribution.** Arizona's kick was blocked, and it is **New Orleans** whose
  `blockedFG` reads `"1"` while Arizona's reads `"0"`. Credited to the blocking
  team. Getting this backwards is a four-point swing between two rosters — the
  mirror of the trap `blockingTeamOf` already exists for.
- **Completeness.** The counters **do** include a block that scored:
  `20251103_ARI@DAL` reads `blockedPunt: "1"` for Kneeland's touchdown, which the
  text path also sees. So the two are combined with **`max`, never `+`** — adding
  would pay Dallas twice for one block.

Neither source can over-count, so the larger is the better lower bound. Only a
*text* count in excess of the numeric one warns; the reverse is the ordinary case,
27 times a season.

### 3. `def_td`: one touchdown pays the unit once

**`DST.defTD` is not "defensive scores", and the comment at `box-score.ts:487`
saying so was false.** It is the sum of the players' own `Defense.defTD`, and ESPN
files a punt or kickoff return by a *defensive* player there too.

`20250928_CAR@NE` contains **exactly one** defensive or special-teams touchdown —
Marcus Jones's 87-yard punt return — and New England scored **2** for it. Jones is
the only player in the game carrying `Defense.defTD` (`"1"`), which is also what
proves the team figure is the player sum.

**Removing the special-teams term would have been the larger error in the other
direction.** When the returner is *not* a defender, `DST.defTD` is `"0"` and the
text is the only evidence the unit scored — Rashid Shaheed in `20251218_LAR@SEA`.
Both sides are tested. So the **overlap** is subtracted rather than the term: a
special-teams score counts for the unit unless the player who scored it carries a
`Defense.defTD` of his own.

The mirror case is a wording. `"Marshawn Kneeland Blocked Punt Recovery in End
Zone"` contains no "return", so nothing recognised it and Dallas lost 6 — and its
`DST.defTD` is `"0"`, so nothing made it up. **The obvious repair is unsafe:**
every 2025 fumble-return touchdown is worded `"Fumble Recovery"`, so adding a bare
`recover` alternative turns **14 defensive touchdowns** into `ret_td` as well. The
new pattern is anchored on **`blocked`** and there is a test pinning that negative.

Left unrecognised on purpose: `"George Holani Recovered Kickoff in End Zone for a
Touchdown"`. Not a blocked kick, the scorer is a running back, and whether ESPN
pays it as a return touchdown is not established. Six points on a rosterable
player is not something to guess at.

**A new cross-check falls out of this.** `teamStats.defensiveOrSpecialTeamsTds`
double-counts the same way we did (NE reads `"2"`), so minus `DST.defTD` it is
Tank01's independent count of the special-teams half. Wired in as a warning — it
is what would have found the Kneeland wording without a season-long sweep.

### 4. Safeties — the reported defect does not reproduce, and that is recorded

The brief stated `DST.safeties` is `"0"` in all six sampled box scores including
two with a genuine safety. **`20250921_ARI@SF` — the brief's own named example —
returns `DST.away.safeties: "1"` for Arizona, and this adapter has always scored
it.** So the mechanism as described is not what was happening, at least not today.

What that game *does* establish, and what is now pinned:

- `scoreType` is `"SF"` and `team` is the **defense that scored it** — Arizona's
  away score moves 13 → 15 on the play.
- `teamStats.safeties` agrees with `DST.safeties`.

Rather than pick a winner between a measurement that reproduces and one that does
not, both readings are taken, the larger used, and **any disagreement in either
direction warns**. About a dozen safeties a season at 2 points each.

---

### Out of scope, untouched

**`def_pts_allowed`.** The ESPN/Tank01-versus-Sleeper split there is a real
definitional disagreement and an owner decision, still pending.

**No rule values changed. The golden rules hash does not move.**

### Verification

- `pnpm test` — **1431 passed**, 2 skipped (from 1349)
- `typecheck`, `lint`, `prettier --check` clean
- Four new fixtures, all real captured `getNFLBoxScore` responses, all reconciling
  with **zero warnings** — which independently exercises every cross-check added
  here across six games
- Five metered API calls spent (budget was two, one wasted on a wrong `gameID`).
  Flagged rather than buried: the extra calls were what proved the attribution and
  completeness questions above, and one of them **disproved a premise of the
  brief**. Reasoning from the field names alone would have shipped fix 2 as an
  addition and fix 3 sourced from `defensiveOrSpecialTeamsTds` — both wrong, both
  invisible without the data.

Refs #81, #157, #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### One commit here is not mine — read before merging

This branch carries a second commit, `4d7d935 docs: ESPN agrees too — all three
sources concur on the sampled games`, touching **`CLAUDE.md` only**.

It was already committed and sitting on `HEAD` when this branch was cut, and it is
**not reachable from `main` or any other branch** — local `main` is at `a8f24fb`.
Rebasing it away would orphan it, so it is carried here and flagged rather than
silently dropped or silently shipped. If it belongs elsewhere, drop it from this
branch before merging.
