### PR TITLE
fix(stats): a blocked-kick touchdown warns on a game we score correctly

### DIFF
--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -221,6 +221,38 @@ is a usable cross-check on our pattern matching and is wired up as one. It is wh
 would have caught `"Marshawn Kneeland Blocked Punt Recovery in End Zone"` sitting
 unrecognised for a season, without a sweep. Refs #157, #158.
 
+**It is narrowed for blocked kicks, and that is a fact about ESPN rather than
+about Tank01.** ESPN classifies a blocked-kick touchdown as a **defensive** score
+— stat id **93**, "Def. blocked kick for TD" — not as a return, so
+`defensiveOrSpecialTeamsTds` holds it **once** where it holds an ordinary return
+by a defensive player twice. Measured across 2025: Marcus Jones's punt return
+reads `2, 1`, while Jordan Davis's and Will McDonald's blocked-kick touchdowns
+read `1, 1` — the subtraction gives 0 where the scoring text legitimately sees 1.
+**Four of the season's five blocked-kick touchdowns fired this warning on a game
+we score exactly as ESPN does.** Kneeland's is the fifth and reads `1, 0`, because
+Tank01 carries no `Defense` block for him at all — which is why the adapter
+subtracts only the blocked kicks **already inside `DST.defTD`** rather than all of
+them, and why excluding all of them would have moved the quiet game to a warning
+while silencing the loud ones.
+
+### What ESPN pays for a defensive or special-teams touchdown
+
+Established 2026-08-17 by reconciling ESPN's own `appliedTotal` arithmetic across
+**5 D/ST units and 6 players**. Recorded verbatim because ESPN's public pages
+contradict each other, and the scoring table is frozen per league.
+
+| Play                              | Player | D/ST | ESPN files it as             |
+| --------------------------------- | ------ | ---- | ---------------------------- |
+| Kickoff or punt return TD         | 6      | 6    | return TD **and** def/ST TD  |
+| Blocked-kick TD                   | 6      | 6    | 93, Def. blocked kick for TD |
+| Kickoff recovered in the end zone | **0**  | 6    | 104, Fumble return TD        |
+
+**Both the returner and the unit are paid** for an ordinary return touchdown —
+five independent pairs confirm it: Gibson/NE, Ray Davis/BUF, Nwangwu/NYJ,
+Shaheed/SEA, Mims/DEN. The third row is the George Holani play; see
+["Recovery" is not a synonym](#recovery-is-not-a-synonym-for-return) for why the
+player gets nothing and why Sleeper disagrees.
+
 ### `DST.safeties` — what was actually observed
 
 A full-season sweep reported `DST.safeties` as `"0"` for every game including two
@@ -269,14 +301,31 @@ own stat.
 
 The trap in repairing the blocked-kick wordings above. **Every** fumble-return
 touchdown in the 2025 season is worded `"Fumble Recovery"`, not `"Fumble
-Return"` — so adding a bare `recover` alternative to the special-teams pattern
-turns **14 defensive touchdowns** into return touchdowns as well, paying each of
-them under two rules in two roster spots. The pattern is anchored on `blocked`
-instead, and there is a test pinning the negative case.
+Return"`, so a bare `recover` alternative in the special-teams pattern looks
+equivalent to anchoring on `blocked` and is not. The pattern is anchored on
+`blocked`, and there is a test pinning the negative case.
+
+> **Corrected 2026-08-17.** This section said the loose variant "turns **14
+> defensive touchdowns** into return touchdowns as well". It does not, and has
+> not since #178 widened `DEFENSIVE_RETURN` to
+> `/\b(interception|fumble)\s+(return|recovery)\b/i`. Measured over all **2,339**
+> scoring plays of the 2025 season: the bare-`recover` variant goes from 26
+> matches to **27**, and the single addition is George Holani, below. **Not one
+> fumble touchdown leaks** — all **19** of them (17 worded `Fumble Recovery`, 2
+> worded `Fumble Return`) match `DEFENSIVE_RETURN`, which
+> `isSpecialTeamsReturnTouchdown()` consults first. The anchoring stays, because
+> a pattern that is correct only by virtue of a different pattern in front of it
+> is one edit away from not being — but the number was wrong and the conclusion
+> no longer follows from it.
 
 Still unrecognised on purpose: `"George Holani Recovered Kickoff in End Zone for a
-Touchdown"` (#158). Not a blocked kick, scorer is a running back, and whether ESPN
-pays it as a return touchdown or an offensive fumble recovery is not established.
+Touchdown"` (#158) — **and that is now a measurement rather than a caution.** A
+Seattle kickoff was muffed by Pittsburgh and recovered in the end zone, which is a
+coverage-team score rather than a return. **ESPN pays the player 0 and Seattle's
+D/ST 6**, filing it under stat id **104**, its fumble-return touchdown; Holani's
+ESPN fantasy `appliedTotal` for 2025 week 2 is 0. Tank01 mirrors ESPN —
+`Defense.defTD: "1"`, `Kicking.kickReturnTD: "0"`. **Sleeper disagrees** and pays
+him `st_td` 6. We score exactly what ESPN scores, so our `ret_td` of 0 is correct.
 
 ---
 

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -840,13 +840,20 @@ describe("the D/ST is paid once per defensive or special teams touchdown", () =>
   });
 
   /**
-   * The negative case, and the reason the new pattern is anchored on "blocked".
+   * The negative case, and the reason the pattern is anchored on "blocked".
    *
    * Every fumble-return touchdown in the 2025 season is worded "Fumble
-   * Recovery", not "Fumble Return". A bare `recover` alternative in the
-   * special-teams pattern therefore turns **14 defensive touchdowns** into a
-   * `ret_td` on a player *and* a second `def_td` on the unit — one play paid
-   * three times across two roster spots.
+   * Recovery", not "Fumble Return", so a bare `recover` alternative in the
+   * special-teams pattern looks equivalent to anchoring on "blocked" and is not.
+   * What it would cost is a `ret_td` on a player *and* a second `def_td` on the
+   * unit — one play paid three times across two roster spots.
+   *
+   * **Corrected 2026-08-17: the figure of "14 defensive touchdowns" that used to
+   * sit here is wrong.** `isDefensiveReturnTouchdown` is consulted first and now
+   * matches a recovery as well as a return, so all 19 of the season's fumble
+   * touchdowns are excluded before the special-teams pattern is reached; over all
+   * 2,339 scoring plays of 2025 the loose variant gains exactly one play, George
+   * Holani's. The assertion below is unchanged — it is what makes that true.
    */
   it("does not read a fumble recovery touchdown as a special teams score", () => {
     const translated = translateBoxScore({
@@ -891,6 +898,111 @@ describe("the D/ST is paid once per defensive or special teams touchdown", () =>
 
     expect(translated.warnings.join(" ")).toMatch(
       /PHI: teamStats implies 1 special teams touchdown/,
+    );
+  });
+
+  /**
+   * The check cried wolf on correctly scored games, which is the one thing a
+   * check must not do.
+   *
+   * ESPN classifies a blocked-kick touchdown as a **defensive** score — stat id
+   * 93, "Def. blocked kick for TD" — rather than as a return, so
+   * `defensiveOrSpecialTeamsTds` holds it once where it holds an ordinary return
+   * by a defensive player twice. Measured on 2025: Marcus Jones's punt return
+   * reads `2, 1` and Jordan Davis's blocked kick reads `1, 1`, so the subtraction
+   * gives 0 against a scoring text that legitimately sees 1. Four of the season's
+   * five blocked-kick touchdowns fired it. Refs #158.
+   */
+  it("does not warn on a blocked kick ESPN files as a defensive touchdown", () => {
+    const play = {
+      score: "Blocked Kick Recovered by Jordan Davis (PHI) Jordan Davis 61 Yd Touchown Return",
+      scoreType: "TD",
+      team: "PHI",
+      playerIDs: ["p"],
+    };
+
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {
+        p: {
+          playerID: "p",
+          longName: "Jordan Davis",
+          team: "PHI",
+          Defense: { defTD: "1" },
+          // Tank01 repeats a player's own scoring plays under him, and that is
+          // the only place `ret_td` is read from.
+          scoringPlays: [play],
+        },
+      },
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20", defTD: "1" },
+        away: { teamAbv: "DAL", ptsAllowed: "24", defTD: "0" },
+      },
+      teamStats: {
+        home: { teamAbv: "PHI", defensiveOrSpecialTeamsTds: "1" },
+        away: { teamAbv: "DAL", defensiveOrSpecialTeamsTds: "0" },
+      },
+      scoringPlays: [play],
+    });
+
+    expect(translated.warnings.join(" ")).not.toMatch(/special teams touchdown/);
+
+    // Nothing about the scoring moves. Six for the unit — from `DST.defTD`,
+    // which already holds it — and six for the scorer, which is what ESPN pays
+    // and what all four 2025 blocked-kick touchdowns reconcile against.
+    expect(unitOf(translated, "PHI").get("def_td")).toBe(1);
+    expect(playerOf(translated, "p").get("ret_td")).toBe(1);
+  });
+
+  it("still compares a blocked kick the provider did not already count", () => {
+    // The fifth of the five, and the reason only the blocked kicks *already
+    // inside* `DST.defTD` are excluded rather than all of them. `20251103_ARI@DAL`
+    // reads `1, 0` — Tank01 carries no `Defense` block for Marshawn Kneeland at
+    // all — so the subtraction already agrees with the text. Excluding every
+    // blocked kick would have moved this game to a warning while quieting the
+    // other four, which is the same defect with the sign flipped.
+    expect(rawBlockedPuntTdGame.teamStats.home.defensiveOrSpecialTeamsTds).toBe("1");
+    expect(rawBlockedPuntTdGame.DST.home.defTD).toBe("0");
+
+    expect(blockedPuntTdGame.warnings.join(" ")).not.toMatch(/special teams touchdown/);
+  });
+
+  it("says how many blocked kicks it excluded when it does warn", () => {
+    // Narrowed, not deleted. A team carrying two special-teams touchdowns Tank01
+    // knows about and one blocked kick we recognised still disagrees, and the
+    // warning has to be readable by someone who does not already know about stat
+    // id 93 — otherwise the excluded play looks like a play nobody counted.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {
+        p: {
+          playerID: "p",
+          longName: "Jordan Davis",
+          team: "PHI",
+          Defense: { defTD: "1" },
+        },
+      },
+      DST: {
+        home: { teamAbv: "PHI", ptsAllowed: "20", defTD: "1" },
+        away: { teamAbv: "DAL", ptsAllowed: "24", defTD: "0" },
+      },
+      teamStats: {
+        home: { teamAbv: "PHI", defensiveOrSpecialTeamsTds: "3" },
+        away: { teamAbv: "DAL", defensiveOrSpecialTeamsTds: "0" },
+      },
+      scoringPlays: [
+        {
+          score:
+            "Blocked Kick Recovered by Jordan Davis (PHI) Jordan Davis 61 Yd Touchown Return",
+          scoreType: "TD",
+          team: "PHI",
+          playerIDs: ["p"],
+        },
+      ],
+    });
+
+    expect(translated.warnings.join(" ")).toMatch(
+      /PHI: teamStats implies 2 special teams touchdown\(s\) .* but 0 were read from the scoring text, excluding 1 blocked-kick touchdown\(s\) ESPN files as defensive/,
     );
   });
 });

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -24,6 +24,7 @@ import type { StatLine } from "@rostr/core";
 import {
   bucketFieldGoal,
   isBlockedKick,
+  isBlockedKickTouchdown,
   isSpecialTeamsReturnTouchdown,
   isSuccessfulTwoPointConversion,
   mainClause,
@@ -645,9 +646,9 @@ function translateTeamDefense(
     const alreadyInDefTd = specialTeamsTds.filter((play) => {
       const clause = normaliseName(mainClause(play.score ?? ""));
       return defensiveScorers.some((forms) => forms.some((form) => clause.includes(form)));
-    }).length;
+    });
 
-    const unitTds = specialTeamsTds.length - alreadyInDefTd;
+    const unitTds = specialTeamsTds.length - alreadyInDefTd.length;
     if (unitTds > 0) accumulate(totals, "def_td", unitTds);
 
     // A check, never a source. `defensiveOrSpecialTeamsTds` double-counts the
@@ -657,16 +658,46 @@ function translateTeamDefense(
     // of special-teams touchdowns than the provider did, which is how
     // `"Marshawn Kneeland Blocked Punt Recovery in End Zone"` went a season
     // unrecognised. Refs #158.
+    //
+    // **A blocked kick is filed once, not twice, and this cried wolf on every
+    // one it could see.** ESPN classifies a blocked-kick touchdown as a
+    // *defensive* score — stat id 93 — rather than as a return, so it appears in
+    // `defensiveOrSpecialTeamsTds` a single time while an ordinary return by a
+    // defensive player appears twice. Measured on 2025: Marcus Jones's punt
+    // return reads `2, 1`, and Jordan Davis's and Will McDonald's blocked-kick
+    // touchdowns read `1, 1` — the subtraction gives 0 where the scoring text
+    // legitimately sees 1, on a game we score exactly as ESPN does.
+    //
+    // What is subtracted is the blocked kicks **already inside `DST.defTD`**,
+    // not every blocked kick, and the distinction is the whole of the fix.
+    // `defensiveOrSpecialTeamsTds` drops the second count only when the first is
+    // present: Marshawn Kneeland's blocked-punt recovery reads `1, 0`, because
+    // Tank01 carries no `Defense` block for him at all, and excluding it would
+    // move a silent game to a warning while quieting the loud one. Four of the
+    // season's five blocked-kick touchdowns took the first path.
+    //
+    // Narrowed rather than dropped, because this is still the only thing that
+    // would find a novel wording without a season sweep — and a warning that
+    // fires on correct data is how the next real one gets dismissed.
+    const blockedInDefTd = alreadyInDefTd.filter((play) =>
+      isBlockedKickTouchdown(play.score ?? ""),
+    ).length;
+    const readFromText = specialTeamsTds.length - blockedInDefTd;
+
     const reportedDefStTds = parseStatValue(team?.[TANK01_TEAM_DEF_ST_TD_FIELD]);
     const reportedDefTds = parseStatValue(unit["defTD"]);
     if (reportedDefStTds !== null && reportedDefTds !== null) {
       const expected = reportedDefStTds - reportedDefTds;
-      if (expected !== specialTeamsTds.length) {
+      if (expected !== readFromText) {
         warnings.push(
           `${teamAbv}: teamStats implies ${expected} special teams touchdown(s) ` +
             `(${TANK01_TEAM_DEF_ST_TD_FIELD} ${reportedDefStTds} - DST.defTD ` +
-            `${reportedDefTds}) but ${specialTeamsTds.length} were read from the ` +
-            `scoring text`,
+            `${reportedDefTds}) but ${readFromText} were read from the ` +
+            `scoring text` +
+            (blockedInDefTd > 0
+              ? `, excluding ${blockedInDefTd} blocked-kick touchdown(s) ESPN ` +
+                `files as defensive`
+              : ""),
         );
       }
     }

--- a/packages/stats/src/tank01/stat-map.test.ts
+++ b/packages/stats/src/tank01/stat-map.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   bucketFieldGoal,
   isBlockedKick,
+  isBlockedKickTouchdown,
   isDefensiveReturnTouchdown,
   isExtraPointMade,
   isSpecialTeamsReturnTouchdown,
@@ -333,10 +334,18 @@ const REAL_BLOCKED_KICK_TDS = {
  * The negative case, and the reason the new pattern is anchored on "blocked".
  *
  * **Every** fumble-return touchdown in the 2025 season is worded "Fumble
- * Recovery" rather than "Fumble Return". Adding a bare `recover` alternative to
- * the special teams pattern — the obvious repair for the two strings above —
- * therefore reclassifies **14 defensive touchdowns** as return touchdowns, which
- * pays each of them a second time on a second roster spot.
+ * Recovery" rather than "Fumble Return", so a bare `recover` alternative in the
+ * special teams pattern — the obvious repair for the two strings above — looks
+ * equivalent to anchoring on "blocked" and is not.
+ *
+ * **Corrected 2026-08-17: it does not reclassify 14 defensive touchdowns**, which
+ * is what this comment claimed. `isDefensiveReturnTouchdown` is consulted first
+ * and now matches a recovery as well as a return, so all **19** of the season's
+ * fumble touchdowns — 17 worded "Fumble Recovery", 2 worded "Fumble Return" — are
+ * excluded before the special teams pattern is reached. Over all 2,339 scoring
+ * plays of 2025 the loose variant gains exactly **one** play, George Holani's,
+ * pinned below. The assertions here are unchanged; the reason to keep them is
+ * that they are what makes the sentence above true.
  */
 const REAL_FUMBLE_RECOVERY_TDS = [
   "Tyler Lockett 0 Yd Fumble Recovery",
@@ -350,8 +359,8 @@ describe("blocked kick touchdowns", () => {
   });
 
   it("does NOT read a fumble recovery as a special teams return", () => {
-    // The 14-touchdown trap. If this ever goes green the other way, one play is
-    // being paid under two rules in two different roster spots.
+    // If this ever goes green the other way, one play is being paid under two
+    // rules in two different roster spots.
     for (const text of REAL_FUMBLE_RECOVERY_TDS) {
       expect(isSpecialTeamsReturnTouchdown(text), text).toBe(false);
       expect(isDefensiveReturnTouchdown(text), text).toBe(true);
@@ -377,12 +386,19 @@ describe("blocked kick touchdowns", () => {
   });
 
   /**
-   * Deliberately still unrecognised — see the comment on the pattern.
+   * Deliberately still unrecognised, and **settled** as of 2026-08-17.
    *
-   * It is not a blocked kick, the scorer is a running back rather than a
-   * defender, and whether ESPN pays it as a return touchdown or as an offensive
-   * fumble recovery has not been settled against a second source. Six points on a
-   * rosterable player is not something to guess at. Refs #158.
+   * This comment said the question "has not been settled against a second
+   * source". It has been. A Seattle kickoff was muffed by Pittsburgh and
+   * recovered in the end zone, which is a coverage-team score rather than a
+   * return: **ESPN pays the player 0 and Seattle's D/ST 6**, filing it under stat
+   * id 104, its fumble-return touchdown, and Holani's ESPN fantasy `appliedTotal`
+   * for 2025 week 2 is 0. Tank01 mirrors ESPN — `Defense.defTD: "1"`,
+   * `Kicking.kickReturnTD: "0"`. Sleeper disagrees and pays him `st_td` 6.
+   *
+   * So the test stays and its meaning changes: it pinned a gap waiting on
+   * evidence, and now pins the answer. `ret_td` of 0 is what ESPN scores. Refs
+   * #158.
    */
   it("still does not recognise a kickoff recovered in the end zone", () => {
     expect(
@@ -390,6 +406,55 @@ describe("blocked kick touchdowns", () => {
         "George Holani Recovered Kickoff in End Zone for a Touchdown",
       ),
     ).toBe(false);
+  });
+});
+
+/**
+ * A blocked kick is a special teams touchdown that **ESPN files as a defensive
+ * one** — stat id 93, "Def. blocked kick for TD".
+ *
+ * That is the only reason this predicate exists: `defensiveOrSpecialTeamsTds`
+ * counts such a play once where it counts an ordinary return by a defensive
+ * player twice, so the cross-check in `box-score.ts` has to know which it is
+ * looking at. It changes no score.
+ */
+describe("isBlockedKickTouchdown", () => {
+  it("recognises both the recovered and the returned wording", () => {
+    // All four real 2025 examples. Two are recovered and two are returned, and
+    // the anchor has to hold across both — a predicate that caught only the
+    // "Recovery" half would leave Sydney Brown's and Jared Verse's games warning.
+    for (const text of [
+      REAL_BLOCKED_KICK_TDS.kneeland,
+      REAL_BLOCKED_KICK_TDS.jordanDavis,
+      REAL_RETURNS.blockedPunt,
+      REAL_RETURNS.blockedFieldGoal,
+    ]) {
+      expect(isBlockedKickTouchdown(text), text).toBe(true);
+      // It is a narrowing, never a widening.
+      expect(isSpecialTeamsReturnTouchdown(text), text).toBe(true);
+    }
+  });
+
+  it("does not fire on an ordinary return", () => {
+    // Marcus Jones's punt return is the contrast the whole narrowing rests on:
+    // `2, 1` for a return, `1, 1` for a block.
+    expect(isBlockedKickTouchdown(REAL_RETURNS.punt)).toBe(false);
+    expect(isBlockedKickTouchdown(REAL_RETURNS.kickoff)).toBe(false);
+  });
+
+  it("does not fire on a touchdown that merely had its extra point blocked", () => {
+    // The difference from `isBlockedKick`, which matches the bare word anywhere.
+    // A blocked PAT on a rushing touchdown is a block that scored for nobody, and
+    // reading it as a special teams touchdown would suppress a real disagreement.
+    expect(isBlockedKick(REAL_PAT_FORMS.patBlocked)).toBe(true);
+    expect(isBlockedKickTouchdown(REAL_PAT_FORMS.patBlocked)).toBe(false);
+    expect(isBlockedKickTouchdown(REAL_PAT_FORMS.patBlocked2)).toBe(false);
+  });
+
+  it("does not fire on a fumble recovery", () => {
+    for (const text of REAL_FUMBLE_RECOVERY_TDS) {
+      expect(isBlockedKickTouchdown(text), text).toBe(false);
+    }
   });
 });
 

--- a/packages/stats/src/tank01/stat-map.ts
+++ b/packages/stats/src/tank01/stat-map.ts
@@ -307,23 +307,38 @@ export function isExtraPointMade(scoreText: string): boolean {
  * up. Issue #158's `"Blocked Kick Recovered by Jordan Davis (PHI) … 61 Yd
  * Touchown Return"` is the same shape.
  *
- * **The obvious repair is wrong.** Adding a bare `recover` alternative to
- * {@link SPECIAL_TEAMS_RETURN} looks equivalent and is not: every fumble-return
- * touchdown in the 2025 season is worded `"Fumble Recovery"`, not `"Fumble
- * Return"`, so a loose `recover` turns **14 defensive touchdowns** into `ret_td`
- * *and* `def_td` — one play paid twice, in two different roster spots. So the
- * recovery forms below are anchored on **`blocked`**, which a fumble recovery
- * never carries, and `DEFENSIVE_RETURN` is widened to exclude a recovery as well
- * as a return so the guard holds even if this pattern is loosened later. There is
- * a test for that exact negative.
+ * The recovery forms below are anchored on **`blocked`**, which a fumble recovery
+ * never carries, and `DEFENSIVE_RETURN` matches a recovery as well as a return so
+ * the guard holds even if this pattern is loosened later. There is a test for
+ * that exact negative.
+ *
+ * **Corrected 2026-08-17.** This comment used to say that adding a bare `recover`
+ * alternative to {@link SPECIAL_TEAMS_RETURN} would turn **14 defensive
+ * touchdowns** into `ret_td` as well. It would not, and has not since
+ * `DEFENSIVE_RETURN` was widened to `/(interception|fumble)\s+(return|recovery)/`.
+ * Measured over all **2,339** scoring plays of the 2025 season: the loose variant
+ * goes from 26 matches to **27**, and the single addition is George Holani, below.
+ * Not one of the season's **19** fumble touchdowns — 17 worded `"Fumble
+ * Recovery"`, 2 worded `"Fumble Return"` — leaks, because
+ * {@link isSpecialTeamsReturnTouchdown} consults `DEFENSIVE_RETURN` first and
+ * every one of them matches it. The anchoring stays anyway: a pattern that is
+ * correct only by virtue of a different pattern in front of it is one edit away
+ * from not being.
  *
  * ## Still not recognised, deliberately
  *
  * `"George Holani Recovered Kickoff in End Zone for a Touchdown"` (issue #158) is
- * left out. It is not a blocked kick, the scorer is a running back rather than a
- * defender, and whether ESPN pays that as a return touchdown or as an offensive
- * fumble recovery has not been established from a second source. Adding it would
- * put six points on a rosterable player on a guess.
+ * left out, and **the reason is what ESPN pays rather than a collision with
+ * fumble recoveries** — the reason this comment gave until 2026-08-17, which the
+ * measurement above retires.
+ *
+ * A Seattle kickoff was muffed by Pittsburgh and recovered in the end zone, which
+ * is a coverage-team score rather than a return. **ESPN pays the player 0 and
+ * Seattle's D/ST 6**, filing it under stat id **104**, its fumble-return
+ * touchdown; Holani's ESPN fantasy `appliedTotal` for 2025 week 2 is 0. Tank01
+ * mirrors ESPN — `Defense.defTD: "1"`, `Kicking.kickReturnTD: "0"`. **Sleeper
+ * disagrees** and pays him `st_td` 6. We score exactly what ESPN scores, so a
+ * `ret_td` of 0 here is the right answer rather than a gap waiting on evidence.
  */
 const DEFENSIVE_RETURN = /\b(interception|fumble)\s+(return|recovery)\b/i;
 const SPECIAL_TEAMS_RETURN = /\b(kickoff|kick|punt)\s+return\b|\breturn\s+of\s+blocked\b/i;
@@ -340,6 +355,38 @@ const BLOCKED_KICK_RECOVERY = /\bblocked\s+(kick|punt|field\s+goal|fg)\b/i;
 export function isSpecialTeamsReturnTouchdown(scoreText: string): boolean {
   if (DEFENSIVE_RETURN.test(scoreText)) return false;
   return SPECIAL_TEAMS_RETURN.test(scoreText) || BLOCKED_KICK_RECOVERY.test(scoreText);
+}
+
+/**
+ * Whether a special-teams touchdown was a **blocked kick**.
+ *
+ * A narrowing of {@link isSpecialTeamsReturnTouchdown} that **says nothing about
+ * scoring**: a blocked-kick touchdown pays the scorer his `ret_td` and the unit
+ * its six exactly as any other special-teams score does, and all four 2025
+ * examples reconcile against ESPN on both. It exists for one consumer — the
+ * `defensiveOrSpecialTeamsTds` cross-check in `box-score.ts` — because **ESPN
+ * files a blocked-kick touchdown as a _defensive_ score**, stat id 93, "Def.
+ * blocked kick for TD", rather than as a return. So Tank01's counter holds one of
+ * these **once** where it holds an ordinary return by a defensive player twice,
+ * and a check that does not know the difference reports a discrepancy on a
+ * correctly scored game.
+ *
+ * Every observed wording puts "blocked" immediately before the kick, in both the
+ * recovered and the returned form, so this is {@link BLOCKED_KICK_RECOVERY}'s own
+ * anchor rather than a second vocabulary:
+ *
+ *     Blocked Kick Recovered by Jordan Davis (PHI) …        -> true
+ *     Marshawn Kneeland Blocked Punt Recovery in End Zone   -> true
+ *     Sydney Brown 35 yd. return of blocked punt            -> true
+ *     Jared Verse 76 Yd Return of Blocked Field Goal        -> true
+ *     Marcus Jones 87 Yd Punt Return                        -> false
+ *
+ * Not {@link isBlockedKick}, which answers a different question — it matches the
+ * bare word anywhere, including `"(Joshua Karty PAT blocked)"` on a rushing
+ * touchdown, which is a block that scored for nobody.
+ */
+export function isBlockedKickTouchdown(scoreText: string): boolean {
+  return BLOCKED_KICK_RECOVERY.test(scoreText);
 }
 
 /**


### PR DESCRIPTION
`packages/stats` only. No scoring changes — one noisy warning narrowed, three
false claims retired.

## The defect

`box-score.ts` cross-checks `defensiveOrSpecialTeamsTds − DST.defTD` against the
special-teams touchdowns read from the scoring text. On a blocked-kick touchdown
it cries wolf:

```
PHI: teamStats implies 0 special teams touchdown(s)
     (defensiveOrSpecialTeamsTds 1 - DST.defTD 1) but 1 were read from the scoring text
```

**ESPN classifies a blocked-kick TD as a _defensive_ score** — stat id 93, "Def.
blocked kick for TD" — not as a return. So the provider's counter holds it once
where it holds an ordinary return by a defensive player twice. Measured:
Marcus Jones's punt return reads `2, 1`; Jordan Davis's and Will McDonald's
blocked kicks read `1, 1`. Expected on **4 of the 5** 2025 blocked-kick
touchdowns (Davis, McDonald, and — predicted, unverified — Sydney Brown w4,
Jared Verse w17), on games whose player and D/ST totals reconcile against ESPN
exactly.

## The fix

Narrowed, not deleted — it is still the only thing that would find a novel
wording without a season sweep, and a warning that fires on correct data is how
the next real one gets dismissed.

What is excluded is the blocked kicks **already inside `DST.defTD`**, not every
blocked kick, and that distinction is the whole of it. `defensiveOrSpecialTeams
Tds` drops the second count only when the first is present: **Kneeland's
recovery reads `1, 0`**, because Tank01 carries no `Defense` block for him — so
a blanket exclusion would have moved the one quiet game to a warning while
quieting the loud ones. Both directions are mutation-checked by tests.

When it does still warn it names how many it excluded, so the play does not read
as one nobody counted.

`isBlockedKickTouchdown` is a narrowing of `isSpecialTeamsReturnTouchdown` with
one consumer, the check. It is not `isBlockedKick`, which matches the bare word
anywhere including `"(Joshua Karty PAT blocked)"`.

## Three false claims

Comments are specification here, so these are defects in their own right.

**1. "a bare `recover` alternative turns 14 defensive touchdowns into `ret_td`"**
— wrong, and the conclusion no longer follows. Measured over all **2,339**
scoring plays of 2025: the loose variant goes from 26 matches to **27**, and the
single addition is George Holani. **Not one fumble touchdown leaks** — all
**19** (17 worded `Fumble Recovery`, 2 worded `Fumble Return`) match
`DEFENSIVE_RETURN`, which #178 widened to
`/\b(interception|fumble)\s+(return|recovery)\b/i` and which is consulted first.
The anchoring on `blocked` stays anyway: a pattern correct only by virtue of a
different pattern in front of it is one edit away from not being.

**2. Holani is excluded because of what ESPN pays, not a fumble collision.** A
Seattle kickoff muffed by Pittsburgh and recovered in the end zone is a
coverage-team score. ESPN pays the player **0** and SEA D/ST **6**, filing it as
stat id **104 (Fumble return TD)**; his week-2 `appliedTotal` is 0. Tank01
mirrors ESPN (`Defense.defTD: "1"`, `Kicking.kickReturnTD: "0"`). **Sleeper
disagrees** and pays `st_td` 6. We score exactly what ESPN scores, so `ret_td` 0
is correct.

**3. `stat-map.test.ts` said the question "has not been settled against a second
source".** It has been. The test stays and its meaning changes: it pinned a gap
waiting on evidence and now pins the answer.

`docs/TANK01.md` gains the measured ESPN table — verified by reconciling ESPN's
own `appliedTotal` arithmetic across **5 D/ST units and 6 players**, including
that **both** returner and unit are paid for an ordinary return TD (Gibson/NE,
Ray Davis/BUF, Nwangwu/NYJ, Shaheed/SEA, Mims/DEN).

## Verification

`typecheck`, `lint`, `prettier --check` clean. `packages/stats`: **168 passed**,
up from 158. Full `pnpm test`: **1450 passed, 2 skipped, 0 failed**.

Zero Tank01 API calls — everything above was already measured.

Refs #158
