### PR TITLE
The deploy could not build the workspace packages it imports

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "vercel-build": "cd ../.. && pnpm --filter \"@rostr/web...\" build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
The first production deploy failed:

```
Module not found: Can't resolve '@rostr/escrow'
./src/components/CreateLeagueForm.tsx
./src/components/DepositPanel.tsx
./src/components/JoinPanel.tsx
```

## Why

`apps/web` imports five workspace packages. Each resolves to `./dist/index.js`, `dist/` is gitignored, and the host only ever ran `next build` inside `apps/web` — so on a fresh clone nothing had compiled them and the imports did not exist.

It builds locally only because `dist/` is left over from earlier work. **No gate catches this**: `pnpm test`, `typecheck`, `lint` and CI all either build the packages first or run in a tree where they are already built. Reproduced here by deleting every `dist/`, which failed identically to the deploy.

## The fix

`vercel-build` takes precedence over `build` on Vercel, and builds the dependencies before the app:

```
cd ../.. && pnpm --filter "@rostr/web..." build
```

The `...` suffix is the load-bearing part — "this package **and everything it depends on**", in dependency order, so `core` emits its types before `pinning` and `db` compile against them.

## Verified against a genuinely clean tree

Every `dist/` **and** every `.tsbuildinfo` deleted, which is the state a clone arrives in — then `pnpm vercel-build` run from `apps/web` exactly as the host runs it. It compiled all five packages and the app, through to the route table.

That second half matters and cost a wrong diagnosis on the way here: **deleting `dist/` alone leaves `tsc --build` believing its output is current**, so it reports `Done`, emits nothing, and a broken build looks fine. Worth knowing when reproducing this class of failure locally.

`format:check`, `typecheck` and `lint` all clean. No behaviour change — a script addition only.

## Why in the repo rather than the dashboard

The deploy was made to work by typing a Build Command override into a web form. That override lives nowhere in version control, no review can see it, and no clone carries it — so anyone re-importing the project or standing up a second environment meets the identical failure with nothing to point at. The dashboard override can stay; it simply stops being the only thing holding the deploy up.

## Not covered

CI still does not build the web app from a clean tree, so a future regression of this exact shape would pass every check and fail only on deploy. Worth a follow-up; it needs a job that builds without a prior `tsc --build`, which is more than a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
