### PR TITLE
The commissioner checklist threw on every render

### DIFF
--- a/apps/web/src/components/CommissionerSetup.tsx
+++ b/apps/web/src/components/CommissionerSetup.tsx
@@ -1,4 +1,5 @@
 import type { CommissionerSetupView, SetupBlocker, SetupStepKey } from "@/lib/setup";
+import { withZone } from "@/lib/when";
 
 /**
  * The commissioner's own checklist, on the league page.
@@ -48,27 +49,6 @@ const COPY: Record<SetupStepKey, { title: string; detail: string }> = {
       "One approval, which also stakes your buy-in if this league has a pot. Both or neither.",
   },
 };
-
-/**
- * Formatted with the zone named, because the value is the **server's** clock.
- *
- * This is a server component and `toLocaleString()` runs in Node's locale — UTC
- * on Vercel — while the commissioner picked the draft time in their own zone in
- * a `datetime-local` field. Rendering an unlabelled wall-clock instant would be
- * silently wrong for everyone outside that zone, and off by a day boundary for an
- * evening draft. Naming the zone makes it correct rather than merely careful.
- *
- * `RulesView` renders this same instant the same unlabelled way, on this same
- * page. That is worth fixing there too and is not this change's job; the two do
- * not contradict each other, since one carries the zone and the other omits it.
- */
-function withZone(at: Date): string {
-  return at.toLocaleString(undefined, {
-    dateStyle: "long",
-    timeStyle: "short",
-    timeZoneName: "short",
-  });
-}
 
 const BLOCKED: Record<SetupBlocker["code"], string> = {
   LEAGUE_CLOSED: "it is no longer forming",

--- a/apps/web/src/lib/when.test.ts
+++ b/apps/web/src/lib/when.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { withZone } from "./when.js";
+
+/**
+ * The checklist's draft deadline, formatted.
+ *
+ * This file exists because the formatter shipped inside a `.tsx` component and
+ * threw on every single call — `dateStyle`/`timeStyle` combined with
+ * `timeZoneName` is a `TypeError` by specification. It typechecked, passed the
+ * whole suite, and produced a 500 the first time a commissioner opened their
+ * own league page, because `apps/web` has no jsdom and nothing in a component
+ * can be exercised by a test.
+ *
+ * The first assertion below is the one that matters: it simply calls the thing.
+ */
+
+const AT = new Date("2026-08-25T18:00:00Z");
+
+describe("withZone", () => {
+  it("does not throw", () => {
+    // The whole bug. `dateStyle` + `timeZoneName` threw here on every render,
+    // in every runtime, and no gate in this repo could see it.
+    expect(() => withZone(AT)).not.toThrow();
+  });
+
+  it("names the zone, because the reader's clock is not the server's", () => {
+    // Without this the commissioner sees a bare wall-clock time formatted in
+    // Node's locale — UTC on Vercel — and reads it as their own.
+    expect(withZone(AT)).toMatch(/\b(UTC|GMT|[A-Z]{2,5}T|[A-Z]{3,4})\b/);
+  });
+
+  it("carries the date and the time", () => {
+    const formatted = withZone(AT);
+    expect(formatted).toMatch(/2026/);
+    expect(formatted).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("survives every hour of the day, including midnight and noon", () => {
+    // `hour: "numeric"` with a 12-hour locale renders midnight as 12 AM; a
+    // formatter that throws or blanks on an edge hour would only be found by
+    // someone scheduling a draft at exactly that time.
+    for (let hour = 0; hour < 24; hour++) {
+      const at = new Date(Date.UTC(2026, 7, 25, hour, 0, 0));
+      expect(() => withZone(at)).not.toThrow();
+      expect(withZone(at).length).toBeGreaterThan(10);
+    }
+  });
+
+  it("survives a date either side of a daylight-saving change", () => {
+    // US DST ends 1 November 2026. The zone abbreviation differs on each side,
+    // which is the point of printing it at all.
+    expect(() => withZone(new Date("2026-10-31T18:00:00Z"))).not.toThrow();
+    expect(() => withZone(new Date("2026-11-02T18:00:00Z"))).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/when.ts
+++ b/apps/web/src/lib/when.ts
@@ -1,0 +1,45 @@
+/**
+ * Rendering an instant with its zone named.
+ *
+ * Server components format in Node's locale — UTC on Vercel — while a
+ * commissioner picks a draft time in their own zone in a `datetime-local`
+ * field. An unlabelled wall-clock reading is silently wrong for everyone
+ * outside that zone, and off by a day boundary for an evening draft. Naming the
+ * zone makes it correct rather than merely careful.
+ *
+ * ## Why this is not in the component that uses it
+ *
+ * It was, and it threw on every render — see {@link withZone}. `apps/web` has
+ * no jsdom in either vitest project, so nothing that lives in a `.tsx` file can
+ * be exercised by a test: the checklist compiled, typechecked, passed the whole
+ * suite, and produced a 500 the first time a commissioner opened their own
+ * league. Moved here so the formatting is covered by a node test, which is the
+ * same reasoning that put `commissionerSetup` in `lib/setup.ts` and the lobby's
+ * view model in `lib/lobby.ts`.
+ */
+
+/**
+ * A date and time with the time zone named — "August 25, 2026 at 2:00 PM EDT".
+ *
+ * ## The bug this exists to prevent recurring
+ *
+ * The first version asked for `dateStyle: "long"`, `timeStyle: "short"` and
+ * `timeZoneName: "short"` together. ECMA-402 forbids that combination outright:
+ * `dateStyle` and `timeStyle` are shorthands for a whole pattern, so pairing
+ * either with an individual component option is a `TypeError: Invalid option`,
+ * thrown on every call in every runtime. Not a fallback, not a locale
+ * difference — always.
+ *
+ * So the components are spelled out individually. It is more to read and it is
+ * the only form that can carry the zone.
+ */
+export function withZone(at: Date): string {
+  return at.toLocaleString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}


### PR DESCRIPTION
Opening your own league as its commissioner returned a **500**. Reproduced against production with a real session, then locally for the stack:

```
TypeError: Invalid option : option
    at Date.toLocaleString
    at withZone (CommissionerSetup.tsx:66)
    at CommissionerSetup (CommissionerSetup.tsx:221)
```

## The bug

```ts
at.toLocaleString(undefined, {
  dateStyle: "long",
  timeStyle: "short",
  timeZoneName: "short",   // ← TypeError, always
});
```

ECMA-402 forbids this combination outright. `dateStyle` and `timeStyle` are shorthands for an entire pattern, so pairing either with an individual component option throws. **Not a fallback, not a locale difference — it throws on every call, in every runtime.**

So the checklist added in #167 has **never once rendered**. It shipped under its own note — *"Not seen in a browser"* — and that turned out to be the whole story: it compiled, typechecked, and passed the full suite while being broken 100% of the time on the single page it exists for.

## The fix

Components spelled out individually, which is the only form that can carry the zone:

```
August 25, 2026 at 2:00 PM EDT
```

## Moved to `lib/`, which is the part that matters

`apps/web` has no jsdom in either vitest project, so **nothing in a `.tsx` file can be exercised by a test**. A formatter that throws unconditionally is exactly what a test catches in a millisecond and what no gate in this repo could see.

`lib/when.ts` puts it where a node test reaches it — the same reasoning that put `commissionerSetup` in `lib/setup.ts`, the lobby's view model in `lib/lobby.ts`, and `expectedTermsFromRules` in `@rostr/escrow` because both defects review found there were in the mapping rather than the comparison.

Five tests. The first one only calls the function, and would have been enough:

```ts
it("does not throw", () => {
  expect(() => withZone(AT)).not.toThrow();
});
```

The others cover the zone being named, every hour of the day including midnight, and either side of a daylight-saving change.

## Verified end to end

| | |
| --- | --- |
| Before | league page **500** for the commissioner, against production |
| After | **200**, rendering "August 25, 2026 at 2:00 PM EDT — the field locks at that moment" |

`pnpm test` **1719 passed**, 2 skipped. `typecheck`, `lint`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
