### PR TITLE
The site forgot you the moment setup finished

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 import { InvitationBadge } from "@/components/InvitationsCorner";
 import { SessionBar } from "@/components/SessionBar";
 import { currentUser } from "@/lib/session";
@@ -32,20 +33,20 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     <div className="nocturne flex min-h-screen flex-col">
       <header className="border-b border-nocturne-neutral-900">
         <nav className="mx-auto flex w-full max-w-[1180px] items-center justify-between px-10 py-[14px]">
-          <a href="/" className="flex items-baseline gap-[10px]">
+          <Link href="/" className="flex items-baseline gap-[10px]">
             <span className="text-[19px] font-semibold tracking-[-0.02em]">rostr</span>
             <span className="text-[11px] uppercase tracking-[0.14em] text-nocturne-neutral-600">
               fantasy football
             </span>
-          </a>
+          </Link>
 
           <div className="flex items-center gap-6">
-            <a
+            <Link
               href="/scoring"
               className="text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
             >
               How scoring works
-            </a>
+            </Link>
             {/*
               Joining and creating sit side by side, and joining is first.
               Creating a league has had a front door since A10; joining one has
@@ -54,12 +55,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               rather than to run one.
             */}
             <span className="flex items-center gap-2">
-              <a
+              <Link
                 href="/leagues"
                 className="text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
               >
                 Join a league
-              </a>
+              </Link>
               {/*
                 Rendered only when something is waiting, and only for a signed-in
                 visitor — the route answers an empty list to anyone else, so a
@@ -67,12 +68,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               */}
               {user && <InvitationBadge />}
             </span>
-            <a
+            <Link
               href="/leagues/new"
               className="rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
             >
               Create a league
-            </a>
+            </Link>
             <SessionBar email={user?.email ?? null} username={user?.username ?? null} />
           </div>
         </nav>

--- a/apps/web/src/app/(app)/welcome/page.tsx
+++ b/apps/web/src/app/(app)/welcome/page.tsx
@@ -25,9 +25,19 @@ export default async function WelcomePage({
   const { next } = await searchParams;
   const user = await currentUser();
 
-  // `next` is carried through the sign-in redirect, so it survives the round
-  // trip from here to the code and back.
-  const destination = safeRedirect(next ?? null);
+  /**
+   * Where to go when this is finished.
+   *
+   * `next` is carried through the sign-in redirect, so it survives the round trip
+   * from here to the code and back.
+   *
+   * **The fallback is `/leagues`, not `/`.** `safeRedirect(null)` answers `/`,
+   * which is the marketing page — so somebody who had just claimed a username and
+   * verified a wallet was returned to a page that shows neither, and reasonably
+   * concluded nothing had been saved. Finishing setup should land on the thing
+   * setup was for: leagues you can join, with your invitations beside them.
+   */
+  const destination = next ? safeRedirect(next) : "/leagues";
 
   if (!user) {
     redirect(`/signin?next=${encodeURIComponent(`/welcome?next=${destination}`)}`);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { HeroThrow } from "@/components/landing/HeroThrow";
+import { LandingAccountLink } from "@/components/landing/LandingAccountLink";
 import { LandingDraftBoard } from "@/components/landing/LandingDraftBoard";
 
 /**
@@ -208,27 +209,20 @@ function SiteHeader() {
           {/*
             **A link, not a wallet button, and that is a deliberate divergence.**
 
-            The design draws this as a `<button>` because connecting is an action.
-            Doing that here would mean mounting the wallet adapter on the
-            marketing page — hundreds of kilobytes of JavaScript on the one page
-            that has to load fast for people who have never heard of us, to open
-            a popup that cannot do anything useful until there is an account
-            behind it.
+            The design draws this as a `<button>` because connecting is an
+            action. Doing that here would mean mounting the wallet adapter on
+            the marketing page to open a popup that can do nothing useful until
+            there is an account behind it. `/welcome` is where connecting
+            actually works — it verifies the wallet by signature, and is also
+            where a username is claimed.
 
-            So it goes where connecting actually works and is actually needed:
-            `/welcome`, which verifies the wallet by signature and is also where
-            a username is claimed. The affordance the design asked for is kept —
-            it reads as an action and sits in the same place.
+            **It also has to know whether you are already signed in.** It said
+            `Connect wallet` unconditionally, so somebody who had just claimed a
+            username and verified a wallet came back to this page and saw the
+            same control as a stranger — which reads as "it forgot me". The
+            wallet was connected throughout; nothing here said so.
           */}
-          <a
-            href="/welcome"
-            className="flex items-center gap-2 text-[13px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
-          >
-            <svg viewBox="0 0 16 16" aria-hidden className="h-[15px] w-[15px] fill-current">
-              <path d="M13 4H3a1 1 0 0 1 0-2h9.5a.5.5 0 0 0 0-1H3a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm-1.5 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
-            </svg>
-            Connect wallet
-          </a>
+          <LandingAccountLink />
         </div>
       </nav>
     </header>

--- a/apps/web/src/components/CompleteAccount.tsx
+++ b/apps/web/src/components/CompleteAccount.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 // The subpath, not the package root: `@rostr/db` reaches `identity.ts`, which
 // imports `node:crypto`, and webpack cannot bundle that for a browser. The
@@ -185,12 +186,16 @@ export function CompleteAccount({
 
       <section className="border-t border-nocturne-neutral-900 pt-8">
         {done ? (
-          <a
+          // A soft navigation, so the wallet just verified stays connected
+          // through it. An `<a href>` here unmounts the provider and makes the
+          // next page render disconnected — which is exactly the moment somebody
+          // concludes it did not work.
+          <Link
             href={next}
             className="inline-block rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
           >
             Continue
-          </a>
+          </Link>
         ) : (
           <p className="text-sm text-nocturne-neutral-600">
             {/*

--- a/apps/web/src/components/landing/LandingAccountLink.tsx
+++ b/apps/web/src/components/landing/LandingAccountLink.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import useSWR from "swr";
+
+/**
+ * The account control in the marketing header.
+ *
+ * **Why this is a client component on an otherwise static page.** The landing
+ * page is prerendered, and reading the session cookie on the server would make
+ * the whole thing render per-request — a real cost on the one page that has to
+ * load fast for people who have never heard of us. So the page stays static and
+ * this one corner resolves after hydration.
+ *
+ * **It renders nothing until it knows**, rather than assuming signed out. A
+ * header that says "Connect wallet" and then flips to your username reads as if
+ * you had been signed out and quietly let back in — the same reason
+ * `(app)/layout.tsx` resolves its user on the server rather than fetching. Here
+ * the static requirement wins, so the compromise is to show no answer instead of
+ * a wrong one, in a reserved space so the nav does not jump.
+ *
+ * ## What it fixes
+ *
+ * The header used to say "Connect wallet" unconditionally. Somebody who signed
+ * in, claimed a username and verified a wallet was returned to this page and
+ * shown exactly the same control as a stranger — which reads, correctly, as "it
+ * did not keep my wallet and it does not think I am signed in". The wallet was
+ * connected the whole time; `WalletProvider` has `autoConnect` and the adapter
+ * persists its choice. Nothing on this page said so.
+ */
+
+interface Me {
+  user: { username: string | null } | null;
+  gaps: string[];
+}
+
+const fetcher = async (url: string): Promise<Me> => {
+  const response = await fetch(url);
+  if (!response.ok) return { user: null, gaps: [] };
+  return response.json() as Promise<Me>;
+};
+
+const LINK =
+  "flex items-center gap-2 text-[13px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text";
+
+export function LandingAccountLink() {
+  const { data, isLoading } = useSWR<Me>("/api/me", fetcher, {
+    revalidateOnFocus: true,
+  });
+
+  // Reserved space, no claim. See the note above about flashing the wrong state.
+  if (isLoading || !data) {
+    return <span className="h-[19px] w-[104px]" aria-hidden />;
+  }
+
+  if (!data.user) {
+    return (
+      <a href="/welcome" className={LINK}>
+        <WalletIcon />
+        Connect wallet
+      </a>
+    );
+  }
+
+  // Signed in, but not finished — the username or the wallet is still missing,
+  // and until both are there nobody can invite them to anything.
+  if (data.gaps.length > 0) {
+    return (
+      <a href="/welcome" className={`${LINK} text-nocturne-accent-300`}>
+        <WalletIcon />
+        Finish setting up
+      </a>
+    );
+  }
+
+  return (
+    <a href="/leagues" className={LINK} title="Your leagues and invitations">
+      <span
+        className="grid h-[22px] w-[22px] place-items-center rounded-full bg-nocturne-accent/20 text-[10px] font-semibold text-nocturne-accent-200"
+        aria-hidden
+      >
+        {(data.user.username ?? "?").slice(0, 1).toUpperCase()}
+      </span>
+      <span className="max-w-[14ch] truncate">{data.user.username}</span>
+    </a>
+  );
+}
+
+function WalletIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden className="h-[15px] w-[15px] fill-current">
+      <path d="M13 4H3a1 1 0 0 1 0-2h9.5a.5.5 0 0 0 0-1H3a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm-1.5 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Reported from the live site: the welcome page works, but afterwards the wallet is not connected and nothing says you're signed in. Both are real, and they share a cause.

## Three fixes

**The marketing header said `Connect wallet` unconditionally.** It's a static page and never consulted the session, so somebody who had just claimed a username and verified a wallet came back to exactly the control a stranger sees. `LandingAccountLink` replaces it — signed out, unfinished, or finished each get their own answer.

It stays a client component on purpose: reading the cookie on the server would make the whole landing render per request, and `/` is still `○` (prerendered) in the build output. It renders **nothing** until the answer arrives rather than assuming signed-out, since a header that flips to your username reads as if you'd been signed out and quietly let back in.

**Finishing setup returned you to `/`** — `safeRedirect(null)` answers `/`, the same marketing page. The last step of signing up landed on the one screen showing neither your username nor your wallet. Now it lands on `/leagues`.

**Every link was a full page load, which tears the wallet down.** `WalletProvider` has `autoConnect` and the adapter remembers your choice, so the connection was never actually lost — but a full navigation unmounts React, reconnects from scratch, and renders disconnected until the handshake finishes. The signed-in header and the Continue button are now `next/link`.

That last one is the honest explanation of "it doesn't keep your wallet connected": it did keep it, then threw it away on the next click.

## Worth knowing

The rest of the app still uses `<a href>` throughout, so navigation elsewhere still costs a reconnect. I converted the paths somebody walks immediately after connecting rather than doing a sweep — a full conversion is worth doing, but it touches every screen and deserves its own pass with eyes on it.

1977 tests, lint and typecheck green, production build compiles and `/` remains static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)