### PR TITLE
fix(stats)!: a blocked punt paid nobody, a returner the play does not name paid nobody, and every warning said "failed"

### DIFF
--- a/apps/web/src/lib/jobs/stats.test.ts
+++ b/apps/web/src/lib/jobs/stats.test.ts
@@ -123,7 +123,7 @@ async function seedDefenses(): Promise<void> {
 }
 
 /** What a healthy response looks like: both defenses present. */
-const healthy = (gameRef: string): ProviderBoxScore => ({
+const healthy = (gameRef: string, warnings: readonly string[] = []): ProviderBoxScore => ({
   gameRef,
   // Zero exactly as the real adapter returns them — the games row is what says
   // which season and week this is.
@@ -133,7 +133,7 @@ const healthy = (gameRef: string): ProviderBoxScore => ({
     ["DST_PHI", [{ statKey: "def_pts_allowed", value: 20 }]],
     ["DST_DAL", [{ statKey: "def_pts_allowed", value: 24 }]],
   ]),
-  warnings: [],
+  warnings,
 });
 
 const lastOutcome = async (): Promise<string | null | undefined> =>
@@ -210,6 +210,91 @@ describe("the stats cron", () => {
     expect(calls).toEqual(["g1", "g2"]);
     expect(body.runs.map((entry) => entry.season)).toEqual([2026, 2027]);
     expect(await lastOutcome()).toBe("1 game(s) failed to ingest");
+  });
+
+  /**
+   * Warnings, which reached a human as the word "failed" and nothing else.
+   *
+   * The translator's whole `fatal`/`warnings` split exists so that a discrepancy
+   * does not discard a game — and then every warning it raised was pushed onto
+   * `failures` and announced as "N game(s) failed to ingest" on a run where
+   * every player landed correctly. The cost is not the wording. A week finalises
+   * after 48 hours and is never rescored, so the window for acting on a warning
+   * is short, and a channel that cries failure on healthy runs is one people
+   * stop opening — which is exactly how a novel play type stays invisible for
+   * two seasons.
+   */
+  it("reports a warning as a warning, not as a failed ingest", async () => {
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    await league(2026);
+    await seedDefenses();
+    await finishedGame(2026, "g1");
+
+    const { provider } = fakeProvider((gameRef) =>
+      healthy(gameRef, ['scoreType "XPR" has not been seen before']),
+    );
+
+    const response = await runStatsJob(db, provider, NOW);
+    const body = (await response.json()) as {
+      runs: { failures: unknown[]; warnings: { warning: string }[] }[];
+    };
+
+    expect(body.runs[0]?.failures).toEqual([]);
+    expect(body.runs[0]?.warnings?.[0]?.warning).toContain("XPR");
+    expect(await lastOutcome()).toBe("1 warning(s) from games that did ingest");
+  });
+
+  it("says both when a run has failures and warnings", async () => {
+    // This was a chain of ternaries, so the first true branch won and the rest
+    // went unsaid. A heartbeat is read once and acted on once.
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    await league(2026);
+    await seedDefenses();
+    await finishedGame(2026, "g1");
+    await finishedGame(2026, "g2");
+
+    const { provider } = fakeProvider((gameRef) =>
+      gameRef === "g1"
+        ? new Error("provider exploded")
+        : healthy(gameRef, ["something did not add up"]),
+    );
+
+    await runStatsJob(db, provider, NOW);
+
+    expect(await lastOutcome()).toBe(
+      "1 game(s) failed to ingest; 1 warning(s) from games that did ingest",
+    );
+  });
+
+  /**
+   * A heartbeat does not remember, and `games.stats_error` does.
+   *
+   * `cron_runs` holds one row per job and the next run overwrites it, so a
+   * warning raised at noon is gone by ten past — and the run that follows a
+   * troubled one is usually the quiet Tuesday run that fetched nothing at all.
+   * `unresolvedStatsProblems` reads the column that survives.
+   */
+  it("keeps reporting a game that is still broken on a run that touched nothing", async () => {
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    await league(2026);
+    await seedDefenses();
+    await finishedGame(2026, "g1");
+
+    const { provider } = fakeProvider((gameRef) =>
+      healthy(gameRef, ["something did not add up"]),
+    );
+    await runStatsJob(db, provider, NOW);
+
+    // Nothing is due now — the game was just read and its retry is paced — so
+    // this run does no work at all and would once have recorded itself clean.
+    const quiet = fakeProvider(() => new Error("must not be called"));
+    await runStatsJob(db, quiet.provider, NOW);
+
+    expect(quiet.calls).toEqual([]);
+    expect(await lastOutcome()).toBe("1 game(s) still carry an unresolved problem");
   });
 
   /**

--- a/apps/web/src/lib/jobs/stats.ts
+++ b/apps/web/src/lib/jobs/stats.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { NFL } from "@rostr/core";
-import { recordCronRun, seasonsInPlay, syncBoxScores } from "@rostr/db";
+import {
+  recordCronRun,
+  seasonsInPlay,
+  syncBoxScores,
+  unresolvedStatsProblems,
+} from "@rostr/db";
 import type { SqlClient } from "@rostr/db";
 import type { StatsProvider } from "@rostr/stats";
 
@@ -27,6 +32,29 @@ import type { StatsProvider } from "@rostr/stats";
  * stop the others, and a route that fails silently reads as one that is working.
  * `syncBoxScores` already reports per-game failures without throwing, so a throw
  * here is a database or provider-level fault rather than one bad game.
+ *
+ * ## And warnings are not failures
+ *
+ * They used to be reported as if they were. Every discrepancy the translator
+ * raised — a field-goal count disagreeing with the plays parsed from it, a
+ * defence missing from the response, and from 2026-08-17 a `scoreType` nobody
+ * has seen before — arrived in `failures` and was announced to the heartbeat as
+ * "N game(s) failed to ingest", on a game whose ninety players had all been
+ * written correctly.
+ *
+ * That is not a naming quibble. The whole value of a warning here is that a week
+ * finalises after 48 hours and is never rescored, so the window in which anybody
+ * can act on one is short — and a channel that cries failure on healthy runs is
+ * a channel people stop opening. The two are counted and reported separately,
+ * and both reach `cron_runs`.
+ *
+ * ## The backlog, because a heartbeat does not remember
+ *
+ * `cron_runs` holds one row per job and the next run overwrites it, so a warning
+ * raised at noon is gone by ten past. `games.stats_error` is where it actually
+ * survives, and until now nothing read that column back. `unresolvedStatsProblems`
+ * does, and its count rides along on every run — so a discrepancy stays visible
+ * until the game is re-read cleanly, rather than until the next tick.
  */
 export async function runStatsJob(
   client: SqlClient,
@@ -44,6 +72,8 @@ export async function runStatsJob(
     /** Named rather than counted — a bare count once hid "every kicker". */
     unmatched?: readonly string[];
     failures?: readonly { gameRef: string; reason: string }[];
+    /** Ingested, with something that did not reconcile. Not a failure. */
+    warnings?: readonly { gameRef: string; warning: string }[];
     error?: string;
   }[] = [];
 
@@ -58,6 +88,7 @@ export async function runStatsJob(
         retracted: outcome.retracted,
         unmatched: outcome.unmatched,
         failures: outcome.failures,
+        warnings: outcome.warnings,
       });
     } catch (error) {
       runs.push({
@@ -73,15 +104,36 @@ export async function runStatsJob(
   // would never reach the heartbeat at all.
   const brokenSeasons = runs.filter((entry) => entry.error).length;
   const gameFailures = runs.reduce((total, entry) => total + (entry.failures?.length ?? 0), 0);
+  const gameWarnings = runs.reduce((total, entry) => total + (entry.warnings?.length ?? 0), 0);
 
+  // Everything unresolved, not only what this run happened to touch. A run that
+  // fetched nothing is the normal case on a Tuesday and would otherwise report
+  // itself clean over a game that has been failing since Sunday.
+  const outstanding = await unresolvedStatsProblems(client, NFL.key);
+
+  // **Every reason, joined — not the first one.** This was a chain of ternaries,
+  // so a run with a broken season announced only that and said nothing about the
+  // twelve games that also failed. A heartbeat is read once and acted on once.
   const problem =
-    brokenSeasons > 0
-      ? `${brokenSeasons} of ${seasons.length} seasons failed`
-      : gameFailures > 0
-        ? `${gameFailures} game(s) failed to ingest`
-        : null;
+    [
+      brokenSeasons > 0 ? `${brokenSeasons} of ${seasons.length} seasons failed` : null,
+      gameFailures > 0 ? `${gameFailures} game(s) failed to ingest` : null,
+      gameWarnings > 0 ? `${gameWarnings} warning(s) from games that did ingest` : null,
+      // Only when this run raised none of its own, or the two counts read as
+      // separate incidents when the second is a superset of the first.
+      gameWarnings === 0 && gameFailures === 0 && outstanding.total > 0
+        ? `${outstanding.total} game(s) still carry an unresolved problem`
+        : null,
+    ]
+      .filter((part) => part !== null)
+      .join("; ") || null;
 
   await recordCronRun(client, "stats", problem);
 
-  return NextResponse.json({ at: now.toISOString(), seasons: seasons.length, runs });
+  return NextResponse.json({
+    at: now.toISOString(),
+    seasons: seasons.length,
+    runs,
+    outstanding,
+  });
 }

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -77,14 +77,20 @@ Missed extra points are unpenalised, which is ESPN's default too.
 
 Scored as a single unit.
 
-| Event                                | Points |
-| ------------------------------------ | ------ |
-| Sack                                 | **1**  |
-| Interception                         | **2**  |
-| Fumble recovery                      | **2**  |
-| Safety                               | **2**  |
-| Defensive or special teams touchdown | **6**  |
-| Blocked kick                         | **2**  |
+| Event                                 | Points |
+| ------------------------------------- | ------ |
+| Sack                                  | **1**  |
+| Interception                          | **2**  |
+| Fumble recovery                       | **2**  |
+| Safety                                | **2**  |
+| Defensive or special teams touchdown  | **6**  |
+| Blocked kick                          | **2**  |
+| Defensive two-point conversion return | **2**  |
+
+A **defensive two-point conversion return** is a failed conversion attempt taken
+back the other way by the defending team. ESPN's value, and Sleeper pays the same.
+It happened three times across the 2024 and 2025 seasons, so it is rare rather
+than theoretical.
 
 **Points allowed**, awarded once per week on the unit's own game:
 

--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -132,10 +132,70 @@ only three seen across the 96 games sampled in [Recheck](#recheck).
 
 > **Corrected 2026-08-17.** This section said "there are exactly **three**
 > `scoreType` values" and that was a claim about a sample, not about the feed. A
-> sweep of the **full** 2025 season also found `2PTC` and a `null`. Nothing in
-> the adapter enumerates the set — every use is an equality test against one of
-> the three — so an unfamiliar value is inert rather than a crash. Do not write a
-> `switch` over this field.
+> sweep of the **full** 2025 season also found `2PTC` and a `null`, and a sweep
+> of **2024** found `BP`. Do not write a `switch` over this field.
+
+### `BP` — and why nothing decides a touchdown by reading this field any more
+
+The fifth value, verbatim from `20241208_BUF@LAR`, captured as
+`__fixtures__/box-score-blocked-punt-scoretype.json`:
+
+```
+BP | LAR | Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)
+```
+
+That is a touchdown. Both places that pay six points for a special-teams score
+asked `play.scoreType === "TD"`, so it reached neither the returner nor the unit
+— **12 points on one play, in two roster spots.** Nothing else made it up:
+`DST.defTD` reads `"0"` for the Rams in that game and
+`defensiveOrSpecialTeamsTds` reads `"0"` too, so even the cross-check agreed with
+the silence. `teamStats.blockedPunt` reads `"1"`, so the _block_ was counted; it
+is the touchdown that is not.
+
+**The adapter now asks the question negatively.** `isTouchdownScoringPlay`
+refuses `FG`, `SF` and `2PTC` — the three values observed carrying a
+non-touchdown event — and treats everything else, including an unfamiliar value
+and an absent one, as eligible. The text pattern is what names the event. An
+allow-list of `TD` and `BP` would fix the one play we found and leave the next
+unknown value exactly as expensive; this list has now been wrong twice.
+
+Two things follow, both of them in code:
+
+- **A `BP` play is in neither of the provider's touchdown counters**, so the
+  `defensiveOrSpecialTeamsTds` cross-check excludes it, or it would fire on a
+  game we have just started scoring correctly. This rests on the single `BP` play
+  in two seasons and says so in `isUncountedSpecialTeamsScoreType`.
+- **An unrecognised `scoreType` is warned about**, once per game per value. `BP`
+  sat in the feed for two seasons and what found it was a human sweeping 544
+  games. Inert is the right behaviour; silent is not.
+
+> A second 2024 play was expected to be `BP` and is not. `20241229_CAR@TB` —
+> `TD | TB | J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)` —
+> is an ordinary `TD` and cost six points for an unrelated reason. See
+> [Who scored](#playerids-does-not-name-the-scorer) below.
+
+### `playerIDs` does not name the scorer
+
+Verbatim, `20241229_CAR@TB`, captured as
+`__fixtures__/box-score-returner-not-in-playerids.json`:
+
+```
+TD | TB | J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)
+   | playerIDs: ["3150744"]
+```
+
+`3150744` is **Chase McLaughlin, the kicker**. The man the sentence names is not
+in the array at all, and Tank01's entire record for him in this game is a
+`snapCounts` block — no `scoringPlays`, no `Defense`. So the per-player loop had
+two independent reasons to miss him, and a fix to either alone would have changed
+nothing.
+
+This is the same shape as the two-point conversion in `20250907_MIA@IND`
+(issue #155), one category over. Return touchdowns are now resolved by a
+game-level pass over the **main clause**, matched against every named player in
+the response, with `playerIDs` demoted to a tiebreak when more than one player
+answers to the same spelling. A return has exactly one scorer, so two distinct
+matches is a fact about our name matching and credits nobody, loudly.
 
 Extra points, two-point conversions, and blocked kicks are **not score types**.
 They appear in the trailing parenthetical of a touchdown's `score` text.
@@ -177,13 +237,48 @@ four defects in the D/ST and player translation. **This block was read nowhere
 until then**, and three of the four fixes come out of it. Same `home` / `away`
 shape as `DST`, same string-typed values (`blockedFG: "1"`, not `1`).
 
-| Field                        | What it is                                          |
-| ---------------------------- | --------------------------------------------------- |
-| `blockedFG`                  | Field goals **this team blocked**                   |
-| `blockedPunt`                | Punts this team blocked                             |
-| `blockedXP`                  | Extra points this team blocked                      |
-| `defensiveOrSpecialTeamsTds` | Def + ST touchdowns — **double-counted, see below** |
-| `safeties`                   | Safeties this team scored                           |
+| Field                                | What it is                                            |
+| ------------------------------------ | ----------------------------------------------------- |
+| `blockedFG`                          | Field goals **this team blocked**                     |
+| `blockedPunt`                        | Punts this team blocked                               |
+| `blockedXP`                          | Extra points this team blocked                        |
+| `defensiveOrSpecialTeamsTds`         | Def + ST touchdowns — **double-counted, see below**   |
+| `safeties`                           | Safeties this team scored                             |
+| `defensiveTwoPointConversionReturns` | Failed conversions this defence took back — **2 pts** |
+| `fumblesLost`                        | Fumbles **this team lost**, not recoveries it made    |
+
+The full key list, from a captured response, so a field can be looked for before
+it is guessed at:
+
+```
+totalYards rushingAttempts rushingYards fumblesLost penalties totalPlays
+possession safeties passCompletionsAndAttempts passingFirstDowns
+interceptionsThrown sacksAndYardsLost thirdDownEfficiency blockedPunt
+yardsPerPlay redZoneScoredAndAttempted teamID defensiveInterceptions
+defensiveOrSpecialTeamsTds totalDrives rushingFirstDowns blockedFG rushTD
+twoPointConversions firstDowns passTD team blockedXP teamAbv
+firstDownsFromPenalties fourthDownEfficiency defensiveTwoPointConversionReturns
+passingYards yardsPerRush snapCounts turnovers yardsPerPass
+```
+
+**There is no fumble-recovery counter here**, which is the point of listing it
+in full — see [fumble recoveries](#dstfumblesrecovered-is-the-opponents-fumbles-lost)
+below.
+
+### Defensive two-point conversion returns
+
+A defence that takes a failed conversion attempt back the other way scores **2**
+under ESPN's table. We had no stat key at all until 2026-08-17, so it scored
+nothing: three occurrences across 2024 and 2025 — Dallas in 2025 week 4
+(`"Markquese Bell Defensive PAT Conversion"`), Miami in 2025 week 13,
+Philadelphia in 2024 week 4.
+
+`teamStats.defensiveTwoPointConversionReturns` carries the count, and it is read
+as a number rather than parsed out of the play text: the wording varies, the
+event is rare enough that a pattern would go years without being exercised, and
+unlike a field goal's distance there is nothing here that only the prose knows.
+
+Added as `def_2pt_ret`, schemaVersion 6 → 7. Stat keys are append-only.
 
 ### Blocked kicks are credited to the blocking team
 
@@ -296,6 +391,39 @@ points.** `Defense.defTD` did the same to Tyler Lockett, a wide receiver, for
 
 **`Defense.fumblesLost` stays mapped.** That one really is the offensive player's
 own stat.
+
+### `DST.fumblesRecovered` is the opponent's fumbles lost
+
+Not this unit's recoveries, which is what the name suggests and what the scoring
+rule wants. Established 2026-08-17 by separating the two candidate readings
+across 22 team-games: they agree on almost all of them, `20251005_TEN@ARI`
+discriminates, and the field follows fumbles-lost.
+
+They agree so often because almost every fumble a team loses is recovered by the
+opposing defence. **They part company when a defender fumbles during an
+interception return and the intercepted team recovers.** ESPN pays the recovering
+unit 2 and this field does not see it. Three occurrences over 2024 and 2025,
+each confirmed against play-by-play, with Sleeper right in all three:
+
+```
+20250925_SEA@ARI    20251130_MIN@SEA    20251208_PHI@LAC
+```
+
+**Left as it is, and that is a finding rather than a deferral.** There is no
+field in this feed that means "this defence's recoveries":
+
+- `teamStats` has no recovery counter at all — see the full key list above.
+- Per-player `Defense.fumblesRecovered` is contaminated by design. A player who
+  falls on his own fumble carries it (185 player-weeks of 2025), and a teammate
+  recovering a teammate's fumble is indistinguishable from a defender recovering
+  an opponent's, so no filter separates them.
+- Summing the per-player field and subtracting `own fumbles − own fumbles lost`
+  would close the arithmetic, and it is a derivation dressed as a reading: two
+  provider fields, one assumption about how fumbles are attributed, and no way to
+  check the answer against anything.
+
+A three-team-week undercount that is written down beats a number nobody can
+check. If this becomes worth fixing, the fix is a second provider, not a formula.
 
 ### `"Recovery"` is not a synonym for `"Return"`
 
@@ -529,7 +657,10 @@ whole phrases.
 
 ## Known gaps
 
-**None that affect the stats we currently score.** Every stat in the PPR table is
+**One, named and measured** — see
+[`DST.fumblesRecovered`](#dstfumblesrecovered-is-the-opponents-fumbles-lost),
+which undercounts a unit's recoveries by one in three team-weeks across two
+seasons and has no substitute in this feed. Everything else in the PPR table is
 obtainable:
 
 - ✅ Passing, rushing, receiving, receptions — direct fields
@@ -544,6 +675,10 @@ obtainable:
 - ✅ Defensive and special teams touchdowns — `DST.defTD` plus the special teams
   scores it does not already contain. **Not a single field**; see
   [`teamStats`](#teamstats--the-second-team-level-block) for why.
+- ✅ Defensive two-point conversion returns —
+  `teamStats.defensiveTwoPointConversionReturns`
+- ⚠️ Fumble recoveries — `DST.fumblesRecovered`, which is really the opponent's
+  fumbles lost and is one low when a defender fumbles during a return
 
 Outstanding questions, none blocking:
 

--- a/packages/core/src/rules/nfl-ppr.ts
+++ b/packages/core/src/rules/nfl-ppr.ts
@@ -68,6 +68,11 @@ export const NFL_PPR_SCORING: readonly ScoringRule[] = [
   { statKey: "def_safety", kind: "LINEAR", milliPointsPerUnit: pts(2) },
   { statKey: "def_td", kind: "LINEAR", milliPointsPerUnit: pts(6) },
   { statKey: "def_blk_kick", kind: "LINEAR", milliPointsPerUnit: pts(2) },
+  // A defence that returns a failed two-point conversion scores 2, exactly as it
+  // does for a safety. ESPN's value; Sleeper pays the same. Added 2026-08-17
+  // because we had no rule for it and therefore paid nothing — three occurrences
+  // over 2024 and 2025, each 2 points to a unit somebody had started.
+  { statKey: "def_2pt_ret", kind: "LINEAR", milliPointsPerUnit: pts(2) },
   // Both defensive tiers are ESPN's, decoded from their own published data
   // rather than from documentation: their scoring API returns values keyed by
   // numeric stat id with no names, so the boundaries were pinned by recomputing
@@ -256,7 +261,7 @@ export function buildNflPprRules(overrides: NflPprOverrides): LeagueRules {
   const pot = overrides.pot ?? null;
 
   return structuredClone({
-    schemaVersion: 6,
+    schemaVersion: 7,
     sportKey: "nfl",
     seasonYear: overrides.seasonYear,
     scoring: NFL_PPR_SCORING,

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -847,8 +847,35 @@ describe("hashLeagueRules", () => {
     //   player-weeks of the 2025 season against the totals ESPN itself
     //   published. See `docs/TANK01.md`.
     // No leagues existed on any of these occasions.
+    //
+    // Moved 2026-08-17: schemaVersion 6 -> 7, adding `def_2pt_ret` — a defensive
+    //   two-point conversion return, which ESPN pays the unit 2 for and we had
+    //   no stat key for at all, so it scored nothing. Three occurrences across
+    //   2024 and 2025: Dallas in 2025 week 4, Miami in 2025 week 13,
+    //   Philadelphia in 2024 week 4. Tank01 carries the count as
+    //   `teamStats.defensiveTwoPointConversionReturns`.
+    //
+    //   **"No leagues existed" is not the claim this time, and repeating it
+    //   would have been false.** Four test leagues were created in the deployed
+    //   database before 2026-08-16 and are recorded as retired to `DISSOLVED`;
+    //   `apps/web/src/app/api/cron/score-week/route.test.ts` also creates and
+    //   dissolves leagues there whenever `DATABASE_URL` is set. What makes this
+    //   safe is a different fact, and a stronger one: **an addition cannot reach
+    //   a league that already exists.** A frozen league holds its own copy of
+    //   the scoring table in `league_rules.rule_json`, `scorePlayer` skips a
+    //   stat with no matching rule by design, and so a key those leagues have
+    //   never heard of scores them nothing — which is exactly right. The move
+    //   that does damage is a *rename* or a removal, which is what #162 and
+    //   `sports/stat-keys.test.ts` exist to catch, and this is neither.
+    //
+    //   Two consequences that are not about the hash. `seedSport` must be re-run
+    //   against any deployed database before the next box-score ingest, or
+    //   `ingestOneGame` throws on a stat key `stat_keys` does not hold — that is
+    //   deliberate and it is loud. And the four dissolved leagues do not gain
+    //   the rule, because frozen rules cannot be migrated; nothing can be done
+    //   about that and nothing should be.
     expect(hashLeagueRules(FIXTURE)).toBe(
-      "78f352c59a0716f3a333fcd5eb641e4f1c32dbe7c31033cb4450535f96275ec3",
+      "01e0dad789032549089087829bf1177569cf968610018c04dff31d00ef33b2bb",
     );
   });
 });

--- a/packages/core/src/rules/types.ts
+++ b/packages/core/src/rules/types.ts
@@ -341,6 +341,17 @@ export type LeagueRules = {
    * 1 → 2 added `pot.feeBps` and `pot.feeRecipient`.
    * 2 → 3 replaced `league.botsAllowed` with `league.maxBots`.
    * 3 → 4 removed `abandonment` and added `roster.autofill`.
+   * 4 → 5 changed the default payout to 70/20/10, so that every prize is
+   *       decidable in a league of any size.
+   * 5 → 6 aligned the scoring table with ESPN — `fg_50_plus` split, `fg_missed`
+   *       and `def_yds_allowed` added, the points-allowed ladder replaced.
+   * 6 → 7 added `def_2pt_ret`, a defensive two-point conversion return.
+   *
+   * This list stopped at 3 → 4 for two versions, which made it look as though
+   * nothing had moved since. The changelog that decides anything is the dated
+   * one on the golden fixture in `rules.test.ts`; this one exists so the
+   * declaration below is readable, and a stale copy of a record is worse than no
+   * copy.
    *
    * Bumping this is the honest way to change the rule schema: it changes the
    * canonical encoding and therefore every hash, so the golden fixture in
@@ -349,7 +360,7 @@ export type LeagueRules = {
    * one does, a schema change means supporting both versions — the rules of a
    * created league can never be re-encoded.
    */
-  readonly schemaVersion: 6;
+  readonly schemaVersion: 7;
   readonly sportKey: string;
   readonly seasonYear: number;
   readonly scoring: readonly ScoringRule[];

--- a/packages/core/src/sports/nfl.ts
+++ b/packages/core/src/sports/nfl.ts
@@ -65,6 +65,13 @@ export const NFL_STAT_KEYS = [
   // points and yards; we had only points, which meant a unit that bent without
   // breaking scored identically to one that did not.
   { key: "def_yds_allowed", displayName: "Yards Allowed", kind: "TIERED" },
+  // A failed two-point conversion taken back the other way, added 2026-08-17.
+  // ESPN pays the unit 2 and we had no key at all, so it scored nothing: three
+  // occurrences across 2024 and 2025. Appended rather than slotted in beside the
+  // other defensive counters — stat keys are append-only, and while a *position*
+  // in this list is not what a frozen league holds on to, keeping additions at
+  // the end is what makes the history readable next to `stat-keys.test.ts`.
+  { key: "def_2pt_ret", displayName: "Defensive Two-Point Returns", kind: "LINEAR" },
 ] as const satisfies SportDef["statKeys"];
 
 export const NFL_POSITIONS = [

--- a/packages/core/src/sports/stat-keys.test.ts
+++ b/packages/core/src/sports/stat-keys.test.ts
@@ -69,6 +69,7 @@ const EVER_DEFINED = [
   "def_blk_kick",
   "def_pts_allowed",
   "def_yds_allowed",
+  "def_2pt_ret",
 ] as const;
 
 /**

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -5,7 +5,7 @@ import type { ProviderBoxScore, StatsProvider } from "@rostr/stats";
 import { seedSport } from "./sports.js";
 import { createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
-import { syncBoxScores } from "./box-scores.js";
+import { syncBoxScores, unresolvedStatsProblems } from "./box-scores.js";
 
 /**
  * The producer, against the real translator.
@@ -294,13 +294,121 @@ describe("syncBoxScores", () => {
 
     expect(await currentValue(fx, "DST_PHI", "def_sack")).toBeNull();
     expect(await currentValue(fx, "qb1", "pass_yd")).toBe(300);
-    expect(result.failures[0]?.reason).toContain("def_pts_allowed");
+
+    // **A warning, not a failure**, and this assertion read `failures` until
+    // 2026-08-17. The game was ingested — the quarterback's line is right there
+    // on the line above — so calling it a failed ingest is false in both
+    // directions: it raises a false alarm on a run that worked, and it puts a
+    // discrepancy in the same count as a game nobody could read at all.
+    expect(result.failures).toEqual([]);
+    expect(result.warnings[0]?.warning).toContain("def_pts_allowed");
+    expect(result.warnings[0]?.gameRef).toBe("g1");
 
     const [row] = await fx.client.query<{ stats_error: string | null }>(
       "SELECT stats_error FROM games WHERE id = $1",
       [fx.gameId],
     );
     expect(row?.stats_error).toContain("DST_PHI");
+  });
+
+  it("keeps a translator warning apart from a game that could not be read", async () => {
+    // The distinction the `fatal`/`warnings` split makes upstream, carried
+    // through to the caller. Both games below produce something worth saying;
+    // only one of them lost any data.
+    const fx = await setup();
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                          kickoff_at, status, final_at)
+       VALUES ($1, 'g2', $2, $3, 'BUF', 'NYJ', now() - interval '3 hours', 'FINAL',
+               now() - interval '1 hour')`,
+      [sport!.id, SEASON, WEEK],
+    );
+
+    const result = await syncBoxScores(
+      fx.client,
+      fakeProvider(
+        new Map<string, ProviderBoxScore | Error>([
+          [
+            "g1",
+            boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses }, [
+              'scoreType "XPR" has not been seen before',
+              "Somebody: unparseable field goal",
+            ]),
+          ],
+          ["g2", new Error("provider exploded")],
+        ]),
+      ),
+      NFL.key,
+      SEASON,
+    );
+
+    // Both warnings survive as separate entries rather than one joined string,
+    // so a caller can count them and a reader can read them.
+    expect(result.warnings.map((entry) => entry.gameRef)).toEqual(["g1", "g1"]);
+    expect(result.warnings[0]?.warning).toContain("XPR");
+    expect(result.failures.map((entry) => entry.gameRef)).toEqual(["g2"]);
+
+    // And the stats still landed for the game that warned.
+    expect(await currentValue(fx, "qb1", "pass_yd")).toBe(300);
+  });
+
+  it("reads unresolved problems back out of the column that stores them", async () => {
+    // `games.stats_error` has been written since `0027` and read by nothing, so
+    // a discrepancy survived the run that found it and was visible to nobody:
+    // `cron_runs` holds one row per job and the next clean run overwrites it.
+    const fx = await setup();
+
+    await syncBoxScores(
+      fx.client,
+      fakeProvider(
+        new Map([
+          ["g1", boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses }, ["odd"])],
+        ]),
+      ),
+      NFL.key,
+      SEASON,
+    );
+
+    const outstanding = await unresolvedStatsProblems(fx.client, NFL.key);
+
+    expect(outstanding.total).toBe(1);
+    expect(outstanding.games).toEqual([
+      { gameRef: "g1", season: SEASON, week: WEEK, problem: "odd" },
+    ]);
+  });
+
+  it("reports nothing once the game has been re-read cleanly", async () => {
+    // The other half: a problem has to be able to stop being reported, or the
+    // count only ever grows and becomes noise. `stats_error` is overwritten on
+    // every ingest, including with null.
+    const fx = await setup();
+    const good = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses });
+
+    await syncBoxScores(
+      fx.client,
+      fakeProvider(
+        new Map([
+          ["g1", boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses }, ["odd"])],
+        ]),
+      ),
+      NFL.key,
+      SEASON,
+    );
+    expect((await unresolvedStatsProblems(fx.client, NFL.key)).total).toBe(1);
+
+    // The retry clause needs the last attempt to be older than
+    // FAILED_RETRY_MINUTES, which it is not in a test that just ran.
+    await fx.client.query(
+      "UPDATE games SET stats_synced_at = now() - interval '1 hour' WHERE id = $1",
+      [fx.gameId],
+    );
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", good]])), NFL.key, SEASON);
+
+    expect((await unresolvedStatsProblems(fx.client, NFL.key)).total).toBe(0);
   });
 
   it("keeps going when one game cannot be read", async () => {

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -92,7 +92,30 @@ export interface BoxScoreSyncResult {
   readonly unchanged: number;
   /** Named, not counted. A bare count once hid "every kicker in the league". */
   readonly unmatched: readonly string[];
+  /**
+   * Games that could not be ingested at all.
+   *
+   * The provider threw, the response translated to nothing, or the sport
+   * registry and the provider map have diverged. Nothing was written for these.
+   */
   readonly failures: readonly { readonly gameRef: string; readonly reason: string }[];
+  /**
+   * Games that **were** ingested, carrying something that did not reconcile.
+   *
+   * Separate from {@link failures}, and it was not: every warning the translator
+   * raised was pushed onto that array, so the stats cron reported a game whose
+   * ninety players all landed correctly as one that "failed to ingest". Both
+   * directions of that are bad. A discrepancy read as a failure is a false alarm
+   * on a healthy run, and — worse — it buries a real failure in the same count,
+   * which is how a check stops being read at all.
+   *
+   * It matters more here than the mislabelling suggests. A week finalises after
+   * 48 hours and is never rescored, so a warning nobody reads before then is a
+   * permanently wrong score, and this is the only path by which a novel play
+   * type or a renamed provider field becomes visible without somebody sweeping a
+   * season by hand.
+   */
+  readonly warnings: readonly { readonly gameRef: string; readonly warning: string }[];
 }
 
 interface DueGame {
@@ -224,6 +247,7 @@ export async function syncBoxScores(
   let unchanged = 0;
   const unmatched: string[] = [];
   const failures: { gameRef: string; reason: string }[] = [];
+  const warnings: { gameRef: string; warning: string }[] = [];
 
   for (const game of due) {
     try {
@@ -235,8 +259,11 @@ export async function syncBoxScores(
       retracted += outcome.retracted;
       unchanged += outcome.unchanged;
       unmatched.push(...outcome.unmatched);
-      if (outcome.problem) {
-        failures.push({ gameRef: game.external_ref, reason: outcome.problem });
+      // One entry per warning rather than one joined string per game, so a
+      // caller can count them and a reader can see them. The joined form still
+      // goes to `games.stats_error`, which is a column and wants one value.
+      for (const warning of outcome.warnings) {
+        warnings.push({ gameRef: game.external_ref, warning });
       }
     } catch (error) {
       // **One game's failure never stops the other fifteen.** The shape every
@@ -257,7 +284,82 @@ export async function syncBoxScores(
     }
   }
 
-  return { games: due.length, inserted, revised, retracted, unchanged, unmatched, failures };
+  return {
+    games: due.length,
+    inserted,
+    revised,
+    retracted,
+    unchanged,
+    unmatched,
+    failures,
+    warnings,
+  };
+}
+
+/**
+ * Games still carrying an unresolved ingest problem.
+ *
+ * **The reader `games.stats_error` never had.** The column has been written
+ * since `0027` — by warnings as much as by failures, which is exactly what paces
+ * the retry — and nothing anywhere read it back. So a discrepancy survived the
+ * run that found it, survived the week finalising around it, and was visible to
+ * nobody: `cron_runs.last_outcome` holds one row per job and the next clean run
+ * overwrites it, so a warning raised at noon is gone by ten past.
+ *
+ * Ordered most recent first and bounded, because this is read on a ten-minute
+ * cadence and the interesting thing is that there are problems rather than the
+ * full list of them. The count is returned alongside so a truncated list cannot
+ * read as the whole of it.
+ *
+ * Not scoped to a season on purpose. A game inside its correction window is
+ * still being re-read, and one past it never will be again — that second case is
+ * the one worth surfacing, because whatever it says is now permanent.
+ */
+export async function unresolvedStatsProblems(
+  db: SqlClient,
+  sportKey: string,
+  limit = 20,
+): Promise<{
+  readonly total: number;
+  readonly games: readonly {
+    readonly gameRef: string;
+    readonly season: number;
+    readonly week: number;
+    readonly problem: string;
+  }[];
+}> {
+  const ids = await loadSportIds(db, sportKey);
+
+  const [counted] = await db.query<{ total: string }>(
+    `SELECT count(*)::text AS total
+       FROM games
+      WHERE sport_id = $1 AND stats_error IS NOT NULL`,
+    [ids.sportId],
+  );
+
+  const games = await db.query<{
+    external_ref: string;
+    season: number;
+    week: number;
+    stats_error: string;
+  }>(
+    `SELECT external_ref, season, week, stats_error
+       FROM games
+      WHERE sport_id = $1 AND stats_error IS NOT NULL
+      ORDER BY kickoff_at DESC
+      LIMIT $2`,
+    [ids.sportId, limit],
+  );
+
+  return {
+    total: Number(counted?.total ?? 0),
+    games: games.map((row) => ({
+      gameRef: row.external_ref,
+      season: Number(row.season),
+      week: Number(row.week),
+      problem: row.stats_error,
+    })),
+  };
 }
 
 interface GameOutcome {
@@ -266,8 +368,14 @@ interface GameOutcome {
   readonly retracted: number;
   readonly unchanged: number;
   readonly unmatched: string[];
-  /** Set when the game was only partly ingested and must be re-read. */
-  readonly problem: string | null;
+  /**
+   * Everything about this game that did not reconcile.
+   *
+   * The game was still ingested — that is the whole of the `fatal`/`warnings`
+   * split the translator makes, and it is why these are not failures. They are
+   * joined into `games.stats_error`, which is what paces the re-read.
+   */
+  readonly warnings: string[];
 }
 
 async function ingestOneGame(
@@ -406,6 +514,10 @@ async function ingestOneGame(
       [season, week, source, covered, rowPlayer, rowStatKey, ptsAllowedId],
     );
 
+    // Joined into one column, and still called `stats_error` because that is
+    // what `0027` named it and what the work-list query above reads to pace a
+    // re-read. The column's own comment says it is set by warnings too. What the
+    // *caller* is handed is the list, unjoined — see `GameOutcome.warnings`.
     const problem = problems.length > 0 ? problems.join("; ") : null;
     await tx.query("UPDATE games SET stats_synced_at = now(), stats_error = $2 WHERE id = $1", [
       game.id,
@@ -425,7 +537,7 @@ async function ingestOneGame(
       retracted: zeroed.length,
       unchanged: rowValue.length - written.length,
       unmatched,
-      problem,
+      warnings: problems,
     };
   });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -154,6 +154,7 @@ export {
   LIVE_WINDOW_HOURS,
   MAX_GAMES_PER_RUN,
   syncBoxScores,
+  unresolvedStatsProblems,
   type BoxScoreSyncResult,
 } from "./box-scores.js";
 

--- a/packages/stats/src/tank01/__fixtures__/box-score-blocked-punt-scoretype.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-blocked-punt-scoretype.json
@@ -1,0 +1,2801 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "BUF",
+      "teamID": "4",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "0",
+      "ydsAllowed": "457",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "44",
+      "safeties": "0"
+    },
+    "home": {
+      "teamAbv": "LAR",
+      "teamID": "19",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "0",
+      "ydsAllowed": "445",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "42",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Frank Steratore, Craig Wrolstad, Rich Martinez, Steve Woods, Danny Short, Jeff Shears, Brett Bergman",
+  "arena": "SoFi Stadium",
+  "arenaCapacity": "71,500",
+  "attendance": "73,493",
+  "away": "BUF",
+  "awayPts": "42",
+  "awayResult": "L",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20241208",
+  "gameLocation": "Inglewood, CA",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 14",
+  "home": "LAR",
+  "homePts": "44",
+  "homeResult": "W",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "7",
+      "Q2": "7",
+      "Q3": "7",
+      "Q4": "21",
+      "teamID": "4",
+      "currentlyInPossession": "False",
+      "totalPts": "42",
+      "teamAbv": "BUF"
+    },
+    "home": {
+      "Q1": "7",
+      "Q2": "17",
+      "Q3": "14",
+      "Q4": "6",
+      "teamID": "19",
+      "currentlyInPossession": "False",
+      "totalPts": "44",
+      "teamAbv": "LAR"
+    }
+  },
+  "network": "FOX",
+  "playerStats": {
+    "12483": {
+      "gameID": "20241208_BUF@LAR",
+      "Passing": {
+        "qbr": "97.5",
+        "rtg": "132.6",
+        "sacked": "0-0",
+        "passAttempts": "30",
+        "passAvg": "10.7",
+        "passTD": "2",
+        "passYds": "320",
+        "int": "0",
+        "passCompletions": "23"
+      },
+      "scoringPlays": [
+        {
+          "score": "Cooper Kupp 17 Yd pass from Matthew Stafford (Joshua Karty Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "38",
+          "awayScore": "21",
+          "teamID": "19",
+          "scoreDetails": "7 plays, 70 yards, 3:36",
+          "scoreType": "TD",
+          "scoreTime": "0:18",
+          "team": "LAR",
+          "playerIDs": ["12483", "2977187", "4566192"]
+        },
+        {
+          "score": "Puka Nacua 19 Yd pass from Matthew Stafford (Joshua Karty PAT failed)",
+          "scorePeriod": "Q4",
+          "homeScore": "44",
+          "awayScore": "35",
+          "teamID": "19",
+          "scoreDetails": "11 plays, 71 yards, 6:55",
+          "scoreType": "TD",
+          "scoreTime": "1:54",
+          "team": "LAR",
+          "playerIDs": ["12483", "4426515", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "12483",
+      "longName": "Matthew Stafford"
+    },
+    "13976": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "25",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.32"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "13976",
+      "longName": "Von Miller"
+    },
+    "15928": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "101",
+        "punts": "2",
+        "puntAvg": "50.5",
+        "puntsin20": "1",
+        "puntTouchBacks": "0",
+        "puntLong": "55"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "15928",
+      "longName": "Sam Martin"
+    },
+    "16910": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "44",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.57"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "16910",
+      "longName": "DaQuan Jones"
+    },
+    "2310331": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.21",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "16",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "2310331",
+      "longName": "Tyler Johnson"
+    },
+    "2515613": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "2515613",
+      "longName": "Rob Havenstein"
+    },
+    "2577078": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "19",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.25"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "2577078",
+      "longName": "Quinton Jefferson"
+    },
+    "2976499": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "6",
+        "recTD": "0",
+        "longRec": "26",
+        "targets": "14",
+        "recYds": "95",
+        "recAvg": "15.8"
+      },
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.53",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "32",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "2976499",
+      "longName": "Amari Cooper"
+    },
+    "2976549": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "2976549",
+      "longName": "Reid Ferguson"
+    },
+    "2977187": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "37",
+        "targets": "8",
+        "recYds": "92",
+        "recAvg": "18.4"
+      },
+      "scoringPlays": [
+        {
+          "score": "Cooper Kupp 17 Yd pass from Matthew Stafford (Joshua Karty Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "38",
+          "awayScore": "21",
+          "teamID": "19",
+          "scoreDetails": "7 plays, 70 yards, 3:36",
+          "scoreType": "TD",
+          "scoreTime": "0:18",
+          "team": "LAR",
+          "playerIDs": ["12483", "2977187", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.83",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "64",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "2977187",
+      "longName": "Cooper Kupp"
+    },
+    "2979591": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "21",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.27"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "2979591",
+      "longName": "Austin Johnson"
+    },
+    "2991662": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "4",
+        "recTD": "1",
+        "longRec": "21",
+        "targets": "6",
+        "recYds": "57",
+        "recAvg": "14.3"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mack Hollins 21 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "38",
+          "awayScore": "35",
+          "teamID": "4",
+          "scoreDetails": "10 plays, 91 yards, 4:03",
+          "scoreType": "TD",
+          "scoreTime": "8:49",
+          "team": "BUF",
+          "playerIDs": ["3918298", "2991662", "3917232"]
+        }
+      ],
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.77",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "46",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "2991662",
+      "longName": "Mack Hollins"
+    },
+    "3043116": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "0",
+        "recTD": "0",
+        "longRec": "0",
+        "targets": "1",
+        "recYds": "0",
+        "recAvg": "0.0"
+      },
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.61",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "3043116",
+      "longName": "Demarcus Robinson"
+    },
+    "3046287": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "65",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.84"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3046287",
+      "longName": "Matt Milano"
+    },
+    "3051324": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3051324",
+      "longName": "Dion Dawkins"
+    },
+    "3121003": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "76",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "0",
+        "defSnapPct": "0.99"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3121003",
+      "longName": "Taron Johnson"
+    },
+    "3121427": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "1.0",
+        "rushYds": "1",
+        "carries": "1",
+        "longRush": "1",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "11",
+        "targets": "3",
+        "recYds": "15",
+        "recAvg": "7.5"
+      },
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.60",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "36",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3121427",
+      "longName": "Curtis Samuel"
+    },
+    "3122630": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "6",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.10"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "3122630",
+      "longName": "Ahkello Witherspoon"
+    },
+    "3892883": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "15",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.25"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3892883",
+      "longName": "Neville Gallimore"
+    },
+    "3909013": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "48",
+        "stSnap": "10",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.80"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3909013",
+      "longName": "Christian Rozeboom"
+    },
+    "3915411": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "1",
+        "longRec": "41",
+        "targets": "3",
+        "recYds": "55",
+        "recAvg": "27.5"
+      },
+      "scoringPlays": [
+        {
+          "score": "Ty Johnson 41 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "17",
+          "awayScore": "14",
+          "teamID": "4",
+          "scoreDetails": "4 plays, 70 yards, 2:06",
+          "scoreType": "TD",
+          "scoreTime": "10:23",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3915411", "3917232"]
+        }
+      ],
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.35",
+        "defSnap": "0",
+        "stSnap": "4",
+        "stSnapPct": "0.12",
+        "offSnap": "21",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3915411",
+      "longName": "Ty Johnson"
+    },
+    "3916577": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "13",
+        "stSnap": "27",
+        "stSnapPct": "0.82",
+        "offSnap": "0",
+        "defSnapPct": "0.17"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3916577",
+      "longName": "Cam Lewis"
+    },
+    "3917232": {
+      "gameID": "20241208_BUF@LAR",
+      "scoringPlays": [
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "7",
+          "teamID": "4",
+          "scoreDetails": "9 plays, 70 yards, 5:04",
+          "scoreType": "TD",
+          "scoreTime": "3:22",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        },
+        {
+          "score": "Ty Johnson 41 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "17",
+          "awayScore": "14",
+          "teamID": "4",
+          "scoreDetails": "4 plays, 70 yards, 2:06",
+          "scoreType": "TD",
+          "scoreTime": "10:23",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3915411", "3917232"]
+        },
+        {
+          "score": "Khalil Shakir 51 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "31",
+          "awayScore": "21",
+          "teamID": "4",
+          "scoreDetails": "6 plays, 80 yards, 4:32",
+          "scoreType": "TD",
+          "scoreTime": "3:54",
+          "team": "BUF",
+          "playerIDs": ["3918298", "4373678", "3917232"]
+        },
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "38",
+          "awayScore": "28",
+          "teamID": "4",
+          "scoreDetails": "5 plays, 70 yards, 0:51",
+          "scoreType": "TD",
+          "scoreTime": "14:27",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        },
+        {
+          "score": "Mack Hollins 21 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "38",
+          "awayScore": "35",
+          "teamID": "4",
+          "scoreDetails": "10 plays, 91 yards, 4:03",
+          "scoreType": "TD",
+          "scoreTime": "8:49",
+          "team": "BUF",
+          "playerIDs": ["3918298", "2991662", "3917232"]
+        },
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "44",
+          "awayScore": "42",
+          "teamID": "4",
+          "scoreDetails": "8 plays, 70 yards, 0:54",
+          "scoreType": "TD",
+          "scoreTime": "1:00",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        }
+      ],
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "13",
+        "stSnapPct": "0.40",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "0",
+        "fgMade": "0",
+        "fgAttempts": "0",
+        "xpMade": "6",
+        "fgPct": "0.0",
+        "kickingPts": "5",
+        "xpAttempts": "6",
+        "fgMissed": "0",
+        "xpMissed": "0"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3917232",
+      "longName": "Tyler Bass"
+    },
+    "3917599": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "3917599",
+      "longName": "Kevin Dotson"
+    },
+    "3917660": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3917660",
+      "longName": "David Edwards"
+    },
+    "3918298": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "8.2",
+        "rushYds": "82",
+        "carries": "10",
+        "longRush": "30",
+        "rushTD": "3"
+      },
+      "Passing": {
+        "qbr": "90.8",
+        "rtg": "117.2",
+        "sacked": "0-0",
+        "passAttempts": "37",
+        "passAvg": "9.2",
+        "passTD": "3",
+        "passYds": "342",
+        "int": "0",
+        "passCompletions": "22"
+      },
+      "scoringPlays": [
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "7",
+          "teamID": "4",
+          "scoreDetails": "9 plays, 70 yards, 5:04",
+          "scoreType": "TD",
+          "scoreTime": "3:22",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        },
+        {
+          "score": "Ty Johnson 41 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "17",
+          "awayScore": "14",
+          "teamID": "4",
+          "scoreDetails": "4 plays, 70 yards, 2:06",
+          "scoreType": "TD",
+          "scoreTime": "10:23",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3915411", "3917232"]
+        },
+        {
+          "score": "Khalil Shakir 51 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "31",
+          "awayScore": "21",
+          "teamID": "4",
+          "scoreDetails": "6 plays, 80 yards, 4:32",
+          "scoreType": "TD",
+          "scoreTime": "3:54",
+          "team": "BUF",
+          "playerIDs": ["3918298", "4373678", "3917232"]
+        },
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "38",
+          "awayScore": "28",
+          "teamID": "4",
+          "scoreDetails": "5 plays, 70 yards, 0:51",
+          "scoreType": "TD",
+          "scoreTime": "14:27",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        },
+        {
+          "score": "Mack Hollins 21 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "38",
+          "awayScore": "35",
+          "teamID": "4",
+          "scoreDetails": "10 plays, 91 yards, 4:03",
+          "scoreType": "TD",
+          "scoreTime": "8:49",
+          "team": "BUF",
+          "playerIDs": ["3918298", "2991662", "3917232"]
+        },
+        {
+          "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "44",
+          "awayScore": "42",
+          "teamID": "4",
+          "scoreDetails": "8 plays, 70 yards, 0:54",
+          "scoreType": "TD",
+          "scoreTime": "1:00",
+          "team": "BUF",
+          "playerIDs": ["3918298", "3917232"]
+        }
+      ],
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3918298",
+      "longName": "Josh Allen"
+    },
+    "3930086": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "1",
+        "recYds": "5",
+        "recAvg": "5.0"
+      },
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.82",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "49",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3930086",
+      "longName": "Dawson Knox"
+    },
+    "3931408": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "12",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.16"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "3931408",
+      "longName": "Casey Toohill"
+    },
+    "3943270": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "61",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.79"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3943270",
+      "longName": "Rasul Douglas"
+    },
+    "4030899": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4030899",
+      "longName": "Spencer Brown"
+    },
+    "4033234": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "14",
+        "stSnapPct": "0.42",
+        "offSnap": "0",
+        "defSnapPct": "0.60"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4033234",
+      "longName": "Michael Hoecht"
+    },
+    "4033748": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4033748",
+      "longName": "Connor McGovern"
+    },
+    "4036060": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "13",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "7",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4036060",
+      "longName": "Damar Hamlin"
+    },
+    "4036135": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4036135",
+      "longName": "Alaric Jackson"
+    },
+    "4036448": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.02",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4036448",
+      "longName": "Jalen Virgil"
+    },
+    "4039007": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "13",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "8",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4039007",
+      "longName": "Taylor Rapp"
+    },
+    "4039303": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "53",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.69"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "2",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4039303",
+      "longName": "Ed Oliver"
+    },
+    "4039505": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.05",
+        "defSnap": "0",
+        "stSnap": "24",
+        "stSnapPct": "0.73",
+        "offSnap": "3",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4039505",
+      "longName": "Reggie Gilliam"
+    },
+    "4239140": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4239140",
+      "longName": "Ryan Van Demark"
+    },
+    "4239833": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "58",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.97"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4239833",
+      "longName": "Darious Williams"
+    },
+    "4239944": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "0",
+        "recTD": "0",
+        "longRec": "0",
+        "targets": "1",
+        "recYds": "0",
+        "recAvg": "0.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "17",
+          "awayScore": "7",
+          "teamID": "19",
+          "scoreDetails": "4 plays, 18 yards, 1:08",
+          "scoreType": "BP",
+          "scoreTime": "12:29",
+          "team": "LAR",
+          "playerIDs": ["4239944", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.23",
+        "defSnap": "0",
+        "stSnap": "26",
+        "stSnapPct": "0.79",
+        "offSnap": "18",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4239944",
+      "longName": "Hunter Long"
+    },
+    "4240059": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "16",
+        "stSnap": "23",
+        "stSnapPct": "0.70",
+        "offSnap": "0",
+        "defSnapPct": "0.21"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240059",
+      "longName": "Ja'Marcus Ingram"
+    },
+    "4240585": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "52",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.68"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240585",
+      "longName": "AJ Epenesa"
+    },
+    "4241250": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "2",
+        "stSnap": "24",
+        "stSnapPct": "0.73",
+        "offSnap": "0",
+        "defSnapPct": "0.03"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4241250",
+      "longName": "Jacob Hummel"
+    },
+    "4242154": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "56",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.93"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4242154",
+      "longName": "Kamren Curl"
+    },
+    "4242557": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "11",
+        "targets": "1",
+        "recYds": "11",
+        "recAvg": "11.0"
+      },
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.48",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "37",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4242557",
+      "longName": "Colby Parkinson"
+    },
+    "4243003": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "19",
+        "stSnapPct": "0.58",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4243003",
+      "longName": "Ronnie Rivers"
+    },
+    "4243545": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4243545",
+      "longName": "Alex Ward"
+    },
+    "4249128": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "60",
+        "stSnap": "8",
+        "stSnapPct": "0.24",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4249128",
+      "longName": "Quentin Lake"
+    },
+    "4250621": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "45",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.75"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4250621",
+      "longName": "Kobie Turner"
+    },
+    "4259166": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "8",
+        "stSnapPct": "0.24",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "10",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "4",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4259166",
+      "longName": "Terrel Bernard"
+    },
+    "4360773": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "19",
+        "stSnapPct": "0.58",
+        "offSnap": "0",
+        "defSnapPct": "0.05"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4360773",
+      "longName": "Nick Hampton"
+    },
+    "4360797": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "21",
+        "targets": "3",
+        "recYds": "45",
+        "recAvg": "15.0"
+      },
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.45",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "35",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4360797",
+      "longName": "Tutu Atwell"
+    },
+    "4360859": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4360859",
+      "longName": "Justin Dedich"
+    },
+    "4362245": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.63"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362245",
+      "longName": "Braden Fiske"
+    },
+    "4362294": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "13",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.22"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362294",
+      "longName": "Desjuan Johnson"
+    },
+    "4362474": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4362474",
+      "longName": "Steve Avila"
+    },
+    "4362506": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "58",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.75"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4362506",
+      "longName": "Greg Rousseau"
+    },
+    "4366349": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "26",
+        "stSnapPct": "0.79",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4366349",
+      "longName": "Joe Andreessen"
+    },
+    "4367203": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.15",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.30",
+        "offSnap": "9",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4367203",
+      "longName": "Alec Anderson"
+    },
+    "4368113": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.52",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4368113",
+      "longName": "Charles Woods"
+    },
+    "4372518": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "15",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.25"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4372518",
+      "longName": "Bobby Brown III"
+    },
+    "4373678": {
+      "gameID": "20241208_BUF@LAR",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "1",
+        "longRec": "51",
+        "targets": "8",
+        "recYds": "106",
+        "recAvg": "21.2"
+      },
+      "scoringPlays": [
+        {
+          "score": "Khalil Shakir 51 Yd pass from Josh Allen (Tyler Bass Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "31",
+          "awayScore": "21",
+          "teamID": "4",
+          "scoreDetails": "6 plays, 80 yards, 4:32",
+          "scoreType": "TD",
+          "scoreTime": "3:54",
+          "team": "BUF",
+          "playerIDs": ["3918298", "4373678", "3917232"]
+        }
+      ],
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.78",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4373678",
+      "longName": "Khalil Shakir"
+    },
+    "4379399": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "3.3",
+        "rushYds": "20",
+        "carries": "6",
+        "longRush": "8",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "2",
+        "recYds": "9",
+        "recAvg": "4.5"
+      },
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.45",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "27",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4379399",
+      "longName": "James Cook"
+    },
+    "4379778": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "Defense": {
+        "totalTackles": "8",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "2"
+      },
+      "playerID": "4379778",
+      "longName": "Christian Benford"
+    },
+    "4384549": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "50",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.83"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4384549",
+      "longName": "Cobie Durant"
+    },
+    "4386544": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntReturns": "1",
+        "puntReturnYds": "8",
+        "puntReturnAvg": "8.0",
+        "puntReturnLong": "8",
+        "puntReturnTD": "0"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4386544",
+      "longName": "Xavier Smith"
+    },
+    "4426515": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "3.2",
+        "rushYds": "16",
+        "carries": "5",
+        "longRush": "9",
+        "rushTD": "1"
+      },
+      "Receiving": {
+        "receptions": "12",
+        "recTD": "1",
+        "longRec": "21",
+        "targets": "14",
+        "recYds": "162",
+        "recAvg": "13.5"
+      },
+      "scoringPlays": [
+        {
+          "score": "Puka Nacua 4 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "24",
+          "awayScore": "14",
+          "teamID": "19",
+          "scoreDetails": "12 plays, 76 yards, 7:47",
+          "scoreType": "TD",
+          "scoreTime": "2:36",
+          "team": "LAR",
+          "playerIDs": ["4426515", "4566192"]
+        },
+        {
+          "score": "Puka Nacua 19 Yd pass from Matthew Stafford (Joshua Karty PAT failed)",
+          "scorePeriod": "Q4",
+          "homeScore": "44",
+          "awayScore": "35",
+          "teamID": "19",
+          "scoreDetails": "11 plays, 71 yards, 6:55",
+          "scoreType": "TD",
+          "scoreTime": "1:54",
+          "team": "LAR",
+          "playerIDs": ["12483", "4426515", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.77",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4426515",
+      "longName": "Puka Nacua"
+    },
+    "4426536": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.49",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4426536",
+      "longName": "Lewis Cine"
+    },
+    "4426553": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.29",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "22",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4426553",
+      "longName": "Davis Allen"
+    },
+    "4426883": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.31"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4426883",
+      "longName": "DeWayne Carter"
+    },
+    "4427120": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "23",
+        "stSnapPct": "0.70",
+        "offSnap": "0",
+        "defSnapPct": "0.40"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4427120",
+      "longName": "Jaylen McCollough"
+    },
+    "4428548": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.55",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4428548",
+      "longName": "Javon Solomon"
+    },
+    "4428550": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "14",
+        "stSnapPct": "0.42",
+        "offSnap": "0",
+        "defSnapPct": "0.60"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428550",
+      "longName": "Omar Speights"
+    },
+    "4428696": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "60",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4428696",
+      "longName": "O'Cyrus Torrence"
+    },
+    "4429096": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "4.3",
+        "rushYds": "34",
+        "carries": "8",
+        "longRush": "11",
+        "rushTD": "0"
+      },
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.17",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.48",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4429096",
+      "longName": "Blake Corum"
+    },
+    "4429501": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.22",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.27",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "14",
+        "kickReturnAvg": "14.0",
+        "kickReturnLong": "14"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4429501",
+      "longName": "Ray Davis"
+    },
+    "4430737": {
+      "gameID": "20241208_BUF@LAR",
+      "Rushing": {
+        "rushAvg": "3.0",
+        "rushYds": "87",
+        "carries": "29",
+        "longRush": "12",
+        "rushTD": "2"
+      },
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "6",
+        "targets": "2",
+        "recYds": "10",
+        "recAvg": "5.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Kyren Williams 3 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "0",
+          "teamID": "19",
+          "scoreDetails": "12 plays, 70 yards, 6:34",
+          "scoreType": "TD",
+          "scoreTime": "8:26",
+          "team": "LAR",
+          "playerIDs": ["4430737", "4566192"]
+        },
+        {
+          "score": "Kyren Williams 7 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "31",
+          "awayScore": "14",
+          "teamID": "19",
+          "scoreDetails": "11 plays, 76 yards, 5:29",
+          "scoreType": "TD",
+          "scoreTime": "8:26",
+          "team": "LAR",
+          "playerIDs": ["4430737", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.83",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "64",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4430737",
+      "longName": "Kyren Williams"
+    },
+    "4430815": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.18",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4430815",
+      "longName": "Sedrick Van Pran-Granger"
+    },
+    "4566192": {
+      "gameID": "20241208_BUF@LAR",
+      "scoringPlays": [
+        {
+          "score": "Kyren Williams 3 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "0",
+          "teamID": "19",
+          "scoreDetails": "12 plays, 70 yards, 6:34",
+          "scoreType": "TD",
+          "scoreTime": "8:26",
+          "team": "LAR",
+          "playerIDs": ["4430737", "4566192"]
+        },
+        {
+          "score": "Joshua Karty 22 Yd Field Goal ",
+          "scorePeriod": "Q2",
+          "homeScore": "10",
+          "awayScore": "7",
+          "teamID": "19",
+          "scoreDetails": "10 plays, 65 yards, 4:45",
+          "scoreType": "FG",
+          "scoreTime": "13:37",
+          "team": "LAR",
+          "playerIDs": ["4566192"]
+        },
+        {
+          "score": "Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "17",
+          "awayScore": "7",
+          "teamID": "19",
+          "scoreDetails": "4 plays, 18 yards, 1:08",
+          "scoreType": "BP",
+          "scoreTime": "12:29",
+          "team": "LAR",
+          "playerIDs": ["4239944", "4566192"]
+        },
+        {
+          "score": "Puka Nacua 4 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "24",
+          "awayScore": "14",
+          "teamID": "19",
+          "scoreDetails": "12 plays, 76 yards, 7:47",
+          "scoreType": "TD",
+          "scoreTime": "2:36",
+          "team": "LAR",
+          "playerIDs": ["4426515", "4566192"]
+        },
+        {
+          "score": "Kyren Williams 7 Yd Run (Joshua Karty Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "31",
+          "awayScore": "14",
+          "teamID": "19",
+          "scoreDetails": "11 plays, 76 yards, 5:29",
+          "scoreType": "TD",
+          "scoreTime": "8:26",
+          "team": "LAR",
+          "playerIDs": ["4430737", "4566192"]
+        },
+        {
+          "score": "Cooper Kupp 17 Yd pass from Matthew Stafford (Joshua Karty Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "38",
+          "awayScore": "21",
+          "teamID": "19",
+          "scoreDetails": "7 plays, 70 yards, 3:36",
+          "scoreType": "TD",
+          "scoreTime": "0:18",
+          "team": "LAR",
+          "playerIDs": ["12483", "2977187", "4566192"]
+        },
+        {
+          "score": "Puka Nacua 19 Yd pass from Matthew Stafford (Joshua Karty PAT failed)",
+          "scorePeriod": "Q4",
+          "homeScore": "44",
+          "awayScore": "35",
+          "teamID": "19",
+          "scoreDetails": "11 plays, 71 yards, 6:55",
+          "scoreType": "TD",
+          "scoreTime": "1:54",
+          "team": "LAR",
+          "playerIDs": ["12483", "4426515", "4566192"]
+        }
+      ],
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "22",
+        "fgMade": "1",
+        "fgAttempts": "1",
+        "xpMade": "5",
+        "fgPct": "100.0",
+        "kickingPts": "8",
+        "xpAttempts": "6",
+        "fgMissed": "0",
+        "xpMissed": "1"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4566192",
+      "longName": "Joshua Karty"
+    },
+    "4567175": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.21",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4567175",
+      "longName": "Beaux Limmer"
+    },
+    "4568217": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "11",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.18"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4568217",
+      "longName": "Tyler Davis"
+    },
+    "4568624": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "27",
+        "stSnapPct": "0.82",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4568624",
+      "longName": "Dorian Williams"
+    },
+    "4569382": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.13",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.55",
+        "offSnap": "10",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "3",
+        "kickReturnTD": "0",
+        "kickReturnYds": "82",
+        "kickReturnAvg": "27.3",
+        "kickReturnLong": "33"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "4569382",
+      "longName": "Jordan Whittington"
+    },
+    "4572371": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "23",
+        "stSnapPct": "0.70",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4572371",
+      "longName": "Josh Wallace"
+    },
+    "4576069": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "20",
+        "kickReturnAvg": "20.0",
+        "kickReturnLong": "20"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4576069",
+      "longName": "Brandon Codrington"
+    },
+    "4578085": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "45",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.75"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4578085",
+      "longName": "Jared Verse"
+    },
+    "4596363": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "10",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.78"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4596363",
+      "longName": "Kamren Kinchens"
+    },
+    "4676004": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "20",
+        "stSnapPct": "0.61",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4676004",
+      "longName": "Cole Bishop"
+    },
+    "4746079": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "4",
+      "snapCounts": {
+        "offSnapPct": "0.27",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.49",
+        "offSnap": "16",
+        "defSnapPct": "0.00"
+      },
+      "team": "BUF",
+      "teamAbv": "BUF",
+      "playerID": "4746079",
+      "longName": "Zach Davidson"
+    },
+    "4875196": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "52",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.87"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "Defense": {
+        "totalTackles": "4",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4875196",
+      "longName": "Byron Young"
+    },
+    "5125875": {
+      "gameID": "20241208_BUF@LAR",
+      "teamID": "19",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.52",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "95",
+        "punts": "2",
+        "puntAvg": "47.5",
+        "puntsin20": "1",
+        "puntTouchBacks": "1",
+        "puntLong": "53"
+      },
+      "team": "LAR",
+      "teamAbv": "LAR",
+      "playerID": "5125875",
+      "longName": "Ethan Evans"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Kyren Williams 3 Yd Run (Joshua Karty Kick)",
+      "scorePeriod": "Q1",
+      "homeScore": "7",
+      "awayScore": "0",
+      "teamID": "19",
+      "scoreDetails": "12 plays, 70 yards, 6:34",
+      "scoreType": "TD",
+      "scoreTime": "8:26",
+      "team": "LAR",
+      "playerIDs": ["4430737", "4566192"]
+    },
+    {
+      "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+      "scorePeriod": "Q1",
+      "homeScore": "7",
+      "awayScore": "7",
+      "teamID": "4",
+      "scoreDetails": "9 plays, 70 yards, 5:04",
+      "scoreType": "TD",
+      "scoreTime": "3:22",
+      "team": "BUF",
+      "playerIDs": ["3918298", "3917232"]
+    },
+    {
+      "score": "Joshua Karty 22 Yd Field Goal ",
+      "scorePeriod": "Q2",
+      "homeScore": "10",
+      "awayScore": "7",
+      "teamID": "19",
+      "scoreDetails": "10 plays, 65 yards, 4:45",
+      "scoreType": "FG",
+      "scoreTime": "13:37",
+      "team": "LAR",
+      "playerIDs": ["4566192"]
+    },
+    {
+      "score": "Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "17",
+      "awayScore": "7",
+      "teamID": "19",
+      "scoreDetails": "4 plays, 18 yards, 1:08",
+      "scoreType": "BP",
+      "scoreTime": "12:29",
+      "team": "LAR",
+      "playerIDs": ["4239944", "4566192"]
+    },
+    {
+      "score": "Ty Johnson 41 Yd pass from Josh Allen (Tyler Bass Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "17",
+      "awayScore": "14",
+      "teamID": "4",
+      "scoreDetails": "4 plays, 70 yards, 2:06",
+      "scoreType": "TD",
+      "scoreTime": "10:23",
+      "team": "BUF",
+      "playerIDs": ["3918298", "3915411", "3917232"]
+    },
+    {
+      "score": "Puka Nacua 4 Yd Run (Joshua Karty Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "24",
+      "awayScore": "14",
+      "teamID": "19",
+      "scoreDetails": "12 plays, 76 yards, 7:47",
+      "scoreType": "TD",
+      "scoreTime": "2:36",
+      "team": "LAR",
+      "playerIDs": ["4426515", "4566192"]
+    },
+    {
+      "score": "Kyren Williams 7 Yd Run (Joshua Karty Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "31",
+      "awayScore": "14",
+      "teamID": "19",
+      "scoreDetails": "11 plays, 76 yards, 5:29",
+      "scoreType": "TD",
+      "scoreTime": "8:26",
+      "team": "LAR",
+      "playerIDs": ["4430737", "4566192"]
+    },
+    {
+      "score": "Khalil Shakir 51 Yd pass from Josh Allen (Tyler Bass Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "31",
+      "awayScore": "21",
+      "teamID": "4",
+      "scoreDetails": "6 plays, 80 yards, 4:32",
+      "scoreType": "TD",
+      "scoreTime": "3:54",
+      "team": "BUF",
+      "playerIDs": ["3918298", "4373678", "3917232"]
+    },
+    {
+      "score": "Cooper Kupp 17 Yd pass from Matthew Stafford (Joshua Karty Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "38",
+      "awayScore": "21",
+      "teamID": "19",
+      "scoreDetails": "7 plays, 70 yards, 3:36",
+      "scoreType": "TD",
+      "scoreTime": "0:18",
+      "team": "LAR",
+      "playerIDs": ["12483", "2977187", "4566192"]
+    },
+    {
+      "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "38",
+      "awayScore": "28",
+      "teamID": "4",
+      "scoreDetails": "5 plays, 70 yards, 0:51",
+      "scoreType": "TD",
+      "scoreTime": "14:27",
+      "team": "BUF",
+      "playerIDs": ["3918298", "3917232"]
+    },
+    {
+      "score": "Mack Hollins 21 Yd pass from Josh Allen (Tyler Bass Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "38",
+      "awayScore": "35",
+      "teamID": "4",
+      "scoreDetails": "10 plays, 91 yards, 4:03",
+      "scoreType": "TD",
+      "scoreTime": "8:49",
+      "team": "BUF",
+      "playerIDs": ["3918298", "2991662", "3917232"]
+    },
+    {
+      "score": "Puka Nacua 19 Yd pass from Matthew Stafford (Joshua Karty PAT failed)",
+      "scorePeriod": "Q4",
+      "homeScore": "44",
+      "awayScore": "35",
+      "teamID": "19",
+      "scoreDetails": "11 plays, 71 yards, 6:55",
+      "scoreType": "TD",
+      "scoreTime": "1:54",
+      "team": "LAR",
+      "playerIDs": ["12483", "4426515", "4566192"]
+    },
+    {
+      "score": "Josh Allen 1 Yd Run (Tyler Bass Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "44",
+      "awayScore": "42",
+      "teamID": "4",
+      "scoreDetails": "8 plays, 70 yards, 0:54",
+      "scoreType": "TD",
+      "scoreTime": "1:00",
+      "team": "BUF",
+      "playerIDs": ["3918298", "3917232"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "4",
+  "teamIDHome": "19",
+  "teamStats": {
+    "away": {
+      "totalYards": "445",
+      "rushingAttempts": "17",
+      "rushingYards": "103",
+      "fumblesLost": "0",
+      "penalties": "7-59",
+      "totalPlays": "54",
+      "possession": "21:30",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "22-37",
+      "passingFirstDowns": "14",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "0-0",
+      "thirdDownEfficiency": "5-9",
+      "blockedPunt": "0",
+      "yardsPerPlay": "8.2",
+      "redZoneScoredAndAttempted": "3-3",
+      "teamID": "4",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "9",
+      "rushingFirstDowns": "6",
+      "blockedFG": "0",
+      "rushTD": "3",
+      "twoPointConversions": "0",
+      "firstDowns": "25",
+      "passTD": "3",
+      "team": "BUF",
+      "blockedXP": "0",
+      "teamAbv": "BUF",
+      "firstDownsFromPenalties": "5",
+      "fourthDownEfficiency": "0-0",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "342",
+      "yardsPerRush": "6.1",
+      "snapCounts": {
+        "totalSpecialTeams": "33",
+        "totalOffensive": "60",
+        "totalDefensive": "77"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "9.2"
+    },
+    "home": {
+      "totalYards": "457",
+      "rushingAttempts": "42",
+      "rushingYards": "137",
+      "fumblesLost": "0",
+      "penalties": "9-99",
+      "totalPlays": "72",
+      "possession": "38:30",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "23-30",
+      "passingFirstDowns": "15",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "0-0",
+      "thirdDownEfficiency": "11-15",
+      "blockedPunt": "1",
+      "yardsPerPlay": "6.3",
+      "redZoneScoredAndAttempted": "5-6",
+      "teamID": "19",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "9",
+      "rushingFirstDowns": "10",
+      "blockedFG": "0",
+      "rushTD": "3",
+      "twoPointConversions": "0",
+      "firstDowns": "28",
+      "passTD": "2",
+      "team": "LAR",
+      "blockedXP": "0",
+      "teamAbv": "LAR",
+      "firstDownsFromPenalties": "3",
+      "fourthDownEfficiency": "1-1",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "320",
+      "yardsPerRush": "3.3",
+      "snapCounts": {
+        "totalSpecialTeams": "33",
+        "totalOffensive": "77",
+        "totalDefensive": "60"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "10.7"
+    }
+  },
+  "gameID": "20241208_BUF@LAR",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/__fixtures__/box-score-returner-not-in-playerids.json
+++ b/packages/stats/src/tank01/__fixtures__/box-score-returner-not-in-playerids.json
@@ -1,0 +1,2826 @@
+{
+  "DST": {
+    "away": {
+      "teamAbv": "CAR",
+      "teamID": "5",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "2",
+      "ydsAllowed": "551",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "48",
+      "safeties": "0"
+    },
+    "home": {
+      "teamAbv": "TB",
+      "teamID": "30",
+      "defTD": "0",
+      "defensiveInterceptions": "0",
+      "sacks": "5",
+      "ydsAllowed": "204",
+      "fumblesRecovered": "0",
+      "ptsAllowed": "14",
+      "safeties": "0"
+    }
+  },
+  "Referees": "Greg Wilson, Clay Martin, Jerod Phillips, Dave Hawkshaw, Alonzo Ramsey III, James Carter II, Brian Perry",
+  "arena": "Raymond James Stadium",
+  "arenaCapacity": "65,844",
+  "attendance": "64,434",
+  "away": "CAR",
+  "awayPts": "14",
+  "awayResult": "L",
+  "currentPeriod": "Final",
+  "gameClock": "",
+  "gameDate": "20241229",
+  "gameLocation": "Tampa, FL",
+  "gameStatus": "Completed",
+  "gameWeek": "Week 17",
+  "home": "TB",
+  "homePts": "48",
+  "homeResult": "W",
+  "lineScore": {
+    "period": "Final",
+    "gameClock": "",
+    "away": {
+      "Q1": "7",
+      "Q2": "7",
+      "Q3": "0",
+      "Q4": "0",
+      "teamID": "5",
+      "currentlyInPossession": "False",
+      "totalPts": "14",
+      "teamAbv": "CAR"
+    },
+    "home": {
+      "Q1": "10",
+      "Q2": "17",
+      "Q3": "14",
+      "Q4": "7",
+      "teamID": "30",
+      "currentlyInPossession": "False",
+      "totalPts": "48",
+      "teamAbv": "TB"
+    }
+  },
+  "network": "CBS",
+  "playerStats": {
+    "11759": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "11759",
+      "longName": "JJ Jansen"
+    },
+    "14985": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "36",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.77"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "14985",
+      "longName": "Lavonte David"
+    },
+    "15153": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "226",
+        "punts": "5",
+        "puntAvg": "45.2",
+        "puntsin20": "3",
+        "puntTouchBacks": "0",
+        "puntLong": "51"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "15153",
+      "longName": "Johnny Hekker"
+    },
+    "16019": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "4",
+        "stSnap": "4",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.09"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "16019",
+      "longName": "William Gholston"
+    },
+    "16460": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "2",
+        "longRec": "40",
+        "targets": "6",
+        "recYds": "110",
+        "recAvg": "22.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Adam Thielen 17 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "7",
+          "teamID": "5",
+          "scoreDetails": "6 plays, 70 yards, 3:20",
+          "scoreType": "TD",
+          "scoreTime": "8:15",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        },
+        {
+          "score": "Adam Thielen 40 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "14",
+          "teamID": "5",
+          "scoreDetails": "4 plays, 70 yards, 0:21",
+          "scoreType": "TD",
+          "scoreTime": "0:50",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.85",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "40",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "16460",
+      "longName": "Adam Thielen"
+    },
+    "16734": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "40",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.52"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "16734",
+      "longName": "Jadeveon Clowney"
+    },
+    "16737": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "8",
+        "recTD": "2",
+        "longRec": "34",
+        "targets": "9",
+        "recYds": "97",
+        "recAvg": "12.1"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mike Evans 2 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "0",
+          "teamID": "30",
+          "scoreDetails": "6 plays, 70 yards, 3:25",
+          "scoreType": "TD",
+          "scoreTime": "11:35",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        },
+        {
+          "score": "Mike Evans 1 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "20",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "4 plays, 81 yards, 1:50",
+          "scoreType": "TD",
+          "scoreTime": "8:19",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        }
+      ],
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.62",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "48",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "16737",
+      "longName": "Mike Evans"
+    },
+    "2576508": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "2576508",
+      "longName": "DeShawn Williams"
+    },
+    "2976545": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "2976545",
+      "longName": "Deion Jones"
+    },
+    "3040572": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "12",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3040572",
+      "longName": "Xavier Woods"
+    },
+    "3052587": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "2.0",
+        "rushYds": "2",
+        "carries": "1",
+        "longRush": "2",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "90.1",
+        "rtg": "153.0",
+        "sacked": "2-10",
+        "passAttempts": "32",
+        "passAvg": "11.2",
+        "passTD": "5",
+        "passYds": "359",
+        "int": "0",
+        "passCompletions": "27"
+      },
+      "scoringPlays": [
+        {
+          "score": "Mike Evans 2 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "0",
+          "teamID": "30",
+          "scoreDetails": "6 plays, 70 yards, 3:25",
+          "scoreType": "TD",
+          "scoreTime": "11:35",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        },
+        {
+          "score": "Mike Evans 1 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "20",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "4 plays, 81 yards, 1:50",
+          "scoreType": "TD",
+          "scoreTime": "8:19",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        },
+        {
+          "score": "Jalen McMillan 10 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "11 plays, 64 yards, 5:38",
+          "scoreType": "TD",
+          "scoreTime": "1:11",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        },
+        {
+          "score": "Payne Durham 5 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "34",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "10 plays, 94 yards, 5:50",
+          "scoreType": "TD",
+          "scoreTime": "5:48",
+          "team": "TB",
+          "playerIDs": ["3052587", "4372505", "3150744"]
+        },
+        {
+          "score": "Jalen McMillan 16 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "48",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "9 plays, 85 yards, 5:03",
+          "scoreType": "TD",
+          "scoreTime": "13:30",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        }
+      ],
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.86",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "3052587",
+      "longName": "Baker Mayfield"
+    },
+    "3054857": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "38",
+        "stSnap": "7",
+        "stSnapPct": "0.23",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3054857",
+      "longName": "A'Shawn Robinson"
+    },
+    "3116179": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "27",
+        "stSnapPct": "0.90",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3116179",
+      "longName": "Nick Scott"
+    },
+    "3127294": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "15",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.32"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3127294",
+      "longName": "Greg Gaines"
+    },
+    "3134362": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "32",
+        "stSnap": "4",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.68"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3134362",
+      "longName": "Vita Vea"
+    },
+    "3139033": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "5.5",
+        "rushYds": "11",
+        "carries": "2",
+        "longRush": "8",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "0",
+        "recTD": "0",
+        "longRec": "0",
+        "targets": "2",
+        "recYds": "0",
+        "recAvg": "0.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.23",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3139033",
+      "longName": "Mike Boone"
+    },
+    "3150744": {
+      "gameID": "20241229_CAR@TB",
+      "scoringPlays": [
+        {
+          "score": "Mike Evans 2 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "0",
+          "teamID": "30",
+          "scoreDetails": "6 plays, 70 yards, 3:25",
+          "scoreType": "TD",
+          "scoreTime": "11:35",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        },
+        {
+          "score": "Chase McLaughlin 23 Yd Field Goal",
+          "scorePeriod": "Q1",
+          "homeScore": "10",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "12 plays, 75 yards, 7:02",
+          "scoreType": "FG",
+          "scoreTime": "1:13",
+          "team": "TB",
+          "playerIDs": ["3150744"]
+        },
+        {
+          "score": "Chase McLaughlin 34 Yd Field Goal",
+          "scorePeriod": "Q2",
+          "homeScore": "13",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "10 plays, 45 yards, 4:20",
+          "scoreType": "FG",
+          "scoreTime": "10:31",
+          "team": "TB",
+          "playerIDs": ["3150744"]
+        },
+        {
+          "score": "Mike Evans 1 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "20",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "4 plays, 81 yards, 1:50",
+          "scoreType": "TD",
+          "scoreTime": "8:19",
+          "team": "TB",
+          "playerIDs": ["3052587", "16737", "3150744"]
+        },
+        {
+          "score": "Jalen McMillan 10 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "11 plays, 64 yards, 5:38",
+          "scoreType": "TD",
+          "scoreTime": "1:11",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        },
+        {
+          "score": "Payne Durham 5 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "34",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "10 plays, 94 yards, 5:50",
+          "scoreType": "TD",
+          "scoreTime": "5:48",
+          "team": "TB",
+          "playerIDs": ["3052587", "4372505", "3150744"]
+        },
+        {
+          "score": "J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "41",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "3 plays, 0 yards, 0:25",
+          "scoreType": "TD",
+          "scoreTime": "5:23",
+          "team": "TB",
+          "playerIDs": ["3150744"]
+        },
+        {
+          "score": "Jalen McMillan 16 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "48",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "9 plays, 85 yards, 5:03",
+          "scoreType": "TD",
+          "scoreTime": "13:30",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        }
+      ],
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "34",
+        "fgMade": "2",
+        "fgAttempts": "2",
+        "xpMade": "6",
+        "fgPct": "100.0",
+        "kickingPts": "12",
+        "xpAttempts": "6",
+        "fgMissed": "0",
+        "xpMissed": "0"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "3150744",
+      "longName": "Chase McLaughlin"
+    },
+    "3155647": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "41",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.87"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3155647",
+      "longName": "Mike Edwards"
+    },
+    "3871880": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3871880",
+      "longName": "Yosh Nijman"
+    },
+    "3873935": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "23",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.49"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "3873935",
+      "longName": "Jamel Dean"
+    },
+    "3886601": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "39",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.51"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3886601",
+      "longName": "Shy Tuttle"
+    },
+    "3894856": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "31",
+        "stSnap": "13",
+        "stSnapPct": "0.43",
+        "offSnap": "0",
+        "defSnapPct": "0.66"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "3894856",
+      "longName": "Anthony Nelson"
+    },
+    "3895791": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.64"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3895791",
+      "longName": "Dane Jackson"
+    },
+    "3895798": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3895798",
+      "longName": "Jordan Whitehead"
+    },
+    "3915777": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.17",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "13",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "3915777",
+      "longName": "Justin Skule"
+    },
+    "3917592": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "3917592",
+      "longName": "Robert Hunt"
+    },
+    "3917853": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "7",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "6",
+        "tfl": "2",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3917853",
+      "longName": "Michael Jackson"
+    },
+    "3929637": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "8",
+        "targets": "1",
+        "recYds": "8",
+        "recAvg": "8.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.06",
+        "defSnap": "0",
+        "stSnap": "16",
+        "stSnapPct": "0.53",
+        "offSnap": "3",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "3929637",
+      "longName": "Dan Chisena"
+    },
+    "4034496": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "19",
+        "stSnapPct": "0.63",
+        "offSnap": "0",
+        "defSnapPct": "0.31"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4034496",
+      "longName": "Cam Gill"
+    },
+    "4034779": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.26",
+        "defSnap": "0",
+        "stSnap": "26",
+        "stSnapPct": "0.87",
+        "offSnap": "20",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4034779",
+      "longName": "Ko Kieft"
+    },
+    "4034946": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "-0.7",
+        "rushYds": "-2",
+        "carries": "3",
+        "longRush": "0",
+        "rushTD": "0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.14",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4034946",
+      "longName": "Kyle Trask"
+    },
+    "4034948": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.02",
+        "defSnap": "0",
+        "stSnap": "22",
+        "stSnapPct": "0.73",
+        "offSnap": "1",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4034948",
+      "longName": "Feleipe Franks"
+    },
+    "4034949": {
+      "gameID": "20241229_CAR@TB",
+      "scoringPlays": [
+        {
+          "score": "Adam Thielen 17 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "7",
+          "teamID": "5",
+          "scoreDetails": "6 plays, 70 yards, 3:20",
+          "scoreType": "TD",
+          "scoreTime": "8:15",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        },
+        {
+          "score": "Adam Thielen 40 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "14",
+          "teamID": "5",
+          "scoreDetails": "4 plays, 70 yards, 0:21",
+          "scoreType": "TD",
+          "scoreTime": "0:50",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "fgLong": "0",
+        "fgMade": "0",
+        "fgAttempts": "1",
+        "xpMade": "2",
+        "fgPct": "0.0",
+        "kickingPts": "2",
+        "xpAttempts": "2",
+        "fgMissed": "1",
+        "xpMissed": "0"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4034949",
+      "longName": "Eddy Pineiro"
+    },
+    "4035693": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "0.0",
+        "rushYds": "0",
+        "carries": "1",
+        "longRush": "0",
+        "rushTD": "0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.06",
+        "defSnap": "0",
+        "stSnap": "10",
+        "stSnapPct": "0.33",
+        "offSnap": "3",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "19",
+        "kickReturnAvg": "19.0",
+        "kickReturnLong": "19"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4035693",
+      "longName": "Velus Jones Jr."
+    },
+    "4038849": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "49",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.64"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "5",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4038849",
+      "longName": "D.J. Wonnum"
+    },
+    "4044133": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "27",
+        "stSnapPct": "0.90",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4044133",
+      "longName": "Sam Franklin Jr."
+    },
+    "4046551": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.86",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4046551",
+      "longName": "Ben Bredeson"
+    },
+    "4052017": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.06"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4052017",
+      "longName": "C.J. Brewer"
+    },
+    "4077786": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "9",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "0",
+        "defSnapPct": "0.12"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4077786",
+      "longName": "Sam Roberts"
+    },
+    "4212909": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "17",
+        "targets": "1",
+        "recYds": "17",
+        "recAvg": "17.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.32",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "15",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4212909",
+      "longName": "David Moore"
+    },
+    "4240589": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.86",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "66",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4240589",
+      "longName": "Tristan Wirfs"
+    },
+    "4240623": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "12",
+        "stSnapPct": "0.40",
+        "offSnap": "0",
+        "defSnapPct": "0.36"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240623",
+      "longName": "DJ Johnson"
+    },
+    "4240780": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "16",
+        "stSnapPct": "0.53",
+        "offSnap": "0",
+        "defSnapPct": "0.04"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240780",
+      "longName": "Lonnie Johnson Jr."
+    },
+    "4240859": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4240859",
+      "longName": "Caleb Farley"
+    },
+    "4241473": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "37",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.48"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4241473",
+      "longName": "LaBryan Ray"
+    },
+    "4242391": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.14",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "11",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4242391",
+      "longName": "Robert Hainsey"
+    },
+    "4242515": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "14",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "7",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4242515",
+      "longName": "Chandler Wooten"
+    },
+    "4242521": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "17",
+        "stSnap": "14",
+        "stSnapPct": "0.47",
+        "offSnap": "0",
+        "defSnapPct": "0.36"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4242521",
+      "longName": "K.J. Britt"
+    },
+    "4243333": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "5",
+        "stSnapPct": "0.17",
+        "offSnap": "0",
+        "defSnapPct": "0.51"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4243333",
+      "longName": "Joe Tryon-Shoyinka"
+    },
+    "4243366": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "28",
+        "stSnap": "15",
+        "stSnapPct": "0.50",
+        "offSnap": "0",
+        "defSnapPct": "0.60"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4243366",
+      "longName": "J.J. Russell"
+    },
+    "4244607": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "3",
+        "stSnap": "4",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.04"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4244607",
+      "longName": "Akayleb Evans"
+    },
+    "4248533": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "24",
+        "stSnap": "22",
+        "stSnapPct": "0.73",
+        "offSnap": "0",
+        "defSnapPct": "0.51"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4248533",
+      "longName": "Josh Hayes"
+    },
+    "4248545": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.92",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "71",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4248545",
+      "longName": "Cody Mauch"
+    },
+    "4250392": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "47",
+        "stSnap": "13",
+        "stSnapPct": "0.43",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "6",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "5",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "1"
+      },
+      "playerID": "4250392",
+      "longName": "Zyon McCollum"
+    },
+    "4256062": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4256062",
+      "longName": "Brady Christensen"
+    },
+    "4258485": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "27",
+        "stSnapPct": "0.90",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "0",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4258485",
+      "longName": "Jon Rhattigan"
+    },
+    "4259308": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "2.5",
+        "rushYds": "20",
+        "carries": "8",
+        "longRush": "8",
+        "rushTD": "0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.77",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "36",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "0",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "4259308",
+      "longName": "Raheem Blackshear"
+    },
+    "4334405": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "22",
+        "stSnapPct": "0.73",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4334405",
+      "longName": "Tavierre Thomas"
+    },
+    "4360189": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "22",
+        "stSnap": "4",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.47"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "2",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4360189",
+      "longName": "Logan Hall"
+    },
+    "4360502": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "11",
+        "stSnap": "12",
+        "stSnapPct": "0.40",
+        "offSnap": "0",
+        "defSnapPct": "0.23"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4360502",
+      "longName": "Kaevon Merriweather"
+    },
+    "4361112": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "3",
+        "recTD": "0",
+        "longRec": "26",
+        "targets": "4",
+        "recYds": "52",
+        "recAvg": "17.3"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.26",
+        "defSnap": "0",
+        "stSnap": "17",
+        "stSnapPct": "0.57",
+        "offSnap": "20",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4361112",
+      "longName": "Devin Culp"
+    },
+    "4361727": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4361727",
+      "longName": "Evan Deckers"
+    },
+    "4361788": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4361788",
+      "longName": "Cade Mays"
+    },
+    "4362066": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.08",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "6",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4362066",
+      "longName": "Elijah Klein"
+    },
+    "4362647": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4362647",
+      "longName": "Damien Lewis"
+    },
+    "4362910": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "25",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "0",
+        "defSnapPct": "0.32"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0.5",
+        "passDeflections": "0"
+      },
+      "playerID": "4362910",
+      "longName": "Jaden Crumedy"
+    },
+    "4367330": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "14",
+        "stSnapPct": "0.47",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4367330",
+      "longName": "Tyrek Funderburk"
+    },
+    "4369466": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "23",
+        "targets": "4",
+        "recYds": "26",
+        "recAvg": "13.0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.56",
+        "defSnap": "0",
+        "stSnap": "12",
+        "stSnapPct": "0.40",
+        "offSnap": "43",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4369466",
+      "longName": "Ryan Miller"
+    },
+    "4371336": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.20",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4371336",
+      "longName": "Shemar Bartholomew"
+    },
+    "4372505": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "1",
+        "longRec": "31",
+        "targets": "3",
+        "recYds": "36",
+        "recAvg": "18.0"
+      },
+      "scoringPlays": [
+        {
+          "score": "Payne Durham 5 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q3",
+          "homeScore": "34",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "10 plays, 94 yards, 5:50",
+          "scoreType": "TD",
+          "scoreTime": "5:48",
+          "team": "TB",
+          "playerIDs": ["3052587", "4372505", "3150744"]
+        }
+      ],
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.77",
+        "defSnap": "0",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "59",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4372505",
+      "longName": "Payne Durham"
+    },
+    "4372780": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.53",
+        "defSnap": "0",
+        "stSnap": "7",
+        "stSnapPct": "0.23",
+        "offSnap": "25",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4372780",
+      "longName": "Tommy Tremble"
+    },
+    "4373474": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4373474",
+      "longName": "Jarrett Kingston"
+    },
+    "4380507": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4380507",
+      "longName": "Luke Goedeke"
+    },
+    "4426407": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.30",
+        "defSnap": "0",
+        "stSnap": "6",
+        "stSnapPct": "0.20",
+        "offSnap": "23",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntReturns": "2",
+        "puntReturnYds": "1",
+        "puntReturnAvg": "0.5",
+        "puntReturnLong": "2",
+        "puntReturnTD": "0"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4426407",
+      "longName": "Trey Palmer"
+    },
+    "4426926": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "77",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "1.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "9",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "3",
+        "tfl": "0",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4426926",
+      "longName": "Demani Richardson"
+    },
+    "4427132": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4427132",
+      "longName": "Ikem Ekwonu"
+    },
+    "4427673": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "0",
+        "defSnapPct": "0.62"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "2",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4427673",
+      "longName": "Calijah Kancey"
+    },
+    "4428522": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "41",
+        "stSnap": "1",
+        "stSnapPct": "0.03",
+        "offSnap": "0",
+        "defSnapPct": "0.87"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "0",
+        "defensiveInterceptions": "0",
+        "sacks": "0",
+        "passDeflections": "0"
+      },
+      "playerID": "4428522",
+      "longName": "Tykee Smith"
+    },
+    "4428909": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "66",
+        "stSnap": "7",
+        "stSnapPct": "0.23",
+        "offSnap": "0",
+        "defSnapPct": "0.86"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "totalTackles": "10",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "7",
+        "tfl": "0",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "0.5",
+        "passDeflections": "1"
+      },
+      "playerID": "4428909",
+      "longName": "Jacoby Windmon"
+    },
+    "4428989": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "13",
+        "stSnap": "12",
+        "stSnapPct": "0.40",
+        "offSnap": "0",
+        "defSnapPct": "0.28"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "1",
+        "defTD": "0",
+        "forcedFumbles": "1",
+        "soloTackles": "1",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4428989",
+      "longName": "Chris Braswell"
+    },
+    "4429006": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "11",
+        "targets": "1",
+        "recYds": "11",
+        "recAvg": "11.0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.32",
+        "defSnap": "0",
+        "stSnap": "8",
+        "stSnapPct": "0.27",
+        "offSnap": "25",
+        "defSnapPct": "0.00"
+      },
+      "Kicking": {
+        "kickReturns": "1",
+        "kickReturnTD": "0",
+        "kickReturnYds": "15",
+        "kickReturnAvg": "15.0",
+        "kickReturnLong": "15"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4429006",
+      "longName": "Rakim Jarrett"
+    },
+    "4429251": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "77",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4429251",
+      "longName": "Graham Barton"
+    },
+    "4430034": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "0",
+        "longRec": "10",
+        "targets": "9",
+        "recYds": "28",
+        "recAvg": "5.6"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.68",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "32",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4430034",
+      "longName": "Xavier Legette"
+    },
+    "4430834": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "9.0",
+        "rushYds": "9",
+        "carries": "1",
+        "longRush": "9",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "5",
+        "recTD": "2",
+        "longRec": "16",
+        "targets": "5",
+        "recYds": "51",
+        "recAvg": "10.2"
+      },
+      "scoringPlays": [
+        {
+          "score": "Jalen McMillan 10 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "7",
+          "teamID": "30",
+          "scoreDetails": "11 plays, 64 yards, 5:38",
+          "scoreType": "TD",
+          "scoreTime": "1:11",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        },
+        {
+          "score": "Jalen McMillan 16 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+          "scorePeriod": "Q4",
+          "homeScore": "48",
+          "awayScore": "14",
+          "teamID": "30",
+          "scoreDetails": "9 plays, 85 yards, 5:03",
+          "scoreType": "TD",
+          "scoreTime": "13:30",
+          "team": "TB",
+          "playerIDs": ["3052587", "4430834", "3150744"]
+        }
+      ],
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.69",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "53",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4430834",
+      "longName": "Jalen McMillan"
+    },
+    "4430871": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "4.9",
+        "rushYds": "39",
+        "carries": "8",
+        "longRush": "9",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "1",
+        "recYds": "5",
+        "recAvg": "5.0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.19",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "15",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4430871",
+      "longName": "Sean Tucker"
+    },
+    "4431588": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "5",
+        "targets": "1",
+        "recYds": "5",
+        "recAvg": "5.0"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.55",
+        "defSnap": "0",
+        "stSnap": "9",
+        "stSnapPct": "0.30",
+        "offSnap": "26",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4431588",
+      "longName": "Ja'Tavion Sanders"
+    },
+    "4568439": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "14",
+        "stSnap": "18",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.18"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4568439",
+      "longName": "Amare Barno"
+    },
+    "4596448": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "5.7",
+        "rushYds": "113",
+        "carries": "20",
+        "longRush": "34",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "4",
+        "recTD": "0",
+        "longRec": "42",
+        "targets": "4",
+        "recYds": "77",
+        "recAvg": "19.3"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.55",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "42",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4596448",
+      "longName": "Bucky Irving"
+    },
+    "4685720": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "4.0",
+        "rushYds": "8",
+        "carries": "2",
+        "longRush": "7",
+        "rushTD": "0"
+      },
+      "Passing": {
+        "qbr": "62.1",
+        "rtg": "100.7",
+        "sacked": "5-38",
+        "passAttempts": "28",
+        "passAvg": "7.3",
+        "passTD": "2",
+        "passYds": "203",
+        "int": "0",
+        "passCompletions": "15"
+      },
+      "scoringPlays": [
+        {
+          "score": "Adam Thielen 17 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q1",
+          "homeScore": "7",
+          "awayScore": "7",
+          "teamID": "5",
+          "scoreDetails": "6 plays, 70 yards, 3:20",
+          "scoreType": "TD",
+          "scoreTime": "8:15",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        },
+        {
+          "score": "Adam Thielen 40 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+          "scorePeriod": "Q2",
+          "homeScore": "27",
+          "awayScore": "14",
+          "teamID": "5",
+          "scoreDetails": "4 plays, 70 yards, 0:21",
+          "scoreType": "TD",
+          "scoreTime": "0:50",
+          "team": "CAR",
+          "playerIDs": ["4685720", "16460", "4034949"]
+        }
+      ],
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "1.00",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "47",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "Defense": {
+        "fumblesLost": "0",
+        "defensiveInterceptions": "0",
+        "forcedFumbles": "0",
+        "fumbles": "2",
+        "fumblesRecovered": "1"
+      },
+      "playerID": "4685720",
+      "longName": "Bryce Young"
+    },
+    "4686334": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "29",
+        "stSnap": "4",
+        "stSnapPct": "0.13",
+        "offSnap": "0",
+        "defSnapPct": "0.62"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "Defense": {
+        "totalTackles": "3",
+        "defTD": "0",
+        "forcedFumbles": "0",
+        "soloTackles": "2",
+        "tfl": "1",
+        "qbHits": "1",
+        "defensiveInterceptions": "0",
+        "sacks": "1",
+        "passDeflections": "0"
+      },
+      "playerID": "4686334",
+      "longName": "Yaya Diaby"
+    },
+    "4695883": {
+      "gameID": "20241229_CAR@TB",
+      "Receiving": {
+        "receptions": "2",
+        "recTD": "0",
+        "longRec": "20",
+        "targets": "2",
+        "recYds": "35",
+        "recAvg": "17.5"
+      },
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.87",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "41",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4695883",
+      "longName": "Jalen Coker"
+    },
+    "4697815": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "5.0",
+        "rushYds": "30",
+        "carries": "6",
+        "longRush": "16",
+        "rushTD": "0"
+      },
+      "Receiving": {
+        "receptions": "1",
+        "recTD": "0",
+        "longRec": "4",
+        "targets": "1",
+        "recYds": "4",
+        "recAvg": "4.0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.36",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "28",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4697815",
+      "longName": "Rachaad White"
+    },
+    "4710661": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "5",
+      "snapCounts": {
+        "offSnapPct": "0.04",
+        "defSnap": "0",
+        "stSnap": "3",
+        "stSnapPct": "0.10",
+        "offSnap": "2",
+        "defSnapPct": "0.00"
+      },
+      "team": "CAR",
+      "teamAbv": "CAR",
+      "playerID": "4710661",
+      "longName": "Chandler Zavala"
+    },
+    "4876013": {
+      "gameID": "20241229_CAR@TB",
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.00",
+        "defSnap": "0",
+        "stSnap": "18",
+        "stSnapPct": "0.60",
+        "offSnap": "0",
+        "defSnapPct": "0.00"
+      },
+      "Punting": {
+        "puntYds": "52",
+        "punts": "1",
+        "puntAvg": "52.0",
+        "puntsin20": "0",
+        "puntTouchBacks": "0",
+        "puntLong": "52"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "4876013",
+      "longName": "Jack Browning"
+    },
+    "5097554": {
+      "gameID": "20241229_CAR@TB",
+      "Rushing": {
+        "rushAvg": "11.0",
+        "rushYds": "11",
+        "carries": "1",
+        "longRush": "11",
+        "rushTD": "0"
+      },
+      "teamID": "30",
+      "snapCounts": {
+        "offSnapPct": "0.09",
+        "defSnap": "0",
+        "stSnap": "0",
+        "stSnapPct": "0.00",
+        "offSnap": "7",
+        "defSnapPct": "0.00"
+      },
+      "team": "TB",
+      "teamAbv": "TB",
+      "playerID": "5097554",
+      "longName": "Kameron Johnson"
+    }
+  },
+  "scoringPlays": [
+    {
+      "score": "Mike Evans 2 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+      "scorePeriod": "Q1",
+      "homeScore": "7",
+      "awayScore": "0",
+      "teamID": "30",
+      "scoreDetails": "6 plays, 70 yards, 3:25",
+      "scoreType": "TD",
+      "scoreTime": "11:35",
+      "team": "TB",
+      "playerIDs": ["3052587", "16737", "3150744"]
+    },
+    {
+      "score": "Adam Thielen 17 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+      "scorePeriod": "Q1",
+      "homeScore": "7",
+      "awayScore": "7",
+      "teamID": "5",
+      "scoreDetails": "6 plays, 70 yards, 3:20",
+      "scoreType": "TD",
+      "scoreTime": "8:15",
+      "team": "CAR",
+      "playerIDs": ["4685720", "16460", "4034949"]
+    },
+    {
+      "score": "Chase McLaughlin 23 Yd Field Goal",
+      "scorePeriod": "Q1",
+      "homeScore": "10",
+      "awayScore": "7",
+      "teamID": "30",
+      "scoreDetails": "12 plays, 75 yards, 7:02",
+      "scoreType": "FG",
+      "scoreTime": "1:13",
+      "team": "TB",
+      "playerIDs": ["3150744"]
+    },
+    {
+      "score": "Chase McLaughlin 34 Yd Field Goal",
+      "scorePeriod": "Q2",
+      "homeScore": "13",
+      "awayScore": "7",
+      "teamID": "30",
+      "scoreDetails": "10 plays, 45 yards, 4:20",
+      "scoreType": "FG",
+      "scoreTime": "10:31",
+      "team": "TB",
+      "playerIDs": ["3150744"]
+    },
+    {
+      "score": "Mike Evans 1 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "20",
+      "awayScore": "7",
+      "teamID": "30",
+      "scoreDetails": "4 plays, 81 yards, 1:50",
+      "scoreType": "TD",
+      "scoreTime": "8:19",
+      "team": "TB",
+      "playerIDs": ["3052587", "16737", "3150744"]
+    },
+    {
+      "score": "Jalen McMillan 10 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "27",
+      "awayScore": "7",
+      "teamID": "30",
+      "scoreDetails": "11 plays, 64 yards, 5:38",
+      "scoreType": "TD",
+      "scoreTime": "1:11",
+      "team": "TB",
+      "playerIDs": ["3052587", "4430834", "3150744"]
+    },
+    {
+      "score": "Adam Thielen 40 Yd pass from Bryce Young (Eddy Pineiro Kick)",
+      "scorePeriod": "Q2",
+      "homeScore": "27",
+      "awayScore": "14",
+      "teamID": "5",
+      "scoreDetails": "4 plays, 70 yards, 0:21",
+      "scoreType": "TD",
+      "scoreTime": "0:50",
+      "team": "CAR",
+      "playerIDs": ["4685720", "16460", "4034949"]
+    },
+    {
+      "score": "Payne Durham 5 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "34",
+      "awayScore": "14",
+      "teamID": "30",
+      "scoreDetails": "10 plays, 94 yards, 5:50",
+      "scoreType": "TD",
+      "scoreTime": "5:48",
+      "team": "TB",
+      "playerIDs": ["3052587", "4372505", "3150744"]
+    },
+    {
+      "score": "J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)",
+      "scorePeriod": "Q3",
+      "homeScore": "41",
+      "awayScore": "14",
+      "teamID": "30",
+      "scoreDetails": "3 plays, 0 yards, 0:25",
+      "scoreType": "TD",
+      "scoreTime": "5:23",
+      "team": "TB",
+      "playerIDs": ["3150744"]
+    },
+    {
+      "score": "Jalen McMillan 16 Yd pass from Baker Mayfield (Chase McLaughlin Kick)",
+      "scorePeriod": "Q4",
+      "homeScore": "48",
+      "awayScore": "14",
+      "teamID": "30",
+      "scoreDetails": "9 plays, 85 yards, 5:03",
+      "scoreType": "TD",
+      "scoreTime": "13:30",
+      "team": "TB",
+      "playerIDs": ["3052587", "4430834", "3150744"]
+    }
+  ],
+  "seasonType": "Regular Season",
+  "teamIDAway": "5",
+  "teamIDHome": "30",
+  "teamStats": {
+    "away": {
+      "totalYards": "204",
+      "rushingAttempts": "13",
+      "rushingYards": "39",
+      "fumblesLost": "0",
+      "penalties": "4-30",
+      "totalPlays": "46",
+      "possession": "18:49",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "15-28",
+      "passingFirstDowns": "10",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "5-38",
+      "thirdDownEfficiency": "2-9",
+      "blockedPunt": "0",
+      "yardsPerPlay": "4.4",
+      "redZoneScoredAndAttempted": "1-1",
+      "teamID": "5",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "0",
+      "totalDrives": "10",
+      "rushingFirstDowns": "2",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "13",
+      "passTD": "2",
+      "team": "CAR",
+      "blockedXP": "0",
+      "teamAbv": "CAR",
+      "firstDownsFromPenalties": "1",
+      "fourthDownEfficiency": "0-1",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "165",
+      "yardsPerRush": "3.0",
+      "snapCounts": {
+        "totalSpecialTeams": "30",
+        "totalOffensive": "47",
+        "totalDefensive": "77"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "5.0"
+    },
+    "home": {
+      "totalYards": "551",
+      "rushingAttempts": "40",
+      "rushingYards": "202",
+      "fumblesLost": "0",
+      "penalties": "5-40",
+      "totalPlays": "74",
+      "possession": "41:11",
+      "safeties": "0",
+      "passCompletionsAndAttempts": "27-32",
+      "passingFirstDowns": "17",
+      "interceptionsThrown": "0",
+      "sacksAndYardsLost": "2-10",
+      "thirdDownEfficiency": "10-14",
+      "blockedPunt": "1",
+      "yardsPerPlay": "7.4",
+      "redZoneScoredAndAttempted": "5-8",
+      "teamID": "30",
+      "defensiveInterceptions": "0",
+      "defensiveOrSpecialTeamsTds": "1",
+      "totalDrives": "9",
+      "rushingFirstDowns": "14",
+      "blockedFG": "0",
+      "rushTD": "0",
+      "twoPointConversions": "0",
+      "firstDowns": "33",
+      "passTD": "5",
+      "team": "TB",
+      "blockedXP": "0",
+      "teamAbv": "TB",
+      "firstDownsFromPenalties": "2",
+      "fourthDownEfficiency": "0-0",
+      "defensiveTwoPointConversionReturns": "0",
+      "passingYards": "349",
+      "yardsPerRush": "5.1",
+      "snapCounts": {
+        "totalSpecialTeams": "30",
+        "totalOffensive": "77",
+        "totalDefensive": "47"
+      },
+      "turnovers": "0",
+      "yardsPerPass": "10.3"
+    }
+  },
+  "gameID": "20241229_CAR@TB",
+  "gameStatusCode": "2"
+}

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -8,6 +8,8 @@ import rawBlockedFgGame from "./__fixtures__/box-score-blocked-fg.json" with { t
 import rawSafetyGame from "./__fixtures__/box-score-safety.json" with { type: "json" };
 import rawBlockedPuntTdGame from "./__fixtures__/box-score-blocked-punt-td.json" with { type: "json" };
 import rawOverlapGame from "./__fixtures__/box-score-def-st-overlap.json" with { type: "json" };
+import rawBpGame from "./__fixtures__/box-score-blocked-punt-scoretype.json" with { type: "json" };
+import rawNoPlayerIdGame from "./__fixtures__/box-score-returner-not-in-playerids.json" with { type: "json" };
 
 /**
  * Tests run against a **real captured box score** — Cowboys at Eagles, the 2025
@@ -1056,25 +1058,377 @@ describe("safeties", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Two more real games, from 2024, and between them the two ways a special-teams
+// touchdown could vanish entirely. Both were found by sweeping all 544 games of
+// 2024 and 2025 against Sleeper; both fixtures are captured `getNFLBoxScore`
+// responses.
+// ---------------------------------------------------------------------------
+
+const bpGame = translateBoxScore(rawBpGame);
+const noPlayerIdGame = translateBoxScore(rawNoPlayerIdGame);
+
+/**
+ * `scoreType` has a fifth value, and it paid nobody anything.
+ *
+ * `20241208_BUF@LAR`, verbatim from the fixture:
+ *
+ *     BP | LAR | Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)
+ *
+ * Both places that pay six points for a special-teams score asked
+ * `play.scoreType === "TD"`, so this play reached neither. And nothing else in
+ * the pipeline made it up: `DST.defTD` reads `"0"`, so the unit had no other
+ * source, and `defensiveOrSpecialTeamsTds` reads `"0"` too, so the cross-check
+ * that exists to catch exactly this agreed with the silence. **Twelve points on
+ * one play, in two roster spots, with `warnings: []`.**
+ */
+describe("a blocked punt filed under scoreType BP", () => {
+  const LONG = "4239944";
+
+  it("is the play the fixture was captured for", () => {
+    const play = rawBpGame.scoringPlays.find((p) => p.scoreType === "BP");
+
+    expect(play?.score).toBe("Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)");
+    expect(play?.team).toBe("LAR");
+  });
+
+  it("pays the returner his six", () => {
+    expect(playerOf(bpGame, LONG).get("ret_td")).toBe(1);
+    expect(scorePlayer(bpGame.players.get(LONG) ?? [], RULES)).toBeGreaterThanOrEqual(6000);
+  });
+
+  it("pays the returning unit its six, which no field in the response reports", () => {
+    // The half with no numeric fallback anywhere. Both of the provider's own
+    // touchdown counters read zero for the Rams in this game.
+    expect(rawBpGame.DST.home.defTD).toBe("0");
+    expect(rawBpGame.teamStats.home.defensiveOrSpecialTeamsTds).toBe("0");
+
+    expect(unitOf(bpGame, "LAR").get("def_td")).toBe(1);
+  });
+
+  it("does not credit the opponent", () => {
+    expect(unitOf(bpGame, "BUF").get("def_td")).toBeUndefined();
+  });
+
+  it("still counts the block itself exactly once", () => {
+    // `teamStats.blockedPunt` is "1" and the scoring text describes the same
+    // block, so this is the case the `Math.max` in `def_blk_kick` exists for.
+    expect(rawBpGame.teamStats.home.blockedPunt).toBe("1");
+    expect(unitOf(bpGame, "LAR").get("def_blk_kick")).toBe(1);
+  });
+
+  it("says nothing, because the cross-check knows BP is in neither counter", () => {
+    // The trap in fixing this. Paying the play makes `readFromText` 1 while
+    // `defensiveOrSpecialTeamsTds - DST.defTD` is still 0, so the check would
+    // now fire on a game we have just started scoring correctly — which is the
+    // defect #181 removed for blocked kicks ESPN files as defensive, arriving
+    // from the other side. See `isUncountedSpecialTeamsScoreType`.
+    expect(bpGame.warnings).toEqual([]);
+  });
+});
+
+/**
+ * The returner is not in `playerIDs`, and has no record of his own either.
+ *
+ * `20241229_CAR@TB`, verbatim:
+ *
+ *     TD | TB | J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)
+ *        | playerIDs: ["3150744"]
+ *
+ * `3150744` is Chase McLaughlin, the kicker. The man the sentence names is not
+ * in the array, and Tank01's entire record for him in this game is a
+ * `snapCounts` block — no `scoringPlays`, no `Defense`, nothing. So the old
+ * per-player loop had two independent reasons to miss him and would have needed
+ * both fixed.
+ *
+ * **This is not a `BP` play.** Its `scoreType` is `TD`, which matters because it
+ * means the two defects are genuinely separate: widening the score type alone
+ * would have left these six points on the floor.
+ */
+describe("a return touchdown whose scorer the play does not list", () => {
+  const RUSSELL = "4243366";
+  const KICKER = "3150744";
+
+  it("is the play the fixture was captured for", () => {
+    const play = rawNoPlayerIdGame.scoringPlays.find((p) => /Blocked Punt/i.test(p.score));
+
+    expect(play?.scoreType).toBe("TD");
+    expect(play?.score).toBe(
+      "J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)",
+    );
+    expect(play?.playerIDs).toEqual([KICKER]);
+  });
+
+  it("has no record of its own to be found in", () => {
+    // The second half of why `playerIDs` could not simply be widened: even a
+    // loop that ignored the array entirely would run zero times for this player.
+    const russell = rawNoPlayerIdGame.playerStats[RUSSELL] as Record<string, unknown>;
+
+    expect(russell["longName"]).toBe("J.J. Russell");
+    expect(russell["scoringPlays"]).toBeUndefined();
+    expect(russell["Defense"]).toBeUndefined();
+  });
+
+  it("credits the man the main clause names", () => {
+    expect(playerOf(noPlayerIdGame, RUSSELL).get("ret_td")).toBe(1);
+  });
+
+  it("does not credit the kicker, who is the only id on the play", () => {
+    // The mirror of the Darnold case: `playerIDs` names whoever the provider
+    // felt like naming, and here that is nobody who scored.
+    expect(playerOf(noPlayerIdGame, KICKER).get("ret_td")).toBeUndefined();
+  });
+
+  it("leaves the unit's own six where it already was", () => {
+    // Tampa's `def_td` was correct before this change and must stay correct: the
+    // unit path reads the text rather than `playerIDs`, so it never lost the
+    // play. Stated because "fix the returner" and "fix the unit" are different
+    // code paths and only one of them was broken here.
+    expect(rawNoPlayerIdGame.teamStats.home.defensiveOrSpecialTeamsTds).toBe("1");
+
+    expect(unitOf(noPlayerIdGame, "TB").get("def_td")).toBe(1);
+    expect(unitOf(noPlayerIdGame, "CAR").get("def_td")).toBeUndefined();
+  });
+});
+
+describe("a return touchdown nobody can be credited for is never silent", () => {
+  const play = {
+    score: "Somebody Nobodyknows 40 Yd Punt Return (A Kicker Kick)",
+    scoreType: "TD",
+    team: "PHI",
+    playerIDs: [] as string[],
+  };
+
+  // `ydsAllowed` included because these assertions read the whole warning list,
+  // and a unit missing a tiered field warns about it — correctly, and here it
+  // would only be noise from the fixture rather than from the code under test.
+  const dst = {
+    home: { teamAbv: "PHI", ptsAllowed: "20", ydsAllowed: "300", defTD: "0" },
+    away: { teamAbv: "DAL", ptsAllowed: "24", ydsAllowed: "310", defTD: "0" },
+  };
+
+  it("warns when the main clause names no player in the game", () => {
+    // Six points that would otherwise go to nobody, on a play the unit is
+    // simultaneously being paid six for — so the response is internally
+    // inconsistent and says so rather than reading as a clean game.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: { p: { playerID: "p", longName: "Someone Else", team: "PHI" } },
+      DST: dst,
+      scoringPlays: [play],
+    });
+
+    expect(translated.warnings.join(" ")).toMatch(
+      /return touchdown ".*" names no player this game recognises/,
+    );
+    expect(unitOf(translated, "PHI").get("def_td")).toBe(1);
+  });
+
+  /**
+   * The genuine ambiguity: one abbreviation, two players.
+   *
+   * `"C.Smith"` normalises to `csmith`, and so does the initial-plus-surname
+   * form of both a Chris Smith and a Carl Smith. Tank01 really does write plays
+   * this way — `"(J.Elliott kick)"` is recorded verbatim in `docs/TANK01.md` —
+   * so this is the shape that reaches us rather than an invented collision.
+   */
+  const twoSmiths = {
+    a: { playerID: "a", longName: "Chris Smith", team: "PHI" },
+    b: { playerID: "b", longName: "Carl Smith", team: "PHI" },
+  };
+
+  it("credits nobody, and says so, when one spelling fits two players", () => {
+    // The same answer the two-point pass gives, for the same reason: crediting
+    // the wrong man costs six points twice, once in each direction. A return has
+    // exactly one scorer, so two matches is a fact about our name matching.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: twoSmiths,
+      DST: dst,
+      scoringPlays: [{ ...play, score: "C.Smith 40 Yd Punt Return" }],
+    });
+
+    expect(translated.warnings.join(" ")).toMatch(/return touchdown ".*" matches/);
+    expect(playerOf(translated, "a").get("ret_td")).toBeUndefined();
+    expect(playerOf(translated, "b").get("ret_td")).toBeUndefined();
+  });
+
+  it("uses playerIDs to break that tie rather than refusing", () => {
+    // `playerIDs` is demoted to a tiebreak, not deleted, and this is why: the
+    // old rule required it *and* the main clause, so anything it used to credit
+    // uniquely must still be credited. Only a play that used to pay two players
+    // six each can be lost, and that was never right.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: twoSmiths,
+      DST: dst,
+      scoringPlays: [{ ...play, score: "C.Smith 40 Yd Punt Return", playerIDs: ["a"] }],
+    });
+
+    expect(playerOf(translated, "a").get("ret_td")).toBe(1);
+    expect(playerOf(translated, "b").get("ret_td")).toBeUndefined();
+    expect(translated.warnings).toEqual([]);
+  });
+});
+
+describe("an unfamiliar scoreType is reported rather than absorbed", () => {
+  const base = {
+    gameID: "g",
+    playerStats: {},
+    DST: {
+      home: { teamAbv: "PHI", ptsAllowed: "20" },
+      away: { teamAbv: "DAL", ptsAllowed: "24" },
+    },
+  };
+
+  it("names a value it has never seen", () => {
+    // The whole reason this exists. `BP` was in the feed for two seasons costing
+    // 12 points an appearance, and what found it was a human sweeping 544 games.
+    // An unrecognised value is inert in the scoring by design; inert and silent
+    // are different things.
+    const translated = translateBoxScore({
+      ...base,
+      scoringPlays: [{ score: "Something new", scoreType: "XPR", team: "PHI" }],
+    });
+
+    expect(translated.warnings.join(" ")).toMatch(/scoreType "XPR" has not been seen before/);
+  });
+
+  it("says it once per game, however many plays carry it", () => {
+    const translated = translateBoxScore({
+      ...base,
+      scoringPlays: [
+        { score: "a", scoreType: "XPR", team: "PHI" },
+        { score: "b", scoreType: "XPR", team: "PHI" },
+        { score: "c", scoreType: "XPR", team: "DAL" },
+      ],
+    });
+
+    expect(translated.warnings.filter((w) => w.includes("XPR"))).toHaveLength(1);
+  });
+
+  it.each(["TD", "FG", "SF", "2PTC", "BP", undefined])("says nothing about %s", (scoreType) => {
+    // The absent value is in here deliberately: the full-2025 sweep found one,
+    // so warning about it would put noise on ordinary games.
+    const translated = translateBoxScore({
+      ...base,
+      scoringPlays: [{ score: "Ordinary play", scoreType, team: "PHI" }],
+    });
+
+    expect(translated.warnings.join(" ")).not.toMatch(/has not been seen before/);
+  });
+});
+
+/**
+ * A defensive two-point conversion return.
+ *
+ * ESPN pays the D/ST 2 for taking a failed conversion attempt back the other
+ * way. We had no stat key at all, so it scored nothing — three occurrences over
+ * 2024 and 2025. `teamStats.defensiveTwoPointConversionReturns` carries it, and
+ * it is read as a number rather than parsed out of the play text.
+ */
+describe("defensive two-point conversion returns", () => {
+  const withReturns = (value: string): ReturnType<typeof translateBoxScore> =>
+    translateBoxScore({
+      gameID: "g",
+      playerStats: {},
+      DST: {
+        home: { teamAbv: "DAL", ptsAllowed: "20" },
+        away: { teamAbv: "PHI", ptsAllowed: "24" },
+      },
+      teamStats: {
+        home: { teamAbv: "DAL", defensiveTwoPointConversionReturns: value },
+        away: { teamAbv: "PHI", defensiveTwoPointConversionReturns: "0" },
+      },
+      scoringPlays: [],
+    });
+
+  it("credits the returning unit two points", () => {
+    const translated = withReturns("1");
+
+    expect(unitOf(translated, "DAL").get("def_2pt_ret")).toBe(1);
+    expect(scorePlayer(translated.teamDefense.get("DAL") ?? [], RULES)).toBe(2000);
+  });
+
+  it("emits nothing at zero, unlike the tiered rules", () => {
+    // A plain counter, so absent and zero score identically — and a row a week
+    // for every unit in the league would be a lot of rows for an event that
+    // happens about once a season.
+    expect(unitOf(withReturns("1"), "PHI").get("def_2pt_ret")).toBeUndefined();
+  });
+
+  it("says so when the field is present but unreadable", () => {
+    const translated = withReturns("two");
+
+    expect(translated.warnings.join(" ")).toMatch(
+      /DAL: defensiveTwoPointConversionReturns is "two", which is not a number/,
+    );
+    expect(unitOf(translated, "DAL").get("def_2pt_ret")).toBeUndefined();
+  });
+
+  it("still pays nobody for the failed conversion itself", () => {
+    // The offensive half must not move. Tank01's wording for a conversion the
+    // defence returned names the interception in the same sentence, and the
+    // `Failed` token is the only thing that stops two points being handed to the
+    // offence — which would be the conversion paid to the team that missed it.
+    const translated = translateBoxScore({
+      gameID: "g",
+      playerStats: {
+        q: { playerID: "q", longName: "Minkah Fitzpatrick", team: "PIT" },
+      },
+      DST: {
+        home: { teamAbv: "PIT", ptsAllowed: "20" },
+        away: { teamAbv: "BAL", ptsAllowed: "24" },
+      },
+      scoringPlays: [
+        {
+          score:
+            "Some Guy 3 Yd Run (Two-Point Pass Conversion Failed. " +
+            "Minkah Fitzpatrick Interception Return)",
+          scoreType: "TD",
+          team: "BAL",
+          playerIDs: ["q"],
+        },
+      ],
+    });
+
+    expect(playerOf(translated, "q").get("two_pt")).toBeUndefined();
+    // And it is not a return touchdown either, in either direction: the text
+    // says "Interception Return", which `DEFENSIVE_RETURN` claims first.
+    expect(playerOf(translated, "q").get("ret_td")).toBeUndefined();
+    expect(unitOf(translated, "PIT").get("def_td")).toBeUndefined();
+  });
+});
+
 describe("the newly captured games reconcile", () => {
   it.each([
     ["20250907_ARI@NO", () => blockedFgGame],
     ["20250921_ARI@SF", () => safetyGame],
     ["20251103_ARI@DAL", () => blockedPuntTdGame],
     ["20250928_CAR@NE", () => overlapGame],
+    ["20241208_BUF@LAR", () => bpGame],
+    ["20241229_CAR@TB", () => noPlayerIdGame],
   ])("%s reads cleanly", (gameRef, get) => {
     const translated = get();
 
     expect(translated.gameRef).toBe(gameRef);
     expect(translated.fatal).toEqual([]);
     // Zero warnings is the claim worth making: every cross-check added here
-    // agrees with the provider on four independently captured responses.
+    // agrees with the provider on six independently captured responses, two of
+    // them from a season the rest of this file does not cover.
     expect(translated.warnings).toEqual([]);
     expect(translated.players.size).toBeGreaterThan(50);
   });
 
   it("scores every player and every unit in them without throwing", () => {
-    for (const translated of [blockedFgGame, safetyGame, blockedPuntTdGame, overlapGame]) {
+    for (const translated of [
+      blockedFgGame,
+      safetyGame,
+      blockedPuntTdGame,
+      overlapGame,
+      bpGame,
+      noPlayerIdGame,
+    ]) {
       for (const lines of translated.players.values()) {
         expect(() => scorePlayer(lines, RULES)).not.toThrow();
       }

--- a/packages/stats/src/tank01/box-score.ts
+++ b/packages/stats/src/tank01/box-score.ts
@@ -25,16 +25,19 @@ import {
   bucketFieldGoal,
   isBlockedKick,
   isBlockedKickTouchdown,
+  isKnownScoreType,
   isSpecialTeamsReturnTouchdown,
   isSuccessfulTwoPointConversion,
+  isTouchdownScoringPlay,
+  isUncountedSpecialTeamsScoreType,
   mainClause,
   parseFieldGoalYards,
   parseStatValue,
-  scoredInMainClause,
   TANK01_DST_MAP,
   TANK01_STAT_MAP,
   TANK01_TEAM_BLOCKED_KICK_FIELDS,
   TANK01_TEAM_DEF_ST_TD_FIELD,
+  TANK01_TEAM_STATS_MAP,
 } from "./stat-map.js";
 
 interface ScoringPlay {
@@ -145,6 +148,32 @@ function nameForms(longName: string): readonly string[] {
   return abbreviated ? [full, abbreviated] : [full];
 }
 
+interface RosterEntry {
+  readonly playerID: string;
+  readonly longName: string;
+  readonly forms: readonly string[];
+}
+
+/**
+ * Every named player in the game, with the spellings a play might use.
+ *
+ * Built once and shared by the two passes that resolve a name to a player. A
+ * player carrying no stat categories at all is still in here as long as Tank01
+ * gave him a `longName` — which matters more than it sounds, because those are
+ * exactly the players the per-player loops cannot see. J.J. Russell's entire
+ * record in `20241229_CAR@TB` is a `snapCounts` block, and he scored a
+ * touchdown.
+ */
+function rosterOf(playerStats: Record<string, RawPlayer>): readonly RosterEntry[] {
+  return Object.values(playerStats)
+    .filter((player) => player.playerID && player.longName)
+    .map((player) => ({
+      playerID: player.playerID as string,
+      longName: player.longName as string,
+      forms: nameForms(player.longName as string),
+    }));
+}
+
 /**
  * Everyone credited with a two-point conversion in this game, by player id.
  *
@@ -184,14 +213,7 @@ function twoPointCreditsByPlayer(
   warnings: string[],
 ): Map<string, number> {
   const credits = new Map<string, number>();
-
-  const roster = Object.values(playerStats)
-    .filter((player) => player.playerID && player.longName)
-    .map((player) => ({
-      playerID: player.playerID as string,
-      longName: player.longName as string,
-      forms: nameForms(player.longName as string),
-    }));
+  const roster = rosterOf(playerStats);
 
   for (const play of scoringPlays) {
     const text = play.score ?? "";
@@ -242,6 +264,91 @@ function twoPointCreditsByPlayer(
 }
 
 /**
+ * Everyone credited with a special-teams return touchdown, by player id.
+ *
+ * ## Why this is a game-level pass, like the conversions above
+ *
+ * It used to run inside each player's own loop, over his own `scoringPlays`,
+ * gated on `play.playerIDs` naming him. **Both halves lose the scorer**, and
+ * unlike the conversion case they lose him on a play that is entirely his.
+ * Verbatim, from `20241229_CAR@TB`:
+ *
+ *     TD | TB | J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)
+ *        | playerIDs: ["3150744"]
+ *
+ * `3150744` is the kicker. The returner is not in `playerIDs`, and Tank01's
+ * whole record for him in that game is a `snapCounts` block — no `scoringPlays`,
+ * no `Defense` — so his own loop ran zero times whatever the gate said. Six
+ * points, in silence, on a play whose text names him first. This is issue #155's
+ * shape exactly, one category over.
+ *
+ * ## The main clause, and only one scorer
+ *
+ * A conversion legitimately credits two players — a passer and a receiver — so
+ * that pass tolerates several matches. A return touchdown has exactly one
+ * scorer, so several distinct matches is a fact about our name matching rather
+ * than about the play, and this refuses instead.
+ *
+ * **`playerIDs` is the tiebreak, not the gate.** Demoting it that far and no
+ * further is deliberate: this pass matches names against every player in the
+ * game, where the old per-player check was only ever asked about players the
+ * play already named, and `scoredInMainClause` said in as many words that
+ * widening it needed a stricter comparison. Falling back to the intersection
+ * makes the new rule a superset of the old one — anything the gate used to
+ * credit uniquely is still credited — so the only behaviour that can be lost is
+ * a play crediting *two* players six points each, which was never right.
+ */
+function returnTouchdownCredits(
+  scoringPlays: readonly ScoringPlay[],
+  playerStats: Record<string, RawPlayer>,
+  warnings: string[],
+): Map<string, number> {
+  const credits = new Map<string, number>();
+  const roster = rosterOf(playerStats);
+
+  for (const play of scoringPlays) {
+    const text = play.score ?? "";
+    if (!isTouchdownScoringPlay(play.scoreType)) continue;
+    if (!isSpecialTeamsReturnTouchdown(text)) continue;
+
+    // The complement of the window a conversion is read in: who scored is
+    // outside the parentheses, the PAT or conversion inside them.
+    const haystack = normaliseName(mainClause(text));
+    const matched = roster.filter((player) =>
+      player.forms.some((form) => haystack.includes(form)),
+    );
+
+    const distinct = [...new Map(matched.map((player) => [player.playerID, player])).values()];
+
+    const candidates =
+      distinct.length === 1
+        ? distinct
+        : distinct.filter((player) => play.playerIDs?.includes(player.playerID));
+
+    const only = candidates.length === 1 ? candidates[0] : undefined;
+
+    if (!only) {
+      // Never silent. A return touchdown definitely happened — the text says so
+      // and the unit is about to be paid six for it — so a scorer we cannot name
+      // is six points nobody receives, which is the failure this whole pass
+      // exists to make loud.
+      warnings.push(
+        distinct.length === 0
+          ? `return touchdown "${text}" names no player this game recognises, ` +
+              `so nobody was credited for it`
+          : `return touchdown "${text}" matches ` +
+              `${distinct.map((c) => c.longName).join(" and ")}, so nobody was credited for it`,
+      );
+      continue;
+    }
+
+    credits.set(only.playerID, (credits.get(only.playerID) ?? 0) + 1);
+  }
+
+  return credits;
+}
+
+/**
  * Cross-check the conversions parsed from text against the numbers Tank01 gives.
  *
  * Field goals have had this since they were written, for the reason stated
@@ -283,6 +390,8 @@ function translatePlayerWithConversions(
   warnings: string[],
   /** Decided for the whole game — see `twoPointCreditsByPlayer`. */
   twoPointConversions: number,
+  /** Decided for the whole game — see `returnTouchdownCredits`. */
+  returnTouchdowns: number,
 ): { playerID: string; lines: StatLine[] } | null {
   const playerID = player.playerID;
   if (!playerID) return null;
@@ -308,7 +417,12 @@ function translatePlayerWithConversions(
     }
   }
 
-  // 2. Scoring plays this player was involved in.
+  // 2. Field goals, whose distances exist only in this player's own play text.
+  //
+  //    Still per-player, and it is the one thing here that should be: a kicker's
+  //    own `scoringPlays` array is exactly his own field goals, which is what
+  //    makes distance attribution need no name matching at all, and `fgMade` is
+  //    on the same record to check it against.
   let fieldGoalsParsed = 0;
 
   for (const play of player.scoringPlays ?? []) {
@@ -324,26 +438,15 @@ function translatePlayerWithConversions(
       }
       accumulate(totals, bucketFieldGoal(yards), 1);
       fieldGoalsParsed++;
-      continue;
-    }
-
-    if (play.scoreType === "TD") {
-      // The scorer is whoever the main clause names — not `playerIDs[0]`, which
-      // is the conversion passer when the parenthetical holds a successful
-      // two-pointer. See `scoredInMainClause`.
-      if (
-        isSpecialTeamsReturnTouchdown(text) &&
-        player.longName &&
-        scoredInMainClause(text, player.longName)
-      ) {
-        accumulate(totals, "ret_td", 1);
-      }
     }
   }
 
-  // Two-point conversions are decided for the whole game, not here: the player
-  // credited is often absent from this play's `playerIDs` and sometimes has no
-  // `scoringPlays` of his own at all. See `twoPointCreditsByPlayer`.
+  // Return touchdowns and two-point conversions are both decided for the whole
+  // game rather than here, and for the same reason in the end: the player who
+  // scored is often absent from the play's `playerIDs`, and sometimes has no
+  // `scoringPlays` of his own at all. See `returnTouchdownCredits` and
+  // `twoPointCreditsByPlayer`.
+  if (returnTouchdowns > 0) accumulate(totals, "ret_td", returnTouchdowns);
   if (twoPointConversions > 0) accumulate(totals, "two_pt", twoPointConversions);
 
   // 3. Cross-check parsed field goals against the count Tank01 reports.
@@ -565,6 +668,33 @@ function translateTeamDefense(
     }
 
     // ---------------------------------------------------------------------
+    // Team-level counters that are a source in their own right
+    // ---------------------------------------------------------------------
+    //
+    // Only `def_2pt_ret` so far. Kept apart from the `DST` loop above because the
+    // block genuinely does not carry the field, not as a stylistic split — and
+    // apart from the blocked-kick and safety sections below because those
+    // reconcile two readings against each other and this has exactly one.
+    //
+    // Not emitted at zero. It is a plain counter rather than a tiered rule, so
+    // absent and zero score the same, and every unit in the league carrying an
+    // explicit `def_2pt_ret: 0` would be a row a week for an event that happens
+    // about once a season.
+    for (const [field, statKey] of Object.entries(TANK01_TEAM_STATS_MAP)) {
+      if (team?.[field] === undefined) continue;
+
+      const parsed = parseStatValue(team[field]);
+      if (parsed === null) {
+        warnings.push(
+          `${teamAbv}: ${field} is ${JSON.stringify(team[field])}, which is not a number — ` +
+            `${statKey} was dropped`,
+        );
+        continue;
+      }
+      if (parsed !== 0) accumulate(totals, statKey, parsed);
+    }
+
+    // ---------------------------------------------------------------------
     // Blocked kicks
     // ---------------------------------------------------------------------
     //
@@ -633,12 +763,21 @@ function translateTeamDefense(
     // `play.team` is the team that scored, which for a return is the returning
     // team — the opposite of the blocked-kick case above, where the block is
     // usually noted on the opponent's score. That is why this cannot reuse
-    // `blockingTeamOf`. Gated on `scoreType` so a non-scoring play that merely
-    // mentions a return cannot pay six points.
+    // `blockingTeamOf`.
+    //
+    // **The `scoreType` gate is a deny-list now, not `=== "TD"`.** It was the
+    // latter until 2026-08-17 and Tank01 has a fifth value: `20241208_BUF@LAR`
+    // files Hunter Long's blocked-punt return under `BP`, so the Rams' unit was
+    // paid nothing for a special-teams touchdown — and nothing else made it up,
+    // because `DST.defTD` reads `"0"` for that game too. See
+    // `isTouchdownScoringPlay` for why the question is asked negatively. The
+    // guard against a non-scoring play that merely mentions a return is
+    // `isSpecialTeamsReturnTouchdown`, which names the event, rather than a
+    // vocabulary we have now been wrong about twice.
     const defensiveScorers = defensiveTouchdownScorers(playerStats, teamAbv);
     const specialTeamsTds = scoringPlays.filter(
       (play) =>
-        play.scoreType === "TD" &&
+        isTouchdownScoringPlay(play.scoreType) &&
         play.team === teamAbv &&
         isSpecialTeamsReturnTouchdown(play.score ?? ""),
     );
@@ -679,25 +818,45 @@ function translateTeamDefense(
     // Narrowed rather than dropped, because this is still the only thing that
     // would find a novel wording without a season sweep — and a warning that
     // fires on correct data is how the next real one gets dismissed.
-    const blockedInDefTd = alreadyInDefTd.filter((play) =>
-      isBlockedKickTouchdown(play.score ?? ""),
+    //
+    // **And a `BP` play is in neither counter**, which is the same defect
+    // arriving from the other side. Newly relevant because such a play now
+    // reaches `specialTeamsTds` at all: before the deny-list above it was
+    // excluded from the count *and* from the scoring, so the comparison happened
+    // to balance while both halves were wrong. See
+    // `isUncountedSpecialTeamsScoreType`, which records that this rests on the
+    // single `BP` play in two seasons.
+    const uncountedByType = specialTeamsTds.filter((play) =>
+      isUncountedSpecialTeamsScoreType(play.scoreType),
+    );
+    const blockedInDefTd = alreadyInDefTd.filter(
+      (play) => isBlockedKickTouchdown(play.score ?? "") && !uncountedByType.includes(play),
     ).length;
-    const readFromText = specialTeamsTds.length - blockedInDefTd;
+    const readFromText = specialTeamsTds.length - blockedInDefTd - uncountedByType.length;
 
     const reportedDefStTds = parseStatValue(team?.[TANK01_TEAM_DEF_ST_TD_FIELD]);
     const reportedDefTds = parseStatValue(unit["defTD"]);
     if (reportedDefStTds !== null && reportedDefTds !== null) {
       const expected = reportedDefStTds - reportedDefTds;
       if (expected !== readFromText) {
+        // Every exclusion is named. The check is narrowed in two places now, and
+        // a reader who does not already know about ESPN's stat id 93 or about
+        // `BP` would otherwise read a suppressed play as a play nobody counted.
+        const excluded = [
+          ...(blockedInDefTd > 0
+            ? [`${blockedInDefTd} blocked-kick touchdown(s) ESPN files as defensive`]
+            : []),
+          ...(uncountedByType.length > 0
+            ? [`${uncountedByType.length} scored under a scoreType Tank01 does not total`]
+            : []),
+        ];
+
         warnings.push(
           `${teamAbv}: teamStats implies ${expected} special teams touchdown(s) ` +
             `(${TANK01_TEAM_DEF_ST_TD_FIELD} ${reportedDefStTds} - DST.defTD ` +
             `${reportedDefTds}) but ${readFromText} were read from the ` +
             `scoring text` +
-            (blockedInDefTd > 0
-              ? `, excluding ${blockedInDefTd} blocked-kick touchdown(s) ESPN ` +
-                `files as defensive`
-              : ""),
+            (excluded.length > 0 ? `, excluding ${excluded.join(" and ")}` : ""),
         );
       }
     }
@@ -738,6 +897,44 @@ function translateTeamDefense(
   return result;
 }
 
+/**
+ * Say so when a play carries a `scoreType` this adapter has never seen.
+ *
+ * **The tripwire, and the only reason it is worth its noise.** `"BP"` sat in the
+ * feed for two seasons costing 12 points every time it appeared, and what found
+ * it was somebody sweeping 544 games by hand. Nothing in the pipeline said
+ * anything, because an unrecognised value is *inert* here by design — no
+ * `switch`, no throw, just a set of equality tests that all miss. Inert is the
+ * right behaviour and silent is not.
+ *
+ * Distinct values, once each per game, because the interesting thing is that a
+ * value exists rather than how many plays carry it — and a warning repeated
+ * ninety times is one nobody finishes reading.
+ *
+ * Not fatal, and not a reason to drop the play either: {@link
+ * isTouchdownScoringPlay} deliberately treats an unfamiliar type as eligible, so
+ * the scoring already does the best available thing. This only makes sure
+ * somebody gets to check whether it was right.
+ */
+function reportUnknownScoreTypes(
+  scoringPlays: readonly ScoringPlay[],
+  warnings: string[],
+): void {
+  const unknown = new Set(
+    scoringPlays
+      .map((play) => play.scoreType)
+      .filter((scoreType) => !isKnownScoreType(scoreType))
+      .map((scoreType) => String(scoreType)),
+  );
+
+  for (const scoreType of unknown) {
+    warnings.push(
+      `scoreType ${JSON.stringify(scoreType)} has not been seen before — it was treated ` +
+        `as a possible touchdown, and what it actually is should be checked against ESPN`,
+    );
+  }
+}
+
 /** Translate a raw `getNFLBoxScore` response. */
 export function translateBoxScore(raw: unknown): TranslatedBoxScore {
   const box = raw as Record<string, unknown>;
@@ -747,17 +944,21 @@ export function translateBoxScore(raw: unknown): TranslatedBoxScore {
   const playerStats = (box["playerStats"] ?? {}) as Record<string, RawPlayer>;
   const scoringPlays = (box["scoringPlays"] ?? []) as ScoringPlay[];
 
+  reportUnknownScoreTypes(scoringPlays, warnings);
+
   /*
-    Conversions first, and for the game rather than per player.
+    Conversions and return touchdowns first, and for the game rather than per
+    player.
 
     The credited player is frequently not in the play's `playerIDs` — those name
     the touchdown's participants — and is sometimes a player with no
-    `scoringPlays` and no receiving block of his own at all (issue #155). No
-    amount of looking at one player's own record finds him; the conversion only
-    exists on somebody else's.
+    `scoringPlays` and no category block of his own at all (issue #155, and
+    `20241229_CAR@TB` for the return). No amount of looking at one player's own
+    record finds him; the play exists only on somebody else's.
   */
   const twoPoint = twoPointCreditsByPlayer(scoringPlays, playerStats, warnings);
   crossCheckTwoPoint(playerStats, twoPoint, warnings);
+  const returns = returnTouchdownCredits(scoringPlays, playerStats, warnings);
 
   const players = new Map<string, readonly StatLine[]>();
   for (const player of Object.values(playerStats)) {
@@ -765,6 +966,7 @@ export function translateBoxScore(raw: unknown): TranslatedBoxScore {
       player,
       warnings,
       player.playerID ? (twoPoint.get(player.playerID) ?? 0) : 0,
+      player.playerID ? (returns.get(player.playerID) ?? 0) : 0,
     );
     if (translated) players.set(translated.playerID, translated.lines);
   }

--- a/packages/stats/src/tank01/stat-map.test.ts
+++ b/packages/stats/src/tank01/stat-map.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from "vitest";
+import { NFL } from "@rostr/core";
 import {
   bucketFieldGoal,
   isBlockedKick,
   isBlockedKickTouchdown,
   isDefensiveReturnTouchdown,
   isExtraPointMade,
+  isKnownScoreType,
   isSpecialTeamsReturnTouchdown,
   isSuccessfulTwoPointConversion,
+  isTouchdownScoringPlay,
+  isUncountedSpecialTeamsScoreType,
+  KNOWN_SCORE_TYPES,
   parseFieldGoalYards,
   parseStatValue,
   TANK01_DST_MAP,
   TANK01_STAT_MAP,
   TANK01_TEAM_BLOCKED_KICK_FIELDS,
   TANK01_TEAM_DEF_ST_TD_FIELD,
+  TANK01_TEAM_STATS_MAP,
   TANK01_UNMAPPED_PLAYER_DEFENSE_FIELDS,
 } from "./stat-map.js";
 
@@ -189,6 +195,11 @@ const REAL_RETURNS = {
   puntWithTwoPoint: "Parker Washington 87 Yd Punt Return (Two-Point Pass Conversion Failed)",
   blockedPunt: "Sydney Brown 35 yd. return of blocked punt (J.Elliott kick)",
   blockedFieldGoal: "Jared Verse 76 Yd Return of Blocked Field Goal (Harrison Mevis Kick)",
+  // 2024, and the two that were losing points until 2026-08-17. The first is the
+  // only `BP` play in either season; the second is a `TD` whose `playerIDs` name
+  // the kicker and nobody else. See `box-score.test.ts` for what each cost.
+  blockedPuntBp: "Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)",
+  blockedPuntNoIds: "J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)",
   interception: "Christian Benford 63 Yd Interception Return (Matt Prater Kick)",
   interception2: "T.J. Edwards 34 Yd Interception Return (Cairo Santos Kick)",
 } as const;
@@ -209,6 +220,27 @@ describe("isSpecialTeamsReturnTouchdown", () => {
     // abbreviated name, full stop after "yd". Tank01's text is not uniform.
     expect(isSpecialTeamsReturnTouchdown(REAL_RETURNS.blockedPunt)).toBe(true);
     expect(isSpecialTeamsReturnTouchdown(REAL_RETURNS.blockedFieldGoal)).toBe(true);
+    expect(isSpecialTeamsReturnTouchdown(REAL_RETURNS.blockedPuntBp)).toBe(true);
+    expect(isSpecialTeamsReturnTouchdown(REAL_RETURNS.blockedPuntNoIds)).toBe(true);
+  });
+
+  it("does not read a blocked extra point taken the other way as a touchdown", () => {
+    // The narrowing of 2026-08-17, and the reason it had to happen in the same
+    // change as the deny-list. `return of blocked` used to match anything, and
+    // `scoreType === "TD"` was the only thing keeping a conversion attempt out —
+    // so removing that equality test without this would have paid **six** points
+    // for a play worth **two**, to a unit, on a return of a blocked PAT.
+    //
+    // `BLOCKED_KICK_RECOVERY` already excluded the extra point in as many words.
+    // This makes the sibling pattern say the same thing rather than relying on a
+    // guard somewhere else.
+    for (const text of [
+      "Somebody 40 Yd Return of Blocked Extra Point",
+      "Somebody 40 Yd Return of Blocked PAT",
+      "Somebody Blocked Extra Point Recovery in End Zone",
+    ]) {
+      expect(isSpecialTeamsReturnTouchdown(text), text).toBe(false);
+    }
   });
 
   it("does NOT count interception returns", () => {
@@ -252,42 +284,36 @@ describe("field goals against real plays", () => {
 });
 
 describe("mapping integrity", () => {
-  const REGISTRY_KEYS = new Set([
-    "pass_yd",
-    "pass_td",
-    "pass_int",
-    "rush_yd",
-    "rush_td",
-    "rec",
-    "rec_yd",
-    "rec_td",
-    "fum_lost",
-    "two_pt",
-    "fg_0_39",
-    "fg_40_49",
-    "fg_50_59",
-    "fg_60_plus",
-    "fg_missed",
-    "xp_made",
-    "def_sack",
-    "def_int",
-    "def_fum_rec",
-    "def_safety",
-    "def_td",
-    "def_blk_kick",
-    "def_pts_allowed",
-    "def_yds_allowed",
-  ]);
+  /**
+   * Read from the registry rather than copied out of it.
+   *
+   * This was a hand-written list until 2026-08-17, and it had already gone
+   * stale: `ret_td` was missing from it, so any map pointing at that key would
+   * have been reported as unknown. A duplicate of a list whose whole purpose is
+   * to be the one true list is the drift it exists to catch.
+   */
+  const REGISTRY_KEYS = new Set(NFL.statKeys.map((key) => key.key));
 
   it("maps only to registry stat keys", () => {
     // A provider field name leaking through as a stat key would put Tank01's
     // vocabulary inside the scoring engine.
-    for (const statKey of Object.values(TANK01_STAT_MAP)) {
-      expect(REGISTRY_KEYS, `unknown stat key: ${statKey}`).toContain(statKey);
+    for (const map of [TANK01_STAT_MAP, TANK01_DST_MAP, TANK01_TEAM_STATS_MAP]) {
+      for (const statKey of Object.values(map)) {
+        expect(REGISTRY_KEYS, `unknown stat key: ${statKey}`).toContain(statKey);
+      }
     }
-    for (const statKey of Object.values(TANK01_DST_MAP)) {
-      expect(REGISTRY_KEYS, `unknown stat key: ${statKey}`).toContain(statKey);
-    }
+  });
+
+  it("reads each stat key from exactly one provider field", () => {
+    // Three maps now, and they all feed the same `totals` for a unit. Two of
+    // them naming one stat key would accumulate it twice — a doubled score with
+    // nothing to catch it, since both values would be real numbers from a real
+    // response.
+    const emitted = [TANK01_STAT_MAP, TANK01_DST_MAP, TANK01_TEAM_STATS_MAP].flatMap((map) =>
+      Object.values(map),
+    );
+
+    expect(new Set(emitted).size).toBe(emitted.length);
   });
 
   it("keeps fumbles under Defense, where Tank01 actually puts them", () => {
@@ -509,5 +535,92 @@ describe("the team-level fields", () => {
     // touchdown in week 4.
     expect(Object.keys(TANK01_DST_MAP)).not.toContain(TANK01_TEAM_DEF_ST_TD_FIELD);
     expect(Object.keys(TANK01_STAT_MAP)).not.toContain(TANK01_TEAM_DEF_ST_TD_FIELD);
+    expect(Object.keys(TANK01_TEAM_STATS_MAP)).not.toContain(TANK01_TEAM_DEF_ST_TD_FIELD);
+  });
+
+  it("reads defensive two-point returns from teamStats, which is the only block carrying them", () => {
+    // The `DST` block's fields, verbatim from every captured fixture:
+    // `teamAbv teamID defTD defensiveInterceptions sacks ydsAllowed
+    // fumblesRecovered ptsAllowed safeties`. This is not among them, which is
+    // why the map is separate rather than a stylistic split.
+    expect(TANK01_TEAM_STATS_MAP["defensiveTwoPointConversionReturns"]).toBe("def_2pt_ret");
+    expect(Object.keys(TANK01_DST_MAP)).not.toContain("defensiveTwoPointConversionReturns");
+  });
+});
+
+describe("which scoring plays may be touchdowns", () => {
+  it("accepts the two types that carry one", () => {
+    // `BP` is the one this function exists for. It was in the feed for two
+    // seasons and `scoreType === "TD"` sent it to neither the returner nor the
+    // unit — 12 points a play, silently. `20241208_BUF@LAR`.
+    expect(isTouchdownScoringPlay("TD")).toBe(true);
+    expect(isTouchdownScoringPlay("BP")).toBe(true);
+  });
+
+  it("refuses the three that carry something else", () => {
+    expect(isTouchdownScoringPlay("FG")).toBe(false);
+    expect(isTouchdownScoringPlay("SF")).toBe(false);
+    expect(isTouchdownScoringPlay("2PTC")).toBe(false);
+  });
+
+  it("treats an unfamiliar value as eligible rather than as a refusal", () => {
+    // The inversion, and the whole point. An allow-list of TD and BP fixes the
+    // one play we found and leaves the next one exactly as expensive; the text
+    // pattern is what actually names the event. `isKnownScoreType` is how the
+    // next unfamiliar value gets looked at instead of being trusted quietly.
+    expect(isTouchdownScoringPlay("XPR")).toBe(true);
+    expect(isTouchdownScoringPlay(undefined)).toBe(true);
+    expect(isTouchdownScoringPlay(null)).toBe(true);
+    expect(isTouchdownScoringPlay("")).toBe(true);
+  });
+
+  it("is not fooled by case or padding", () => {
+    expect(isTouchdownScoringPlay(" fg ")).toBe(false);
+    expect(isTouchdownScoringPlay("sf")).toBe(false);
+  });
+});
+
+describe("isKnownScoreType", () => {
+  it("knows every value two seasons of sweeping have turned up", () => {
+    expect([...KNOWN_SCORE_TYPES].sort()).toEqual(["2PTC", "BP", "FG", "SF", "TD"]);
+
+    for (const scoreType of KNOWN_SCORE_TYPES) {
+      expect(isKnownScoreType(scoreType), scoreType).toBe(true);
+    }
+  });
+
+  it("counts an absent value as known, because one was observed", () => {
+    // Warning about it would put noise on ordinary games, which is how a
+    // tripwire stops being read.
+    expect(isKnownScoreType(undefined)).toBe(true);
+    expect(isKnownScoreType(null)).toBe(true);
+    expect(isKnownScoreType("")).toBe(true);
+  });
+
+  it("does not know anything else", () => {
+    expect(isKnownScoreType("XPR")).toBe(false);
+    expect(isKnownScoreType("DEF2PT")).toBe(false);
+  });
+});
+
+describe("isUncountedSpecialTeamsScoreType", () => {
+  it("names BP, and only BP", () => {
+    // Not a scoring question. It tells the `defensiveOrSpecialTeamsTds`
+    // cross-check which plays the provider leaves out of its own totals, so that
+    // paying a `BP` play does not make the check fire on a game we have just
+    // started scoring correctly. `20241208_BUF@LAR` reads `0` and `0` for the
+    // Rams while the scoring text plainly shows one.
+    expect(isUncountedSpecialTeamsScoreType("BP")).toBe(true);
+    expect(isUncountedSpecialTeamsScoreType("bp")).toBe(true);
+
+    for (const scoreType of ["TD", "FG", "SF", "2PTC", "", undefined, null]) {
+      expect(isUncountedSpecialTeamsScoreType(scoreType), String(scoreType)).toBe(false);
+    }
+  });
+
+  it("does not decide whether the play scores", () => {
+    // The two questions are independent, and conflating them would have been the
+    // easy mistake: a `BP` play is a touchdown that pays six twice over.
+    expect(isTouchdownScoringPlay("BP")).toBe(true);
   });
 });

--- a/packages/stats/src/tank01/stat-map.ts
+++ b/packages/stats/src/tank01/stat-map.ts
@@ -105,6 +105,26 @@ export const TANK01_DST_MAP: Readonly<Record<string, string>> = {
   ydsAllowed: "def_yds_allowed",
   sacks: "def_sack",
   defensiveInterceptions: "def_int",
+  // **This is the opponent's fumbles *lost*, not this unit's recoveries**, and it
+  // is kept anyway because Tank01 offers nothing that is the latter. Established
+  // 2026-08-17 by separating the two readings across 22 team-games:
+  // `20251005_TEN@ARI` discriminates them and the field follows fumbles-lost.
+  //
+  // The two agree on almost every game, because almost every fumble a team loses
+  // is recovered by the defence. They part company when a *defender* fumbles
+  // during a return and the intercepted team recovers: ESPN pays the recovering
+  // unit 2, and this field does not see it. Measured across 2024 and 2025:
+  // `20250925_SEA@ARI`, `20251130_MIN@SEA` and `20251208_PHI@LAC` — three
+  // team-weeks, 2 points each, Sleeper right in all three.
+  //
+  // **No substitute exists and none was invented.** `teamStats` carries no
+  // recovery counter at all (see `docs/TANK01.md`), and the per-player
+  // `Defense.fumblesRecovered` is contaminated by design — a player who falls on
+  // his own fumble carries it, 185 player-weeks of 2025 did, and a teammate
+  // recovering a teammate's fumble is indistinguishable from a defender
+  // recovering an opponent's. Summing it per team and subtracting an estimate of
+  // the own-fumble half would be a derivation dressed as a reading, and a
+  // three-team-week undercount is a better answer than a number nobody can check.
   fumblesRecovered: "def_fum_rec",
   defTD: "def_td",
   safeties: "def_safety",
@@ -165,6 +185,31 @@ export const TANK01_TEAM_BLOCKED_KICK_FIELDS: readonly string[] = [
 export const TANK01_TEAM_DEF_ST_TD_FIELD = "defensiveOrSpecialTeamsTds";
 
 /**
+ * `teamStats` fields read as a **source**, not as a cross-check.
+ *
+ * The only one so far, and the reason it is here rather than in
+ * {@link TANK01_DST_MAP} is simply that the `DST` block does not carry it: the
+ * `DST` keys are `teamAbv teamID defTD defensiveInterceptions sacks ydsAllowed
+ * fumblesRecovered ptsAllowed safeties` and nothing else.
+ *
+ * **A defensive two-point conversion return** is what happens when a defence
+ * takes a failed conversion attempt back the other way. ESPN pays the D/ST **2**
+ * for it and we had no stat key at all until 2026-08-17, so it scored nothing.
+ * Three occurrences across 2024 and 2025 — Dallas in 2025 week 4
+ * (`"Markquese Bell Defensive PAT Conversion"`), Miami in 2025 week 13, and
+ * Philadelphia in 2024 week 4.
+ *
+ * Read from the number rather than parsed out of the text, deliberately. The
+ * wording varies (`"Defensive PAT Conversion"` is not the only form), the event
+ * is rare enough that a pattern would go years without being exercised, and
+ * unlike a field goal's distance there is nothing here that only the prose
+ * knows.
+ */
+export const TANK01_TEAM_STATS_MAP: Readonly<Record<string, string>> = {
+  defensiveTwoPointConversionReturns: "def_2pt_ret",
+};
+
+/**
  * Everything our scoring table needs is obtainable.
  *
  * An earlier version of this file claimed blocked kicks were unavailable. They
@@ -210,9 +255,9 @@ export function parseFieldGoalYards(scoreText: string): number | null {
  * `TD`, `FG` and `SF` are the three that carry meaning here, and they were the
  * only three seen across 48 games of 2025 weeks 1-3. **That is not the whole
  * vocabulary**, and this comment used to say it was: a sweep of the full season
- * also found `2PTC` and a `null`. Nothing below enumerates the set — every use
- * is an equality test against one of the three — so an unfamiliar value is inert
- * rather than a crash, and that is deliberate.
+ * also found `2PTC` and a `null`, and a sweep of 2024 found **`BP`** — see
+ * {@link isTouchdownScoringPlay}, which is why nothing decides a touchdown by
+ * asking whether this field equals `"TD"` any more.
  *
  * Extra points, two-point conversions, and blocked kicks are not score types at
  * all: they live in the trailing parenthetical of a touchdown's `score` text, the
@@ -266,6 +311,108 @@ export function isBlockedKick(scoreText: string): boolean {
 /** Whether the play's PAT attempt was a successful kick. */
 export function isExtraPointMade(scoreText: string): boolean {
   return /\(\s*[^)]*\bKick\s*\)/i.test(scoreText) && !FAILED_PATTERN.test(scoreText);
+}
+
+// ---------------------------------------------------------------------------
+// Which scoring plays are touchdowns
+// ---------------------------------------------------------------------------
+
+/**
+ * The `scoreType` values this adapter has actually seen.
+ *
+ * Not consulted to decide anything — {@link isTouchdownScoringPlay} deliberately
+ * does not read it — but a value outside it is worth saying out loud, because
+ * this list has now been wrong twice and both times the symptom was silence. See
+ * {@link isKnownScoreType}.
+ *
+ * `TD` `FG` `SF` across 96 games of 2025 weeks 1-3; `2PTC` and an absent value
+ * from the full 2025 sweep; `BP` from 2024, verbatim below.
+ */
+export const KNOWN_SCORE_TYPES: ReadonlySet<string> = new Set(["TD", "FG", "SF", "2PTC", "BP"]);
+
+/**
+ * `scoreType` values that are definitely **not** a touchdown.
+ *
+ * The list this file is prepared to be exhaustive about, because each member was
+ * observed carrying its own non-touchdown event: a field goal, a safety, a
+ * conversion attempt. Everything else is *eligible*, and the text decides.
+ */
+const NON_TOUCHDOWN_SCORE_TYPES: ReadonlySet<string> = new Set(["FG", "SF", "2PTC"]);
+
+/**
+ * Whether a scoring play may be a touchdown.
+ *
+ * **A deny-list, and that inversion is the whole point.** This used to be
+ * `play.scoreType === "TD"` in the two places that pay six points, and Tank01
+ * has a fifth value. Verbatim, from `20241208_BUF@LAR`:
+ *
+ *     BP | LAR | Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)
+ *
+ * That is a touchdown. Under the equality test the returner got no `ret_td` and
+ * the Rams' unit no `def_td` — **12 points on one play, in silence**, because
+ * `DST.defTD` reads `"0"` and `defensiveOrSpecialTeamsTds` reads `"0"` too, so
+ * no other path and no cross-check made it up.
+ *
+ * An allow-list of `TD` and `BP` would fix that one play and leave the next
+ * unknown value exactly as expensive. So the question asked is the negative one:
+ * a play is eligible unless its type names something that is known not to be a
+ * touchdown. An unfamiliar value, and an absent one, are eligible.
+ *
+ * **This is only safe because the type is never the deciding evidence.** Both
+ * callers require {@link isSpecialTeamsReturnTouchdown} on the play text as
+ * well, and that pattern names the event — a kickoff, punt or blocked-kick
+ * return. What this function removes is a veto, not a requirement. The
+ * deliberate exclusion of the extra point from {@link BLOCKED_KICK_RECOVERY} and
+ * from {@link SPECIAL_TEAMS_RETURN} is what stops the one thing that would
+ * otherwise leak in: a blocked *extra point* taken back the other way is a
+ * defensive two-point conversion return worth 2, not a touchdown worth 6.
+ */
+export function isTouchdownScoringPlay(scoreType: string | null | undefined): boolean {
+  return !NON_TOUCHDOWN_SCORE_TYPES.has((scoreType ?? "").trim().toUpperCase());
+}
+
+/**
+ * Whether this `scoreType` is one we have seen before.
+ *
+ * The tripwire, and the reason it exists rather than being inferred later:
+ * `"BP"` was invisible for as long as it was, and cost 12 points every time it
+ * appeared, precisely because nothing anywhere said "this is a value we do not
+ * know". A season sweep is what found it, and a season sweep is not something
+ * that happens on a schedule.
+ *
+ * An absent or empty value counts as known — the full-2025 sweep found one, so
+ * warning about it would be noise on the very first game rather than a signal.
+ */
+export function isKnownScoreType(scoreType: string | null | undefined): boolean {
+  const value = (scoreType ?? "").trim().toUpperCase();
+  return value === "" || KNOWN_SCORE_TYPES.has(value);
+}
+
+/**
+ * Whether Tank01 leaves this play out of {@link TANK01_TEAM_DEF_ST_TD_FIELD}.
+ *
+ * Read by the cross-check in `box-score.ts` and by nothing that scores. A `BP`
+ * play is a special-teams touchdown we now pay for, and it appears in **neither**
+ * of the provider's own two counters, so a comparison that includes it reports a
+ * discrepancy on a game we have just started scoring correctly — which is the
+ * defect #181 fixed for blocked kicks filed as defensive, arriving from the
+ * other direction.
+ *
+ * **This rests on one observation and says so.** `20241208_BUF@LAR` is the only
+ * `BP` play in 2024 or 2025: the Rams have one blocked-punt return touchdown,
+ * `defensiveOrSpecialTeamsTds` reads `"0"` and `DST.defTD` reads `"0"`.
+ * (`teamStats.blockedPunt` reads `"1"`, so the block itself is counted; it is
+ * the touchdown that is not.) Whether that is how `BP` is always filed or how
+ * one game happened to be filed cannot be told apart from a single play — but a
+ * warning that fires on a correctly scored game trains people to dismiss the
+ * next real one, and the exclusion is reported in the warning text when the
+ * check still disagrees, so a genuinely uncounted play cannot read as one nobody
+ * noticed.
+ */
+export function isUncountedSpecialTeamsScoreType(
+  scoreType: string | null | undefined,
+): boolean {
+  return (scoreType ?? "").trim().toUpperCase() === "BP";
 }
 
 /**
@@ -341,7 +488,24 @@ export function isExtraPointMade(scoreText: string): boolean {
  * `ret_td` of 0 here is the right answer rather than a gap waiting on evidence.
  */
 const DEFENSIVE_RETURN = /\b(interception|fumble)\s+(return|recovery)\b/i;
-const SPECIAL_TEAMS_RETURN = /\b(kickoff|kick|punt)\s+return\b|\breturn\s+of\s+blocked\b/i;
+/**
+ * A return, named by what was returned.
+ *
+ * **The second alternative used to be a bare `return of blocked`**, and it was
+ * narrowed on 2026-08-17 to name the kick, so that it carries the same exclusion
+ * {@link BLOCKED_KICK_RECOVERY} spells out below: a blocked **extra point**
+ * taken the other way is a two-point defensive conversion return, not a
+ * touchdown. That mattered only once {@link isTouchdownScoringPlay} stopped
+ * insisting on a `scoreType` of `"TD"` — the equality test was previously doing
+ * the job this narrowing now does explicitly, which is exactly the shape of
+ * guard that stops holding the moment somebody edits the thing in front of it.
+ *
+ * No known string moves. All four blocked-kick returns name a punt or a field
+ * goal: `"22 Yd Return of Blocked Punt"`, `"35 yd. return of blocked punt"`,
+ * `"76 Yd Return of Blocked Field Goal"`.
+ */
+const SPECIAL_TEAMS_RETURN =
+  /\b(kickoff|kick|punt)\s+return\b|\breturn\s+of\s+blocked\s+(kick|punt|field\s+goal|fg)\b/i;
 /**
  * A blocked kick recovered rather than returned. Anchored on "blocked".
  *
@@ -418,18 +582,17 @@ export function mainClause(scoreText: string): string {
   return scoreText.replace(/\([^)]*\)/g, " ");
 }
 
-/**
- * Whether this player is the one the main clause says scored.
- *
- * A substring match, like `twoPointCredit`'s, and safe for the same reason: it
- * is only ever asked about players the play already names in `playerIDs`, so a
- * coincidental hit needs two participants in one play whose names contain one
- * another. It is **not** safe to widen this to the whole roster without a
- * stricter comparison.
+/*
+ * `scoredInMainClause` used to live here — a raw substring test, safe only
+ * because it was asked exclusively about players the play already named in
+ * `playerIDs`, and saying so. It was removed on 2026-08-17 when return
+ * touchdowns stopped being gated on `playerIDs` at all, because that gate
+ * dropped the scorer outright on `20241229_CAR@TB`. Its own docstring named the
+ * condition for widening — "not safe … without a stricter comparison" — and
+ * `returnTouchdownCredits` is that comparison: normalised name forms, every
+ * spelling, and a refusal when more than one player answers. Deleted rather than
+ * left, so nothing reaches for the weaker one.
  */
-export function scoredInMainClause(scoreText: string, longName: string): boolean {
-  return mainClause(scoreText).includes(longName);
-}
 
 /**
  * Whether a touchdown was a defensive return — an interception or a fumble,


### PR DESCRIPTION
Four fixes from a sweep of **all 544 games of 2024 and 2025** against Sleeper
using the shipped translator. The scoring engine never disagreed with anything;
every difference was stat extraction or reporting.

**Breaking: schemaVersion 6 → 7, new golden hash.** `seedSport` must be re-run
against any deployed database before the next box-score ingest, or
`ingestOneGame` throws on a stat key `stat_keys` does not hold — deliberately,
and loudly.

---

## 1. `scoreType` has a fifth value, `BP`, and it paid nobody

Verbatim, `20241208_BUF@LAR`, now a fixture:

```
BP | LAR | Hunter Long 22 Yd Return of Blocked Punt (Joshua Karty Kick)
```

Both places that pay six points for a special-teams score asked
`scoreType === "TD"`, so the returner got no `ret_td` and the unit no `def_td`.
**12 points on one play, in two roster spots, with `warnings: []`** — `DST.defTD`
reads `"0"` for the Rams and `defensiveOrSpecialTeamsTds` reads `"0"` too, so
even the cross-check agreed with the silence.

The question is now asked **negatively**: `isTouchdownScoringPlay` refuses `FG`,
`SF` and `2PTC`, each observed carrying its own non-touchdown event, and treats
everything else — an unfamiliar value, an absent one — as eligible. The text
pattern names the event. An allow-list of `TD` and `BP` fixes the one play we
found and leaves the next unknown value exactly as expensive.

That inversion is only safe because `SPECIAL_TEAMS_RETURN`'s blocked branch is
narrowed to name the kick. A blocked *extra point* taken the other way is a
two-point conversion return, not a six-point touchdown, and `scoreType === "TD"`
was silently doing that job. No known string moves.

A `BP` play is in neither of the provider's counters, so the
`defensiveOrSpecialTeamsTds` check excludes it — otherwise it fires on a game we
have just started scoring correctly, which is #181's defect from the other side.
That rests on the single `BP` play in two seasons and says so in the code.

## 2. `playerIDs` does not name the scorer

```
TD | TB | J.J. Russell 23 Yd Return of Blocked Punt (Chase McLaughlin Kick)
   | playerIDs: ["3150744"]
```

`3150744` is the kicker. **This is a `TD`, not a `BP`** — it was expected to be
2024's second `BP` occurrence and one metered call showed otherwise — so it is a
genuinely separate defect, and widening the score type alone would have left its
six points on the floor. Tank01's whole record for Russell is a `snapCounts`
block, so his own per-player loop ran zero times whatever the gate said: issue
\#155's shape, one category over.

Return touchdowns are now resolved by a game-level pass over the **main clause**,
with `playerIDs` demoted to a tiebreak when one spelling fits two people. A
return has exactly one scorer, so two distinct matches credits nobody and warns.
Demoting rather than deleting keeps the new rule a **superset** of the old one.

A `scoreType` nobody has seen is now warned about, once per game per value.

## 3. `def_2pt_ret` — ESPN pays the D/ST 2 for returning a failed conversion

We had no stat key, so it scored nothing. Three occurrences over 2024 and 2025.
Appended, never reordered (#162), read from
`teamStats.defensiveTwoPointConversionReturns` as a number.

The changelog entry does **not** repeat "no leagues existed", which would be
false: four test leagues exist in the deployed database and
`score-week/route.test.ts` creates more whenever `DATABASE_URL` is set. What
makes it safe is stronger — an **addition** cannot reach a league that already
exists, because a frozen league holds its own copy and `scorePlayer` skips a stat
with no rule. The move that does damage is a rename, which is what #162 catches.

## 4. `DST.fumblesRecovered` — a gap, left open on purpose

It is the **opponent's fumbles lost**, not this unit's recoveries. Established by
separating the two readings across 22 team-games; `20251005_TEN@ARI`
discriminates. One low when a defender fumbles during an interception return and
the intercepted team recovers — `20250925_SEA@ARI`, `20251130_MIN@SEA`,
`20251208_PHI@LAC`, 2 points each, Sleeper right in all three.

**No field in this feed means "this defence's recoveries".** `teamStats` has no
recovery counter; per-player `Defense.fumblesRecovered` is contaminated by design.
Deriving it would be two provider fields plus an assumption with nothing to check
the answer against. Documented in `docs/TANK01.md` and in the map, and left alone.

## 5. Warnings reached the operator as the word "failed"

Every warning the translator raised was pushed onto `failures` and announced as
"N game(s) failed to ingest" on runs where all ninety players landed correctly.
A healthy run cried failure, and a real failure was diluted into the same count.

- Warnings are counted and reported separately, one entry each.
- The heartbeat says **every** reason rather than the first — it was a chain of
  ternaries, so a broken season hid twelve failed games.
- `games.stats_error` is finally **read back**, by `unresolvedStatsProblems`. It
  has been written since `0027` and read by nothing, so a discrepancy survived
  the run that found it and was visible to nobody: `cron_runs` holds one row per
  job and the next run overwrites it.

No migration — the column already exists. Nothing here can block an ingest.

---

## Why one PR

The schema change's translator half lives in the same two functions in
`box-score.ts` that the `BP` fix rewrites, and in the same map file. Splitting it
out would mean two PRs blocked on identical hunks, and this repo has twice paid
for a deep queue. It is a separate commit with the reasoning in its message, and
the durable record is the dated changelog on the golden fixture.

## Verification

- `pnpm typecheck`, `pnpm lint`, `prettier --check` clean.
- Full suite: **1503 passed, 2 skipped**, including the owner's in-progress work.
- Both new fixtures are real captured responses and reconcile with **zero
  warnings**, as do the four already here.
- **Nine mutations applied, nine caught** — the score-type deny-list, the
  `playerIDs` gate, the `BP` cross-check exclusion, the `teamStats` map, the
  unknown-type tripwire, the `return of blocked` narrowing, warnings-as-failures,
  the backlog count, and the warning count.
- Two metered Tank01 calls spent: `20241229_CAR@TB` (which disproved the expected
  `BP`) and `20241208_BUF@LAR`.

Refs #157
Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
