### PR TITLE
Nothing has ever run on a schedule, and nothing said so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,23 +137,54 @@ lineup at all** — `setLineup` refuses with `SCHEDULE_MISSING`. `currentWeek` w
 minutes since it shipped. And with `games` hand-populated but no stat lines, every week
 would have finalised **0–0, permanently**, because a finalised week is never rescored.
 
-`docs/LIVE-SCORING.md` describes six automation jobs in the present tense and only one of
-them exists. Reading a plan as a description is how the claim above got written.
+`docs/LIVE-SCORING.md` describes six automation jobs in the present tense. **Four now
+exist** — season sync, the stats poller, score finalisation and week finalisation.
+**Injury sync and inactives do not exist at all**, and that document argues inactives is
+the one that matters most. Its table now carries an "Exists?" column so the plan and the
+code can be told apart at a glance. Reading a plan as a description is how the claim above
+got written.
 
 **Corrected 2026-08-17, and this passage was the stale one.** It said `syncBoxScores` did
 not exist and that every player therefore scores zero. Both halves are now false, and the
 second was false in a way that reads as urgent — which is how it survived being repeated.
 
-`syncBoxScores` **exists** (`packages/db/src/box-scores.ts`, PR #95), `/api/cron/stats`
-calls it every ten minutes alongside `syncGames`, and `apps/web/vercel.json` schedules it.
-Issue #96 is closed and complete. `syncGames` is also wired into `pnpm db:sync`.
+`syncBoxScores` **exists** (`packages/db/src/box-scores.ts`, PR #95) and `/api/cron/stats`
+runs it every ten minutes. Issue #96 is closed and complete.
 
-`stat_lines` is empty in the deployed database for a much duller reason: **all 248 games
-are `SCHEDULED` and none is `FINAL`, because the 2026 season has not started.** There is
+**`syncGames` is not in that job**, and the sentence here used to say it was. It belongs
+to `/api/cron/season-sync`, daily at 09:20 UTC (`apps/web/src/lib/jobs/season-sync.ts`),
+which runs the same set as `pnpm db:sync` — players, byes, all eighteen weeks of fixtures,
+rankings, projections. Two jobs, two cadences: a box score changes during a game, a
+schedule changes overnight. Anyone debugging a stale schedule by reading the ten-minute
+job would have found `syncGames` absent and concluded the wiring was broken.
+
+**And none of it has ever fired.** `cron_runs` (migration `0029`) is the heartbeat every
+job stamps at the end of every run, and on 2026-08-17 it was **empty** — no rows, for any
+job, ever. `apps/web/vercel.json` schedules six crons; scheduling is not running. Every
+game, player, ranking and projection in the deployed database was put there by somebody
+typing `pnpm db:sync` at a terminal.
+
+So **every sentence in this file of the form "the cron does X" describes code that is
+correct and has never executed outside a test.** Check before believing any of them —
+including this paragraph, which is only true until somebody deploys:
+
+```bash
+pnpm cron:status        # per job: never ran / stale / failing. Exits non-zero.
+pnpm db:status          # now carries a one-line scheduler summary
+```
+
+`cron:status` reads the expected job list out of `vercel.json` itself rather than restating
+it, so a job added to the schedule cannot be forgotten here. **A green result means the
+routes ran, not that they did any work** — a run over zero games is a healthy run. The
+deployment it is all waiting on is now an entry in `docs/SETUP-REQUIRED.md`, where it
+should have been all along.
+
+`stat_lines` is empty in the deployed database for a duller reason as well: **every game is
+`SCHEDULED` and none is `FINAL`, because the 2026 season has not started.** There is
 nothing to ingest until 9 September. The pipeline has never had a finished game to run on,
 which is a different problem from not existing — and the honest description of the Sep 9
-risk is now **"the producer has never been exercised against a real box score"**, not
-"there is no producer".
+risk is **"the producer has never been exercised against a real box score, and nothing has
+ever run it on a schedule"**.
 
 **All four of #81's defects are now closed**, the last two by #175 (two-point attribution,
 with #155). Its defects were filed as latent "only because nothing calls `getBoxScore`" —
@@ -417,6 +448,14 @@ suite passes, which is not the same thing.
 change and `games` was **completely empty** — no schedule at all, which makes
 `weekHasSchedule` false and `setLineup` refuse every lineup. Re-seeded, and the
 2026 season synced: 248 games, 1,017 players on the draft board.
+
+**The 248 was eight short, and nothing noticed for two days.** `syncGames` discarded any
+fixture the provider had not given a kickoff time — four in week 16 and four in week 17,
+the playoff and championship weeks, because the NFL holds those hours back for flex
+scheduling. Fixed by #182; the count is **256**, which is complete for weeks 1–17 (every
+team has its 16 games). Week 18 is absent and is meant to be: every one of its fixtures is
+undated, so no conservative kickoff can be derived, and week 18 falls after the fantasy
+championship anyway. See "A fixture with no kickoff time" below.
 
 #### What is true about Aug 22, said plainly
 
@@ -1781,8 +1820,25 @@ his game with nothing to show for it, and reading zero as "has not played" tells
 they are still live when they have already lost. Kickoff passed and not final means
 in-progress, whatever the stat line says. Tested.
 
-A player with no game that week is `BYE`, not `YET_TO_PLAY` — there are no points still
-coming.
+**A player with no game that week is not automatically `BYE`**, and reading it that way is
+what #182 fixed. `gameAvailability` (`packages/core/src/season/availability.ts`) separates
+the cases from data already held:
+
+- a stored fixture whose hour the NFL has not fixed → **`TIME_TBD`**
+- no row at all, in a week that is not the team's bye → **`UNSCHEDULED`**
+- no row, on the team's actual bye → **`BYE`**, and there are no points still coming
+
+They are opposite instructions to a manager. A bye says start someone else. A pending
+kickoff says he will play and nobody has said at what hour — the same player, the decision
+reversed, in the weeks that decide a season.
+
+**`UNSCHEDULED` is claimed only when the bye week is known and falls elsewhere.** An
+unknown bye keeps the old answer, because a wrong `BYE` costs one player's week while a
+wrong `UNSCHEDULED` is the screen promising a game out of a gap in our own ingest.
+
+And it **decides nothing**: `loadKickoffs` is still the only definition of when a slot
+freezes. Bye weeks and the TBD flag load through `loadByeWeeks` and `loadTbdKickoffs`,
+separately, so a bug in this labelling can mislabel a row and cannot unlock one.
 
 `loadWeekMatchups` takes `now` rather than calling `Date.now()`, so game state is
 deterministic and the finalisation cases are testable.

--- a/docs/LIVE-SCORING.md
+++ b/docs/LIVE-SCORING.md
@@ -85,22 +85,44 @@ Sunday by changing a number.
 
 ## Automation
 
-Fully automated. No human in the loop at any point.
+> **This section is the design. Read it in the future tense.**
+>
+> The intent is full automation with no human in the loop. As of **2026-08-17 the loop is
+> entirely human**: `cron_runs` holds no rows, so no scheduled job has ever executed
+> against the deployed database, and every sync so far was somebody running `pnpm db:sync`.
+> Check with `pnpm cron:status`. The deployment this waits on is an entry in
+> `docs/SETUP-REQUIRED.md`.
+>
+> Four of the six jobs below exist as code. Two do not exist at all. The **Exists?** column
+> says which — added because this table read as a description of production for months, and
+> `CLAUDE.md` names that mistake as how a false claim survived being repeated.
 
-The NFL schedule is published in May, so **every kickoff time is known months ahead**.
-That makes the whole thing schedule-driven rather than reactive:
+The NFL schedule is published in May, so **which teams play, and on what date, is known
+months ahead**. The _hour_ is not: late-December kickoffs are held back for flex
+scheduling and fixed last. Verified against Tank01 on 2026-08-17 — those fixtures arrive
+with `gameDate` set and `gameTime: "TBD"`, `gameTime_epoch: ""`, so the day is known and
+the hour is not.
 
-| Job                | Fires                                      | Does                                           |
-| ------------------ | ------------------------------------------ | ---------------------------------------------- |
-| **Season sync**    | Daily, 4am                                 | Players, teams, byes, schedule changes         |
-| **Injury sync**    | Every 6h, and hourly on game days          | Injury designations                            |
-| **Inactives**      | **100 minutes before each kickoff**        | Official inactive list — see below             |
-| **Game watcher**   | 2.5h after each kickoff, then every 10 min | Polls until status is `final`                  |
-| **Score finalise** | On `final`                                 | Box score → `stat_lines` → recompute → publish |
-| **Week finalise**  | T+48h, or T+7d for Weeks 14 and 17         | Locks the week for settlement                  |
+That still makes the whole thing schedule-driven rather than reactive. But an ingest that
+_requires_ a kickoff time silently drops the games in the two weeks that decide a season,
+and it did: eight fixtures across weeks 16 and 17 of 2026. See `games.kickoff_tbd`
+(migration `0030`) and `gameAvailability` in `@rostr/core`.
 
-The game watcher is the only job that polls, and only from 2.5 hours after kickoff until
-the game ends — roughly 20–40 minutes of polling per game.
+| Job                | Fires                               | Does                                           | Exists? | Where                   |
+| ------------------ | ----------------------------------- | ---------------------------------------------- | ------- | ----------------------- |
+| **Season sync**    | Daily, 09:20 UTC                    | Players, byes, schedule, rankings, projections | ✅      | `/api/cron/season-sync` |
+| **Injury sync**    | Every 6h, and hourly on game days   | Injury designations                            | ❌      | —                       |
+| **Inactives**      | **100 minutes before each kickoff** | Official inactive list — see below             | ❌      | —                       |
+| **Game watcher**   | Every 10 min, unconditionally       | Polls until status is `final`                  | 🟡      | `/api/cron/stats`       |
+| **Score finalise** | Same job, on `final`                | Box score → `stat_lines` → recompute → publish | ✅      | `syncBoxScores`         |
+| **Week finalise**  | T+48h, or T+7d for Weeks 14 and 17  | Locks the week for settlement                  | ✅      | `/api/cron/score-week`  |
+
+**The game watcher is 🟡 because it does not watch.** It polls every ten minutes all week
+rather than from 2.5 hours after a kickoff — simpler, and more provider calls. The
+2.5-hour window described below is the design, not the code.
+
+**Injuries and inactives have no code at all**, and inactives is the one this document
+argues matters most.
 
 ### Inactives matter more than live scoring
 

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -12,6 +12,49 @@ Status key: ⬜ not started · 🟡 in progress · ✅ done
 
 ## Blocking soon
 
+### ⬜ A deployment, and `CRON_SECRET`
+
+**Blocks:** every automated job in `docs/LIVE-SCORING.md`. A draft can be run and a
+lineup can be set against a hand-synced database; a **season** cannot.
+**Needed by:** Sep 9 2026, and realistically a fortnight earlier so a full weekly cycle
+is watched once before it counts.
+
+**Nothing has ever run on a schedule.** `apps/web/vercel.json` schedules six crons, and
+on 2026-08-17 `cron_runs` — the heartbeat table every job stamps, migration `0029` —
+held **zero rows**. Not one job, not once. Every game, player, projection and ranking in
+the deployed database was put there by somebody typing `pnpm db:sync` at a terminal.
+
+Scheduling is not running. Check it with **`pnpm cron:status`**, which reads the job list
+out of `vercel.json` itself and exits non-zero when a job has never run, is stale, or is
+failing. `pnpm db:status` now carries a one-line summary of the same thing, because this
+gap survived for months precisely because nothing was obliged to ask.
+
+**This entry did not exist until 2026-08-17, and that is why the gap lasted.** This file
+is the list of things only the owner can do, and "there is no host" was on it nowhere.
+
+**Needed:** a Vercel project whose **Root Directory is `apps/web`**, with `DATABASE_URL`,
+`TANK01_API_KEY`, `SOLANA_RPC_URL`, `SOLANA_CLUSTER`, `NEXT_PUBLIC_SOLANA_RPC_URL`,
+`NEXT_PUBLIC_SOLANA_CLUSTER`, `FEE_RECIPIENT`, `NEXT_PUBLIC_FEE_RECIPIENT` and
+`CRON_SECRET` set.
+
+> **Four traps, in the order they bite.**
+>
+> 1. **`vercel.json` lives at `apps/web/`, not the repo root.** If the project's Root
+>    Directory is left at the root, the crons are silently not registered — the deploy
+>    succeeds, the site works, and nothing ever fires. That failure is indistinguishable
+>    from today's state.
+> 2. **Plan tier.** Cron frequency is limited on the free tier; six jobs at minute and
+>    ten-minute granularity needs a paid plan. Check current limits — the **Running cost**
+>    table below has no hosting line and needs one.
+> 3. **`CRON_SECRET` must be set on the deployment**, or `cronForbidden` refuses every
+>    cron route in production: a fully deployed, fully dead scheduler.
+> 4. **Function timeout versus `season-sync`**, which makes eighteen weeks of provider
+>    calls in a single invocation.
+>
+> **And a green `pnpm cron:status` means the routes ran, not that they did any work.** A
+> run over zero games is a healthy run. `stat_lines` is empty today and every player
+> scores zero; that is a separate check and this is not it.
+
 ### ⬜ Solana RPC endpoint (`SOLANA_RPC_URL`)
 
 **Blocks:** drawing draft orders. Every league needs one draw, at its scheduled draft

--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -21,27 +21,54 @@ node packages/stats/dist/cli.js verify 1,2,3   # hunt rare scoring events
 Confirmed by calling each. `getNFLTeamStats` returned 404 and does not appear to
 exist under that name.
 
-| Endpoint               | Returns                                      | We use it for                                    |
-| ---------------------- | -------------------------------------------- | ------------------------------------------------ |
-| `getNFLTeams`          | 32 teams; `rosters=true` embeds full rosters | Team refs, **bye weeks**, one-call roster sync   |
-| `getNFLPlayerList`     | 4,295 players                                | Full player universe                             |
-| `getNFLPlayerInfo`     | One player, optionally with stats            | Targeted lookups                                 |
-| `getNFLTeamRoster`     | `{team, roster}`                             | Per-team roster                                  |
-| `getNFLDepthCharts`    | 32 teams, `RB1`/`RB2`…                       | Starter inference, smarter bots                  |
-| **`getNFLADP`**        | `{adpDate, adpType, adpList}`                | **Draft rankings**                               |
-| `getNFLProjections`    | Player + team-defense projections            | Waiver guidance, bot drafting                    |
-| `getNFLGamesForWeek`   | 16 games with `gameID`, `gameTime_epoch`     | **Schedule and kickoff times**                   |
-| `getNFLGamesForDate`   | Games on a date                              | Daily job scoping                                |
-| `getNFLGamesForPlayer` | **A player's whole season, one call**        | Season-to-date averages, fixtures                |
-| `getNFLTeamSchedule`   | `{team, schedule}`                           | Team-level schedule                              |
-| `getNFLScoresOnly`     | Scores + line score, no player stats         | **Cheap game-watcher polling**                   |
-| `getNFLBoxScore`       | Full player stats, DST, scoring plays        | **Weekly scoring**                               |
-| `getNFLGameInfo`       | Game metadata                                | Venue, referees                                  |
-| `getNFLNews`           | `{link, title}`                              | Injury/news feed                                 |
-| `getNFLDFS`            | DraftKings, FanDuel, Yahoo salaries          | Ranking cross-check                              |
-| `getNFLBettingOdds`    | Many sportsbooks                             | Not used                                         |
-| `getNFLChangelog`      | Recent data corrections                      | **Stat-correction detection**                    |
-| `getNFLInactiveList`   | Whole season, per game, per team `players[]` | **Gameday inactives** — see docs/LIVE-SCORING.md |
+| Endpoint               | Returns                                       | We use it for                                    |
+| ---------------------- | --------------------------------------------- | ------------------------------------------------ |
+| `getNFLTeams`          | 32 teams; `rosters=true` embeds full rosters  | Team refs, **bye weeks**, one-call roster sync   |
+| `getNFLPlayerList`     | 4,295 players                                 | Full player universe                             |
+| `getNFLPlayerInfo`     | One player, optionally with stats             | Targeted lookups                                 |
+| `getNFLTeamRoster`     | `{team, roster}`                              | Per-team roster                                  |
+| `getNFLDepthCharts`    | 32 teams, `RB1`/`RB2`…                        | Starter inference, smarter bots                  |
+| **`getNFLADP`**        | `{adpDate, adpType, adpList}`                 | **Draft rankings**                               |
+| `getNFLProjections`    | Player + team-defense projections             | Waiver guidance, bot drafting                    |
+| `getNFLGamesForWeek`   | 16 games; `gameTime_epoch` **empty when TBD** | **Schedule and kickoff times** — see below       |
+| `getNFLGamesForDate`   | Games on a date                               | Daily job scoping                                |
+| `getNFLGamesForPlayer` | **A player's whole season, one call**         | Season-to-date averages, fixtures                |
+| `getNFLTeamSchedule`   | `{team, schedule}`                            | Team-level schedule                              |
+| `getNFLScoresOnly`     | Scores + line score, no player stats          | **Cheap game-watcher polling**                   |
+| `getNFLBoxScore`       | Full player stats, DST, scoring plays         | **Weekly scoring**                               |
+| `getNFLGameInfo`       | Game metadata                                 | Venue, referees                                  |
+| `getNFLNews`           | `{link, title}`                               | Injury/news feed                                 |
+| `getNFLDFS`            | DraftKings, FanDuel, Yahoo salaries           | Ranking cross-check                              |
+| `getNFLBettingOdds`    | Many sportsbooks                              | Not used                                         |
+| `getNFLChangelog`      | Recent data corrections                       | **Stat-correction detection**                    |
+| `getNFLInactiveList`   | Whole season, per game, per team `players[]`  | **Gameday inactives** — see docs/LIVE-SCORING.md |
+
+---
+
+## A fixture with no kickoff time — verbatim, 2026-08-17
+
+The NFL fixes late-December kickoff **hours** last, holding them back for flex scheduling.
+Tank01 still returns **all 16 fixtures** for those weeks. The untimed ones carry:
+
+```
+gameDate:        "20261227"      ← the day IS known
+gameTime:        "TBD"
+gameTime_epoch:  ""              ← empty string. Not "0", not absent, not null.
+```
+
+So `Number.parseFloat(gameTime_epoch)` is `NaN` and `Number(gameTime_epoch)` is `0` — any
+code treating a falsy epoch as "there is no fixture" drops a real game. **It did:** eight
+fixtures across weeks 16 and 17 of 2026, the playoff and championship weeks, absent from
+the deployed database for two days before anyone counted.
+
+`syncGames` now stores them with `kickoff_tbd` set and a conservative kickoff borrowed
+from a dated sibling on the same date; `gameAvailability` in `@rostr/core` turns that into
+`TIME_TBD`. Where **no** game on that date is dated there is nothing safe to borrow and
+the fixture is still skipped, which is `UNSCHEDULED`.
+
+**Week 18 is entirely undated** as of 2026-08-17 — all 16 fixtures on `20270110`, every
+one `"TBD"` — so none of it is stored. That is correct and harmless here: week 18 falls
+after the fantasy championship in week 17.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:seed": "node --env-file-if-exists=.env packages/db/dist/cli.js seed",
     "db:audit": "node --env-file-if-exists=.env packages/db/dist/cli.js audit",
     "db:sync": "node --env-file-if-exists=.env packages/db/dist/cli.js sync",
+    "cron:status": "node --env-file-if-exists=.env packages/db/dist/cli.js cron",
     "stats:check": "node --env-file-if-exists=.env packages/stats/dist/cli.js check",
     "stats:probe": "node --env-file-if-exists=.env packages/stats/dist/cli.js probe",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",

--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -5,13 +5,18 @@
  *   pnpm db:status    show what is applied and what is pending
  *   pnpm db:seed      insert the sport registry
  *   pnpm db:audit     check exposure: grants, RLS, and BYPASSRLS roles
+ *   pnpm cron:status  has the scheduler ever run, and is it succeeding
  *
  * Reads DATABASE_URL from the environment. Nothing here is needed to run the
  * test suite — that uses PGlite and no credentials at all.
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { NFL } from "@rostr/core";
 import { Tank01Provider } from "@rostr/stats";
+import { cronHealth, expectedJobs, type CronConfig } from "./cron-health.js";
+import { listCronRuns } from "./cron-runs.js";
 import { loadMigrations, migrate } from "./migrate.js";
 import { createPostgresClient } from "./postgres.js";
 import { seedSport } from "./sports.js";
@@ -37,6 +42,20 @@ import {
  * only file permitted to name a football fact.
  */
 const REGULAR_SEASON_WEEKS = NFL.seasonWeeks;
+
+/**
+ * The deployment's own cron schedule.
+ *
+ * Read from `apps/web/vercel.json` rather than restated here, because a second
+ * copy of the job list is a copy that drifts — and it would drift silently in
+ * the worst direction, with a job added to the schedule and never reported
+ * missing. If the file moves, this throws and `cron` reports it, which is the
+ * loud failure rather than the quiet one.
+ */
+function loadCronConfig(): CronConfig {
+  const path = fileURLToPath(new URL("../../../apps/web/vercel.json", import.meta.url));
+  return JSON.parse(readFileSync(path, "utf8")) as CronConfig;
+}
 
 function connectionString(): string {
   const url = process.env["DATABASE_URL"];
@@ -81,6 +100,24 @@ async function main(): Promise<void> {
             `${appliedVersions.has(m.version) ? "applied " : "PENDING "} ${m.filename}`,
           );
         }
+
+        // The anti-forgetting hook. `pnpm db:status` is the documented first
+        // command on arriving at a machine, and until 2026-08-17 nothing on that
+        // path would have told you that no job had ever run — the schedule and
+        // the heartbeat were both present and nobody compared them.
+        const scheduled = expectedJobs(loadCronConfig());
+        const ran = await listCronRuns(client).catch(() => []);
+        const health = cronHealth(scheduled, ran, new Date());
+        const unhealthy = health.jobs.filter((job) => job.state !== "OK").length;
+
+        console.log(
+          `\nscheduler: ${scheduled.length} job(s) scheduled, ` +
+            (health.neverRanAtAll
+              ? "0 have ever run — pnpm cron:status"
+              : unhealthy === 0
+                ? "all running"
+                : `${unhealthy} not healthy — pnpm cron:status`),
+        );
         break;
       }
 
@@ -237,8 +274,65 @@ async function main(): Promise<void> {
         break;
       }
 
+      case "cron": {
+        // The same argument as `audit` above, one layer out: `cron_runs` was
+        // written by every job on every run and read by nobody, so a scheduler
+        // that had never started looked exactly like a quiet week. Measured on
+        // 2026-08-17 the table held zero rows — six jobs scheduled, `draft-tick`
+        // every minute, nothing had ever fired. This makes it a command.
+        const expected = expectedJobs(loadCronConfig());
+        const health = cronHealth(expected, await listCronRuns(client), new Date());
+
+        if (expected.length === 0) {
+          console.error(
+            "No crons found in apps/web/vercel.json.\n" +
+              "That file is the schedule the host obeys; if it moved, this check is blind.",
+          );
+          process.exit(1);
+        }
+
+        for (const job of health.jobs) {
+          const every =
+            job.everyMinutes === null ? "schedule unreadable" : `every ${job.everyMinutes}m`;
+          const last = job.minutesSince === null ? "never" : `${job.minutesSince}m ago`;
+          console.log(
+            `${job.state.padEnd(17)} ${job.name.padEnd(13)} ${every.padEnd(20)} last: ${last}` +
+              (job.lastOutcome === null ? "" : ` — ${job.lastOutcome}`),
+          );
+        }
+
+        if (health.healthy) {
+          console.log(`\nOK — ${health.jobs.length} job(s) running.`);
+          // Said on the green path, because this is the reading that matters and
+          // the one nobody would otherwise question. A run over zero games is a
+          // healthy run: every job here can be OK while `stat_lines` is empty
+          // and every player scores zero.
+          console.log("This means the routes ran. It does not mean they did any work.");
+          break;
+        }
+
+        if (health.neverRanAtAll) {
+          console.error(
+            "\nFAIL — no scheduled job has ever run against this database.\n\n" +
+              "`cron_runs` is empty and the table exists, which is the signature of a\n" +
+              "deployment that does not exist rather than a scheduler that faltered.\n" +
+              "Everything in this database was put there by hand.\n\n" +
+              "See docs/SETUP-REQUIRED.md — a deployment, and CRON_SECRET.",
+          );
+          process.exit(1);
+        }
+
+        console.error(
+          `\nFAIL — ${health.jobs.filter((j) => j.state !== "OK").length} job(s) not healthy.`,
+        );
+        process.exit(1);
+        break;
+      }
+
       default:
-        console.error(`Unknown command "${command}". Use migrate, status, seed, or audit.`);
+        console.error(
+          `Unknown command "${command}". Use migrate, status, seed, sync, audit, or cron.`,
+        );
         process.exit(1);
     }
   } finally {

--- a/packages/db/src/cron-health.test.ts
+++ b/packages/db/src/cron-health.test.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  cronHealth,
+  everyMinutesOf,
+  expectedJobs,
+  stalenessLimitMinutes,
+  type CronConfig,
+} from "./cron-health.js";
+import type { CronRun } from "./cron-runs.js";
+
+const NOW = new Date("2026-08-17T12:00:00Z");
+const ago = (minutes: number): Date => new Date(NOW.getTime() - minutes * 60_000);
+
+const run = (name: string, minutesAgo: number, outcome: string | null = null): CronRun => ({
+  name,
+  lastRanAt: ago(minutesAgo),
+  lastOutcome: outcome,
+});
+
+describe("everyMinutesOf", () => {
+  it("reads every-minute", () => {
+    expect(everyMinutesOf("* * * * *")).toBe(1);
+  });
+
+  it("reads a step", () => {
+    expect(everyMinutesOf("*/10 * * * *")).toBe(10);
+  });
+
+  it("reads a ranged step, which score-week actually uses", () => {
+    // Offset from the stats job so it reads that run rather than the previous
+    // one. Not an exotic expression — it is in vercel.json today.
+    expect(everyMinutesOf("5-59/10 * * * *")).toBe(10);
+  });
+
+  it("reads hourly", () => {
+    expect(everyMinutesOf("0 * * * *")).toBe(60);
+  });
+
+  it("reads daily", () => {
+    expect(everyMinutesOf("20 9 * * *")).toBe(24 * 60);
+  });
+
+  it("refuses a day-of-week schedule rather than approximating it", () => {
+    // A Tuesday job's gap depends on the calendar; one number cannot say it.
+    expect(everyMinutesOf("0 9 * * 2")).toBeNull();
+  });
+
+  it("refuses a day-of-month schedule", () => {
+    expect(everyMinutesOf("0 9 1 * *")).toBeNull();
+  });
+
+  it("refuses nonsense rather than guessing", () => {
+    expect(everyMinutesOf("not a cron")).toBeNull();
+    expect(everyMinutesOf("* * * *")).toBeNull();
+    expect(everyMinutesOf("*/0 * * * *")).toBeNull();
+  });
+
+  it("refuses a repeating minute on a fixed hour", () => {
+    // "*/10 9 * * *" fires six times, then not for 23 hours. No single interval
+    // describes it, so it must not claim one.
+    expect(everyMinutesOf("*/10 9 * * *")).toBeNull();
+  });
+});
+
+describe("expectedJobs", () => {
+  it("names a job by the last path segment, as the routes do", () => {
+    const config: CronConfig = {
+      crons: [{ path: "/api/cron/season-sync", schedule: "20 9 * * *" }],
+    };
+    expect(expectedJobs(config)).toEqual([{ name: "season-sync", everyMinutes: 1440 }]);
+  });
+
+  it("keeps a job whose schedule it cannot read, with a null interval", () => {
+    // Dropping it would make an unreadable schedule indistinguishable from a
+    // job nobody configured — silence, in the file that decides what runs.
+    const config: CronConfig = { crons: [{ path: "/api/cron/x", schedule: "0 9 * * 2" }] };
+    expect(expectedJobs(config)).toEqual([{ name: "x", everyMinutes: null }]);
+  });
+
+  it("ignores malformed entries rather than throwing", () => {
+    const config = { crons: [{ schedule: "* * * * *" }, { path: 42 }] } as CronConfig;
+    expect(expectedJobs(config)).toEqual([]);
+  });
+
+  it("handles a config with no crons at all", () => {
+    expect(expectedJobs({})).toEqual([]);
+  });
+
+  it("pins the six real jobs against the real vercel.json", () => {
+    // The tripwire. If the file moves, or a job is added or renamed without
+    // this being revisited, the check silently reports zero jobs scheduled —
+    // which is exactly the "everything is fine" reading that hid the problem.
+    const path = fileURLToPath(new URL("../../../apps/web/vercel.json", import.meta.url));
+    const config = JSON.parse(readFileSync(path, "utf8")) as CronConfig;
+
+    expect(expectedJobs(config)).toEqual([
+      { name: "draft-tick", everyMinutes: 1 },
+      { name: "stats", everyMinutes: 10 },
+      { name: "score-week", everyMinutes: 10 },
+      { name: "waivers", everyMinutes: 60 },
+      { name: "trades", everyMinutes: 60 },
+      { name: "season-sync", everyMinutes: 1440 },
+    ]);
+  });
+});
+
+describe("cronHealth", () => {
+  const jobs = [
+    { name: "draft-tick", everyMinutes: 1 },
+    { name: "season-sync", everyMinutes: 1440 },
+  ];
+
+  it("reports a job that has never run", () => {
+    const health = cronHealth(jobs, [], NOW);
+
+    expect(health.jobs.map((j) => j.state)).toEqual(["NEVER_RAN", "NEVER_RAN"]);
+    expect(health.healthy).toBe(false);
+  });
+
+  it("distinguishes nothing-has-ever-run from a job being late", () => {
+    // The signature of a deployment that does not exist, as against a scheduler
+    // that faltered. Measured on 2026-08-17: zero rows, six jobs scheduled.
+    expect(cronHealth(jobs, [], NOW).neverRanAtAll).toBe(true);
+    expect(cronHealth(jobs, [run("draft-tick", 0)], NOW).neverRanAtAll).toBe(false);
+  });
+
+  it("is healthy when every job has run recently and cleanly", () => {
+    const health = cronHealth(jobs, [run("draft-tick", 1), run("season-sync", 60)], NOW);
+    expect(health.healthy).toBe(true);
+  });
+
+  it("calls a punctual job with a failing outcome FAILING, not OK", () => {
+    // A job that fires every minute and fails every time is worse than one that
+    // never fires, and a bare timestamp reports both as healthy.
+    const health = cronHealth(jobs, [run("draft-tick", 0, "2 of 3 seasons failed")], NOW);
+
+    expect(health.jobs[0]?.state).toBe("FAILING");
+    expect(health.jobs[0]?.lastOutcome).toBe("2 of 3 seasons failed");
+  });
+
+  it("calls a job late by more than two intervals STALE", () => {
+    const health = cronHealth(jobs, [run("draft-tick", 30), run("season-sync", 60)], NOW);
+    expect(health.jobs[0]?.state).toBe("STALE");
+  });
+
+  it("tolerates one missed invocation", () => {
+    // A scheduler is allowed to be slightly late; a check that cries wolf is one
+    // people stop reading.
+    const health = cronHealth(
+      [{ name: "waivers", everyMinutes: 60 }],
+      [run("waivers", 90)],
+      NOW,
+    );
+    expect(health.jobs[0]?.state).toBe("OK");
+  });
+
+  it("does not call an unreadable schedule healthy", () => {
+    const health = cronHealth([{ name: "odd", everyMinutes: null }], [run("odd", 5)], NOW);
+
+    expect(health.jobs[0]?.state).toBe("UNKNOWN_SCHEDULE");
+    expect(health.healthy).toBe(false);
+  });
+
+  it("reports a run with no schedule behind it as UNSCHEDULED", () => {
+    // Migration 0029 names "a deploy that dropped the cron config" as a way the
+    // crons stop. This is the only shape that catches it — the job leaves the
+    // config and its history stays.
+    const health = cronHealth([jobs[0]!], [run("draft-tick", 0), run("waivers", 10)], NOW);
+
+    expect(health.jobs.find((j) => j.name === "waivers")?.state).toBe("UNSCHEDULED");
+    expect(health.healthy).toBe(false);
+  });
+
+  it("reports minutes since the last run, and null when there was none", () => {
+    const health = cronHealth(jobs, [run("draft-tick", 7)], NOW);
+
+    expect(health.jobs[0]?.minutesSince).toBe(7);
+    expect(health.jobs[1]?.minutesSince).toBeNull();
+  });
+});
+
+describe("stalenessLimitMinutes", () => {
+  it("allows two intervals plus slack", () => {
+    expect(stalenessLimitMinutes(1)).toBe(7);
+    expect(stalenessLimitMinutes(60)).toBe(125);
+  });
+});

--- a/packages/db/src/cron-health.ts
+++ b/packages/db/src/cron-health.ts
@@ -1,0 +1,249 @@
+/**
+ * Is the scheduler running, and is it succeeding?
+ *
+ * `cron_runs` (migration `0029`) records that a job reached the end of a run,
+ * and `listCronRuns` deliberately returns everything so that a *missing* row is
+ * as visible as a stale one. Its docstring names the caller that was supposed to
+ * exist — "a caller comparing against the expected job list" — and until now
+ * nothing did. So the table was written on every invocation and read by nobody,
+ * which is the same blind spot one layer up: the heartbeat existed and no one
+ * took the pulse.
+ *
+ * Measured on 2026-08-17: `cron_runs` held **zero rows**. Six jobs are scheduled
+ * in `apps/web/vercel.json`, `draft-tick` every minute, and the table had been
+ * live for two days. Nothing had ever run. Everything in the deployed database
+ * was put there by somebody typing `pnpm db:sync`.
+ *
+ * ## The expected list is parsed, never restated
+ *
+ * {@link expectedJobs} reads `apps/web/vercel.json` — the file the host actually
+ * obeys. A second copy of the job list in this file would be a copy that drifts,
+ * and the drift would be silent in the direction that matters: a job added to
+ * the schedule and forgotten here would never be reported missing. This is the
+ * `potDepositGate` property — the thing that decides is the thing that ships.
+ *
+ * ## An unreadable schedule is reported, never assumed healthy
+ *
+ * A cron expression this cannot parse yields `UNKNOWN_SCHEDULE` rather than a
+ * guess. That is the same direction `blockTime` takes for an unrecognised RPC
+ * error, and for the same reason: refusing costs someone a look, while guessing
+ * costs the thing the check exists to protect. A staleness threshold derived
+ * from a misread expression would report a dead job as healthy.
+ *
+ * ## What a green result does NOT mean
+ *
+ * **It means the routes ran. It does not mean they did anything.** A run over
+ * zero games is a healthy run, so every job here can report `OK` while
+ * `stat_lines` stays empty and every player scores zero. That is a real and
+ * current state of this project, not a hypothetical. Read this as "the
+ * scheduler is alive", never as "the data is right" — the data has its own
+ * checks and this is not one of them.
+ */
+
+import type { CronRun } from "./cron-runs.js";
+
+/** A job the deployment is configured to run, and how often. */
+export interface ExpectedJob {
+  /** The job name, matching what the route passes to `recordCronRun`. */
+  readonly name: string;
+  /** Minutes between runs, or `null` when the schedule could not be parsed. */
+  readonly everyMinutes: number | null;
+}
+
+export type CronJobState =
+  /** Ran recently enough for its schedule, and the last run was clean. */
+  | "OK"
+  /** Scheduled, and has never recorded a single run. */
+  | "NEVER_RAN"
+  /** Ran once, but not recently enough for its schedule. */
+  | "STALE"
+  /** Running, and the last run reported a problem. */
+  | "FAILING"
+  /** Its cron expression could not be parsed, so staleness is unknowable. */
+  | "UNKNOWN_SCHEDULE"
+  /** Has a `cron_runs` row and is in no schedule — a dropped cron config. */
+  | "UNSCHEDULED";
+
+export interface CronJobHealth {
+  readonly name: string;
+  readonly state: CronJobState;
+  readonly everyMinutes: number | null;
+  readonly lastRanAt: Date | null;
+  readonly lastOutcome: string | null;
+  /** Minutes since the last run, or `null` if it has never run. */
+  readonly minutesSince: number | null;
+}
+
+export interface CronHealth {
+  readonly jobs: readonly CronJobHealth[];
+  /** True only when every job is `OK`. */
+  readonly healthy: boolean;
+  /** True when nothing has ever run — the "not deployed" shape. */
+  readonly neverRanAtAll: boolean;
+}
+
+/** The shape of `vercel.json` this reads. Anything else is ignored. */
+export interface CronConfig {
+  readonly crons?: readonly { readonly path?: unknown; readonly schedule?: unknown }[];
+}
+
+/**
+ * One missed invocation is not an outage; two is.
+ *
+ * Plus five minutes of slack, because a scheduler is allowed to be a little late
+ * and a check that cries wolf is one people stop reading.
+ */
+export function stalenessLimitMinutes(everyMinutes: number): number {
+  return everyMinutes * 2 + 5;
+}
+
+/**
+ * How many minutes apart a cron expression fires, or `null` if unreadable.
+ *
+ * Handles only the shapes this repo actually schedules, and refuses everything
+ * else rather than approximating. Day-of-month and day-of-week must be `*`: a
+ * job that runs on Tuesdays has a gap that depends on the calendar, and a single
+ * "every N minutes" number cannot describe it.
+ */
+export function everyMinutesOf(schedule: string): number | null {
+  const parts = schedule.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  if (dayOfMonth !== "*" || month !== "*" || dayOfWeek !== "*") return null;
+
+  const minuteStep = stepOf(minute);
+  if (minuteStep === null) return null;
+
+  // Every hour: the minute field decides. A single minute (`0 * * * *`) fires
+  // once an hour; a step (`*/10 * * * *`) fires at that step.
+  if (hour === "*") return minuteStep === FIXED ? 60 : minuteStep;
+
+  // Hourly or daily: the minute field must name a single minute, or the gap is
+  // not constant.
+  if (minuteStep !== FIXED) return null;
+
+  const hourStep = stepOf(hour);
+  if (hourStep === null) return null;
+  return hourStep === FIXED ? 24 * 60 : hourStep * 60;
+}
+
+/** Marker for a field naming exactly one value rather than an interval. */
+const FIXED = -1;
+
+/**
+ * The interval a single cron field describes: `FIXED` for one value, a positive
+ * number for a repeating step, or `null` when it cannot be read.
+ *
+ * `5-59/10` is deliberately supported — `score-week` uses it to run offset from
+ * `stats`, so it is not an exotic case.
+ */
+function stepOf(field: string): number | null {
+  if (field === "*") return 1;
+
+  const stepped = /^(\*|\d+-\d+)\/(\d+)$/.exec(field);
+  if (stepped) {
+    const step = Number(stepped[2]);
+    return Number.isInteger(step) && step > 0 ? step : null;
+  }
+
+  return /^\d+$/.test(field) ? FIXED : null;
+}
+
+/**
+ * The jobs a deployment is configured to run, from its own cron config.
+ *
+ * The name is the last path segment, which is what each route passes to
+ * `recordCronRun` — `/api/cron/season-sync` records as `season-sync`. If that
+ * convention is ever broken the job reports `NEVER_RAN` while running perfectly,
+ * which is loud and wrong rather than quiet and wrong; there is a test pinning
+ * the six real names against the real file for exactly that reason.
+ */
+export function expectedJobs(config: CronConfig): readonly ExpectedJob[] {
+  return (config.crons ?? [])
+    .map((entry) => {
+      const path = typeof entry.path === "string" ? entry.path : "";
+      const name = path.split("/").filter(Boolean).pop() ?? "";
+      const schedule = typeof entry.schedule === "string" ? entry.schedule : "";
+      return { name, everyMinutes: schedule === "" ? null : everyMinutesOf(schedule) };
+    })
+    .filter((job) => job.name !== "");
+}
+
+/**
+ * Compare what should be running against what has run.
+ *
+ * Pure, so the interesting states are testable without a scheduler, a
+ * deployment, or waiting a day for a daily job to be late.
+ */
+export function cronHealth(
+  expected: readonly ExpectedJob[],
+  runs: readonly CronRun[],
+  now: Date,
+): CronHealth {
+  const byName = new Map(runs.map((run) => [run.name, run]));
+  const jobs: CronJobHealth[] = [];
+
+  for (const job of expected) {
+    const run = byName.get(job.name);
+    const minutesSince =
+      run === undefined ? null : Math.floor((now.getTime() - run.lastRanAt.getTime()) / 60_000);
+
+    jobs.push({
+      name: job.name,
+      state: stateOf(job, run, minutesSince),
+      everyMinutes: job.everyMinutes,
+      lastRanAt: run?.lastRanAt ?? null,
+      lastOutcome: run?.lastOutcome ?? null,
+      minutesSince,
+    });
+  }
+
+  // A row with no schedule behind it. Migration 0029's comment names "a deploy
+  // that dropped `vercel.json`" as a way the crons stop, and this is the only
+  // shape that catches it: the job vanishes from the config while its history
+  // remains.
+  const scheduled = new Set(expected.map((job) => job.name));
+  for (const run of runs) {
+    if (scheduled.has(run.name)) continue;
+    jobs.push({
+      name: run.name,
+      state: "UNSCHEDULED",
+      everyMinutes: null,
+      lastRanAt: run.lastRanAt,
+      lastOutcome: run.lastOutcome,
+      minutesSince: Math.floor((now.getTime() - run.lastRanAt.getTime()) / 60_000),
+    });
+  }
+
+  return {
+    jobs,
+    healthy: jobs.every((job) => job.state === "OK"),
+    // Distinguished from "some job is stale" on purpose: no rows at all, with
+    // the table present, is the signature of a deployment that does not exist
+    // rather than a scheduler that faltered.
+    neverRanAtAll: runs.length === 0 && expected.length > 0,
+  };
+}
+
+function stateOf(
+  job: ExpectedJob,
+  run: CronRun | undefined,
+  minutesSince: number | null,
+): CronJobState {
+  if (run === undefined) return "NEVER_RAN";
+  // Checked before staleness: a job failing every minute is punctual, and
+  // reporting it as OK is the exact failure `last_outcome` was added to prevent.
+  if (run.lastOutcome !== null) return "FAILING";
+  if (job.everyMinutes === null) return "UNKNOWN_SCHEDULE";
+  if (minutesSince !== null && minutesSince > stalenessLimitMinutes(job.everyMinutes)) {
+    return "STALE";
+  }
+  return "OK";
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -163,6 +163,18 @@ export {
 export { listCronRuns, recordCronRun, type CronRun } from "./cron-runs.js";
 
 export {
+  cronHealth,
+  everyMinutesOf,
+  expectedJobs,
+  stalenessLimitMinutes,
+  type CronConfig,
+  type CronHealth,
+  type CronJobHealth,
+  type CronJobState,
+  type ExpectedJob,
+} from "./cron-health.js";
+
+export {
   loadDraftBoard,
   loadProjections,
   seasonsInPlay,


### PR DESCRIPTION
`cron_runs` (migration `0029`) is the heartbeat every job stamps at the end of every run. On **2026-08-17 it held zero rows** — no job, not once. Six crons are scheduled in `apps/web/vercel.json`, `draft-tick` every minute, and the table had been live for two days.

Every game, player, ranking and projection in the deployed database was put there by somebody typing `pnpm db:sync`.

The table was written by everyone and read by nobody. `listCronRuns` had **no production caller**, and its own docstring names the one that was meant to exist — *"a caller comparing against the expected job list"*. That list lives in `vercel.json` and nothing imported it.

## `pnpm cron:status`

```
NEVER_RAN         draft-tick    every 1m             last: never
NEVER_RAN         stats         every 10m            last: never
NEVER_RAN         score-week    every 10m            last: never
NEVER_RAN         waivers       every 60m            last: never
NEVER_RAN         trades        every 60m            last: never
NEVER_RAN         season-sync   every 1440m          last: never

FAIL — no scheduled job has ever run against this database.
```

That is the real output against production, and the command exits non-zero. Same argument as `pnpm db:audit` one layer out — *"a configuration you have to remember to check is one you stop checking. This makes it a command."*

Five decisions worth reviewing:

**The expected list is parsed from `vercel.json`, never restated.** A second copy of the job list drifts, and silently in the worst direction: a job added to the schedule and forgotten here would never be reported missing. Same property as `potDepositGate` reading the committed IDL — the thing that decides is the thing that ships. A test pins the six real names against the real file, so moving it fails CI rather than quietly reporting zero jobs scheduled.

**An unreadable cron expression is `UNKNOWN_SCHEDULE`, never a guess.** The direction `blockTime` takes for an unrecognised RPC error, for the same reason: a staleness threshold derived from a misread expression would call a dead job healthy. `5-59/10` is supported because `score-week` uses it; day-of-week is refused, because one number cannot describe a gap that depends on the calendar.

**`FAILING` is checked before staleness.** A job firing every minute and throwing every time is punctual, and reporting it `OK` is the exact failure `last_outcome` exists to prevent.

**`UNSCHEDULED`** catches a `cron_runs` row with no entry in `vercel.json`. Migration `0029` names "a deploy that dropped the cron config" as a way the crons stop, and this is the only shape that sees it.

**`neverRanAtAll` is distinguished from "some job is late"** — zero rows with the table present is the signature of a deployment that does not exist, not a scheduler that faltered, and it deserves a different message.

`pnpm db:status` now carries a one-line summary, because this gap survived precisely because nothing was obliged to ask:

```
scheduler: 6 job(s) scheduled, 0 have ever run — pnpm cron:status
```

**A green result means the routes ran, not that they did any work.** A run over zero games is a healthy run, so every job can report `OK` while `stat_lines` is empty and every player scores zero — which is the state today. The command says so on the green path, not only in a docstring.

## Docs that described a system which has never executed

- **`SETUP-REQUIRED.md` had no deployment entry at all.** That file is the list of things only the owner can do, and "there is no host" was on it nowhere. Added, with four traps in the order they bite: the Vercel Root Directory must be `apps/web` or the crons silently never register; plan tier limits; `CRON_SECRET` unset means every cron route 503s — a fully deployed, fully dead scheduler; function timeout versus `season-sync`'s eighteen weeks of provider calls.

- **CLAUDE.md said `/api/cron/stats` calls `syncGames`.** It does not — that job runs `syncBoxScores` only. `syncGames` belongs to `/api/cron/season-sync`, daily at 09:20 UTC, which the file never mentioned anywhere. Someone debugging a stale schedule would have read that, checked the ten-minute job, found `syncGames` absent and concluded the wiring was broken.

- **"248 games" → 256**, with what the number means: complete for weeks 1–17, every team on 16. Week 18 is absent and is meant to be — all 16 of its fixtures are undated, so no conservative kickoff can be derived, and it falls after the fantasy championship.

- **The scoreboard's `BYE` rule** still stated the conflation #182 removed.

- **`LIVE-SCORING.md` said "Fully automated. No human in the loop at any point."** The loop is entirely human. Its table now has an **Exists?** column — four of six exist, injuries and inactives have no code at all, and the game watcher does not watch, it polls unconditionally. Also corrected the false premise that caused #182: *"every kickoff time is known months ahead"* is the assumption `syncGames` was written on, and it is wrong.

- **`TANK01.md` now records the verbatim TBD strings**, which is that file's entire purpose: `gameTime_epoch: ""` — empty string, not `"0"`, not absent.

## Verified

`pnpm test` **1525 passed, 2 skipped** · typecheck · lint · `format:check` · `pnpm --filter @rostr/web build`. `cron:status` and `db:status` both exercised against the deployed database.

No migration, no schema change, no route change — the six cron routes already called `recordCronRun` and are untouched.

## What this does not do

It does not deploy anything. `cron_runs` is still empty and will stay empty until there is a host; this only makes that fact impossible to miss rather than impossible to have. The deployment is owner-only work and now has an entry saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
