### PR TITLE
Weeks 16 and 17 were four fixtures short each, because a TBD kickoff time discarded the game

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -18,6 +18,7 @@ import {
   loadProjectedPoints,
   loadKickoffs,
   loadRosterForWeek,
+  loadTbdKickoffs,
   loadWeekStats,
   setAutofillEnabled,
   setLineup,
@@ -79,11 +80,18 @@ export async function GET(
       week,
     );
 
-    // Bye weeks, loaded separately from the kickoffs above and deliberately so:
-    // `loadKickoffs` is the lock oracle and widening it is how the lock bypass
-    // happened. This only decides whether an empty week reads as "resting" or
-    // "not dated yet", and can mislabel a row without unlocking one.
+    // Bye weeks, and which fixtures carry a stand-in kickoff. Both are loaded
+    // separately from the kickoffs above and deliberately so: `loadKickoffs` is
+    // the lock oracle and widening it is how the lock bypass happened. These
+    // only decide what the screen says, and can mislabel a row without
+    // unlocking one — the lock uses the conservative time exactly as stored.
     const byeWeeks = await loadByeWeeks(client, [...roster.keys()], context.season);
+    const tbdKickoffs = await loadTbdKickoffs(
+      client,
+      [...roster.keys()],
+      context.season,
+      week,
+    );
 
     // Points so far this week, so a manager can see what their lineup is doing
     // while it is doing it.
@@ -143,6 +151,7 @@ export async function GET(
          */
         availability: gameAvailability({
           kickoffAt: player.kickoffAt,
+          kickoffTbd: tbdKickoffs.has(player.playerId),
           byeWeek: byeWeeks.get(player.playerId) ?? null,
           week,
         }),

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import {
+  gameAvailability,
   indexScoringRules,
   scorePlayer,
   slotIsLocked,
@@ -12,6 +13,7 @@ import {
   getAutofillEnabled,
   LineupError,
   loadAverages,
+  loadByeWeeks,
   loadLineup,
   loadProjectedPoints,
   loadKickoffs,
@@ -77,6 +79,12 @@ export async function GET(
       week,
     );
 
+    // Bye weeks, loaded separately from the kickoffs above and deliberately so:
+    // `loadKickoffs` is the lock oracle and widening it is how the lock bypass
+    // happened. This only decides whether an empty week reads as "resting" or
+    // "not dated yet", and can mislabel a row without unlocking one.
+    const byeWeeks = await loadByeWeeks(client, [...roster.keys()], context.season);
+
     // Points so far this week, so a manager can see what their lineup is doing
     // while it is doing it.
     const stats = await loadWeekStats(client, NFL.key, context.season, week);
@@ -127,6 +135,17 @@ export async function GET(
         positions: player.positions,
         status: player.status,
         kickoffAt: player.kickoffAt,
+        /**
+         * Why an empty week is empty. A bye and a fixture the provider has not
+         * dated both arrive here as a null kickoff and mean opposite things to
+         * someone choosing a lineup, so the screen is told which it is rather
+         * than inferring "bye" from the absence.
+         */
+        availability: gameAvailability({
+          kickoffAt: player.kickoffAt,
+          byeWeek: byeWeeks.get(player.playerId) ?? null,
+          week,
+        }),
         milliPoints: scorePlayer(stats.get(player.playerId) ?? [], scoring),
         /**
          * This week's projection, under this league's own scoring. `null` when

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -86,12 +86,7 @@ export async function GET(
     // only decide what the screen says, and can mislabel a row without
     // unlocking one — the lock uses the conservative time exactly as stored.
     const byeWeeks = await loadByeWeeks(client, [...roster.keys()], context.season);
-    const tbdKickoffs = await loadTbdKickoffs(
-      client,
-      [...roster.keys()],
-      context.season,
-      week,
-    );
+    const tbdKickoffs = await loadTbdKickoffs(client, [...roster.keys()], context.season, week);
 
     // Points so far this week, so a manager can see what their lineup is doing
     // while it is doing it.
@@ -144,10 +139,11 @@ export async function GET(
         status: player.status,
         kickoffAt: player.kickoffAt,
         /**
-         * Why an empty week is empty. A bye and a fixture the provider has not
-         * dated both arrive here as a null kickoff and mean opposite things to
-         * someone choosing a lineup, so the screen is told which it is rather
-         * than inferring "bye" from the absence.
+         * How settled this player's week is. A bye, a fixture whose kickoff
+         * time the NFL has not fixed, and an ordinary game mean quite
+         * different things to someone choosing a lineup — and the first two
+         * are indistinguishable from a kickoff alone. The screen is told which
+         * it is rather than inferring "bye" from an absence.
          */
         availability: gameAvailability({
           kickoffAt: player.kickoffAt,

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -30,6 +30,12 @@ interface RosterPlayer {
   positions: string[];
   status: string;
   kickoffAt: number | null;
+  /**
+   * Why an empty week is empty. `BYE` is a rest week and he cannot score;
+   * `UNSCHEDULED` is a real fixture the NFL has not dated yet, so he will play
+   * and the slot is worth holding. Both arrive with a null kickoff.
+   */
+  availability: "SCHEDULED" | "BYE" | "UNSCHEDULED";
   milliPoints: number;
   /** This week's projection under this league's scoring. Null if unpublished. */
   projectedMilliPoints: number | null;
@@ -285,6 +291,12 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                       >
                         {candidate.name} ({candidate.positions.join("/")})
                         {played ? " — played" : ""}
+                        {candidate.availability === "BYE" ? " — bye" : ""}
+                        {/* Not folded into the bye label: a bye scores nothing
+                            and this player will score, once the fixture has a
+                            date. Choosing between them is the point of this
+                            list. */}
+                        {candidate.availability === "UNSCHEDULED" ? " — TBD" : ""}
                         {OUT_STATUSES.has(candidate.status.toUpperCase())
                           ? ` — ${candidate.status}`
                           : ""}
@@ -299,7 +311,9 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                 title={
                   slot.locksAt
                     ? `Locks at ${new Date(slot.locksAt * 1000).toLocaleString()}`
-                    : "This player has no game this week"
+                    : player?.availability === "UNSCHEDULED"
+                      ? "This fixture has no kickoff time yet, so the slot cannot lock. He will play once the NFL announces when."
+                      : "This player has no game this week"
                 }
               >
                 {untilLock(slot.locksAt, now)}
@@ -337,8 +351,16 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
               {OUT_STATUSES.has(player.status.toUpperCase()) && (
                 <span className="text-amber-400/70">{player.status}</span>
               )}
-              {player.kickoffAt === null && (
+              {player.availability === "BYE" && (
                 <span className="text-nocturne-neutral-600">bye</span>
+              )}
+              {player.availability === "UNSCHEDULED" && (
+                <span
+                  className="text-nocturne-neutral-600"
+                  title="This fixture has no kickoff time yet. He will play — the NFL has not announced when."
+                >
+                  TBD
+                </span>
               )}
               {isBreakout(player) && (
                 <span

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -31,11 +31,12 @@ interface RosterPlayer {
   status: string;
   kickoffAt: number | null;
   /**
-   * Why an empty week is empty. `BYE` is a rest week and he cannot score;
-   * `UNSCHEDULED` is a real fixture the NFL has not dated yet, so he will play
-   * and the slot is worth holding. Both arrive with a null kickoff.
+   * How settled this player's week is. `BYE` is a rest week and he cannot
+   * score. `TIME_TBD` is a real fixture whose hour the NFL has not fixed — he
+   * will play, and `kickoffAt` is the earliest he could, not a promise.
+   * `UNSCHEDULED` is the same news with less of it: no fixture stored at all.
    */
-  availability: "SCHEDULED" | "BYE" | "UNSCHEDULED";
+  availability: "SCHEDULED" | "TIME_TBD" | "BYE" | "UNSCHEDULED";
   milliPoints: number;
   /** This week's projection under this league's scoring. Null if unpublished. */
   projectedMilliPoints: number | null;
@@ -296,7 +297,10 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                             and this player will score, once the fixture has a
                             date. Choosing between them is the point of this
                             list. */}
-                        {candidate.availability === "UNSCHEDULED" ? " — TBD" : ""}
+                        {candidate.availability === "UNSCHEDULED" ||
+                        candidate.availability === "TIME_TBD"
+                          ? " — TBD"
+                          : ""}
                         {OUT_STATUSES.has(candidate.status.toUpperCase())
                           ? ` — ${candidate.status}`
                           : ""}
@@ -312,7 +316,7 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                   slot.locksAt
                     ? `Locks at ${new Date(slot.locksAt * 1000).toLocaleString()}`
                     : player?.availability === "UNSCHEDULED"
-                      ? "This fixture has no kickoff time yet, so the slot cannot lock. He will play once the NFL announces when."
+                      ? "No fixture stored for his team this week, and it is not their bye, so the slot cannot lock."
                       : "This player has no game this week"
                 }
               >
@@ -354,10 +358,15 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
               {player.availability === "BYE" && (
                 <span className="text-nocturne-neutral-600">bye</span>
               )}
-              {player.availability === "UNSCHEDULED" && (
+              {(player.availability === "UNSCHEDULED" ||
+                player.availability === "TIME_TBD") && (
                 <span
                   className="text-nocturne-neutral-600"
-                  title="This fixture has no kickoff time yet. He will play — the NFL has not announced when."
+                  title={
+                    player.availability === "TIME_TBD"
+                      ? "He plays this week. The NFL has not fixed the kickoff time, so this slot locks at the earliest hour the game could start."
+                      : "No fixture stored for his team this week, and it is not their bye. Check back once the schedule syncs."
+                  }
                 >
                   TBD
                 </span>

--- a/apps/web/src/components/Scoreboard.tsx
+++ b/apps/web/src/components/Scoreboard.tsx
@@ -27,7 +27,7 @@ interface PlayerLine {
   position: string;
   slot: string;
   milliPoints: number;
-  gameState: "BYE" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
+  gameState: "BYE" | "UNSCHEDULED" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
   kickoffAt: string | null;
 }
 
@@ -39,6 +39,8 @@ interface Side {
   restatedMilliPoints: number | null;
   yetToPlay: number;
   inProgress: number;
+  /** Starters whose fixture has no kickoff time yet. Never "all done". */
+  unscheduled: number;
   starters: PlayerLine[];
   bench: PlayerLine[];
 }
@@ -153,6 +155,24 @@ export function Scoreboard({ leagueId }: { leagueId: string }) {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * How much of this side's week is still to come.
+ *
+ * "All done" is the claim worth being careful with: it is what tells a manager
+ * the result is settled, and a starter whose fixture has no kickoff time yet has
+ * not played and is not counted anywhere else on this line. Saying "all done"
+ * over an undated fixture would report a loss that has not happened.
+ */
+function progressLabel(side: Side): string {
+  const parts: string[] = [];
+  if (side.yetToPlay > 0) parts.push(`${side.yetToPlay} still to play`);
+  if (side.inProgress > 0) parts.push(`${side.inProgress} playing`);
+  if (side.unscheduled > 0) {
+    parts.push(`${side.unscheduled} not scheduled yet`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "all done";
+}
+
 function Header({ side, opponent }: { side: Side; opponent: Side | null }) {
   const winning = opponent !== null && side.milliPoints > opponent.milliPoints;
 
@@ -162,12 +182,7 @@ function Header({ side, opponent }: { side: Side; opponent: Side | null }) {
       <p className={`text-3xl font-semibold ${winning ? "text-nocturne-accent-300" : ""}`}>
         {points(side.milliPoints)}
       </p>
-      <p className="text-xs text-nocturne-neutral-600">
-        {side.yetToPlay > 0 && `${side.yetToPlay} still to play`}
-        {side.yetToPlay > 0 && side.inProgress > 0 && " · "}
-        {side.inProgress > 0 && `${side.inProgress} playing`}
-        {side.yetToPlay === 0 && side.inProgress === 0 && "all done"}
-      </p>
+      <p className="text-xs text-nocturne-neutral-600">{progressLabel(side)}</p>
     </div>
   );
 }
@@ -312,11 +327,16 @@ function Score({ line }: { line: PlayerLine }) {
   const label =
     line.gameState === "BYE"
       ? "bye"
-      : line.gameState === "YET_TO_PLAY"
-        ? kickoffLabel(line.kickoffAt)
-        : line.gameState === "IN_PROGRESS"
-          ? "live"
-          : null;
+      : // A fixture with no kickoff time yet. Distinct from a bye, because this
+        // player will play and a bye player cannot — the difference decides
+        // whether a manager holds the roster spot.
+        line.gameState === "UNSCHEDULED"
+        ? "TBD"
+        : line.gameState === "YET_TO_PLAY"
+          ? kickoffLabel(line.kickoffAt)
+          : line.gameState === "IN_PROGRESS"
+            ? "live"
+            : null;
 
   return (
     <span className="flex shrink-0 items-baseline gap-1.5">

--- a/apps/web/src/components/Scoreboard.tsx
+++ b/apps/web/src/components/Scoreboard.tsx
@@ -27,7 +27,7 @@ interface PlayerLine {
   position: string;
   slot: string;
   milliPoints: number;
-  gameState: "BYE" | "UNSCHEDULED" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
+  gameState: "BYE" | "UNSCHEDULED" | "TIME_TBD" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
   kickoffAt: string | null;
 }
 
@@ -327,10 +327,12 @@ function Score({ line }: { line: PlayerLine }) {
   const label =
     line.gameState === "BYE"
       ? "bye"
-      : // A fixture with no kickoff time yet. Distinct from a bye, because this
+      : // A fixture whose hour is not fixed. Distinct from a bye, because this
         // player will play and a bye player cannot — the difference decides
-        // whether a manager holds the roster spot.
-        line.gameState === "UNSCHEDULED"
+        // whether a manager holds the roster spot. The stored kickoff is the
+        // earliest the game could start, so it is deliberately not shown as a
+        // time: the date is real and the clock beside it would not be.
+        line.gameState === "TIME_TBD" || line.gameState === "UNSCHEDULED"
         ? "TBD"
         : line.gameState === "YET_TO_PLAY"
           ? kickoffLabel(line.kickoffAt)

--- a/apps/web/src/lib/jobs/season-sync.ts
+++ b/apps/web/src/lib/jobs/season-sync.ts
@@ -55,6 +55,8 @@ export async function runSeasonSyncJob(
     players?: number;
     byeWeeks?: number;
     games?: number;
+    /** Fixtures the provider has not given a kickoff time. See the loop below. */
+    undatedGames?: number;
     ranked?: number;
     projections?: number;
     error?: string;
@@ -77,10 +79,25 @@ export async function runSeasonSyncJob(
       // `NFL.seasonWeeks`, not a local 18. The sport registry is where a fact
       // about football belongs, and a copy here would be a second answer to a
       // question that already has one.
+      // `skipped` is reported rather than discarded, and that is the whole of
+      // how an undated fixture becomes visible to an operator.
+      //
+      // `syncGames` drops a game the provider has not given a kickoff time,
+      // deliberately — storing a zero would lock lineups at the epoch. The count
+      // used to be thrown away here, so the only symptom of a missing fixture
+      // was a team quietly absent from a week, and the only way to find it was
+      // to query the database by hand. The NFL dates its late-December games
+      // last, which puts those weeks squarely on the championship.
+      //
+      // A steady small number late in the season is normal and resolves itself
+      // as the fixtures are announced. A number that grows, or one in an early
+      // week, is a broken ingest.
       let games = 0;
+      let undated = 0;
       for (let week = 1; week <= NFL.seasonWeeks; week++) {
         const result = await syncGames(client, provider, NFL.key, season, week);
         games += result.inserted + result.updated;
+        undated += result.skipped;
       }
 
       const rankings = await syncRankings(client, provider, NFL.key, season);
@@ -91,6 +108,7 @@ export async function runSeasonSyncJob(
         players: players.inserted + players.updated,
         byeWeeks,
         games,
+        undatedGames: undated,
         ranked: rankings.inserted,
         projections: projections.inserted,
       });
@@ -105,12 +123,23 @@ export async function runSeasonSyncJob(
     }
   }
 
+  // Both facts reach `cron_runs`, which migration 0029 describes as the answer
+  // to "is the scheduler running, and is it succeeding" without dashboard
+  // access. Undated fixtures are not a failure and must not read as one — the
+  // job did exactly what it should — but they are the thing somebody wants to
+  // know about before week 16, so a clean run says so rather than saying
+  // nothing.
   const failed = runs.filter((entry) => entry.error).length;
-  await recordCronRun(
-    client,
-    "season-sync",
+  const undated = runs.reduce((total, entry) => total + (entry.undatedGames ?? 0), 0);
+
+  const outcome = [
     failed > 0 ? `${failed} of ${seasons.length} seasons failed` : null,
-  );
+    undated > 0 ? `${undated} fixtures awaiting a kickoff time` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join("; ");
+
+  await recordCronRun(client, "season-sync", outcome === "" ? null : outcome);
 
   return NextResponse.json({ at: now.toISOString(), seasons: seasons.length, runs });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,6 +197,12 @@ export {
 } from "./season/lineup.js";
 
 export {
+  gameAvailability,
+  type GameAvailability,
+  type GameAvailabilityInput,
+} from "./season/availability.js";
+
+export {
   BracketError,
   buildBracket,
   thirdPlaceWinner,

--- a/packages/core/src/season/availability.test.ts
+++ b/packages/core/src/season/availability.test.ts
@@ -18,6 +18,28 @@ describe("gameAvailability", () => {
     expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 16, week: 16 })).toBe("SCHEDULED");
   });
 
+  it("calls a stored fixture with a provisional kickoff TIME_TBD", () => {
+    // The row exists and carries a conservative stand-in. Reporting it as
+    // SCHEDULED would let the screen print an hour nobody has announced.
+    expect(
+      gameAvailability({ kickoffAt: 1_767_000_000, kickoffTbd: true, byeWeek: 11, week: 16 }),
+    ).toBe("TIME_TBD");
+  });
+
+  it("prefers TIME_TBD over the bye week, because the fixture is the fact", () => {
+    expect(
+      gameAvailability({ kickoffAt: 1_767_000_000, kickoffTbd: true, byeWeek: 16, week: 16 }),
+    ).toBe("TIME_TBD");
+  });
+
+  it("treats an absent kickoffTbd as a real kickoff", () => {
+    // Callers written before the flag existed keep their answer, rather than
+    // every fixture silently downgrading to provisional.
+    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 11, week: 16 })).toBe(
+      "SCHEDULED",
+    );
+  });
+
   it("reports a bye when the missing week is the team's bye week", () => {
     expect(gameAvailability({ kickoffAt: null, byeWeek: 7, week: 7 })).toBe("BYE");
   });

--- a/packages/core/src/season/availability.test.ts
+++ b/packages/core/src/season/availability.test.ts
@@ -3,19 +3,27 @@ import { gameAvailability } from "./availability.js";
 
 describe("gameAvailability", () => {
   it("reports a game as scheduled whenever there is a kickoff", () => {
-    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 7, week: 16 })).toBe("SCHEDULED");
+    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 7, week: 16 })).toBe(
+      "SCHEDULED",
+    );
   });
 
   it("accepts a Date as well as an epoch second", () => {
-    expect(gameAvailability({ kickoffAt: new Date("2026-12-27T18:00:00Z"), byeWeek: null, week: 16 })).toBe(
-      "SCHEDULED",
-    );
+    expect(
+      gameAvailability({
+        kickoffAt: new Date("2026-12-27T18:00:00Z"),
+        byeWeek: null,
+        week: 16,
+      }),
+    ).toBe("SCHEDULED");
   });
 
   it("still calls it scheduled in the team's own bye week, because the row wins", () => {
     // Contradictory inputs, and the fixture is the fact. A game row in the bye
     // week means the bye moved, not that the game is imaginary.
-    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 16, week: 16 })).toBe("SCHEDULED");
+    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 16, week: 16 })).toBe(
+      "SCHEDULED",
+    );
   });
 
   it("calls a stored fixture with a provisional kickoff TIME_TBD", () => {

--- a/packages/core/src/season/availability.test.ts
+++ b/packages/core/src/season/availability.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { gameAvailability } from "./availability.js";
+
+describe("gameAvailability", () => {
+  it("reports a game as scheduled whenever there is a kickoff", () => {
+    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 7, week: 16 })).toBe("SCHEDULED");
+  });
+
+  it("accepts a Date as well as an epoch second", () => {
+    expect(gameAvailability({ kickoffAt: new Date("2026-12-27T18:00:00Z"), byeWeek: null, week: 16 })).toBe(
+      "SCHEDULED",
+    );
+  });
+
+  it("still calls it scheduled in the team's own bye week, because the row wins", () => {
+    // Contradictory inputs, and the fixture is the fact. A game row in the bye
+    // week means the bye moved, not that the game is imaginary.
+    expect(gameAvailability({ kickoffAt: 1_767_000_000, byeWeek: 16, week: 16 })).toBe("SCHEDULED");
+  });
+
+  it("reports a bye when the missing week is the team's bye week", () => {
+    expect(gameAvailability({ kickoffAt: null, byeWeek: 7, week: 7 })).toBe("BYE");
+  });
+
+  it("reports unscheduled when the team's bye is a different week", () => {
+    // The live case: Tampa Bay have no week 16 fixture and their bye was week 11.
+    expect(gameAvailability({ kickoffAt: null, byeWeek: 11, week: 16 })).toBe("UNSCHEDULED");
+  });
+
+  it("falls back to a bye when the bye week is unknown", () => {
+    // Never claim a fixture is coming on the strength of data we do not hold.
+    expect(gameAvailability({ kickoffAt: null, byeWeek: null, week: 16 })).toBe("BYE");
+  });
+
+  it("treats any non-bye gap as unscheduled, early weeks included", () => {
+    // Not only the late-December case. A week 3 hole is a likelier sign of a
+    // broken ingest than a fixture the NFL has not dated, and both want saying
+    // out loud rather than rendering as a restful afternoon.
+    expect(gameAvailability({ kickoffAt: null, byeWeek: 11, week: 3 })).toBe("UNSCHEDULED");
+  });
+});

--- a/packages/core/src/season/availability.ts
+++ b/packages/core/src/season/availability.ts
@@ -1,0 +1,87 @@
+/**
+ * Why a player has no game this week.
+ *
+ * ## The distinction this exists to make
+ *
+ * A missing `games` row has always read as "bye" everywhere it surfaces, and for
+ * most of the season that is correct. It stops being correct at exactly the
+ * point it matters most.
+ *
+ * The NFL fixes the kickoff *times* of its late-December games last, holding
+ * them back for flex scheduling. Verified against the provider on 2026-08-17:
+ * Tank01 returns every one of those fixtures with `gameDate` set and
+ * `gameTime: "TBD"`, `gameTime_epoch: ""` — the **day is known and the hour is
+ * not**. `syncGames` skips a game with no kickoff time deliberately, since
+ * storing a zero would lock lineups at the epoch, and that leaves a team which
+ * is playing looking identical to a team that is resting.
+ *
+ * Those are opposite facts for a manager. A bye means "start someone else, this
+ * player cannot score". A fixture awaiting its kickoff time means "this player
+ * will play, and nobody has said at what hour" — the same player, a decision
+ * reversed, in the week a season is won.
+ *
+ * Note what this therefore cannot say. The skipped row is never stored, so
+ * nothing downstream can reach the opponent or the date the provider *did*
+ * supply. `UNSCHEDULED` is inferred from the game's absence, so it reports that
+ * a fixture is coming without naming when, or against whom. Storing those games
+ * — with a conservative kickoff, because an optimistic one reopens a lock on a
+ * player who has already played — is the larger fix this only labels.
+ *
+ * ## The bye week is what separates them
+ *
+ * Every team's bye is stored (`player_seasons.bye_week`), frozen long before the
+ * season, and never one of the late weeks where dating is outstanding. So the
+ * two cases are told apart with data already held rather than anything new:
+ *
+ *   - a game this week → `SCHEDULED`, whatever else is true
+ *   - no game, and this **is** the team's bye → `BYE`
+ *   - no game, and the team's bye is elsewhere → `UNSCHEDULED`
+ *
+ * ## Not knowing the bye week reads as a bye
+ *
+ * `UNSCHEDULED` is claimed only when the bye week is known **and** falls in a
+ * different week. An unknown bye — a player with no `player_seasons` row, a
+ * free agent, a provider gap — keeps today's answer.
+ *
+ * That direction is deliberate. `UNSCHEDULED` tells a manager to hold a roster
+ * spot for a game that is coming; inferring it from absent data would invent
+ * that promise out of a gap in our own ingest. A wrong `BYE` costs one player's
+ * week, and is what already happens today; a wrong `UNSCHEDULED` is the screen
+ * asserting something nobody told it.
+ *
+ * ## It decides nothing
+ *
+ * This is a label, never a lock and never a score. `loadKickoffs` remains the
+ * only definition of when a slot freezes, and an unscheduled game has no kickoff
+ * to freeze on — so an `UNSCHEDULED` player is movable, exactly as a bye player
+ * is, and scores zero if the week ends without his game. Widening the lock to
+ * cover this case would need a kickoff time, which is the one thing that does
+ * not exist yet.
+ */
+
+/** Why a player's week is empty, when it is. */
+export type GameAvailability = "SCHEDULED" | "BYE" | "UNSCHEDULED";
+
+export interface GameAvailabilityInput {
+  /** Kickoff of this player's game this week, or null when there is no row. */
+  readonly kickoffAt: number | Date | null;
+  /** The player's team's bye week this season. Null when it is not known. */
+  readonly byeWeek: number | null;
+  /** The week being asked about. */
+  readonly week: number;
+}
+
+/**
+ * Whether this player's week is a bye, a fixture awaiting its kickoff time, or
+ * an ordinary game.
+ *
+ * Takes the bye week rather than a roster or a team so the rule stays pure and
+ * one implementation serves both the scoreboard and the lineup editor. Two
+ * screens disagreeing about whether a player is on a bye is the kind of split
+ * that sends a manager to the wrong decision.
+ */
+export function gameAvailability(input: GameAvailabilityInput): GameAvailability {
+  if (input.kickoffAt !== null) return "SCHEDULED";
+  if (input.byeWeek === null) return "BYE";
+  return input.byeWeek === input.week ? "BYE" : "UNSCHEDULED";
+}

--- a/packages/core/src/season/availability.ts
+++ b/packages/core/src/season/availability.ts
@@ -20,12 +20,18 @@
  * will play, and nobody has said at what hour" — the same player, a decision
  * reversed, in the week a season is won.
  *
- * Note what this therefore cannot say. The skipped row is never stored, so
- * nothing downstream can reach the opponent or the date the provider *did*
- * supply. `UNSCHEDULED` is inferred from the game's absence, so it reports that
- * a fixture is coming without naming when, or against whom. Storing those games
- * — with a conservative kickoff, because an optimistic one reopens a lock on a
- * player who has already played — is the larger fix this only labels.
+ * ## Two states, because there are two situations
+ *
+ * `syncGames` now stores such a fixture with `kickoff_tbd` set and a
+ * conservative kickoff taken from its dated siblings, so the ordinary case has a
+ * row and answers **`TIME_TBD`** — the screen can name the date and the
+ * opponent, and say the hour is pending.
+ *
+ * **`UNSCHEDULED` is what remains when even that fails**: no row at all, on a
+ * week that is not the team's bye. Reachable when every game on a date is
+ * untimed, so no stand-in could be derived, or when the sync has not run. It
+ * says a fixture is coming without being able to name when or against whom,
+ * which is worth saying and is strictly less than `TIME_TBD` says.
  *
  * ## The bye week is what separates them
  *
@@ -59,12 +65,18 @@
  * not exist yet.
  */
 
-/** Why a player's week is empty, when it is. */
-export type GameAvailability = "SCHEDULED" | "BYE" | "UNSCHEDULED";
+/** Why a player's week is empty, or when it is not quite settled. */
+export type GameAvailability = "SCHEDULED" | "TIME_TBD" | "BYE" | "UNSCHEDULED";
 
 export interface GameAvailabilityInput {
   /** Kickoff of this player's game this week, or null when there is no row. */
   readonly kickoffAt: number | Date | null;
+  /**
+   * The stored kickoff is a conservative stand-in, not the real time.
+   *
+   * `games.kickoff_tbd`. The fixture and its date are known; the hour is not.
+   */
+  readonly kickoffTbd?: boolean;
   /** The player's team's bye week this season. Null when it is not known. */
   readonly byeWeek: number | null;
   /** The week being asked about. */
@@ -81,6 +93,9 @@ export interface GameAvailabilityInput {
  * that sends a manager to the wrong decision.
  */
 export function gameAvailability(input: GameAvailabilityInput): GameAvailability {
+  // A stored fixture whose hour is provisional. Ranked above `SCHEDULED`
+  // because the row does carry a timestamp and it must not be read as one.
+  if (input.kickoffAt !== null && input.kickoffTbd === true) return "TIME_TBD";
   if (input.kickoffAt !== null) return "SCHEDULED";
   if (input.byeWeek === null) return "BYE";
   return input.byeWeek === input.week ? "BYE" : "UNSCHEDULED";

--- a/packages/db/migrations/0030_kickoff_time_pending.sql
+++ b/packages/db/migrations/0030_kickoff_time_pending.sql
@@ -1,0 +1,44 @@
+-- A fixture whose kickoff time the NFL has not fixed yet.
+--
+-- The NFL holds back the kickoff *times* of its late-December games for flex
+-- scheduling, and `syncGames` skipped any game the provider gave no time —
+-- deliberately, because a game stored at the epoch locks every lineup in it at
+-- 1970. The reasoning was right; what it discarded was not. The provider sends
+-- the date, the opponent and the fixture's existence alongside the missing time,
+-- and all three went in the bin with it.
+--
+-- Measured on the deployed database, 2026-08-17: `games` held 248 fixtures for
+-- weeks 1-17 against a correct 256, with weeks **16 and 17** each four short.
+-- Those are the playoff and championship weeks. A player whose team has no game
+-- has no stat line, and an absent stat line scores zero — correctly, by
+-- `results.ts`'s own rules — so a championship could have been decided by eight
+-- teams' players scoring nothing, with nothing raising an error and
+-- `weekHasSchedule` answering true off the twelve games that did exist.
+--
+-- **`kickoff_at` stays NOT NULL, and that is the whole shape of this fix.** It
+-- is read as a real timestamp by the lineup lock, the game watcher,
+-- `weekFirstKickoff`, the scoreboard and the box-score sweep. Making it nullable
+-- would push a null check into every one of them, and the cost of missing one is
+-- a slot that never locks — the exact defect `loadKickoffs` was rewritten to
+-- close. So the row carries a genuine, conservative timestamp and a flag saying
+-- the time is provisional.
+--
+-- **The conservative time is derived, never invented.** `syncGames` takes the
+-- earliest kickoff among already-dated games on the same calendar date — for 27
+-- December, the 13:00 ET Sunday slot, which is the earliest hour the pending
+-- game could start. A fixture with no dated sibling on its date is still
+-- skipped, so this only ever stores a game whose lock time comes from data.
+--
+-- Locking early is the safe direction and is chosen deliberately. It costs a
+-- manager some Sunday-morning flexibility on one player; the opposite error lets
+-- someone start a player after watching him score, which is the entire reason
+-- the lock exists.
+
+ALTER TABLE games
+  ADD COLUMN kickoff_tbd boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN games.kickoff_tbd IS
+  'True when the provider has given this fixture a date but not a kickoff time, '
+  'so kickoff_at holds a conservative earliest-possible time rather than the '
+  'real one. Locks may use it as-is; screens must not present it as fact, and '
+  'must not read the clock passing it as the game having started.';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -92,6 +92,7 @@ export {
   autoFillLineup,
   ensureLineups,
   LineupError,
+  loadByeWeeks,
   loadLineup,
   loadKickoffs,
   loadRosterForWeek,
@@ -198,6 +199,7 @@ export {
   type OrderDraw,
   type RecordedPick,
   type RecordPickInput,
+  type SeasonStartOracle,
 } from "./draft.js";
 
 export {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -96,6 +96,7 @@ export {
   loadLineup,
   loadKickoffs,
   loadRosterForWeek,
+  loadTbdKickoffs,
   loadWeekLineups,
   loadWeekStats,
   PRIMARY_PROJECTION_SOURCE,
@@ -199,7 +200,6 @@ export {
   type OrderDraw,
   type RecordedPick,
   type RecordPickInput,
-  type SeasonStartOracle,
 } from "./draft.js";
 
 export {

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -238,6 +238,39 @@ export async function loadKickoffs(
 }
 
 /**
+ * Each of these players' bye week this season, `null` where it is not recorded.
+ *
+ * ## Why this is not part of `loadKickoffs`
+ *
+ * That function is the single definition of when a slot freezes, and its own
+ * docstring is emphatic that widening it is how the lock bypass happened. A bye
+ * week decides nothing about locking — it only separates "resting" from "not yet
+ * dated" for the screen — so it is loaded alongside rather than folded in.
+ * Keeping them apart means a bug here can mislabel a row and cannot unlock one.
+ *
+ * Absent from the result means absent from `player_seasons`, which
+ * `gameAvailability` reads as a bye rather than as a fixture still to come.
+ */
+export async function loadByeWeeks(
+  db: SqlClient,
+  playerIds: readonly string[],
+  season: number,
+): Promise<ReadonlyMap<string, number | null>> {
+  if (playerIds.length === 0) return new Map();
+
+  const rows = await db.query<{ player_id: string; bye_week: number | null }>(
+    `SELECT player_id, bye_week
+       FROM player_seasons
+      WHERE season = $2 AND player_id = ANY($1)`,
+    [[...playerIds], season],
+  );
+
+  return new Map(
+    rows.map((row) => [row.player_id, row.bye_week === null ? null : Number(row.bye_week)]),
+  );
+}
+
+/**
  * The earliest kickoff of the week, or `null` when the week has no games.
  *
  * The conservative lock time for a player whose team is nowhere in the schedule:

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -271,6 +271,39 @@ export async function loadByeWeeks(
 }
 
 /**
+ * Which of these players' games this week carry a provisional kickoff.
+ *
+ * `games.kickoff_tbd`: the fixture and its date are known, the hour is not, and
+ * `kickoff_at` holds the earliest time it could start. Separate from
+ * `loadKickoffs` for the same reason `loadByeWeeks` is — that function is the
+ * lock oracle, and this one only decides what a screen says. The lock *should*
+ * use the conservative time exactly as stored, which is why it needs to know
+ * nothing about this.
+ */
+export async function loadTbdKickoffs(
+  db: SqlClient,
+  playerIds: readonly string[],
+  season: number,
+  week: number,
+): Promise<ReadonlySet<string>> {
+  if (playerIds.length === 0) return new Set();
+
+  const rows = await db.query<{ player_id: string }>(
+    `SELECT p.id AS player_id
+       FROM players p
+       JOIN games g
+         ON g.sport_id = p.sport_id
+        AND g.season = $2
+        AND g.week = $3
+        AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
+      WHERE p.id = ANY($1) AND g.kickoff_tbd`,
+    [[...playerIds], season, week],
+  );
+
+  return new Set(rows.map((row) => row.player_id));
+}
+
+/**
  * The earliest kickoff of the week, or `null` when the week has no games.
  *
  * The conservative lock time for a player whose team is nowhere in the schedule:

--- a/packages/db/src/matchup.test.ts
+++ b/packages/db/src/matchup.test.ts
@@ -274,14 +274,71 @@ describe("what is still to come", () => {
     // manager points are still coming when none are.
     const fx = await setup();
     await fx.client.query("UPDATE players SET team_ref = 'DEN' WHERE external_ref = 'qb-0'");
+    await recordBye(fx, "qb-0", WEEK);
 
     const views = await loadWeekMatchups(fx.client, fx.leagueId, WEEK, BEFORE);
     const side = sideOf(views, fx.teamIds[0]!);
 
     expect(side?.starters[0]?.gameState).toBe("BYE");
     expect(side?.yetToPlay).toBe(0);
+    expect(side?.unscheduled).toBe(0);
+  });
+
+  it("calls an undated fixture unscheduled, not a bye", async () => {
+    // The live case that prompted this: the NFL dates its late-December games
+    // last, `syncGames` skips a game with no kickoff time, and the player's team
+    // then looks exactly like a team on a bye. One means he cannot score and the
+    // other means he will — in the weeks that decide a championship.
+    const fx = await setup();
+    await fx.client.query("UPDATE players SET team_ref = 'DEN' WHERE external_ref = 'qb-0'");
+    await recordBye(fx, "qb-0", WEEK + 5);
+
+    const views = await loadWeekMatchups(fx.client, fx.leagueId, WEEK, BEFORE);
+    const side = sideOf(views, fx.teamIds[0]!);
+
+    expect(side?.starters[0]?.gameState).toBe("UNSCHEDULED");
+    expect(side?.unscheduled).toBe(1);
+  });
+
+  it("does not count an undated fixture as still to play", async () => {
+    // `yetToPlay` means "points are coming, at a known time". Folding an undated
+    // fixture into it would put a kickoff on a game that has none.
+    const fx = await setup();
+    await fx.client.query("UPDATE players SET team_ref = 'DEN' WHERE external_ref = 'qb-0'");
+    await recordBye(fx, "qb-0", WEEK + 5);
+
+    const views = await loadWeekMatchups(fx.client, fx.leagueId, WEEK, BEFORE);
+    const side = sideOf(views, fx.teamIds[0]!);
+
+    expect(side?.yetToPlay).toBe(0);
+    expect(side?.inProgress).toBe(0);
+  });
+
+  it("falls back to a bye when no bye week is recorded", async () => {
+    // Never claim a fixture is coming on the strength of a row we do not hold.
+    // A missing `player_seasons` row keeps the answer this screen gave before.
+    const fx = await setup();
+    await fx.client.query("UPDATE players SET team_ref = 'DEN' WHERE external_ref = 'qb-0'");
+
+    const views = await loadWeekMatchups(fx.client, fx.leagueId, WEEK, BEFORE);
+    const side = sideOf(views, fx.teamIds[0]!);
+
+    expect(side?.starters[0]?.gameState).toBe("BYE");
+    expect(side?.unscheduled).toBe(0);
   });
 });
+
+/** Give a player's team a bye week, which is what separates a bye from an
+ * undated fixture. */
+async function recordBye(fx: Fixture, handle: string, week: number): Promise<void> {
+  const playerId = fx.players.get(handle);
+  await fx.client.query(
+    `INSERT INTO player_seasons (player_id, season, team_ref, bye_week)
+     VALUES ($1, $2, 'DEN', $3)
+     ON CONFLICT (player_id, season) DO UPDATE SET bye_week = EXCLUDED.bye_week`,
+    [playerId, SEASON, week],
+  );
+}
 
 describe("a finalised week", () => {
   it("reports the stored total, not a fresh recompute", async () => {

--- a/packages/db/src/matchup.ts
+++ b/packages/db/src/matchup.ts
@@ -47,12 +47,20 @@ export class MatchupError extends Error {
 /**
  * Where a player's game stands.
  *
- * `UNSCHEDULED` is a real fixture whose kickoff time the NFL has not fixed yet,
- * which `syncGames` skips rather than storing at the epoch. It used to be
- * indistinguishable from `BYE`, and the two mean opposite things to anyone
- * deciding a lineup. See `gameAvailability` in `@rostr/core`.
+ * `TIME_TBD` is a stored fixture whose hour the NFL has not fixed — the row
+ * carries a conservative stand-in kickoff, so the clock passing it must **not**
+ * read as the game having started. `UNSCHEDULED` is the weaker case: no row at
+ * all on a week that is not the team's bye. Both used to be indistinguishable
+ * from `BYE`, and a bye means the opposite thing to anyone deciding a lineup.
+ * See `gameAvailability` in `@rostr/core`.
  */
-export type PlayerGameState = "BYE" | "UNSCHEDULED" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
+export type PlayerGameState =
+  | "BYE"
+  | "UNSCHEDULED"
+  | "TIME_TBD"
+  | "YET_TO_PLAY"
+  | "IN_PROGRESS"
+  | "FINAL";
 
 export interface PlayerLine {
   readonly playerId: string;
@@ -207,7 +215,9 @@ export async function loadWeekMatchups(
         bench: lines.filter((line) => !line.counted),
         yetToPlay: starters.filter((line) => line.gameState === "YET_TO_PLAY").length,
         inProgress: starters.filter((line) => line.gameState === "IN_PROGRESS").length,
-        unscheduled: starters.filter((line) => line.gameState === "UNSCHEDULED").length,
+        unscheduled: starters.filter(
+          (line) => line.gameState === "UNSCHEDULED" || line.gameState === "TIME_TBD",
+        ).length,
       };
     };
 
@@ -247,6 +257,8 @@ interface PlayerFacts {
   readonly position: string;
   readonly kickoffAt: Date | null;
   readonly gameStatus: string | null;
+  /** `games.kickoff_tbd` — the kickoff above is a conservative stand-in. */
+  readonly kickoffTbd: boolean;
   /** This season's bye week, null when unrecorded. Separates a bye from a
    * fixture whose kickoff time is not fixed yet. */
   readonly byeWeek: number | null;
@@ -270,6 +282,7 @@ async function playerContext(
     position: string;
     kickoff_at: string | null;
     status: string | null;
+    kickoff_tbd: boolean | null;
     bye_week: number | null;
   }>(
     `SELECT DISTINCT p.id,
@@ -277,6 +290,7 @@ async function playerContext(
             pos.key AS position,
             g.kickoff_at,
             g.status,
+            g.kickoff_tbd,
             ps.bye_week
        FROM roster_entries r
        JOIN teams t ON t.id = r.team_id
@@ -302,6 +316,7 @@ async function playerContext(
         position: row.position,
         kickoffAt: row.kickoff_at ? new Date(row.kickoff_at) : null,
         gameStatus: row.status,
+        kickoffTbd: row.kickoff_tbd === true,
         byeWeek: row.bye_week === null ? null : Number(row.bye_week),
       },
     ]),
@@ -357,6 +372,14 @@ function gameStateOf(
 
   const status = (facts.gameStatus ?? "").toUpperCase();
   if (status === "FINAL") return "FINAL";
+
+  // A provisional kickoff is not a kickoff, and the clock passing it says
+  // nothing. `syncGames` stores the earliest hour the game could start, so a
+  // fixture actually played at 20:20 would otherwise read as under way from
+  // 13:00 — seven hours of a manager being told a game is live before it has
+  // begun, in the week the season is decided. The provider's own status is
+  // still believed, so this resolves itself the moment the game really starts.
+  if (facts.kickoffTbd && status !== "IN_PROGRESS") return "TIME_TBD";
 
   // The clock decides when the provider has not spoken. Kickoff has passed and
   // the game is not final, so it is under way — a player sitting on zero at

--- a/packages/db/src/matchup.ts
+++ b/packages/db/src/matchup.ts
@@ -27,7 +27,7 @@
  * every lineup lock is derived from.
  */
 
-import { indexScoringRules, scoreTeamLineup } from "@rostr/core";
+import { gameAvailability, indexScoringRules, scoreTeamLineup } from "@rostr/core";
 import type { PlayerScore, TeamLineup } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
@@ -44,8 +44,15 @@ export class MatchupError extends Error {
   }
 }
 
-/** Where a player's game stands. Absent from the schedule reads as a bye. */
-export type PlayerGameState = "BYE" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
+/**
+ * Where a player's game stands.
+ *
+ * `UNSCHEDULED` is a real fixture whose kickoff time the NFL has not fixed yet,
+ * which `syncGames` skips rather than storing at the epoch. It used to be
+ * indistinguishable from `BYE`, and the two mean opposite things to anyone
+ * deciding a lineup. See `gameAvailability` in `@rostr/core`.
+ */
+export type PlayerGameState = "BYE" | "UNSCHEDULED" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
 
 export interface PlayerLine {
   readonly playerId: string;
@@ -77,6 +84,15 @@ export interface MatchupSide {
   readonly yetToPlay: number;
   /** Starters whose game is under way. */
   readonly inProgress: number;
+  /**
+   * Starters whose fixture exists but has no kickoff time yet.
+   *
+   * Counted apart from `yetToPlay` rather than folded into it: that number is
+   * "points still to come, at a known time", and this one carries no time at
+   * all. Adding them would make a side with a fixture still awaiting its time
+   * look ready to play when nobody can say what hour it starts.
+   */
+  readonly unscheduled: number;
 }
 
 export interface MatchupView {
@@ -175,7 +191,7 @@ export async function loadWeekMatchups(
       const scored = scoreTeamLineup(lineup, stats, scoring, stored.rules.roster);
       const live = scored.milliPoints;
 
-      const lines = scored.players.map((player) => toLine(player, context, now));
+      const lines = scored.players.map((player) => toLine(player, context, week, now));
       const starters = lines.filter((line) => line.counted);
 
       // Final wins over live: the stored number is what the week was settled on.
@@ -191,6 +207,7 @@ export async function loadWeekMatchups(
         bench: lines.filter((line) => !line.counted),
         yetToPlay: starters.filter((line) => line.gameState === "YET_TO_PLAY").length,
         inProgress: starters.filter((line) => line.gameState === "IN_PROGRESS").length,
+        unscheduled: starters.filter((line) => line.gameState === "UNSCHEDULED").length,
       };
     };
 
@@ -230,6 +247,9 @@ interface PlayerFacts {
   readonly position: string;
   readonly kickoffAt: Date | null;
   readonly gameStatus: string | null;
+  /** This season's bye week, null when unrecorded. Separates a bye from a
+   * fixture whose kickoff time is not fixed yet. */
+  readonly byeWeek: number | null;
 }
 
 /**
@@ -250,12 +270,14 @@ async function playerContext(
     position: string;
     kickoff_at: string | null;
     status: string | null;
+    bye_week: number | null;
   }>(
     `SELECT DISTINCT p.id,
             p.full_name,
             pos.key AS position,
             g.kickoff_at,
-            g.status
+            g.status,
+            ps.bye_week
        FROM roster_entries r
        JOIN teams t ON t.id = r.team_id
        JOIN players p ON p.id = r.player_id
@@ -265,6 +287,9 @@ async function playerContext(
         AND g.season = $2
         AND g.week = $3
         AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
+       LEFT JOIN player_seasons ps
+         ON ps.player_id = p.id
+        AND ps.season = $2
       WHERE t.league_id = $1 AND r.released_at IS NULL`,
     [leagueId, season, week],
   );
@@ -277,6 +302,7 @@ async function playerContext(
         position: row.position,
         kickoffAt: row.kickoff_at ? new Date(row.kickoff_at) : null,
         gameStatus: row.status,
+        byeWeek: row.bye_week === null ? null : Number(row.bye_week),
       },
     ]),
   );
@@ -293,6 +319,7 @@ async function playerContext(
 function toLine(
   player: PlayerScore,
   context: ReadonlyMap<string, PlayerFacts>,
+  week: number,
   now: Date,
 ): PlayerLine {
   const facts = context.get(player.playerId);
@@ -304,15 +331,29 @@ function toLine(
     slot: player.slotType,
     milliPoints: player.milliPoints,
     counted: player.counted,
-    gameState: gameStateOf(facts, now),
+    gameState: gameStateOf(facts, week, now),
     kickoffAt: facts?.kickoffAt ?? null,
   };
 }
 
-function gameStateOf(facts: PlayerFacts | undefined, now: Date): PlayerGameState {
-  // No game in this week's schedule: a bye. His slot never locks and he cannot
-  // score, which the screen should say rather than showing a hopeful zero.
-  if (!facts || facts.kickoffAt === null) return "BYE";
+function gameStateOf(
+  facts: PlayerFacts | undefined,
+  week: number,
+  now: Date,
+): PlayerGameState {
+  // No game in this week's schedule, and there are two reasons for that. A bye
+  // means he cannot score, and the screen should say so rather than show a
+  // hopeful zero. A fixture awaiting its time means he will play and nobody yet
+  // knows at what hour — telling a manager the first when the second is true is
+  // what gets the player dropped in the week that decides the season.
+  if (!facts || facts.kickoffAt === null) {
+    const availability = gameAvailability({
+      kickoffAt: facts?.kickoffAt ?? null,
+      byeWeek: facts?.byeWeek ?? null,
+      week,
+    });
+    return availability === "UNSCHEDULED" ? "UNSCHEDULED" : "BYE";
+  }
 
   const status = (facts.gameStatus ?? "").toUpperCase();
   if (status === "FINAL") return "FINAL";

--- a/packages/db/src/matchup.ts
+++ b/packages/db/src/matchup.ts
@@ -55,12 +55,7 @@ export class MatchupError extends Error {
  * See `gameAvailability` in `@rostr/core`.
  */
 export type PlayerGameState =
-  | "BYE"
-  | "UNSCHEDULED"
-  | "TIME_TBD"
-  | "YET_TO_PLAY"
-  | "IN_PROGRESS"
-  | "FINAL";
+  "BYE" | "UNSCHEDULED" | "TIME_TBD" | "YET_TO_PLAY" | "IN_PROGRESS" | "FINAL";
 
 export interface PlayerLine {
   readonly playerId: string;
@@ -351,11 +346,7 @@ function toLine(
   };
 }
 
-function gameStateOf(
-  facts: PlayerFacts | undefined,
-  week: number,
-  now: Date,
-): PlayerGameState {
+function gameStateOf(facts: PlayerFacts | undefined, week: number, now: Date): PlayerGameState {
   // No game in this week's schedule, and there are two reasons for that. A bye
   // means he cannot score, and the screen should say so rather than show a
   // hopeful zero. A fixture awaiting its time means he will play and nobody yet

--- a/packages/db/src/sync.test.ts
+++ b/packages/db/src/sync.test.ts
@@ -198,12 +198,10 @@ describe("syncGames", () => {
     gameDate: date,
   });
 
-  const dated = (
-    ref: string,
-    week: number,
-    kickoff: number,
-    date: string,
-  ): ProviderGame => ({ ...game(ref, week, kickoff), gameDate: date });
+  const dated = (ref: string, week: number, kickoff: number, date: string): ProviderGame => ({
+    ...game(ref, week, kickoff),
+    gameDate: date,
+  });
 
   it("inserts games", async () => {
     const client = await fresh();

--- a/packages/db/src/sync.test.ts
+++ b/packages/db/src/sync.test.ts
@@ -187,8 +187,23 @@ describe("syncGames", () => {
     homeTeamRef: "PHI",
     awayTeamRef: "DAL",
     kickoffAt: kickoff,
+    kickoffTbd: kickoff <= 0,
+    gameDate: null,
     status: "SCHEDULED",
   });
+
+  /** A fixture the NFL has dated but not timed, as Tank01 actually sends it. */
+  const undated = (ref: string, week: number, date: string): ProviderGame => ({
+    ...game(ref, week, 0),
+    gameDate: date,
+  });
+
+  const dated = (
+    ref: string,
+    week: number,
+    kickoff: number,
+    date: string,
+  ): ProviderGame => ({ ...game(ref, week, kickoff), gameDate: date });
 
   it("inserts games", async () => {
     const client = await fresh();
@@ -197,15 +212,105 @@ describe("syncGames", () => {
     expect(await syncGames(client, provider, "nfl", 2026)).toMatchObject({ inserted: 1 });
   });
 
-  it("skips a game with no kickoff time", async () => {
+  it("skips a game with no kickoff time and no dated sibling", async () => {
     // kickoffAt drives lineup locks and every scheduled job. Storing zero would
-    // lock lineups at the epoch.
+    // lock lineups at the epoch, and with nothing on the same date there is no
+    // conservative time to stand in for it.
     const client = await fresh();
     const provider = new FakeProvider([], [game("g1", 1, 0)]);
 
     expect(await syncGames(client, provider, "nfl", 2026)).toMatchObject({
       inserted: 0,
       skipped: 1,
+    });
+  });
+
+  describe("a fixture the NFL has dated but not timed", () => {
+    // The live case: weeks 16 and 17 were each four games short because the
+    // kickoff hour was pending, in the two weeks that decide a championship.
+    const SUNDAY_1PM = 1_798_988_400;
+    const SUNDAY_820PM = 1_798_914_000 + 98_400;
+
+    it("stores it, using the earliest kickoff known on the same date", async () => {
+      const client = await fresh();
+      const provider = new FakeProvider(
+        [],
+        [
+          dated("early", 16, SUNDAY_1PM, "20261227"),
+          dated("late", 16, SUNDAY_820PM, "20261227"),
+          undated("pending", 16, "20261227"),
+        ],
+      );
+
+      expect(await syncGames(client, provider, "nfl", 2026)).toMatchObject({
+        inserted: 3,
+        skipped: 0,
+      });
+
+      const [row] = await client.query<{ kickoff_at: string; kickoff_tbd: boolean }>(
+        "SELECT kickoff_at, kickoff_tbd FROM games WHERE external_ref = 'pending'",
+      );
+      expect(row?.kickoff_tbd).toBe(true);
+      // The earliest, not the latest: a slot that locks early costs a manager
+      // flexibility, where one that locks late lets them start a player they
+      // have already watched score.
+      expect(Math.floor(new Date(row!.kickoff_at).getTime() / 1000)).toBe(SUNDAY_1PM);
+    });
+
+    it("does not mark a properly timed game as provisional", async () => {
+      const client = await fresh();
+      const provider = new FakeProvider(
+        [],
+        [dated("early", 16, SUNDAY_1PM, "20261227"), undated("pending", 16, "20261227")],
+      );
+      await syncGames(client, provider, "nfl", 2026);
+
+      const [row] = await client.query<{ kickoff_tbd: boolean }>(
+        "SELECT kickoff_tbd FROM games WHERE external_ref = 'early'",
+      );
+      expect(row?.kickoff_tbd).toBe(false);
+    });
+
+    it("will not borrow a time from a different date", async () => {
+      // Thursday's kickoff is no evidence about Sunday's game, and standing it
+      // in would lock the Sunday slot three days early.
+      const client = await fresh();
+      const provider = new FakeProvider(
+        [],
+        [
+          dated("thursday", 16, SUNDAY_1PM - 3 * 86_400, "20261224"),
+          undated("pending", 16, "20261227"),
+        ],
+      );
+
+      expect(await syncGames(client, provider, "nfl", 2026)).toMatchObject({
+        inserted: 1,
+        skipped: 1,
+      });
+    });
+
+    it("clears the flag once the real time arrives", async () => {
+      const client = await fresh();
+      const first = new FakeProvider(
+        [],
+        [dated("early", 16, SUNDAY_1PM, "20261227"), undated("pending", 16, "20261227")],
+      );
+      await syncGames(client, first, "nfl", 2026);
+
+      const second = new FakeProvider(
+        [],
+        [
+          dated("early", 16, SUNDAY_1PM, "20261227"),
+          dated("pending", 16, SUNDAY_820PM, "20261227"),
+        ],
+      );
+      await syncGames(client, second, "nfl", 2026);
+
+      const [row] = await client.query<{ kickoff_at: string; kickoff_tbd: boolean }>(
+        "SELECT kickoff_at, kickoff_tbd FROM games WHERE external_ref = 'pending'",
+      );
+      expect(row?.kickoff_tbd).toBe(false);
+      expect(Math.floor(new Date(row!.kickoff_at).getTime() / 1000)).toBe(SUNDAY_820PM);
     });
   });
 

--- a/packages/db/src/sync.ts
+++ b/packages/db/src/sync.ts
@@ -10,7 +10,7 @@
  * quietly.
  */
 
-import type { StatsProvider } from "@rostr/stats";
+import type { ProviderGame, StatsProvider } from "@rostr/stats";
 import type { SqlClient } from "./client.js";
 import { PRIMARY_PROJECTION_SOURCE } from "./lineups.js";
 import { loadSportIds } from "./sports.js";
@@ -149,12 +149,65 @@ export async function syncByeWeeks(
 }
 
 /**
+ * The earliest kickoff already known on each calendar date in a batch.
+ *
+ * The stand-in for a fixture the NFL has dated but not timed. It is derived from
+ * the game's own dated siblings — for 27 December 2026, the 13:00 ET Sunday
+ * slot — which is the earliest hour that fixture could possibly start.
+ *
+ * Derived rather than computed, deliberately. The obvious alternative is
+ * midnight on `gameDate` in US Eastern, and that means getting EST against EDT
+ * right by hand for a date months away. Hand-rolled calendar arithmetic has
+ * already cost this repo a live bug (`latestWeekly`, where a week was assumed to
+ * be 168 hours and is not across a clock change), and the sibling games carry
+ * the answer with no arithmetic at all.
+ *
+ * A date whose games are *all* untimed yields nothing, and those fixtures stay
+ * skipped. That keeps the change strictly additive: a game is only ever stored
+ * when its lock time comes from data.
+ */
+function earliestKickoffByDate(
+  games: readonly ProviderGame[],
+): ReadonlyMap<string, number> {
+  const earliest = new Map<string, number>();
+
+  for (const game of games) {
+    if (game.kickoffTbd || game.gameDate === null || game.kickoffAt <= 0) continue;
+    const known = earliest.get(game.gameDate);
+    if (known === undefined || game.kickoffAt < known) {
+      earliest.set(game.gameDate, game.kickoffAt);
+    }
+  }
+
+  return earliest;
+}
+
+/**
  * Schedule.
  *
  * `kickoffAt` is the load-bearing field: lineup locks, the inactives job, and
  * the game watcher are all derived from it. A game whose kickoff the provider
- * did not supply is skipped rather than stored with a zero, which would lock
- * lineups at the epoch.
+ * did not supply is never stored with a zero, which would lock every lineup in
+ * it at the epoch.
+ *
+ * ## A missing time is no longer a missing fixture
+ *
+ * It used to be, and the cost was measured rather than theorised: on 2026-08-17
+ * the deployed database held 248 fixtures for weeks 1-17 against a correct 256,
+ * four short in **each of weeks 16 and 17** — the playoff and championship
+ * weeks. The NFL holds those kickoff times back for flex scheduling, so the
+ * provider sends the date and both teams with `gameTime: "TBD"`, and all of it
+ * was discarded for want of an hour. Players on those teams had no game, no stat
+ * line, and therefore a permanent zero, with `weekHasSchedule` answering true
+ * off the twelve games that did exist.
+ *
+ * Such a fixture is now stored with `kickoff_tbd` set and a **conservative**
+ * kickoff from `earliestKickoffByDate`. Locking early is the safe direction: it
+ * costs a manager some Sunday-morning flexibility, where the opposite error lets
+ * someone start a player after watching him score.
+ *
+ * Screens must read `kickoff_tbd` and not present that timestamp as fact — in
+ * particular, the clock passing it does not mean the game has started.
  */
 export async function syncGames(
   db: SqlClient,
@@ -165,24 +218,37 @@ export async function syncGames(
 ): Promise<SyncResult> {
   const ids = await loadSportIds(db, sportKey);
   const games = await provider.listGames(season, week);
+  const earliest = earliestKickoffByDate(games);
 
   let inserted = 0;
   let updated = 0;
   let skipped = 0;
 
   for (const game of games) {
-    if (!game.kickoffAt || !game.homeTeamRef || !game.awayTeamRef) {
+    if (!game.homeTeamRef || !game.awayTeamRef) {
+      skipped++;
+      continue;
+    }
+
+    // A real time wins outright. Otherwise stand in the earliest kickoff known
+    // on the same date, and only if there is one.
+    const standIn = game.gameDate === null ? undefined : earliest.get(game.gameDate);
+    const kickoffAt = game.kickoffAt > 0 ? game.kickoffAt : (standIn ?? 0);
+    const kickoffTbd = game.kickoffAt <= 0;
+
+    if (kickoffAt <= 0) {
       skipped++;
       continue;
     }
 
     const rows = await db.query<{ inserted: boolean }>(
       `INSERT INTO games
-         (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status, final_at)
-       VALUES ($1, $2, $3, $4, $5, $6, to_timestamp($7), $8, $9)
+         (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, kickoff_tbd, status, final_at)
+       VALUES ($1, $2, $3, $4, $5, $6, to_timestamp($7), $8, $9, $10)
        ON CONFLICT (sport_id, external_ref) DO UPDATE
          SET week = EXCLUDED.week,
              kickoff_at = EXCLUDED.kickoff_at,
+             kickoff_tbd = EXCLUDED.kickoff_tbd,
              status = EXCLUDED.status,
              final_at = COALESCE(games.final_at, EXCLUDED.final_at)
        RETURNING (xmax = 0) AS inserted`,
@@ -193,7 +259,8 @@ export async function syncGames(
         game.week,
         game.homeTeamRef,
         game.awayTeamRef,
-        game.kickoffAt,
+        kickoffAt,
+        kickoffTbd,
         game.status,
         game.status === "FINAL" ? new Date().toISOString() : null,
       ],

--- a/packages/db/src/sync.ts
+++ b/packages/db/src/sync.ts
@@ -166,9 +166,7 @@ export async function syncByeWeeks(
  * skipped. That keeps the change strictly additive: a game is only ever stored
  * when its lock time comes from data.
  */
-function earliestKickoffByDate(
-  games: readonly ProviderGame[],
-): ReadonlyMap<string, number> {
+function earliestKickoffByDate(games: readonly ProviderGame[]): ReadonlyMap<string, number> {
   const earliest = new Map<string, number>();
 
   for (const game of games) {

--- a/packages/stats/src/provider.ts
+++ b/packages/stats/src/provider.ts
@@ -29,8 +29,28 @@ export interface ProviderGame {
   readonly week: number;
   readonly homeTeamRef: string;
   readonly awayTeamRef: string;
-  /** Unix seconds. Drives lineup locks and every scheduled job. */
+  /** Unix seconds. Drives lineup locks and every scheduled job. `0` when the
+   * provider has not fixed a kickoff time — see `kickoffTbd`. */
   readonly kickoffAt: number;
+  /**
+   * The provider has this fixture's date but not its kickoff time.
+   *
+   * The NFL holds back the times of its late-December games for flex
+   * scheduling, and Tank01 sends those with `gameTime: "TBD"` and an empty
+   * `gameTime_epoch` while still giving the date and both teams. Before this
+   * flag existed the whole row was discarded, which is how weeks 16 and 17 came
+   * to be four fixtures short each.
+   *
+   * A consumer must not treat `kickoffAt` as fact while this is true.
+   */
+  readonly kickoffTbd: boolean;
+  /**
+   * The provider's own calendar date for the fixture, `YYYYMMDD`, or null.
+   *
+   * Carried so a conservative kickoff can be derived from the game's dated
+   * siblings rather than computed from a timezone by hand.
+   */
+  readonly gameDate: string | null;
   readonly status: "SCHEDULED" | "IN_PROGRESS" | "FINAL" | "POSTPONED" | "CANCELLED";
 }
 

--- a/packages/stats/src/tank01/adapter.ts
+++ b/packages/stats/src/tank01/adapter.ts
@@ -98,6 +98,11 @@ interface RawGame {
   away?: string;
   gameTime_epoch?: string;
   gameStatus?: string;
+  /** `YYYYMMDD`. Present even when the kickoff time is not — verified live on
+   * 2026-08-17, see `listGames`. */
+  gameDate?: string;
+  /** `"TBD"` for a fixture the NFL has not given a time. Observed, not guessed. */
+  gameTime?: string;
 }
 
 /**
@@ -217,6 +222,29 @@ export class Tank01Provider implements StatsProvider {
     return players;
   }
 
+  /**
+   * A week's fixtures.
+   *
+   * ## A missing kickoff time is not a missing game
+   *
+   * Probed live on 2026-08-17, because this had been assumed and never checked.
+   * Tank01 returns **all 16** fixtures for every week. The ones the NFL has not
+   * yet timed come back fully formed apart from the hour:
+   *
+   * ```
+   * TB @ ATL  gameID=20261227_TB@ATL  gameDate="20261227"
+   *           gameTime="TBD"  gameTime_epoch=""  gameStatus="Scheduled"
+   * ```
+   *
+   * This used to collapse that into `kickoffAt: 0` and nothing else, so
+   * `syncGames` skipped the row and the date, the opponent and the fixture's
+   * existence went with it — which is how weeks 16 and 17 ended up four games
+   * short each, in the two weeks that decide a championship.
+   *
+   * The emptiness is reported rather than resolved here. Choosing a stand-in
+   * kickoff needs the game's dated siblings, which is a decision for the caller
+   * holding the whole week, not for a translator holding one row.
+   */
   async listGames(season: number, week?: number): Promise<readonly ProviderGame[]> {
     const params: Record<string, string> = { season: String(season), seasonType: "reg" };
     if (week !== undefined) params["week"] = String(week);
@@ -227,6 +255,14 @@ export class Tank01Provider implements StatsProvider {
       .filter((game): game is RawGame & { gameID: string } => Boolean(game.gameID))
       .map((game) => {
         const kickoff = Number.parseFloat(game.gameTime_epoch ?? "0");
+        const kickoffAt = Number.isFinite(kickoff) ? Math.round(kickoff) : 0;
+
+        // Derived from the epoch alone, never from `gameTime === "TBD"`. The
+        // epoch is what every downstream consumer actually uses, so keying the
+        // flag on it means the flag cannot disagree with the number it
+        // describes — and a provider that invents a new wording for "no time
+        // yet" still lands here rather than shipping a game stored at 1970.
+        const kickoffTbd = kickoffAt <= 0;
 
         return {
           externalRef: game.gameID,
@@ -235,7 +271,9 @@ export class Tank01Provider implements StatsProvider {
           week: Number.parseInt((game.gameWeek ?? "").replace(/\D+/g, ""), 10) || (week ?? 0),
           homeTeamRef: game.home ?? "",
           awayTeamRef: game.away ?? "",
-          kickoffAt: Number.isFinite(kickoff) ? Math.round(kickoff) : 0,
+          kickoffAt,
+          kickoffTbd,
+          gameDate: game.gameDate && /^\d{8}$/.test(game.gameDate) ? game.gameDate : null,
           status: mapGameStatus(game.gameStatus),
         };
       });


### PR DESCRIPTION
Refs #180.

Found by auditing the 2026 schedule in the deployed database. `games` holds **248** fixtures for weeks 1–17; the correct figure is 256. Weeks 1–15 reconcile exactly — teams playing plus teams on bye equals 32 every week — and weeks **16 and 17 are four fixtures short each**. Those are the playoff and championship weeks.

A player whose team has no game has no stat line, and `results.ts` scores an absent stat line as zero — correctly, by its own rules. So a championship could have been decided by eight teams' players scoring nothing, with `weekHasSchedule` answering true off the twelve games that did exist and nothing raising a word.

## Why the games were missing

`syncGames` skips a game the provider gives no kickoff time. That is deliberate and right — `kickoff_at` drives every lock and scheduled job, and a game stored at the epoch locks its lineups at 1970. What was wrong is that it discarded the whole row.

**Probed live rather than assumed.** Tank01 returns all 16 fixtures for both weeks; the four skipped in each carry `gameDate` with `gameTime: "TBD"` and an empty `gameTime_epoch`:

```
TB @ ATL    gameID=20261227_TB@ATL   date="20261227"  time="TBD"  epoch=""
WSH @ JAX   gameID=20270103_WSH@JAX  date="20270103"  time="TBD"  epoch=""
```

The NFL holds those kickoff times back for flex scheduling. The date and both teams were there all along and went in the bin with the missing hour.

## What this does

**Stores the fixture** (migration `0030`, `games.kickoff_tbd`) with a **conservative** kickoff: the earliest time already known on the same calendar date. For 27 December that is the 13:00 ET Sunday slot — the earliest hour the pending game could start.

`kickoff_at` stays `NOT NULL`. It is read as a real timestamp by the lineup lock, the game watcher, `weekFirstKickoff`, the scoreboard and the box-score sweep; making it nullable would push a null check into every one of them, and the cost of missing one is a slot that never locks.

**Derived from the game's dated siblings, not computed from a timezone.** The alternative is midnight ET from `YYYYMMDD`, which means getting EST against EDT right by hand for a date months out. Hand-rolled calendar arithmetic has already cost this repo a live bug — `latestWeekly`, where a week was assumed to be 168 hours and is not across a clock change. A date whose games are *all* untimed yields no stand-in, and those fixtures stay skipped, so the change is strictly additive: a game is stored only when its lock time comes from data.

**`loadKickoffs` is untouched**, which was the goal. It reads the conservative time as-is, so the slot locks at the earliest hour the game could start. Locking early costs a manager some Sunday-morning flexibility; the opposite error lets someone start a player after watching him score, which is the entire reason the lock exists.

**`TIME_TBD` keeps the screen honest.** A game stood in at 13:00 and actually played at 20:20 would otherwise read as in progress from 13:01 — seven hours telling a manager a game is live before it has begun. The provider's own status is still believed, so it resolves the moment the game really starts.

**`UNSCHEDULED`** survives as the weaker case: no row at all in a week that is not the team's bye. It is claimed only when the bye week is known and falls elsewhere — an unknown bye keeps today's answer, because "a game is coming" must never be inferred from a gap in our own ingest.

**`season-sync` stops discarding the `skipped` count** it already computes. It now reports `undatedGames` and writes "N fixtures awaiting a kickoff time" to `cron_runs`, which migration 0029 describes as the answer to "is the scheduler running, and is it succeeding" without dashboard access. Finding these 8 games took a hand-written SQL query; it should have taken a glance.

## Where the rules live

`gameAvailability` is in `@rostr/core`, pure and unit-tested, and shared by the scoreboard and the lineup editor — `apps/web` cannot render a component in a test, so a rule written in `.tsx` is verified only by being run in production. Two screens disagreeing about whether a player is out is exactly the split that sends a manager to the wrong decision.

Bye weeks and the TBD flag load through `loadByeWeeks` and `loadTbdKickoffs`, separate from `loadKickoffs`, so a bug in this labelling can mislabel a row and cannot unlock one.

## Verified

`pnpm test` 1448 passed, 2 skipped. `pnpm typecheck`, `pnpm lint` clean. Migration guard confirms `0030` against main's highest of 29.

**Not seen in a browser** — no jsdom in either vitest project, so the components compile and are not rendered.

## This does not repair the deployed database on its own

The migration has to be applied and the sync re-run before the 8 fixtures exist. And `cron_runs` is empty — the scheduler has never run against that database, so once the NFL sets these kickoff times nothing picks them up until the app is deployed with its crons live. This makes the sync do the right thing; it does not make the sync happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
