### PR TITLE
Build drop 7's landing: seven panels behind a rail

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -109,3 +109,34 @@ body {
  * animating, because there is no keyframe or transition for a media query to
  * switch off — the flight is driven frame by frame from JavaScript.
  */
+
+/**
+ * The panel fade in the landing page's section explorer.
+ *
+ * Defined here because `animate-[rostrFade_…]` names a keyframe rather than
+ * providing one — without this the class is generated, applied, and animates
+ * nothing. It came from the design handoff, where the keyframe lives in the
+ * prototype's own `<style>` block and does not travel with the markup.
+ *
+ * Switched off under `prefers-reduced-motion`, which a JavaScript-driven
+ * animation has to handle itself but a CSS one can simply decline. `HeroThrow`
+ * reads the same preference in its own way, for the opposite reason: its flight
+ * is driven frame by frame, so there is no declaration for a media query to
+ * override.
+ */
+@keyframes rostrFade {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-\[rostrFade_260ms_ease-out\] {
+    animation: none;
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { HeroThrow } from "@/components/landing/HeroThrow";
 import { LandingAccountLink } from "@/components/landing/LandingAccountLink";
-import { LandingDraftBoard } from "@/components/landing/LandingDraftBoard";
+import { SectionExplorer } from "@/components/landing/SectionExplorer";
 
 /**
  * The marketing page.
@@ -33,18 +33,13 @@ export default function LandingPage() {
       <SiteHeader />
 
       {/*
-        Two columns: the claim, and a draft mid-round.
+        Full-width text again — drop 7.
 
-        The board is illustrative and says so — see `LandingDraftBoard`. It sits
-        beside the headline rather than below it because the product's argument
-        is visual: a snake board with a block-drawn order is the thing no other
-        platform can show.
-
-        `overflow-hidden` stays on the section. `HeroThrow` animates a ball
-        across its own box and the board crops twelve columns to three; both
-        would otherwise widen the page on a narrow viewport.
+        Drop 6 put a condensed draft board beside the headline; drop 7 moves it
+        into the section explorer below, where it gets the width a twelve-column
+        board actually needs. The hero goes back to carrying one claim.
       */}
-      <section className="mx-auto grid w-full max-w-[1180px] gap-8 overflow-hidden lg:grid-cols-[minmax(0,1fr)_26rem]">
+      <section className="mx-auto w-full max-w-[1180px] overflow-hidden">
         <HeroThrow
           headline={
             <>
@@ -86,17 +81,21 @@ export default function LandingPage() {
             <li>Built for the Solana Seeker</li>
           </ul>
         </HeroThrow>
-
-        <div className="px-10 pt-24 lg:pl-0">
-          <LandingDraftBoard />
-        </div>
       </section>
 
       <LeaguePanel />
-      <Differentiators />
-      <HowItWorks />
-      <Format />
-      <MultiSport />
+
+      {/*
+        Seven panels behind a rail, in one band — drop 7.
+
+        `Differentiators`, `HowItWorks`, `Format` and `MultiSport` were four
+        separate scrolling sections and are now four of the seven panels, with
+        the draft board, a league week and the playoff bracket joining them. Their
+        copy moved into `SectionExplorer` rather than being wrapped, because the
+        design rewrote most of it — including demoting every heading a level now
+        that the band owns the h2.
+      */}
+      <SectionExplorer />
       <ClosingBand />
       <SiteFooter />
     </div>
@@ -336,248 +335,6 @@ function LeaguePanel() {
           </div>
         </div>
       </div>
-    </section>
-  );
-}
-
-/* -------------------------------------------------------------------- 4 */
-
-function Differentiators() {
-  return (
-    <section id="how" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
-      {/* Kept because deep links already point here. */}
-      <span id="trust" className="block scroll-mt-[60px]" />
-      <div className="max-w-[640px]">
-        <Kicker>Why it&rsquo;s different</Kicker>
-        <h2 className="mt-4 text-[40px] font-medium leading-[1.1] tracking-[-0.028em]">
-          Every other platform asks you to trust an administrator.
-        </h2>
-        <p className="mt-5 text-[16px] leading-[1.65] text-nocturne-neutral-400">
-          This one doesn&rsquo;t. Four things are true of a rostr league that are not true
-          anywhere else.
-        </p>
-      </div>
-
-      <div className="mt-12 grid gap-5 sm:grid-cols-2">
-        <Card
-          index="01"
-          title="Rules are immutable"
-          closing="No commissioner can rewrite scoring in Week 10 because their team is losing."
-          closingAccent
-        >
-          A league&rsquo;s scoring, roster, payout split, and deadlines are frozen at creation
-          and shown in full before anyone joins. The rule set is hashed on-chain and joining is
-          a signed transaction referencing that hash — so consent is cryptographic, not a
-          checkbox.
-        </Card>
-
-        {/*
-          The escrow is built, tested and deployed — join, stake, settle and the
-          unconditional timelock refund all work against a real validator. What
-          is not happening is the 2026 season running on it, which is a decision
-          rather than a gap, so this card describes it in the future tense and
-          says so plainly rather than quietly dropping the claim.
-
-          Do not restore the present tense here without also opening
-          `POT_LEAGUES_OPEN`. A landing page promising an escrowed pot above a
-          create form that offers only free leagues is the site contradicting
-          itself on the one subject where trust is the product.
-        */}
-        <Card
-          index="02"
-          title="The pot is escrowed"
-          closing="Coming soon. Every league this season is free to play, and everything else on this page is live today."
-        >
-          Built and tested: everyone deposits the same amount of the same token, funds sit in a
-          vault no person holds the keys to, and an unconditional refund opens if a season never
-          settles. Pot leagues are not part of the 2026 season.
-        </Card>
-
-        <Card index="03" title="Nobody declares a winner">
-          The contract holds the bracket, the scores, and the rules, and derives the champion
-          from the Week 17 result. There is no sign-off step to corrupt.
-        </Card>
-
-        {/*
-          This claimed drafted players mint as Token-2022 NFTs held in your wallet.
-          Nothing has ever minted one — there is no NFT program, and as of
-          2026-08-19 the roster-as-NFT design is abandoned rather than pending:
-          the enforcement it needed (transfer hook, permanent delegate) existed
-          only to stop a roster being sold out from under a league, and that is a
-          problem the database already solves.
-
-          What is left here is the half that was true all along and is shipped:
-          the trade escrow, the veto window, and the absence of any commissioner
-          override. Do not restore an NFT sentence to this card until something
-          actually mints.
-        */}
-        <Card index="04" title="Your roster is yours">
-          A trade freezes both sides the moment it is accepted, then waits out a 48-hour window
-          in which a third of the uninvolved managers can veto it. No commissioner can force one
-          through, reverse one, or edit a roster — there is no such function to call.
-        </Card>
-      </div>
-    </section>
-  );
-}
-
-function Card({
-  index,
-  title,
-  children,
-  closing,
-  closingAccent,
-}: {
-  index: string;
-  title: string;
-  children: ReactNode;
-  closing?: string;
-  closingAccent?: boolean;
-}) {
-  return (
-    <div className="rounded-lg bg-nocturne-surface p-[26px] shadow-[0_0_0_1px_#292b31]">
-      <p className="font-mono text-[11.5px] text-nocturne-accent-600">{index}</p>
-      <h3 className="mt-4 text-[21px] font-medium tracking-[-0.018em]">{title}</h3>
-      <p className="mt-3 text-[14.5px] leading-[1.6] text-nocturne-neutral-400">{children}</p>
-      {closing ? (
-        <p
-          className={`mt-4 text-[14.5px] leading-[1.6] ${
-            closingAccent ? "text-nocturne-accent-300" : "text-nocturne-neutral-600"
-          }`}
-        >
-          {closing}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-/* -------------------------------------------------------------------- 5 */
-
-function HowItWorks() {
-  const steps: readonly [string, string][] = [
-    [
-      "Create and freeze",
-      "Pick a format or take the default. The rule set is hashed and written on-chain before anyone joins.",
-    ],
-    [
-      "Draw the order",
-      "The draft order comes from a Solana block produced after the field locks — nobody can grind it, and anyone can recompute it.",
-    ],
-    [
-      "Draft and play",
-      "A snake draft, then head-to-head weeks. Each pick is a signed transaction against the frozen rules.",
-    ],
-    [
-      "Settle",
-      "The champion derives from the Week 17 result. Nothing is signed off, because there is nothing to sign off.",
-    ],
-  ];
-
-  return (
-    <section id="how-steps" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
-      <div className="max-w-[640px]">
-        <Kicker>How it works</Kicker>
-        <h2 className="mt-4 text-[40px] font-medium leading-[1.1] tracking-[-0.028em]">
-          A season, end to end.
-        </h2>
-      </div>
-
-      {/*
-        Fixed 4-up rather than `auto-fit`, which orphans step 4 onto its own row
-        at intermediate widths. 2×2 below the large breakpoint, 1-up on small.
-      */}
-      <ol className="mt-12 grid gap-[30px] sm:grid-cols-2 lg:grid-cols-4">
-        {steps.map(([title, body], i) => (
-          <li key={title}>
-            <div className="h-px w-full bg-gradient-to-r from-nocturne-accent to-nocturne-accent-800" />
-            <p className="mt-4 font-mono text-[11.5px] text-nocturne-neutral-500">
-              Step {i + 1}
-            </p>
-            <h3 className="mt-3 text-[19px] font-medium">{title}</h3>
-            <p className="mt-3 text-[14.5px] leading-[1.6] text-nocturne-neutral-400">{body}</p>
-          </li>
-        ))}
-      </ol>
-    </section>
-  );
-}
-
-/* -------------------------------------------------------------------- 6 */
-
-function Format() {
-  const rows: readonly [string, ReactNode][] = [
-    [
-      "Scoring",
-      "Full PPR. 4pt passing TD, 6pt rushing/receiving TD, 1pt per 25 passing yards, 1pt per 10 rushing/receiving yards, −2 per interception and lost fumble.",
-    ],
-    ["Teams", "12 teams, minimum 2 humans, bots fill the rest."],
-    ["Draft", "Snake draft, fast (90s minimum) or slow (up to 24h per pick)."],
-    [
-      "Season",
-      "Weeks 1–14 regular season, 15–17 playoffs, championship Week 17. Week 18 is excluded — NFL starters rest once seeding is settled.",
-    ],
-    ["Matchups", "Head-to-head weekly. Schedule luck is retained deliberately."],
-    ["Waivers", "Rolling priority. Win a claim, go to the back of the order."],
-    [
-      "Consolation",
-      "The consolation bracket is played, so eliminated teams still have something to play for. This is the anti-abandonment mechanism — punishment doesn't work on someone already guaranteed nothing.",
-    ],
-  ];
-
-  return (
-    <section id="format" className={`${CONTAINER} scroll-mt-[60px] py-[84px]`}>
-      <div className="grid gap-14 lg:grid-cols-[minmax(0,0.6fr)_minmax(0,1fr)]">
-        <div>
-          <Kicker>Format</Kicker>
-          <h2 className="mt-4 text-[34px] font-medium leading-[1.14] tracking-[-0.025em]">
-            The default league, in full.
-          </h2>
-          <p className="mt-5 text-[15px] leading-[1.65] text-nocturne-neutral-400">
-            Every value below is frozen when a league is created. The complete rule set lives in{" "}
-            <a
-              href="https://github.com/6figpsolseeker/rostr/blob/main/docs/RULES.md"
-              className="text-nocturne-accent-300 underline underline-offset-4"
-            >
-              docs/RULES.md
-            </a>
-            .
-          </p>
-        </div>
-
-        <table className="w-full text-[14.5px]">
-          <tbody>
-            {rows.map(([label, value]) => (
-              <tr key={label} className="border-t border-nocturne-neutral-900 first:border-t-0">
-                <th className="w-[150px] py-4 pr-6 text-left align-top font-normal text-nocturne-neutral-500">
-                  {label}
-                </th>
-                <td className="py-4 align-top leading-[1.6] text-nocturne-neutral-400">
-                  {value}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  );
-}
-
-/* -------------------------------------------------------------------- 7 */
-
-function MultiSport() {
-  return (
-    <section className={`${CONTAINER} py-[84px]`}>
-      <Kicker>Multi-sport</Kicker>
-      <p className="mt-6 max-w-[860px] text-[clamp(24px,3.1vw,36px)] font-medium leading-[1.26] tracking-[-0.024em]">
-        Football ships first, but the schema does not know what football is. Sports are data — a
-        registry of stat keys, positions, and lineup slots — never structure or code branches.
-      </p>
-      <p className="mt-6 max-w-[560px] text-[15px] leading-[1.65] text-nocturne-neutral-400">
-        Adding a sport should insert rows and write one provider adapter, with no migration and
-        no change to scoring, drafting, trading, or settlement.
-      </p>
     </section>
   );
 }

--- a/apps/web/src/components/landing/LandingDraftBoard.tsx
+++ b/apps/web/src/components/landing/LandingDraftBoard.tsx
@@ -110,7 +110,11 @@ const COLUMNS = [
 
 export function LandingDraftBoard() {
   return (
-    <aside className="relative hidden lg:block" aria-label="A draft in progress, as an example">
+    // Shown at every width. It was `hidden lg:block` while it sat beside the
+    // hero, where a narrow screen had no room for it. In drop 7 it is the body
+    // of a panel somebody chose to open, and hiding it would leave that panel
+    // as a headline and a caption about a board they cannot see.
+    <div className="relative" aria-label="A draft in progress, as an example">
       <div className="flex items-baseline justify-between px-1 pb-3">
         <span className="text-[11px] tracking-[0.14em] text-nocturne-neutral-600 uppercase">
           Live draft · Round 3
@@ -265,12 +269,10 @@ export function LandingDraftBoard() {
           Says it is a sample, and points at the claim that is not. The draw is
           the checkable half and it is the reason this illustration is here.
         */}
-        A sample board. Three of twelve teams. In a real league the order is drawn from a Solana
-        block nobody could pick in advance.{" "}
-        <a href="#how" className="text-nocturne-accent-300 hover:underline">
-          How the draw works
-        </a>
+        A sample board. Three of twelve teams. Cell colour is the player&rsquo;s position; the
+        draft room colours by positional need instead, recomputed after each of your own picks.
+        In a real league the order is drawn from a Solana block nobody could pick in advance.
       </p>
-    </aside>
+    </div>
   );
 }

--- a/apps/web/src/components/landing/SectionExplorer.tsx
+++ b/apps/web/src/components/landing/SectionExplorer.tsx
@@ -1,0 +1,613 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { LandingDraftBoard } from "./LandingDraftBoard";
+
+/**
+ * The seven panels, behind a rail — drop 7's landing page.
+ *
+ * Five scrolling bands became one band with a left rail. Two things about that
+ * are the designer's own reasoning and worth keeping:
+ *
+ * **A rail rather than a carousel, because all seven labels stay visible.** In a
+ * carousel, panels 2–6 are the whole argument and they sit behind two clicks.
+ *
+ * **Below the hero rather than inside it.** The original ask was to put this in
+ * the hero's right column; that column is about 470×420 and the format table
+ * alone is nine rows, so every panel would have collapsed to a headline or the
+ * hero would have grown until the H1 left the screen.
+ *
+ * The order is a season rather than a menu: the argument leads because it is the
+ * reason to keep reading, then the mechanics run in the order a manager meets
+ * them — which puts the draft fourth rather than last. **Nothing auto-advances.**
+ *
+ * ## What is deliberately not the design's
+ *
+ * Three things the design states are wrong or stale, and are not copied:
+ *
+ * - The **roster-as-NFT** copy in panel 01. There is no NFT program and nothing
+ *   has ever minted one; the claim was removed from this page on 2026-08-19 and
+ *   must not come back. What is here is the half that was always true and is
+ *   shipped — the trade escrow, the veto window, and the absence of any
+ *   commissioner override.
+ * - **Kickoff "September 10"** in the footer. It is the 9th: the first Week 1
+ *   game is `20260909_NE@SEA`, confirmed against the synced schedule and by the
+ *   owner.
+ * - **"614 tests"**. That number is from a much older tree and would be wrong
+ *   again next week, so the claim is made without one.
+ */
+
+const PANELS = [
+  "Why it's different",
+  "How it works",
+  "Format",
+  "The draft",
+  "Inside a league",
+  "Playoffs and payout",
+  "Beyond football",
+] as const;
+
+export function SectionExplorer() {
+  const [panel, setPanel] = useState(0);
+
+  return (
+    <section
+      id="how"
+      className="mx-auto w-full max-w-[1180px] scroll-mt-[60px] px-10 py-[84px]"
+    >
+      <div className="max-w-[640px]">
+        <p className="text-[11px] tracking-[0.14em] text-nocturne-neutral-600 uppercase">
+          A season, end to end
+        </p>
+        <h2 className="mt-4 text-[40px] leading-[1.1] font-medium tracking-[-0.028em]">
+          Everything about how rostr works, in one place.
+        </h2>
+      </div>
+
+      {/*
+          Stacks below `lg`. The design does this with a media query on an
+          `.explore` class defined in its own prototype stylesheet, which does
+          not travel with the markup — carrying the class name across would
+          have been a selector nothing applies, so the breakpoint is expressed
+          the way the rest of this app expresses one.
+        */}
+      <div className="mt-12 grid gap-10 lg:grid-cols-[15rem_minmax(0,1fr)]">
+        {/*
+          The rail. Buttons rather than links: this changes what is shown, it does
+          not navigate, and a list of anchors would put seven entries in the
+          browser's history for one page.
+        */}
+        <nav aria-label="Sections">
+          <ol className="space-y-1">
+            {PANELS.map((label, index) => {
+              const current = index === panel;
+              return (
+                <li key={label}>
+                  <button
+                    onClick={() => setPanel(index)}
+                    aria-current={current ? "true" : undefined}
+                    className={`flex w-full items-baseline gap-3 rounded px-3 py-2 text-left text-[13.5px] transition-colors ${
+                      current
+                        ? "bg-nocturne-accent/10 text-nocturne-text"
+                        : "text-nocturne-neutral-500 hover:text-nocturne-text"
+                    }`}
+                  >
+                    <span
+                      className={`text-[11px] tabular-nums ${
+                        current ? "text-nocturne-accent-300" : "text-nocturne-neutral-700"
+                      }`}
+                    >
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    {label}
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+
+        {/*
+          Keyed on the panel, so switching remounts and the fade replays. Without
+          the key React reuses the subtree and the change reads as a jump.
+        */}
+        <div key={panel} className="min-w-0 animate-[rostrFade_260ms_ease-out]">
+          {panel === 0 && <WhyDifferent />}
+          {panel === 1 && <HowItWorks />}
+          {panel === 2 && <Format />}
+          {panel === 3 && <TheDraft />}
+          {panel === 4 && <InsideALeague />}
+          {panel === 5 && <PlayoffsAndPayout />}
+          {panel === 6 && <BeyondFootball />}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ shared */
+
+function PanelHead({ title, children }: { title: string; children?: ReactNode }) {
+  return (
+    <header className="max-w-[680px]">
+      <h3 className="text-[26px] leading-[1.15] font-medium tracking-[-0.024em]">{title}</h3>
+      {children && (
+        <p className="mt-3 text-[15px] leading-[1.6] text-nocturne-neutral-400">{children}</p>
+      )}
+    </header>
+  );
+}
+
+function Note({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-6 border-l border-nocturne-neutral-800 pl-4 text-[13px] leading-[1.6] text-nocturne-neutral-600">
+      {children}
+    </p>
+  );
+}
+
+/* --------------------------------------------------------------------- 01 */
+
+function WhyDifferent() {
+  return (
+    <div>
+      <PanelHead title="Every other fantasy platform asks you to trust an administrator.">
+        This one doesn&rsquo;t. Four things move off the administrator&rsquo;s desk and into
+        code.
+      </PanelHead>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        <Card index="01" title="Rules are immutable">
+          A league&rsquo;s scoring, roster, payout split and deadlines are frozen at creation
+          and shown in full before anyone joins. The rule set is hashed on-chain and joining is
+          a signed transaction referencing that hash, so consent is cryptographic rather than a
+          checkbox.
+          <Aside>
+            No commissioner can rewrite scoring in Week 10 because their team is losing.
+          </Aside>
+        </Card>
+
+        <Card index="02" title="The pot is escrowed">
+          Optional per league. Everyone deposits the same amount of the same token, and funds
+          unlock only when the season resolves. No treasurer holding a Venmo balance until
+          March.
+          <Aside>
+            Not live yet — the settlement instruction is unwritten, so pot leagues cannot take a
+            deposit today.
+          </Aside>
+        </Card>
+
+        <Card index="03" title="Nobody declares a winner">
+          The contract holds the bracket, the scores, and the rules, and derives the champion
+          from the Week 17 result. There is no sign-off step to corrupt.
+        </Card>
+
+        {/*
+          The design still says drafted players mint as Token-2022 NFTs held in
+          your wallet. Nothing has ever minted one, there is no NFT program, and
+          the roster-as-NFT design was abandoned on 2026-08-19 — the enforcement
+          it needed existed only to stop a roster being sold out from under a
+          league, which the database already prevents.
+
+          What is left is the half that was true all along and is shipped. Do not
+          restore an NFT sentence here until something actually mints.
+        */}
+        <Card index="04" title="Your roster is yours">
+          A trade freezes both sides the moment it is accepted, then waits out a 48-hour window
+          in which a third of the uninvolved managers can veto it. No commissioner can force one
+          through, reverse one, or edit a roster — there is no such function to call.
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  index,
+  title,
+  children,
+}: {
+  index: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-nocturne-neutral-900 p-5">
+      <span className="text-[11px] tabular-nums text-nocturne-neutral-700">{index}</span>
+      <h4 className="mt-2 text-[17px] font-medium tracking-[-0.014em]">{title}</h4>
+      <div className="mt-2 text-[14px] leading-[1.6] text-nocturne-neutral-400">{children}</div>
+    </div>
+  );
+}
+
+function Aside({ children }: { children: ReactNode }) {
+  return <p className="mt-3 text-[13px] text-nocturne-neutral-600">{children}</p>;
+}
+
+/* --------------------------------------------------------------------- 02 */
+
+const STEPS = [
+  {
+    step: "Step 1",
+    title: "Create or join",
+    body: "Sign in with email, pick a username, link a wallet by signature. Every rule is shown in full before you commit — then it is frozen.",
+  },
+  {
+    step: "Step 2",
+    title: "Draft",
+    body: "Snake draft with the order drawn from a Solana block, so nobody picked it. Fast at 90 seconds a pick, or slow up to 24 hours. Queue players and let autopick cover you.",
+  },
+  {
+    step: "Step 3",
+    title: "Play the season",
+    body: "Weeks 1–14, head-to-head. Set lineups, work the waiver wire, trade through the veto window. Schedule luck stays in, deliberately.",
+  },
+  {
+    step: "Step 4",
+    title: "Settle",
+    body: "Playoffs Weeks 15–17, championship in Week 17. The contract reads the result and pays out. Nobody signs anything off.",
+  },
+] as const;
+
+function HowItWorks() {
+  return (
+    <div>
+      <PanelHead title="Four steps, one season.">
+        From an empty league to a settled pot, without a commissioner adjudicating anything.
+      </PanelHead>
+
+      <ol className="mt-8 grid gap-4 sm:grid-cols-2">
+        {STEPS.map((entry) => (
+          <li key={entry.step} className="rounded-lg border border-nocturne-neutral-900 p-5">
+            <span className="text-[11px] tracking-[0.12em] text-nocturne-accent-300 uppercase">
+              {entry.step}
+            </span>
+            <h4 className="mt-2 text-[17px] font-medium tracking-[-0.014em]">{entry.title}</h4>
+            <p className="mt-2 text-[14px] leading-[1.6] text-nocturne-neutral-400">
+              {entry.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+
+      <Note>
+        A league can be created, joined and drafted end to end today. Settlement and the pot are
+        the parts still being written, which is why nothing takes money yet.
+      </Note>
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- 03 */
+
+const FORMAT = [
+  [
+    "Scoring",
+    "Full PPR. 4pt passing TD, 6pt rushing and receiving TD, 1pt per 25 passing yards, 1pt per 10 rushing or receiving yards, −2 per interception and lost fumble.",
+  ],
+  [
+    "Teams",
+    "12, minimum 2 humans. One bot is available in a free league, and only to square an odd field — three humans plus a bot makes four.",
+  ],
+  [
+    "Roster",
+    "9 starters and 5 bench, plus 2 injured-reserve slots that do not count against the limit.",
+  ],
+  ["Draft", "Snake. Fast (90s minimum) or slow (up to 24h per pick)."],
+  [
+    "Season",
+    "Weeks 1–14 regular season, 15–17 playoffs, championship Week 17. Week 18 is excluded — NFL starters rest once seeding is settled.",
+  ],
+  ["Matchups", "Head-to-head, weekly."],
+  ["Waivers", "Rolling priority. Win a claim, go to the back of the order."],
+  [
+    "Trades",
+    "Through escrow, with a 48-hour league veto window. A third of the uninvolved managers can stop one.",
+  ],
+  [
+    "Consolation",
+    "Played, so eliminated teams still have something to play for. This is the anti-abandonment mechanism — punishment does not work on someone already guaranteed nothing.",
+  ],
+] as const;
+
+function Format() {
+  return (
+    <div>
+      <PanelHead title="The default league, in full.">
+        This is the whole rule set, not a summary of it. Every value is also rendered above the
+        join control of any league that uses it, before anyone signs.
+      </PanelHead>
+
+      <dl className="mt-8 divide-y divide-nocturne-neutral-900 border-y border-nocturne-neutral-900">
+        {FORMAT.map(([term, definition]) => (
+          <div key={term} className="grid gap-2 py-4 sm:grid-cols-[9rem_minmax(0,1fr)]">
+            <dt className="text-[13.5px] font-medium text-nocturne-neutral-400">{term}</dt>
+            <dd className="text-[14px] leading-[1.6] text-nocturne-neutral-400">
+              {definition}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- 04 */
+
+function TheDraft() {
+  return (
+    <div>
+      <PanelHead title="Nobody picks the draft order.">
+        It is drawn from a Solana block produced after the deadline to join, so it does not
+        exist until the moment it is drawn. Anyone can recompute it from the blockhash.
+      </PanelHead>
+
+      <div className="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1fr)_18rem]">
+        <LandingDraftBoard />
+
+        <div className="rounded-lg border border-nocturne-neutral-900 p-5">
+          <h4 className="text-[13px] tracking-[0.12em] text-nocturne-neutral-500 uppercase">
+            The draw, verifiable
+          </h4>
+          <dl className="mt-4 space-y-3 text-[13px]">
+            {[
+              ["Slot", "312,884,109"],
+              ["Block time", "22 Aug, 20:00:03 ET"],
+              ["Previous", "20:00:02 ET"],
+              ["Seed", "blockhash + league id"],
+            ].map(([term, value]) => (
+              <div key={term} className="flex justify-between gap-3">
+                <dt className="text-nocturne-neutral-600">{term}</dt>
+                <dd className="text-right tabular-nums text-nocturne-neutral-300">{value}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="mt-4 text-[12px] leading-[1.55] text-nocturne-neutral-600">
+            One second separates this block from the one before it, which is what makes it the
+            only block the league could have used.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- 05 */
+
+const LINEUP = [
+  ["QB", "J. Goff", "DET", "21.4", "24.8"],
+  ["RB", "B. Robinson", "ATL", "14.9", "18.1"],
+  ["WR", "N. Collins", "HOU", "16.2", "9.4"],
+  ["FLEX", "J. Cook", "BUF", "11.7", "15.6"],
+  ["TE", "T. Kraft", "GB", "9.3", "—"],
+] as const;
+
+const WEEKLY = [
+  "Head-to-head weekly matchups, Weeks 1–14",
+  "Rolling waiver priority: win a claim, go to the back",
+  "Trades sit in escrow for 48 hours so the league can veto",
+  "Lineups lock per player, at that player's own kickoff",
+  "Consolation bracket is played, so nobody is out of it",
+] as const;
+
+function InsideALeague() {
+  return (
+    <div>
+      <PanelHead title="The week you already know how to read.">
+        Matchups, projections, waiver order, a starting lineup that autofills if you miss
+        kickoff. Nothing about the format is novel — the format is the part that works. What
+        changes is who holds the rules.
+      </PanelHead>
+
+      <div className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_16rem]">
+        <div className="overflow-hidden rounded-lg border border-nocturne-neutral-900">
+          <div className="flex items-baseline justify-between gap-3 border-b border-nocturne-neutral-900 px-5 py-3">
+            <span className="text-[13.5px] font-medium">Dynasty of Dropped Passes</span>
+            <span className="text-[11px] text-nocturne-neutral-600">Week 3</span>
+          </div>
+
+          <div className="flex items-center justify-between gap-4 border-b border-nocturne-neutral-900 px-5 py-4">
+            <span className="min-w-0">
+              <span className="block truncate text-[14px]">Route 66</span>
+              <span className="block text-[11px] text-nocturne-neutral-600">
+                2–0 · proj 118.4
+              </span>
+            </span>
+            <span className="shrink-0 text-[15px] tabular-nums">
+              86.2 <span className="text-nocturne-neutral-700">vs</span> 71.9
+            </span>
+            <span className="min-w-0 text-right">
+              <span className="block truncate text-[14px]">Tuesday Night Regrets</span>
+              <span className="block text-[11px] text-nocturne-neutral-600">
+                1–1 · proj 104.8
+              </span>
+            </span>
+          </div>
+
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="text-[10px] tracking-[0.1em] text-nocturne-neutral-600 uppercase">
+                <th className="px-5 py-2 text-left font-medium">Slot</th>
+                <th className="py-2 text-left font-medium">Starter</th>
+                <th className="py-2 text-right font-medium">Proj</th>
+                <th className="px-5 py-2 text-right font-medium">Pts</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-nocturne-neutral-900">
+              {LINEUP.map(([slot, name, team, proj, pts]) => (
+                <tr key={slot}>
+                  <td className="px-5 py-2 text-nocturne-neutral-500">{slot}</td>
+                  <td className="py-2">
+                    {name} <span className="text-nocturne-neutral-600">{team}</span>
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-nocturne-neutral-500">
+                    {proj}
+                  </td>
+                  <td className="px-5 py-2 text-right tabular-nums">{pts}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <p className="border-t border-nocturne-neutral-900 px-5 py-3 text-[11px] text-nocturne-neutral-600">
+            Autolineup on · waiver priority 12 of 12
+          </p>
+        </div>
+
+        <ul className="space-y-3 text-[13.5px] leading-[1.55] text-nocturne-neutral-400">
+          {WEEKLY.map((line) => (
+            <li key={line} className="flex gap-2">
+              <span aria-hidden className="text-nocturne-neutral-700">
+                —
+              </span>
+              {line}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Note>
+        Scores stay provisional until 48 hours after a week&rsquo;s last game, because the NFL
+        issues stat corrections for up to seven days.
+      </Note>
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- 06 */
+
+const ROUNDS = [
+  {
+    week: "Week 15 · quarterfinals",
+    games: [
+      ["3 Route 66", "W", "6 Gridiron Heresy", "L"],
+      ["5 Audibles", "W", "4 Hail Mary Inc.", "L"],
+    ],
+    note: "Seeds 1 and 2 are on a bye.",
+  },
+  {
+    week: "Week 16 · semifinals",
+    games: [
+      ["1 Pylon Co.", "W", "5 Audibles", "L"],
+      ["3 Route 66", "W", "2 Cover Two", "L"],
+    ],
+    note: "Survivors reseed, so the 1 draws the 5 and the 3 draws the 2 — not the pairings the first round implied.",
+  },
+] as const;
+
+const DERIVATION = [
+  "The frozen rule set says Week 17 decides it.",
+  "Two stat providers agree on the week's numbers.",
+  "Scores finalise 48 hours after the last game.",
+  "The contract reads the result and pays out.",
+] as const;
+
+function PlayoffsAndPayout() {
+  return (
+    <div>
+      <PanelHead title="The bracket reseeds, and the contract does the rest.">
+        Six teams across Weeks 15 to 17. Every round reseeds — the best surviving seed always
+        draws the worst — so the bracket cannot be drawn in advance. An upset changes who the
+        top seed plays, not just who survives.
+      </PanelHead>
+
+      <div className="mt-8 space-y-5">
+        {ROUNDS.map((round) => (
+          <div key={round.week} className="rounded-lg border border-nocturne-neutral-900 p-5">
+            <h4 className="text-[11px] tracking-[0.12em] text-nocturne-neutral-500 uppercase">
+              {round.week}
+            </h4>
+            <ul className="mt-3 space-y-2 text-[13.5px]">
+              {round.games.map(([home, homeResult, away, awayResult]) => (
+                <li key={home} className="flex flex-wrap items-baseline gap-x-3">
+                  <span className="text-nocturne-text">{home}</span>
+                  <span className="text-[11px] text-nocturne-accent-300">{homeResult}</span>
+                  <span className="text-nocturne-neutral-700">·</span>
+                  <span className="text-nocturne-neutral-500">{away}</span>
+                  <span className="text-[11px] text-nocturne-neutral-700">{awayResult}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 text-[12px] text-nocturne-neutral-600">{round.note}</p>
+          </div>
+        ))}
+
+        <div className="rounded-lg border border-nocturne-accent/30 p-5">
+          <h4 className="text-[11px] tracking-[0.12em] text-nocturne-neutral-500 uppercase">
+            Week 17 · championship
+          </h4>
+          <ul className="mt-3 space-y-2 text-[13.5px]">
+            <li className="flex justify-between gap-3">
+              <span>3 Route 66</span>
+              <span className="tabular-nums text-nocturne-accent-200">132.8</span>
+            </li>
+            <li className="flex justify-between gap-3 text-nocturne-neutral-500">
+              <span>1 Pylon Co.</span>
+              <span className="tabular-nums">128.1</span>
+            </li>
+          </ul>
+          <p className="mt-3 text-[12px] text-nocturne-neutral-600">
+            Third place is played too, so the loser of a semifinal still has a game.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <h4 className="text-[13px] tracking-[0.12em] text-nocturne-neutral-500 uppercase">
+          How the champion is derived
+        </h4>
+        <ol className="mt-3 space-y-2 text-[13.5px] text-nocturne-neutral-400">
+          {DERIVATION.map((line, index) => (
+            <li key={line} className="flex gap-3">
+              <span className="text-[11px] tabular-nums text-nocturne-neutral-700">
+                {index + 1}
+              </span>
+              {line}
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <Note>
+        There is no sign-off step. A week that pays out waits the full seven days the NFL allows
+        for stat corrections rather than 48 hours.
+      </Note>
+    </div>
+  );
+}
+
+/* --------------------------------------------------------------------- 07 */
+
+const SPORT = [
+  ["Stays the same", "Leagues, rosters, drafting, trades, waivers, escrow, settlement."],
+  [
+    "Comes from data",
+    "Positions, lineup slots, stat keys, scoring weights, the season calendar.",
+  ],
+  ["Written once per sport", "One provider adapter that maps a feed onto those stat keys."],
+] as const;
+
+function BeyondFootball() {
+  return (
+    <div>
+      <PanelHead title="The schema does not know what football is.">
+        Football ships first, but sports are data — a registry of stat keys, positions and
+        lineup slots — never structure or code branches. Adding a sport should insert rows and
+        write one provider adapter, with no migration and no change to scoring, drafting,
+        trading or settlement.
+      </PanelHead>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-3">
+        {SPORT.map(([title, body]) => (
+          <div key={title} className="rounded-lg border border-nocturne-neutral-900 p-5">
+            <h4 className="text-[13.5px] font-medium">{title}</h4>
+            <p className="mt-2 text-[13.5px] leading-[1.55] text-nocturne-neutral-400">
+              {body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The last PR installed drop 7 and took one piece from it. This builds the thing it's actually about.

Five scrolling bands become one band with a left rail; the hero returns to full-width text. `Differentiators`, `HowItWorks`, `Format` and `MultiSport` are gone as sections and are four of the seven panels, with the draft board, a league week and the playoff bracket joining them.

The designer's reasoning, kept because it answers the obvious objections: **a rail rather than a carousel** — all seven labels stay visible, where a carousel puts panels 2–6, the whole argument, behind two clicks; and **below the hero rather than inside it** — that column is 470×420 and the format table alone is nine rows.

## Three things the design says that are not copied

- **The roster-as-NFT claim** in panel 01. Removed from this page on 2026-08-19. What's here is the half that was always true and is shipped.
- **Kickoff "September 10."** It's the 9th.
- **"614 tests."** From a much older tree; any number is wrong a week later, so the claim is made without one.

## Found by re-reading my own work

Three defects, each the shape this repo names by hand:

- **`animate-[rostrFade_…]` named a keyframe nothing defined.** Generated, applied, animated nothing — the keyframe lives in the prototype's stylesheet and doesn't travel with the markup. Added to `globals.css` and disabled under `prefers-reduced-motion`.
- **`.explore` and `.draft-split` selected nothing** — the design's media-query hooks, which our CSS doesn't have. The breakpoints are expressed the way this app expresses one; the dead class names are gone.
- **The board's caption linked to `#how`**, the band it now sits inside. Removed, and the caption now states what the colours mean — position identity here, positional need in the draft room, which is the defect the designer caught in their own revision.

Also: the board loses `hidden lg:block` (right beside the hero, wrong inside a panel somebody opened), and 242 lines of dead section components are deleted rather than left for the next reader.

1986 tests, lint, typecheck and format green; production build compiles and `/` is still statically prerendered.

**Not verified in a browser** — `apps/web` has no jsdom. This is a large visual change and worth looking at before it goes to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)