### PR TITLE
Every successful sign-in 500'd

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/join/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/join/route.ts
@@ -75,7 +75,9 @@ export async function POST(
    * request is well-formed and the account is simply unfinished, and the code
    * tells the client where to send them.
    */
-  if (user.username === null || user.username.trim() === "") {
+  // Total, for the reason `accountGaps` records: an omitted column reads as
+  // `undefined` and would throw here rather than refuse.
+  if (typeof user.username !== "string" || user.username.trim() === "") {
     return NextResponse.json(
       {
         error: "Pick a username first — it is how people invite you.",

--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -140,7 +140,9 @@ export async function POST(request: Request): Promise<NextResponse> {
    * request is well-formed and the account is simply unfinished, and the code
    * tells the client where to send them.
    */
-  if (user.username === null || user.username.trim() === "") {
+  // Total, for the reason `accountGaps` records: an omitted column reads as
+  // `undefined` and would throw here rather than refuse.
+  if (typeof user.username !== "string" || user.username.trim() === "") {
     return NextResponse.json(
       {
         error: "Pick a username first — it is how people invite you.",

--- a/apps/web/src/lib/account.ts
+++ b/apps/web/src/lib/account.ts
@@ -65,7 +65,21 @@ export interface AccountState {
  */
 export function accountGaps(state: AccountState): readonly AccountGap[] {
   const gaps: AccountGap[] = [];
-  if (state.username === null || state.username.trim() === "") gaps.push("USERNAME");
+  // `typeof`, not `=== null`, and that is a fix rather than a style.
+  //
+  // `username` is typed `string | null`, so `state.username.trim()` looked total.
+  // It is not: a query that omits the column yields `undefined`, which passes the
+  // null check and then throws on `.trim()`. That happened —
+  // `verifySignInCode`'s `RETURNING` clause was missed when the column was added,
+  // so **every successful sign-in 500'd** while a wrong code answered correctly,
+  // because this line only runs once a code is accepted.
+  //
+  // The query is fixed. This stays total anyway: a row that cannot say whether
+  // somebody has a username has not established that they do, and reading that
+  // as "no username" sends them to `/welcome` instead of taking the site down.
+  if (typeof state.username !== "string" || state.username.trim() === "") {
+    gaps.push("USERNAME");
+  }
   if (state.verifiedWallets < 1) gaps.push("WALLET");
   return gaps;
 }

--- a/packages/db/src/identity.ts
+++ b/packages/db/src/identity.ts
@@ -269,7 +269,7 @@ export async function verifySignInCode(
     // runs on every login. Overwriting would keep resetting "verified since" to
     // the most recent sign-in.
     `UPDATE users SET email_verified_at = COALESCE(email_verified_at, $2) WHERE id = $1
-     RETURNING id, email, display_name, email_verified_at`,
+     RETURNING id, email, display_name, email_verified_at, username`,
     [row.user_id, now.toISOString()],
   );
   return toUser(updated!);

--- a/packages/db/src/usernames.test.ts
+++ b/packages/db/src/usernames.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createUser, findUserByWallet, IdentityError, linkWallet } from "./identity.js";
+import {
+  beginEmailSignIn,
+  createUser,
+  findUserByEmail,
+  findUserByWallet,
+  getUser,
+  IdentityError,
+  linkWallet,
+  verifySignInCode,
+} from "./identity.js";
 import {
   findUserByUsername,
   setUsername,
@@ -146,6 +155,52 @@ describe("setUsername", () => {
     await setUsername(client, first.id, "route67");
 
     expect(await setUsername(client, second.id, "route66")).toBe("route66");
+  });
+});
+
+describe("every path that returns a User carries the username", () => {
+  /**
+   * The regression that took sign-in down on 2026-08-21.
+   *
+   * `username` was added to every `SELECT` that builds a `User` and missed on
+   * one `RETURNING` clause — the one inside `verifySignInCode`. The field is
+   * typed `string | null`, so nothing complained; the row simply omitted the
+   * column and the value came back `undefined`.
+   *
+   * In production that reached `accountGaps`, which did `state.username.trim()`
+   * after a `=== null` check, and threw. **Only on the success path**: a wrong
+   * code answered 401 correctly, and every accepted code 500'd.
+   *
+   * So this asserts the shape rather than the value — `null`, never `undefined`
+   * — across every function that hands back a `User`. A `toBeNull` here fails
+   * on `undefined`, which is exactly the distinction that was missed.
+   */
+  it("verifySignInCode does, which is where it was missing", async () => {
+    const client = await fresh();
+    const { token } = await beginEmailSignIn(client, "code@example.test");
+    const user = await verifySignInCode(client, "code@example.test", token.token);
+
+    expect(user.username).toBeNull();
+  });
+
+  it("createUser, getUser and findUserByEmail do", async () => {
+    const client = await fresh();
+    const created = await createUser(client, "shape@example.test", "Shape");
+    expect(created.username).toBeNull();
+
+    expect((await getUser(client, created.id))?.username).toBeNull();
+    expect((await findUserByEmail(client, "shape@example.test"))?.username).toBeNull();
+  });
+
+  it("and they carry a claimed one back", async () => {
+    const client = await fresh();
+    const created = await createUser(client, "named@example.test", "Named");
+    await setUsername(client, created.id, "route66");
+
+    const { token } = await beginEmailSignIn(client, "named@example.test");
+    const signedIn = await verifySignInCode(client, "named@example.test", token.token);
+    expect(signedIn.username).toBe("route66");
+    expect((await getUser(client, created.id))?.username).toBe("route66");
   });
 });
 


### PR DESCRIPTION
Reported from production. **Diagnosed rather than guessed**: the routes answered correctly for an empty body (400) and a wrong code (401), and `beginEmailSignIn` ran clean against the production database — so the failure was on the **success** path only, which is where the code added yesterday runs.

## The cause: one `RETURNING` clause forgot a column

When `username` was added, every `SELECT` that builds a `User` was updated and the `UPDATE ... RETURNING` inside `verifySignInCode` was not. The field is typed `string | null`, so nothing complained; the row simply omitted it and the value came back `undefined`.

That reached `accountGaps`, which checked `=== null` and then called `.trim()` — total against `null`, a TypeError against `undefined`. So a wrong code answered 401 correctly and every accepted code threw a 500.

## Three changes, one of which is the bug

- **The `RETURNING` clause carries `username`.** Verified against the production database: `null` now, not `undefined`.
- **`accountGaps` tests `typeof … !== "string"`.** A row that cannot say whether somebody has a username has not established that they do, and reading that as "no username" sends them to `/welcome` rather than taking sign-in down. The comment records why, since the null check *looked* total.
- **The two `USERNAME_REQUIRED` guards** added yesterday had the same shape and would have failed identically the next time anything omitted the column.

## Mutation-checked

Reverting exactly that clause fails two of the three new tests with `expected undefined to be null` — the distinction the original edit missed. The tests assert the *shape* (`null`, never `undefined`) across every function that returns a `User`, because that is what was actually wrong.

1989 tests, lint, typecheck and format green.

Also cleaned up: a probe account created against production while reproducing this, and its session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)