### PR TITLE
A mail provider refusing a send showed the user a JSON parse error

### DIFF
--- a/apps/web/src/app/api/auth/request/route.ts
+++ b/apps/web/src/app/api/auth/request/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { beginEmailSignIn, IdentityError, SIGN_IN_PER_EMAIL, SIGN_IN_PER_IP } from "@rostr/db";
 import { db } from "@/lib/db";
-import { EmailNotConfiguredError, sendSignInLink } from "@/lib/email";
+import { EmailDeliveryError, EmailNotConfiguredError, sendSignInLink } from "@/lib/email";
 import { byIp, enforceRateLimit } from "@/lib/rate-limit";
 import { safeRedirect } from "@/lib/session";
 
@@ -53,6 +53,21 @@ export async function POST(request: Request): Promise<NextResponse> {
   } catch (error) {
     if (error instanceof EmailNotConfiguredError) {
       return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+    // A provider refusing to send is expected, not exceptional — a suppressed
+    // address, an exhausted quota, a sender the account may not use. It used to
+    // fall through to the rethrow below, and an unhandled throw here is a 500
+    // with **no body**, which the client then tries to parse as JSON: the user
+    // was shown "Unexpected end of JSON input" for a mail problem.
+    //
+    // 502 rather than 500: the failure is upstream of us and retrying may well
+    // work. The provider's own text is deliberately not forwarded — it can name
+    // the recipient and the sending domain, and this endpoint answers
+    // identically whether or not an account exists.
+    if (error instanceof EmailDeliveryError) {
+      // eslint-disable-next-line no-console
+      console.error(`[auth] provider refused (${error.status}): ${error.detail}`);
+      return NextResponse.json({ error: error.message }, { status: 502 });
     }
     if (error instanceof IdentityError) {
       return NextResponse.json({ error: error.message, code: error.code }, { status: 400 });

--- a/apps/web/src/components/SignInForm.tsx
+++ b/apps/web/src/components/SignInForm.tsx
@@ -28,8 +28,21 @@ export function SignInForm({ next }: { next: string }) {
         body: JSON.stringify({ email, displayName, next }),
       });
 
-      const body = (await response.json()) as { devLink?: string; error?: string };
-      if (!response.ok) throw new Error(body.error ?? "Could not send the link");
+      // Parsed defensively, because a response is not guaranteed to carry a
+      // body. An unhandled throw in a route handler returns 500 with nothing at
+      // all, and calling `.json()` on that threw a `SyntaxError` whose message
+      // — "Unexpected end of JSON input" — was then shown to the user as though
+      // it explained something. The status is the fact; the body is a courtesy.
+      const body = ((await response.json().catch(() => null)) ?? {}) as {
+        devLink?: string;
+        error?: string;
+      };
+
+      if (!response.ok) {
+        throw new Error(
+          body.error ?? `Could not send the link (error ${response.status}). Please try again.`,
+        );
+      }
 
       setDevLink(body.devLink ?? null);
       setStatus("sent");

--- a/apps/web/src/lib/email.test.ts
+++ b/apps/web/src/lib/email.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EmailDeliveryError, EmailNotConfiguredError, sendSignInLink } from "./email.js";
+
+/**
+ * Sending the sign-in link, and — the point of this file — what happens when
+ * the provider says no.
+ *
+ * A refusal is expected rather than exceptional: a suppressed address, an
+ * exhausted quota, or a shared test sender that only delivers to the account
+ * owner. It used to throw a bare `Error`, which the route rethrew, which made a
+ * 500 with an empty body, which the browser tried to parse as JSON — so the
+ * user was shown "Unexpected end of JSON input" for a mail problem. Every step
+ * of that chain was reasonable on its own.
+ */
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+const configure = (): void => {
+  vi.stubEnv("RESEND_API_KEY", "re_test");
+  vi.stubEnv("EMAIL_FROM", "onboarding@resend.dev");
+};
+
+describe("sendSignInLink", () => {
+  it("reports a provider refusal as EmailDeliveryError, not a bare Error", async () => {
+    configure();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response("You can only send testing emails to your own address", { status: 403 }),
+        ),
+    );
+
+    await expect(sendSignInLink("someone@example.com", "https://x/y")).rejects.toBeInstanceOf(
+      EmailDeliveryError,
+    );
+  });
+
+  it("carries the provider's status and detail for the server log", async () => {
+    // Kept for the operator, deliberately not returned to the caller: the text
+    // can name the recipient and the sending domain, and this endpoint answers
+    // identically whether or not an account exists.
+    configure();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("domain not verified", { status: 422 })),
+    );
+
+    const error = await sendSignInLink("a@b.com", "https://x/y").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(EmailDeliveryError);
+    expect((error as EmailDeliveryError).status).toBe(422);
+    expect((error as EmailDeliveryError).detail).toContain("domain not verified");
+  });
+
+  it("says the address is not the problem, because it usually is not", async () => {
+    configure();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 500 })));
+
+    const error = (await sendSignInLink("a@b.com", "https://x/y").catch(
+      (e: unknown) => e,
+    )) as Error;
+
+    expect(error.message).toMatch(/delivery problem/i);
+    expect(error.message).not.toMatch(/Unexpected end of JSON/);
+  });
+
+  it("reports success when the provider accepts", async () => {
+    configure();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: "abc" }), { status: 200 })),
+    );
+
+    await expect(sendSignInLink("a@b.com", "https://x/y")).resolves.toEqual({
+      delivered: true,
+    });
+  });
+
+  it("is a different error when no provider is configured at all", async () => {
+    // A deployment that was never finished, as against one whose provider
+    // refused. The route answers 503 for the first and 502 for the second.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("RESEND_API_KEY", "");
+    vi.stubEnv("EMAIL_FROM", "");
+
+    await expect(sendSignInLink("a@b.com", "https://x/y")).rejects.toBeInstanceOf(
+      EmailNotConfiguredError,
+    );
+  });
+
+  it("hands the link back outside production when unconfigured, so local sign-in works", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("RESEND_API_KEY", "");
+    vi.stubEnv("EMAIL_FROM", "");
+
+    const result = await sendSignInLink("a@b.com", "https://x/y");
+
+    expect(result.delivered).toBe(false);
+    expect(result.devLink).toBe("https://x/y");
+  });
+});

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -22,6 +22,34 @@ export interface DeliveryResult {
   readonly devLink?: string;
 }
 
+/**
+ * The provider was asked to send and refused.
+ *
+ * Separate from {@link EmailNotConfiguredError} because the two need different
+ * answers: that one is a deployment that was never finished, this one is a
+ * working deployment whose provider said no — a suppressed address, an
+ * exhausted quota, a sender the account is not permitted to use, or the
+ * provider being down.
+ *
+ * It is **expected**, not exceptional. The commonest cause in practice is a
+ * shared test sender, which only delivers to the account owner, so every other
+ * address fails here. Letting it escape as an unhandled throw produced a 500
+ * with an empty body, and the browser then showed the user a JSON parse error
+ * instead of anything about email.
+ */
+export class EmailDeliveryError extends Error {
+  constructor(
+    readonly status: number,
+    readonly detail: string,
+  ) {
+    super(
+      "The email provider refused to send the sign-in link. That is a delivery " +
+        "problem rather than a problem with the address.",
+    );
+    this.name = "EmailDeliveryError";
+  }
+}
+
 export class EmailNotConfiguredError extends Error {
   constructor() {
     super(
@@ -66,7 +94,11 @@ export async function sendSignInLink(email: string, link: string): Promise<Deliv
   });
 
   if (!response.ok) {
-    throw new Error(`Email provider returned ${response.status}: ${await response.text()}`);
+    // Typed, so the route can answer with a readable JSON body. This used to be
+    // a bare `Error`, which the route rethrew — and an unhandled throw in a
+    // route handler is a 500 with no body at all. The client then parses that
+    // body as JSON and shows the user the parse failure.
+    throw new EmailDeliveryError(response.status, await response.text());
   }
 
   return { delivered: true };


### PR DESCRIPTION
Signing in with any address other than the Resend account owner's showed this in the browser:

> Failed to execute 'json' on 'Response': Unexpected end of JSON input

Reproduced against production:

```
$ curl -s -o /tmp/b -w "%{http_code} len=%{size_download}" -X POST \
    https://www.rostr.site/api/auth/request -d '{"email":"someone-else@example.com"}'
500 len=0
```

## Three reasonable steps, one useless message

1. `sendSignInLink` threw a bare `Error` when the provider returned non-ok.
2. `/api/auth/request` catches `EmailNotConfiguredError` and `IdentityError` and **rethrows everything else** — and an unhandled throw in a route handler is a 500 with no body at all.
3. `SignInForm` called `response.json()` unconditionally, so parsing that empty body threw a `SyntaxError`, and its message became the error shown to the user.

Every layer behaved sensibly. The user was told about JSON when the problem was email.

## The fix

**`EmailDeliveryError`**, carrying the provider's status and detail. Kept distinct from `EmailNotConfiguredError` because the two need different answers and different remedies: one is a deployment that was never finished (**503**), the other is a working deployment whose provider said no (**502**).

502 rather than 500 because the failure is upstream of us and a retry may well succeed.

**The provider's own text is logged, never forwarded.** It can name the recipient and the sending domain, and this endpoint must answer identically whether or not an account exists — the same reason `beginEmailSignIn` handles registration and sign-in through a single path.

**The client parses defensively** and falls back to the status code. That half stands on its own merit: no route can promise a body, since an unhandled throw anywhere produces the same empty 500, and a parse failure must never again be presented as an explanation.

## Two things deliberately *not* changed

Both looked like bugs from the same incident and turned out to be correct:

- **"That link is not valid" shown after a successful sign-in.** The sign-in page already calls `currentUser()` and returns "Already signed in" *before* any error is rendered. Seeing the error means no session cookie in that context — a mail client's in-app browser has its own cookie jar. The page is right.
- **A user row created before a failed send.** `email_verified_at` stays null, which is precisely what an unconfirmed account is, and the row must exist before a token can be issued against it. Reused on retry.

## Verified

Six tests in `apps/web/src/lib/email.test.ts` — refusal, preserved status and detail, the message not blaming the address, success, the unconfigured production throw, and the development fallback that hands the link back so local sign-in keeps working.

`pnpm test` 1708 passed, 2 skipped. `typecheck`, `lint`, `format:check` clean.

**Not verified in a browser** — `SignInForm.tsx` is a component, and neither vitest project has jsdom, so the client half is compiled and not rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
