### PR TITLE
Build drop 6's landing: nav consolidated, hero draft board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2891,8 +2891,8 @@ These were discussed at length and decided. Re-proposing them wastes the owner's
 | Full PPR scoring                                 | **Settled** — table in `docs/RULES.md` §1                                         |
 | Schedule luck retained                           | **Settled** — median scoring was proposed and **rejected**                        |
 | Rolling waiver priority                          | **Settled** — FAAB proposed and **rejected** for v1                               |
-| NFTs _are_ the roster, not souvenirs             | **Settled** — Token-2022, transfer hook + permanent delegate                      |
-| NFTs persist as trophies, labelled "Player YYYY" | **Settled**                                                                       |
+| NFTs _are_ the roster, not souvenirs             | **Abandoned** 2026-08-19 (`6d28c5e`) — nothing ever minted one; see below         |
+| NFTs persist as trophies, labelled "Player YYYY" | **Abandoned** with it — a weekly claimable award replaces the idea                |
 | Trades vetoable, never automatic                 | **Settled** — 48h escrow, ⅓ of uninvolved managers                                |
 | Trade deadline set by the commissioner           | **Settled** 2026-08-08 — default 11; binds on the execution week                  |
 | Rules immutable, shown before joining            | **Settled**                                                                       |
@@ -2912,6 +2912,30 @@ These were discussed at length and decided. Re-proposing them wastes the owner's
 | Defense is the **team unit**, never a player     | **Settled** 2026-08-17 — no IDP slot, and per-player defensive stats are unmapped |
 
 ---
+
+### The roster is not an NFT, and the site must not say it is
+
+**Abandoned 2026-08-19 in `6d28c5e`, and this table said "Settled" until
+2026-08-19.** There is no NFT program, no Token-2022 code anywhere in the tree,
+and rosters are rows in Postgres — nothing has ever minted one. The enforcement
+that design needed, a transfer hook and a permanent delegate, existed only to
+stop a roster being sold out from under a league, and the database already
+prevents that.
+
+Two places on the front page promised it and both were replaced with claims that
+hold and are checkable in the source. `page.tsx` carries a comment at each site
+asking that no NFT sentence be restored until something actually mints.
+
+**The design handoff still contains both sentences.** `docs/design/screens/Rostr
+Landing.dc.html` says "Drafted players are held in your wallet" in the hero and
+"mint as Token-2022 NFTs" on a card, so anyone building that screen from the
+design will paste them back. `docs/design/STATUS.md` records this as a
+deliberate divergence; read it before implementing any part of that page.
+
+`docs/DECISIONS.md` § "Roster NFTs are the roster, not souvenirs" is the original
+argument and is **not** current. It is left in place because that file is a
+record of reasoning rather than a statement of what is true today, which is what
+this file is for.
 
 ## Environment
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { HeroThrow } from "@/components/landing/HeroThrow";
+import { LandingDraftBoard } from "@/components/landing/LandingDraftBoard";
 
 /**
  * The marketing page.
@@ -30,7 +31,19 @@ export default function LandingPage() {
     <div className="nocturne min-h-screen">
       <SiteHeader />
 
-      <section className="mx-auto w-full max-w-[1180px] overflow-hidden">
+      {/*
+        Two columns: the claim, and a draft mid-round.
+
+        The board is illustrative and says so — see `LandingDraftBoard`. It sits
+        beside the headline rather than below it because the product's argument
+        is visual: a snake board with a block-drawn order is the thing no other
+        platform can show.
+
+        `overflow-hidden` stays on the section. `HeroThrow` animates a ball
+        across its own box and the board crops twelve columns to three; both
+        would otherwise widen the page on a narrow viewport.
+      */}
+      <section className="mx-auto grid w-full max-w-[1180px] gap-8 overflow-hidden lg:grid-cols-[minmax(0,1fr)_26rem]">
         <HeroThrow
           headline={
             <>
@@ -72,6 +85,10 @@ export default function LandingPage() {
             <li>Built for the Solana Seeker</li>
           </ul>
         </HeroThrow>
+
+        <div className="px-10 pt-24 lg:pl-0">
+          <LandingDraftBoard />
+        </div>
       </section>
 
       <LeaguePanel />
@@ -145,6 +162,19 @@ function SiteHeader() {
           </span>
         </a>
         <div className="flex items-center gap-7">
+          {/*
+            One link, not three — drop 6, at the owner's request.
+
+            `#how` lands on the first of three contiguous sections that answer one
+            question between them: why it is different, how a season runs, and
+            what the format is. Three tabs asked a reader to choose between three
+            answers before knowing what any of them were, and the sections were
+            already adjacent.
+
+            The `#trust` and `#format` ids stay on their sections. Nothing points
+            at them now, but they are what anyone who shared a deep link is
+            holding, and breaking those to tidy a nav costs more than it saves.
+          */}
           <a
             href="#how"
             className="text-[13.5px] text-nocturne-neutral-400 hover:text-nocturne-text"
@@ -152,28 +182,52 @@ function SiteHeader() {
             How it works
           </a>
           <a
-            href="#format"
-            className="text-[13.5px] text-nocturne-neutral-400 hover:text-nocturne-text"
-          >
-            Format
-          </a>
-          <a
-            href="#trust"
-            className="text-[13.5px] text-nocturne-neutral-400 hover:text-nocturne-text"
-          >
-            Why it&rsquo;s different
-          </a>
-          <a
             href="https://github.com/6figpsolseeker/rostr"
-            className="text-[13.5px] text-nocturne-neutral-400 hover:text-nocturne-text"
+            aria-label="rostr on GitHub"
+            className="text-nocturne-neutral-500 transition-colors hover:text-nocturne-text"
           >
-            GitHub
+            <svg viewBox="0 0 16 16" aria-hidden className="h-[17px] w-[17px] fill-current">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+            </svg>
+          </a>
+          <a
+            href="https://x.com/rostrfantasy"
+            aria-label="rostr on X"
+            className="text-nocturne-neutral-500 transition-colors hover:text-nocturne-text"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden className="h-[15px] w-[15px] fill-current">
+              <path d="M9.52 6.78 15.48 0h-1.41L8.89 5.89 4.76 0H0l6.25 8.9L0 16h1.41l5.46-6.22L11.24 16H16L9.52 6.78Zm-1.93 2.2-.63-.89L1.92 1.04h2.17l4.06 5.72.63.89 5.28 7.42h-2.17L7.59 8.98Z" />
+            </svg>
           </a>
           <a
             href="/leagues/new"
             className="rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
           >
             Create a league
+          </a>
+          {/*
+            **A link, not a wallet button, and that is a deliberate divergence.**
+
+            The design draws this as a `<button>` because connecting is an action.
+            Doing that here would mean mounting the wallet adapter on the
+            marketing page — hundreds of kilobytes of JavaScript on the one page
+            that has to load fast for people who have never heard of us, to open
+            a popup that cannot do anything useful until there is an account
+            behind it.
+
+            So it goes where connecting actually works and is actually needed:
+            `/welcome`, which verifies the wallet by signature and is also where
+            a username is claimed. The affordance the design asked for is kept —
+            it reads as an action and sits in the same place.
+          */}
+          <a
+            href="/welcome"
+            className="flex items-center gap-2 text-[13px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden className="h-[15px] w-[15px] fill-current">
+              <path d="M13 4H3a1 1 0 0 1 0-2h9.5a.5.5 0 0 0 0-1H3a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm-1.5 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+            </svg>
+            Connect wallet
           </a>
         </div>
       </nav>
@@ -296,7 +350,9 @@ function LeaguePanel() {
 
 function Differentiators() {
   return (
-    <section id="trust" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
+    <section id="how" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
+      {/* Kept because deep links already point here. */}
+      <span id="trust" className="block scroll-mt-[60px]" />
       <div className="max-w-[640px]">
         <Kicker>Why it&rsquo;s different</Kicker>
         <h2 className="mt-4 text-[40px] font-medium leading-[1.1] tracking-[-0.028em]">
@@ -425,7 +481,7 @@ function HowItWorks() {
   ];
 
   return (
-    <section id="how" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
+    <section id="how-steps" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
       <div className="max-w-[640px]">
         <Kicker>How it works</Kicker>
         <h2 className="mt-4 text-[40px] font-medium leading-[1.1] tracking-[-0.028em]">

--- a/apps/web/src/components/landing/LandingDraftBoard.tsx
+++ b/apps/web/src/components/landing/LandingDraftBoard.tsx
@@ -1,0 +1,227 @@
+import { positionColour, shortName } from "@/lib/player";
+
+/**
+ * The hero's right column: a draft, mid-round.
+ *
+ * **Illustrative, and it has to say so.** These are not real players and there
+ * is no live draft behind them — a marketing page cannot show one, because a
+ * public draft in progress is not a thing that reliably exists at the moment
+ * somebody visits. What it must not do is *imply* live data on a product whose
+ * entire argument is that nothing here is invented, so the caption names it as a
+ * sample and the numbers below are internally consistent rather than decorative.
+ *
+ * **It reproduces the shipped component rather than approximating it**, which is
+ * what drop 6's README asks for and the reason it imports from `lib/player`
+ * instead of hard-coding colours:
+ *
+ *   - cells are filled **by position** from `POSITION_COLOURS`, at their real
+ *     alpha and ring
+ *   - each row carries a **direction arrow**, because the snake reversal is the
+ *     one thing people get wrong when planning two picks ahead
+ *   - columns hold `min-w-[7.5rem]` — 120px — showing **three of twelve teams at
+ *     full width rather than twelve squeezed**, since below 120px `shortName`'s
+ *     surnames truncate and initialling the given name stops buying anything
+ *
+ * The pick numbers are a real snake: round 1 runs forward (1.03, 1.04, 1.05),
+ * round 2 comes back (2.10, 2.09, 2.08 — column 3 of 12 is pick 10 in a reversed
+ * round), and round 3 runs forward again. A reader who checks it finds it holds,
+ * which is the only kind of illustration this product should ship.
+ */
+
+interface Cell {
+  readonly label: string;
+  readonly name: string;
+  readonly position: string;
+  readonly team: string;
+}
+
+/** Three columns of a twelve-team board, rounds one to three. */
+const ROUNDS: readonly {
+  readonly round: number;
+  readonly direction: "FORWARD" | "REVERSE";
+  readonly cells: readonly (Cell | null)[];
+}[] = [
+  {
+    round: 1,
+    direction: "FORWARD",
+    cells: [
+      { label: "1.03", name: "Bela Kowalczyk", position: "WR", team: "HOU" },
+      { label: "1.04", name: "Luca Marchetti", position: "RB", team: "MIN" },
+      { label: "1.05", name: "Rene Delacroix", position: "RB", team: "PHI" },
+    ],
+  },
+  {
+    round: 2,
+    direction: "REVERSE",
+    cells: [
+      { label: "2.10", name: "Femi Amadi", position: "TE", team: "DET" },
+      { label: "2.09", name: "Kwame Osei-Bonsu", position: "WR", team: "LV" },
+      { label: "2.08", name: "Gideon Achebe", position: "TE", team: "NYJ" },
+    ],
+  },
+  {
+    round: 3,
+    direction: "FORWARD",
+    cells: [
+      { label: "3.03", name: "Viggo Sorensen", position: "QB", team: "LAR" },
+      // The pick on the clock, and the seat it belongs to.
+      null,
+      { label: "3.05", name: "", position: "", team: "" },
+    ],
+  },
+];
+
+const COLUMNS = [
+  { name: "Pylon Co.", tag: "" },
+  { name: "Route 66", tag: "you" },
+  { name: "Tuesday Night Reg…", tag: "" },
+] as const;
+
+export function LandingDraftBoard() {
+  return (
+    <aside className="relative hidden lg:block" aria-label="A draft in progress, as an example">
+      <div className="flex items-baseline justify-between px-1 pb-3">
+        <span className="text-[11px] tracking-[0.14em] text-nocturne-neutral-600 uppercase">
+          Live draft · Round 3
+        </span>
+        <span className="text-[13px] tabular-nums text-nocturne-neutral-400">0:47</span>
+      </div>
+
+      {/* The card for the pick on the clock, above the board — the one thing a
+          manager looks at when it is their turn. */}
+      <div className="flex items-center gap-4 rounded-lg border border-nocturne-accent/40 bg-nocturne-accent/10 p-4">
+        <span
+          className="grid shrink-0 place-items-center rounded-full bg-nocturne-neutral-900 text-[10px] text-nocturne-neutral-600 ring-1 ring-nocturne-neutral-800"
+          style={{ width: 72, height: 72 }}
+          aria-hidden
+        >
+          {/* Where `PlayerAvatar` draws a headshot in the app. Initials here,
+              because the marketing page ships no photo assets — and in
+              production the initialled disc is the one-in-ten fallback, not the
+              normal case. */}
+          AV
+        </span>
+        <span className="min-w-0">
+          <span className="block text-[10px] tracking-[0.14em] text-nocturne-accent-300 uppercase">
+            Your pick, 3.04
+          </span>
+          <span className="mt-1 block truncate text-[19px] font-medium">A. Villanueva</span>
+          <span className="mt-1 flex items-center gap-2 text-[11px] text-nocturne-neutral-500">
+            <span className={`rounded px-1 py-px font-medium ring-1 ${positionColour("RB")}`}>
+              RB · TEN
+            </span>
+          </span>
+          <span className="mt-1 block text-[11px] text-nocturne-neutral-600">
+            13.6 proj · top of your queue
+          </span>
+        </span>
+      </div>
+
+      {/*
+        The crop, and why the fade is a fixed length.
+
+        The board is twelve columns wide and three of them are shown. The mask
+        must be a **fixed** distance rather than a percentage: this aside doubles
+        in width when the layout stacks, and a percentage fade would eat a whole
+        visible column at the wider size.
+      */}
+      <div
+        className="mt-4 overflow-hidden"
+        style={{
+          maskImage: "linear-gradient(to right, #000 calc(100% - 88px), transparent 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to right, #000 calc(100% - 88px), transparent 100%)",
+        }}
+      >
+        <table className="w-full border-separate border-spacing-0">
+          <thead>
+            <tr>
+              <th className="w-6" />
+              {COLUMNS.map((column) => (
+                <th
+                  key={column.name}
+                  className="min-w-[7.5rem] px-1 pb-2 text-left align-bottom"
+                >
+                  <span className="block truncate text-[12px] font-medium text-nocturne-neutral-400">
+                    {column.name}
+                  </span>
+                  <span className="block text-[10px] text-nocturne-neutral-600">
+                    {column.tag || " "}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+
+          <tbody>
+            {ROUNDS.map((row) => (
+              <tr key={row.round}>
+                <td className="pr-1 text-center align-middle">
+                  <span className="block text-[11px] text-nocturne-neutral-600 tabular-nums">
+                    {row.round}
+                  </span>
+                  <span className="block text-[10px] text-nocturne-neutral-700">
+                    {row.direction === "FORWARD" ? "→" : "←"}
+                  </span>
+                </td>
+
+                {row.cells.map((cell, index) =>
+                  cell === null ? (
+                    <td key={`clock-${row.round}`} className="p-0.5 align-top">
+                      <div className="flex h-14 flex-col justify-center rounded bg-nocturne-accent/20 px-2 ring-1 ring-nocturne-accent">
+                        <span className="text-[10px] text-nocturne-accent-200 tabular-nums">
+                          3.04
+                        </span>
+                        <span className="text-xs font-medium text-nocturne-accent-200">
+                          On the clock
+                        </span>
+                      </div>
+                    </td>
+                  ) : cell.name === "" ? (
+                    <td key={`empty-${row.round}-${index}`} className="p-0.5 align-top">
+                      <div className="flex h-14 flex-col justify-center rounded bg-nocturne-surface/20 px-2">
+                        <span className="text-[10px] text-nocturne-neutral-700 tabular-nums">
+                          {cell.label}
+                        </span>
+                      </div>
+                    </td>
+                  ) : (
+                    <td key={cell.label} className="p-0.5 align-top">
+                      <div
+                        className={`flex h-14 flex-col justify-center rounded px-2 ring-1 ${positionColour(cell.position)}`}
+                      >
+                        <span className="flex items-baseline justify-between gap-1">
+                          <span className="truncate text-xs font-medium">
+                            {shortName(cell.name)}
+                          </span>
+                          <span className="shrink-0 text-[10px] opacity-70 tabular-nums">
+                            {cell.label}
+                          </span>
+                        </span>
+                        <span className="truncate text-[10px] opacity-80">
+                          {cell.position} · {cell.team}
+                        </span>
+                      </div>
+                    </td>
+                  ),
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-3 px-1 text-[12px] leading-[1.5] text-nocturne-neutral-600">
+        {/*
+          Says it is a sample, and points at the claim that is not. The draw is
+          the checkable half and it is the reason this illustration is here.
+        */}
+        A sample board. Three of twelve teams. In a real league the order is drawn from a Solana
+        block nobody could pick in advance.{" "}
+        <a href="#how" className="text-nocturne-accent-300 hover:underline">
+          How the draw works
+        </a>
+      </p>
+    </aside>
+  );
+}

--- a/docs/design/STATUS.md
+++ b/docs/design/STATUS.md
@@ -103,10 +103,44 @@ stored, the veto denominator counting managers rather than teams, per-player
 kickoff locks rather than a league-wide deadline — and a screen that restates
 one of them will drift from the code that owns it.
 
+## Do not build drop 6's landing copy — two sentences are retired
+
+**This is the trap in this directory right now.** `screens/Rostr Landing.dc.html`
+still contains the roster-as-NFT claim, in two places, and the app deliberately
+does not. Anyone implementing that hero from the design will paste a false
+sentence back onto the front page, which is precisely how it got there the first
+time.
+
+The design says:
+
+> Drafted players are held in your wallet, not on a platform's server.
+
+and, on a card lower down:
+
+> Drafted players mint as Token-2022 NFTs held in your wallet.
+
+**Both are untrue and were removed from `apps/web` on 2026-08-19.** Rosters are
+rows in Postgres. Nothing has ever minted an NFT, there is no NFT program, and
+the roster-as-NFT design is abandoned rather than pending. `page.tsx` carries a
+comment at each site saying so and asking that no NFT sentence be restored until
+something actually mints one.
+
+What replaced it is a claim that holds and is checkable in the source: no
+commissioner can edit a team, force a trade, or overrule a result, because there
+is no such function to call.
+
+The design files stay verbatim — they are the designer's artifacts and this file
+is where the repo records divergence. **The divergence is in the app, and it is
+deliberate.** If a future drop drops these sentences, this section goes with it.
+
+Note that `CLAUDE.md`'s settled-decisions table still lists "NFTs _are_ the
+roster, not souvenirs" as **Settled**, which is the same stale claim wearing a
+different hat. It is not this file's to fix, but do not read it as current.
+
 ## Changed from the designer's original
 
-**Nothing, as of drop 6.** This directory is verbatim again, and the paragraph
-that used to sit here is worth keeping as a record of how it got that way.
+Beyond the copy above: **nothing in the files.** The paragraph that used to sit
+here is worth keeping as a record of how that came to be true.
 
 Drop 5's `Rostr Create League.dc.html` printed the scoring table this repo used
 until 2026-08-16 — a shutout worth 10, field goals stopping at 50+, no penalty


### PR DESCRIPTION
Drop 6 landed in `docs/design/` as reference and was never built. This builds it.

## The nav is one link, not three

`#how` lands on the first of three contiguous sections that answer one question between them — why it's different, how a season runs, what the format is. Three tabs asked a reader to choose between three answers before knowing what any of them were, and the sections were already adjacent. GitHub and X become icons; Create a league keeps its button.

`#trust` and `#format` stay on their sections. Nothing points at them now, but they're what anyone who shared a deep link is holding.

## The hero has a draft board

Reproducing the shipped component rather than approximating it, which is what drop 6's README asks for:

- cells filled **by position** from `POSITION_COLOURS`, at their real alpha and ring
- a **direction arrow** per row, because the snake reversal is the one thing people get wrong planning two picks ahead
- `min-w-[7.5rem]` columns — three of twelve teams at full width rather than twelve squeezed, since below 120px `shortName`'s surnames truncate
- a **fixed-length** crop fade, not a percentage, because the aside doubles in width when the layout stacks

It imports `positionColour` and `shortName` rather than restating them. The pick numbers are a real snake — round 1 forward (1.03–1.05), round 2 back (2.10, 2.09, 2.08), round 3 forward — so a reader who checks finds it holds. The caption says it's a sample: a product whose whole argument is that nothing here is invented must not imply live data.

## Two deliberate divergences

**Connect wallet links to `/welcome` rather than being a wallet button.** Mounting the adapter on the marketing page means hundreds of kilobytes on the one page that has to load fast for strangers, to open a popup that can do nothing until there's an account behind it.

**The design's hero copy is not used — and this is the one to read.** `Rostr Landing.dc.html` still says "Drafted players are held in your wallet" and "mint as Token-2022 NFTs". Both were removed from the app on 2026-08-19 in `6d28c5e` because they were never true: rosters are rows in Postgres, nothing has ever minted an NFT, and the design is abandoned rather than pending. **Anyone building that hero from the design pastes them straight back.**

So it's written down in three places instead of left to memory:

- `docs/design/STATUS.md` names both sentences and where they appear
- `CLAUDE.md`'s settled table read **Settled** for "NFTs _are_ the roster" and now reads **Abandoned**, with the reasoning under it
- `page.tsx` already carried a comment at each site; those stay

`docs/DECISIONS.md` keeps the original argument, flagged as a record of reasoning rather than of current truth.

## Not done

The design also demotes the sub-section headings to h3 and their cards to h4 now that the three sections read as one. Left alone: it's a typographic pass over three sections, and worth doing when someone can see it in a browser.

1977 tests, lint and typecheck green, production build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)