### PR TITLE
Drop 8 — the Leagues hub

### DIFF
--- a/docs/design/ANSWERS.md
+++ b/docs/design/ANSWERS.md
@@ -1,0 +1,136 @@
+# Answers to the drops' open questions
+
+Every drop since 6 has carried a list headed "still open, and needing you rather
+than a developer". **Five questions have been asked and three of them are
+settled**, so the list is asking for decisions that already exist.
+
+This file is the reply, and it is written to be pasted into the design session
+rather than read as correspondence — the drops come from the same person the
+answers go to.
+
+Each answer names what settles it, so none of this has to be taken on trust.
+
+---
+
+## 1. How autopick signs a transaction the manager was not present for
+
+**It does not. Nothing about a pick signs anything.**
+
+A pick is `recordPick` in `packages/db/src/draft.ts`: one Postgres transaction
+writing the `draft_picks` row, the `roster_entries` row and the queue cleanup.
+The word "transaction" there is a database transaction. Checked in the route as
+well — `apps/web/src/app/api/leagues/[id]/draft/pick/route.ts` contains no
+signature, no wallet, no instruction, and no import of either.
+
+The question came from the roster-as-NFT design, where each pick would have
+minted a Token-2022 NFT and so needed a signer. **That design was abandoned on
+2026-08-19** (`6d28c5e`) — nothing has ever minted one and there is no NFT
+program in the tree.
+
+### The consequence: draft room state 6 cannot happen
+
+State 6 is "a manager loses the player they chose because a wallet prompt
+outlived its blockhash". There is no wallet prompt in a pick, so there is no
+blockhash to outlive. **That branch can be deleted from the draft room design**,
+along with the session-key / pre-authorisation / delegated-signer decision it
+was waiting on.
+
+**What does sign**, and it is worth the design being exact about which five:
+
+| Moment                | Signs                             |
+| --------------------- | --------------------------------- |
+| Joining a league      | the rules hash, from your wallet  |
+| `deposit`             | a token transfer into the vault   |
+| `refund_stake`        | the timelock withdrawal           |
+| `initialize_league`   | the commissioner anchoring        |
+| `start_season`        | the commissioner closing refunds  |
+
+All five are money or consent. None is a pick, a lineup, a waiver claim or a
+trade proposal — a **trade vote** does not sign either.
+
+---
+
+## 2. Which hero animation ships
+
+**A.** Decided 2026-08-21.
+
+---
+
+## 3. Kickoff — 9 or 10 September
+
+**The 9th.** The README was right and the reasoning against it was wrong.
+
+The drops argue "9 Sept 2026 is a Wednesday and NFL Week 1 opens Thursday". That
+is a general rule about the NFL calendar applied to a season that does not follow
+it. From the synced 2026 schedule:
+
+```
+20260909_NE@SEA   week 1   Wednesday 9 Sept, 8:20 PM ET
+20260910_SF@LAR   week 1   Thursday 10 Sept, 8:35 PM ET
+```
+
+The 10th **is** a Week 1 date, so the designs are not absurd — they are naming
+the second game. The season opens on the 9th.
+
+Confirmed by the owner on 2026-08-21. **Twelve design files say the 10th and
+should say the 9th.**
+
+---
+
+## 4. When a week label flips
+
+**It depends what the label is for, and both answers are already in the code.**
+Tuesday genuinely belongs to two weeks at once, so there is no single right
+answer — there are two functions because there are two questions.
+
+- **Reporting what happened** — `currentWeek` (`packages/db/src/week.ts`) is the
+  week of the most recent kickoff at or before now. On the Tuesday after Week 10
+  it answers **10**. So a screen labelling Tuesday as the week just ended is
+  correct, and the designs are right to do it.
+- **Enforcing a rule** — `transactionWeek` is the week a transaction would
+  *execute into*: the first game after the most recent weekly lock. The lock is
+  Tuesday 00:00 ET, so from Tuesday morning it answers **11**.
+
+The distinction is not cosmetic. A trade deadline checked against `currentWeek`
+would let a trade resolving on the Tuesday after Week 11 execute into Week 12's
+rosters while being checked against Week 11 — which is a bug this repo has
+already had and fixed.
+
+**For the screens:** label the week just ended when reporting results, and label
+the upcoming week wherever a deadline, a waiver run or a trade window is being
+described. If one screen has to do both, they are different labels.
+
+---
+
+## 5. Whether escrow release can move a player whose game is in progress
+
+**Yes, it can, and that is deliberate — the lineup lock is what makes it safe.**
+
+`resolveTrade` does not check kickoff and does not refuse. It cannot: the league
+already approved the trade and waited out the veto window, and a throw inside the
+resolution would leave the trade stuck with no path forward. The two paths that
+*can* refuse do — `dropPlayer` and `addFreeAgent` answer `GAME_STARTED`, which is
+`RULES.md` §6.
+
+What stops the exploit is the **lineup lock**, which holds however a player
+arrived: a slot locks at that player's own kickoff, so a player acquired
+mid-game cannot be started in a game already under way. Closing the route and
+closing the outcome are different jobs, and this needs the second.
+
+**For the screens:** a trade can execute while games are running, and the
+acquired player is simply unstartable until the following week. Do not draw a
+"trade blocked, game in progress" state — it does not exist.
+
+---
+
+## Two things the drops should stop carrying
+
+Not questions, but they recur and they are wrong:
+
+1. **The roster-as-NFT copy.** `Rostr Landing.dc.html` still says "Drafted
+   players are held in your wallet" in the hero and "mint as Token-2022 NFTs" on
+   a card. Both were removed from the app on 2026-08-19 because they were never
+   true. See `STATUS.md`.
+2. **"614 tests."** It is 1,989 as of 2026-08-21 and will be wrong again next
+   week. A claim about test count in marketing copy dates itself; the surrounding
+   sentence works without a number.

--- a/docs/design/PULL_REQUEST.md
+++ b/docs/design/PULL_REQUEST.md
@@ -2,104 +2,116 @@ Branch: `design/screens`
 
 ---
 
-## Design drop 7 — the landing page consolidates into a section explorer
+## Design drop 8 — the Leagues hub
 
-Twelve screen files plus an index and a logo sheet, covering rostr end to end: the public
-landing page, creating and freezing a league, inviting and joining it, the draft lobby and
-the order draw, the draft room and its failure branches, the weekly in-season loop including
-the full trade flow, the playoffs and settlement, amending and dissolving a league, and ten
-screens designed for mobile web.
+Thirteen screen files plus an index and a logo sheet, covering rostr end to end: the public
+landing page, the signed-in Leagues hub, creating and freezing a league, inviting and joining
+it, the draft lobby and the order draw, the draft room and its failure branches, the weekly
+in-season loop including the full trade flow, the playoffs and settlement, amending and
+dissolving a league, and ten screens designed for mobile web.
 
 Nothing here is wired into `apps/web`. `design_handoff/` is the reference to build against.
 
-### What changed since drop 6
+### What changed since drop 7
 
-**Five scrolling sections became one explorer.** Inside a league, How it works, Why it's
-different, Format and Multi-sport were five bands a visitor scrolled past. They are now seven
-panels behind a left rail, in a single band below the hero, with the draft board and a new
-playoffs panel joining them. The hero is full-width text again.
+**One `Leagues` nav item replaces three surfaces.** The shell carried "Join a league", a
+"Create a league" button and an `InvitationBadge` side by side; `/leagues` browsed public
+leagues with an `InvitationsCorner` aside; `/invitations` was a third page. `Rostr
+Leagues.dc.html` is one page ordered **your leagues → invitations → public leagues**, with
+create given equal weight as a card in the page head.
 
-The rail is ordered as a season rather than as a menu: **Why it's different → How it works →
-Format → The draft → Inside a league → Playoffs and payout → Beyond football.** The argument
-leads because it is the reason to keep reading; the mechanics then run in the order a manager
-meets them, which puts the draft fourth instead of last. Nothing auto-advances.
+The gap it closes: nothing on the old `/leagues` listed the leagues you are already in, which
+is the first thing a returning manager wants.
 
-Two things about the placement worth recording, since they were the actual design question:
+**A notification model, in two parts.** An **urgent strip** under the header for anything on a
+clock — on the clock, draft within the hour, veto window closing, lineup unset near kickoff,
+waivers running, a trade awaiting your answer — one item at a time, the most pressing. And a
+**bell** holding everything, including whatever is currently in the strip, so nothing lives
+only in a place that disappears.
 
-- The original ask was to put the explorer **inside the hero's right column**. That column is
-  about 470×420px, and the Format table alone is nine rows — every panel would have collapsed
-  to a headline, or the hero would have grown until the H1 left the screen. Below the hero,
-  the table fits at full size.
-- A rail beats a carousel here because **all seven labels stay visible**. In a carousel,
-  panels 2–6 are the four differentiators — the whole argument — behind two clicks.
+The reasoning worth keeping: a 90-second draft clock cannot live behind a click. If a manager
+has to open a dropdown to learn their pick is live, the dropdown failed. The strip is empty
+almost always, which is what makes it mean something when it is not.
 
-**Real NFL names on the landing page.** The board and its league-home panel now name actual
-players in ADP order: J. Jefferson, B. Robinson, S. Barkley at 1.03–1.05; B. Bowers,
-N. Collins, T. McBride in round 2; J. Allen at 3.03; James Cook as the queue leader at 3.04.
-Board cells keep `shortName`'s initialled form so they hold the 120px column floor.
+Anything needing a **signature** — submitting a pick, voting on a trade — carries a wallet
+mark, so "this will ask for your wallet" is visible before the click.
 
-**Two caveats on that.** The ordering is a designer's guess at 2026 ADP, not data — the repo
-has no ADP fixture, only Tank01 test files — so reconcile it against the live board.
-And Route 66's five starters in panel 05 were rewritten to match what the board shows them
-drafting; those two places have to move together or the demo contradicts itself. The other
-eleven screens still carry invented names.
+**State 4 exists to stop a regression.** Collapsing `SessionBar` into an avatar and a chevron
+silently deletes two shipped affordances: the **Sign out** button, and the `username === null`
+branch that renders **Finish setting up** linking to `/welcome`, because an account with no
+username cannot be invited to anything. Both are drawn in the account menu.
 
-**The bot rule was wrong in one place.** `Rostr Amend and Dissolve.dc.html` said "Bots fill
-any empty seat". Corrected: **one bot, only to square an odd field, never in a league with a
-pot.** The other screens already stated it correctly; the landing page's Format table and
-closing CTA now say it explicitly too.
+### What is grounded, and what is a proposal
 
-**Brand assets are in `brand/`** — the logo, headers, X headers, PNG and SVG, with their own
-README. Social and print only; the product UI keeps its own header.
+**Grounded** — recreate from source, not from these pixels:
 
-### Three defects worth reading before you build the landing page
+- The header is `(app)/layout.tsx` verbatim except where noted: wordmark 19px/600/−0.02em plus
+  the `FANTASY FOOTBALL` descriptor (11px/0.14em/neutral-600), `max-w-[1180px] px-10
+  py-[14px]`, "How scoring works", and the footer on every signed-in page — *Pre-alpha. Not
+  audited. Do not use with funds you cannot lose.*
+- The invitation count is `InvitationBadge`: `INVITATIONS_KEY` = `/api/invitations`,
+  deduplicated with the panel so the count and the list cannot disagree, rendering nothing at
+  zero rather than a `0`.
+- Browse cards are `LeagueBrowser`: PUBLIC and FORMING only, seats against `maxTeams`, draft
+  time in the reader's timezone, buy-in from base units by string surgery (no floating point
+  near money).
 
-Each of these shipped in a revision of this screen and was caught by review, not by writing:
+**Proposals with no backing route:** the urgent strip, the bell, the account menu, and the
+`Your leagues` section. Only the invitation count has a real source today.
 
-**A `minmax(0, 1fr)` column floor is not a floor.** The draft board collapsed to 56px columns
-between roughly 981px and 1105px of viewport — every one of the seven player names clipped to
-15px of a 42–68px string, unreadable, in a window a laptop actually sits in. The shipped
-component pins `min-w-[7.5rem]`; the design now writes `minmax(120px, 1fr)` and stacks the
-panel's inner grid at 1240px so the floor never fights a 300px aside.
+### Three rules this screen must not break
 
-**A caption can claim a rule the markup does not follow.** The board's caption said colour
-tracked positional need; the cells were strict position identity the whole time, including
-Route 66's own filled slots. Need-colouring belongs to the draft room, where it is recomputed
-after each of your own picks.
+**No join control in a list.** Neither a browse card nor an invitation card offers one — both
+lead to the league page, where the whole rule set renders above the join button. `RULES.md`
+requires the full document before anyone joins, and a join button in a directory is a way to
+agree to a rule set nobody read.
 
-**Reseeding arithmetic goes backwards easily.** The playoffs panel first showed seeds 3 and 6
-both advancing out of a round where seeds 1 and 2 were byed — impossible under any pairing.
-The canonical bracket in `Rostr Playoffs.dc.html` is: 3 beat 6 and 5 beat 4, reseed, then 1
-draws 5 and 2 draws 3. This is the second time this exact panel has been wrong on first
-write.
+**Private leagues never appear in the public list.** They arrive only as an invitation or a
+link.
 
-### Read the README's second section first
+**Every public league shows Free.** The escrow program is unwritten, so no league can take a
+deposit. The buy-in filter is drawn for when that changes and the page says so; dollar amounts
+would be designing a feature that does not exist.
 
-Most defects found while designing these were not visual. They were the same league described
-inconsistently in two places. The README lists the twelve facts that must be **derived from
-one source and never restated** — roster limit, standings order, veto threshold, veto
-deadline, draft order, autofill target, positional need, lock state, season dates,
-snake-pick arithmetic, bracket shape, unanimity denominator.
+Two smaller corrections from reading the source: the nav names only routes that exist — there
+is no global `/players` or `/activity`, both are league-scoped — and invitation rows say
+"addressed to your username", because `/api/invitations` returns `addressedAs: "USERNAME" |
+"WALLET"`, which is how you were reached, not who sent it.
+
+### Two CSS traps this screen hit
+
+Both shipped broken here before review caught them, and both are the kind that look fine until
+they don't:
+
+**An absolutely-positioned panel does not push a footer.** The overlay frames flowed their
+footer after only a short paragraph and landed it 400px above the panel's bottom edge. Fixed
+by making the frame a flex column with the footer on `margin-top: auto`.
+
+**Auto side margins on a flex item suppress `align-self: stretch` and trigger shrink-to-fit.**
+That fix immediately collapsed two 1180px columns to content width and re-centred them. Hence
+the explicit `width: 100%` beside every `max-width: 1180px; margin: 0 auto` inside a flex
+frame. If you rebuild these in Tailwind, `mx-auto` on a flex child needs `w-full` with it.
 
 ### Still open, and needing you rather than a developer
 
 - **How autopick signs a transaction the manager was not present for.** Session key,
-  pre-authorization at draft start, or a delegated signer. This also creates draft room
-  state 6, where a manager loses the player they chose because a wallet prompt outlived its
-  blockhash. Settle it before the escrow program is written.
-- **Which hero animation ships, A or B.** Both are in the file behind a switcher.
-- **Kickoff is 9 September in `README.md` and 10 September across all twelve designs.**
-  9 Sept 2026 is a Wednesday and NFL Week 1 opens Thursday, so I believe the README is wrong.
-- **When a week label flips.** The trade and amend screens label Tuesday 17 Nov as Week 10,
-  after Week 10's games are finished and before Week 11's start.
+  pre-authorization at draft start, or a delegated signer. Settle it before the escrow program
+  is written.
+- **Which hero animation ships, A or B.**
+- **Kickoff is 9 September in `README.md` and 10 September across all designs.** 9 Sept 2026 is
+  a Wednesday and NFL Week 1 opens Thursday.
+- **When a week label flips** — Tuesday sits between two weeks and the screens call it the one
+  just ended.
 - **Whether escrow release can move a player whose game is already in progress.**
 
 ### Not done
 
-- Five desktop screens have no mobile design — create league, the commissioner's invite side,
-  draft lobby, amend and dissolve — and neither does the playoff bracket.
+- The Leagues hub has no mobile design. Five other desktop screens have none either — create
+  league, the commissioner's invite side, draft lobby, amend and dissolve — nor does the
+  playoff bracket.
 - Player detail, full standings.
-- The wallet signing round-trip is designed three times and needed in four more places:
-  freezing a league, voting, any pot action, and the landing page's Connect wallet button.
-- The wordmark has no vector version; the ball's SVG is exact but the letters are live Inter
-  text. Needs a vector editor before print.
+- The wallet signing round-trip is designed three times and needed in four more places.
+- Player names are real on the landing page only; the other twelve screens carry invented
+  ones, and the landing page's ADP ordering is a designer's guess — reconcile against the live
+  Tank01 board.
+- The wordmark has no vector version; needs a vector editor before print.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,7 +1,7 @@
 # rostr — design handoff
 
-Twelve screen files plus an index and a logo sheet, covering the whole product as it exists
-today: the public landing page, creating and freezing a league, inviting and joining it, the draft lobby and
+Thirteen screen files plus an index and a logo sheet, covering the whole product as it exists
+today: the public landing page, the Leagues hub, creating and freezing a league, inviting and joining it, the draft lobby and
 the order draw, the draft room, the weekly in-season loop, the playoffs and settlement, amending and dissolving a league,
 and ten screens designed for mobile web.
 
@@ -258,7 +258,68 @@ against the live Tank01 board, which the repo has no fixture for — and Route 6
 starters in panel 05 were rewritten to match what the board shows them drafting, so those two
 places have to move together.
 
-### 2. `Rostr Create League.dc.html` — 2 states
+### 2. `Rostr Leagues.dc.html` — 4 states
+**The signed-in front door, consolidating three shipped surfaces into one.** The app shell
+carried "Join a league", a "Create a league" button and an `InvitationBadge` side by side;
+`/leagues` browsed public leagues with an `InvitationsCorner` aside; `/invitations` was a
+third page. This is one **Leagues** nav item leading to a page ordered your leagues →
+invitations → public leagues, with create given equal weight as a card in the page head.
+
+**Recreate the header from `(app)/layout.tsx`, not from this file's pixels** — that layout is
+the source and this design only changes it in named ways. What it keeps verbatim: the
+wordmark (19px/600/−0.02em) with its `FANTASY FOOTBALL` descriptor (11px/0.14em/neutral-600),
+`max-w-[1180px] px-10 py-[14px]`, "How scoring works", the accent invitation badge
+(`min-w-[1.25rem]`, 11px/600, accent on `--color-bg`), and the footer on every signed-in
+page: *Pre-alpha. Not audited. Do not use with funds you cannot lose.* Every band sits in that
+same 1180px container, including the urgent strip — the strip is full-bleed for its tint and
+border edge, but its row is contained like the rest.
+
+**What this design proposes, i.e. what has no backing route yet.** Only the invitation count
+is grounded (`INVITATIONS_KEY` = `/api/invitations`, deduplicated with `InvitationBadge` so
+the count and the list cannot disagree, and rendering nothing at zero rather than a `0`).
+Everything else in the header is new:
+
+- **The urgent strip** under the header, for anything on a clock: on the clock, draft starting
+  within the hour, veto window closing, lineup unset near kickoff, waivers running tonight, a
+  trade awaiting your answer. One item at a time, the most pressing. It exists because a
+  90-second draft clock cannot live behind a click — if a manager has to open a dropdown to
+  learn their pick is live, the dropdown failed. The strip is empty almost always, which is
+  what makes it mean something when it is not.
+- **The bell**, holding everything including whatever is currently in the strip, so nothing
+  lives only in a place that disappears. Grouped *Needs you* / *Earlier*.
+- **A wallet mark on anything needing a signature** — submitting a pick, voting on a trade —
+  so "this will ask for your wallet" is visible before the click.
+- **The account menu**, which absorbs what `SessionBar` rendered inline. State 4 exists
+  specifically because collapsing that component into a chevron silently deletes two shipped
+  affordances: the **Sign out** button, and the `username === null` branch that renders
+  **Finish setting up** linking to `/welcome`, because an account with no username cannot be
+  invited to anything. Both must survive.
+
+**Two rules this screen must not break.** Neither a browse card nor an invitation card offers
+a join control — both lead to the league page, where the whole rule set renders above the join
+button. `RULES.md` requires the full document before anyone joins, and a join button in a
+directory is a way to agree to a rule set nobody read. And **private leagues never appear in
+the public list**; they arrive only as an invitation or a link.
+
+**Every public league shows Free.** The escrow program is unwritten, so no league can take a
+deposit. The buy-in filter is drawn for when that changes and the page says so; showing dollar
+amounts would be designing a feature that does not exist.
+
+The nav names only routes that exist. There is no global `/players` or `/activity` — both are
+league-scoped — so the bell's footer links to `/invitations`. If you add a global activity
+feed, that is a new route, not an implied one.
+
+Invitation rows say **"addressed to your username"**, because `/api/invitations` returns
+`addressedAs: "USERNAME" | "WALLET"` — how you were reached — and not who sent it.
+
+Two containment notes, both of which shipped broken here first. The overlay frames (states 2
+and 4) hold an absolutely-positioned panel, so their footer flowed after only the short dimmed
+paragraph and landed 400px above the panel's bottom; they are now flex columns with the footer
+on `margin-top: auto`. That fix then collapsed those columns, because **auto side margins on
+a flex item suppress `align-self: stretch` and trigger shrink-to-fit** — hence the explicit
+`width: 100%` beside every `max-width: 1180px; margin: 0 auto`.
+
+### 3. `Rostr Create League.dc.html` — 2 states
 **The finding that shaped this screen: only ten values are the commissioner's.** Scoring
 is set by the project owner, the pot token is set by the service per network, and roster,
 season, playoffs, tiebreakers, waivers, veto threshold and the 1% fee are all fixed. So
@@ -279,7 +340,7 @@ validation the rules require and this screen only partly shows: **pot + bot is r
 outright**, a draft time outside the creation window is refused, and a deadline outside
 Weeks 8–14 is refused.
 
-### 3. `Rostr Invite and Join.dc.html` — 2 states
+### 4. `Rostr Invite and Join.dc.html` — 2 states
 The commissioner's side (invite link, email invites, the twelve-seat field with three row
 states — joined, invitation out, open) and the invited manager's side, which is the more
 important half: the full rule set, an itemised "what you are signing", the wallets already
@@ -288,7 +349,7 @@ in, and an unchecked acknowledgement gating "Sign and join".
 Invitation rows carry real `<button>` actions (Resend, Withdraw) in their own column —
 never a styled span, and never sharing a column with wallet hashes.
 
-### 4. `Rostr Draft Lobby.dc.html` — 2 states
+### 5. `Rostr Draft Lobby.dc.html` — 2 states
 **The best screen in the set for demonstrating the product's argument.** Before the draw:
 a 76px countdown and the plain statement that the order does not exist yet, with the
 reason spelled out — if the seed were fixed in advance a commissioner could add a bot,
@@ -298,7 +359,7 @@ After: the drawn order, and a verification panel giving slot, blockhash, block t
 previous block's time (which is what makes it *the only block the league could have used*)
 and the seed recipe, so anyone can recompute it on an explorer.
 
-### 5. `Rostr Draft Room.dc.html` — 7 states
+### 6. `Rostr Draft Room.dc.html` — 7 states
 Order train, clock, player pool, queue/roster rail, full board. Built on ESPN's
 conventions deliberately — managers arrive with them in muscle memory. Three departures:
 
@@ -347,7 +408,7 @@ present for. Session key, pre-authorization at draft start, or a delegated signe
 this before the escrow program is written. The notice strip reads "signed 0x7f3a…c19d"
 without claiming a mechanism; **do not ship that line until the mechanism is real.**
 
-### 6. `Rostr League Home.dc.html` — 2 states
+### 7. `Rostr League Home.dc.html` — 2 states
 League home (your matchup, your starters, the league scoreboard, activity, standings,
 waiver priority) and the full matchup, slot against slot with both benches.
 
@@ -358,7 +419,7 @@ wait the full seven.
 Standings must be **computed**, and a team mid-game carries a shorter record than a team
 whose week is final. Getting this wrong here inverted the playoff cut line.
 
-### 7. `Rostr Lineup.dc.html` — 2 states
+### 8. `Rostr Lineup.dc.html` — 2 states
 Setting the lineup with a player picked up — three slots lit (both WR and FLEX), the rest
 labelled not eligible — and the lineup partially locked, where seven slots are gone, one
 is empty, and autofill **names who it will start and when**, with the reason the
@@ -368,7 +429,7 @@ The teaching point the copy carries: nobody forfeits anything for not showing up
 abandonment rule, no strikes, no forfeiture — an empty slot simply gets filled, and turning
 autofill off is the only way to score nothing there.
 
-### 8. `Rostr Waivers.dc.html` — 2 states
+### 9. `Rostr Waivers.dc.html` — 2 states
 Filing blind claims Tuesday night, and the Wednesday 3am run. The two player states are
 visually distinct: **on waivers** (accent, "Claim") versus **free agent** (neutral, "Add
 now"), and only players on waivers appear in the run.
@@ -379,7 +440,7 @@ decides which of *your* claims gets your last roster spot. Claims 1 and 3 both n
 same roster spot, claim 1 loses to priority 3, and claim 3 therefore wins — file the
 player you want most first. Winning two claims in one run moves priority **once**.
 
-### 9. `Rostr Trade Veto.dc.html` — 4 states
+### 10. `Rostr Trade Veto.dc.html` — 4 states
 The screen no other fantasy platform has. A one-for-two trade in escrow, its 48-hour
 window, and the ten uninvolved managers' votes — two against, four needed. Then the
 settled state: the threshold was not met, so the contract executed, with a full on-chain
@@ -403,7 +464,7 @@ trade executes, not the week it was proposed.** With a Week 11 deadline ending M
 last moment anything can be proposed is Sat 21 Nov, 11:30 PM. A trade accepted later
 `EXPIRED`s untouched rather than executing.
 
-### 10. `Rostr Playoffs.dc.html` — 2 states
+### 11. `Rostr Playoffs.dc.html` — 2 states
 Championship Sunday with the last two games live, then settled. The ladder is three columns
 — Week 15 quarterfinals with seeds 1–2 on a bye, Week 16 semifinals, Week 17 championship
 and third place — plus the six-team consolation bracket, which needs three rounds and so
@@ -422,7 +483,7 @@ rules to derived champion. The `potLeague` prop adds the 70/20/10 payout and the
 Route 66 wins as the 3 seed, 132.8–128.1, and the Week 17 starter total adds to exactly
 that.
 
-### 11. `Rostr Mobile.dc.html` — 10 screens at 390px
+### 12. `Rostr Mobile.dc.html` — 10 screens at 390px
 Landing, league home, lineup, draft room, join, the wallet signing sheet, waivers, the
 Wednesday waiver run, an incoming trade, and the veto vote — each in a browser frame with a
 620px viewport.
@@ -447,7 +508,7 @@ links were under it on first write. And the acknowledgement gate needs
 `disabled="disabled"` — a bare `disabled` attribute compiles to `disabled=""`, which React
 drops, so the gate rendered as a live full-opacity button next to an unchecked box.
 
-### 12. `Rostr Amend and Dissolve.dc.html` — 4 states
+### 13. `Rostr Amend and Dissolve.dc.html` — 4 states
 The last thing `RULES.md` defines and the only post-creation change permitted. Both amend
 and dissolve need **unanimous signed consent of every stake-holding manager**; a bot seat
 neither signs nor blocks.
@@ -514,9 +575,12 @@ with refunds if the league never fills. `RULES.md` defines them; nothing is draw
 failure branch in state 6, and the mobile sheet) and **four** other places that need it —
 freezing a league, voting, any pot action, and the landing page's Connect wallet button.
 
+**The Leagues hub:** a mobile design, and the notification model's real sources. The urgent
+strip and the bell have no route behind them; only the invitation count does.
+
 ## Files
 
-- `screens/*.dc.html` — the twelve designs, plus `Rostr Screens.dc.html` (an index of them
+- `screens/*.dc.html` — the thirteen designs, plus `Rostr Screens.dc.html` (an index of them
   all with per-screen notes and the open questions) and `Rostr Logo.dc.html` (the logo
   exploration sheet). Open any directly in a browser.
 - `brand/` — the finished logo, headers and X headers as PNG and SVG, with their own

--- a/docs/design/STATUS.md
+++ b/docs/design/STATUS.md
@@ -83,7 +83,17 @@ flex item suppress `align-self: stretch` and trigger shrink-to-fit**, which
 collapsed two 1180px columns to content width. In Tailwind terms: `mx-auto` on a
 flex child needs `w-full` beside it.
 
-#### Three of the "still open" questions are already answered
+#### All five "still open" questions are answered — see `ANSWERS.md`
+
+`ANSWERS.md` in this directory is the reply, written to be pasted into the design
+session rather than read as correspondence. It settles all five, each with the
+source that decides it: drafting signs nothing (so draft room **state 6 can be
+deleted**), hero animation **A**, kickoff the **9th**, the week label flips at the
+Tuesday lock for rules and at the last kickoff for results, and a trade **can**
+execute mid-game because the lineup lock — not the trade path — is what makes
+that safe.
+
+#### Three of them were listed as open in drop 8 as well
 
 Drop 8 repeats them, so the answers have not reached the designer. They should
 go back in the next reply:

--- a/docs/design/STATUS.md
+++ b/docs/design/STATUS.md
@@ -6,8 +6,8 @@ built, and the one rule that matters when using them.
 
 ## Provenance
 
-Drop 5 landed 2026-08-16, drop 6 on 2026-08-19; **drop 7 landed 2026-08-21** and
-is what is here now.
+Drop 5 landed 2026-08-16, drop 6 on 2026-08-19, drop 7 earlier on 2026-08-21;
+**drop 8 landed 2026-08-21** and is what is here now.
 Earlier drops are **superseded entirely** — they were revisions of the same
 screens, not different content:
 
@@ -18,10 +18,85 @@ screens, not different content:
 | 4 | ten screens, plus mobile and playoffs |
 | 5 | all twelve, plus amend-and-dissolve |
 | 6 | landing hero rebuilt, nav consolidated, mobile expanded, plus a screens index |
-| **7** | **the landing becomes a section explorer; real NFL names; a brand kit; a logo sheet** |
+| 7 | the landing becomes a section explorer; real NFL names; a brand kit; a logo sheet |
+| **8** | **the Leagues hub — one screen for your leagues, invitations and browsing** |
 
-If an older drop resurfaces, it is not a source of anything. Nothing in 1–6 is
+If an older drop resurfaces, it is not a source of anything. Nothing in 1–7 is
 absent from this directory.
+
+### What drop 8 changed
+
+**One file: `screens/Rostr Leagues.dc.html`.** Every other screen and the whole
+brand kit are byte-identical to drop 7.
+
+It proposes replacing **three shipped surfaces with one**. Today the shell
+carries "Join a league", a "Create a league" button and `InvitationBadge` side
+by side; `/leagues` browses public leagues with `InvitationsCorner` beside it;
+and `/invitations` is a third page. The design is a single `Leagues` nav item
+ordered **your leagues → invitations → public leagues**, with create as a card in
+the page head.
+
+The gap it names is real and ours: **nothing on `/leagues` lists the leagues you
+are already in**, which is the first thing a returning manager wants. This repo
+has known that since the commissioner's checklist landed — "there is no 'my
+leagues' list to find it in again".
+
+**The designer read the shipped code**, which is worth knowing when reconciling:
+`InvitationBadge` and `INVITATIONS_KEY`, the deduplicated count that renders
+nothing at zero, `LeagueBrowser`'s PUBLIC-and-FORMING filter, seats against
+`maxTeams`, the buy-in computed by string surgery rather than floating point.
+Those parts are described as **grounded — recreate from source, not from these
+pixels.**
+
+**What is a proposal with no backing route:** the urgent strip, the bell, the
+account menu, and the `Your leagues` section. Only the invitation count has a
+real source today. Do not read the screen as a description of what exists.
+
+#### State 4 exists to stop a regression, and it is right
+
+Collapsing `SessionBar` into an avatar and a chevron would silently delete two
+shipped affordances: the **Sign out** button, and the `username === null` branch
+that renders **Finish setting up** linking to `/welcome`. The second matters more
+than it looks — an account with no username cannot be invited to anything, and
+since 2026-08-21 it cannot create or join a league either. Both are drawn into
+the account menu. If that header is ever rebuilt, this is the thing to check.
+
+#### Three rules the screen states, all of which the repo already enforces
+
+- **No join control in a list.** Both card types lead to the league page, where
+  the whole rule set renders above the join button. `RULES.md` requires the full
+  document before anyone joins.
+- **Private leagues never appear in the public list.** They arrive as an
+  invitation or a link.
+- **Every public league shows Free**, because no league can take a deposit until
+  settlement is written. Dollar amounts would be designing a feature that does
+  not exist.
+
+Verified on install: the file contains no roster-as-NFT claim, no
+"held in your wallet", and no join button in a list.
+
+#### Two CSS traps recorded, and one applies to any Tailwind rebuild
+
+An absolutely-positioned panel does not push a footer — the frame needs to be a
+flex column with the footer on `margin-top: auto`. And **auto side margins on a
+flex item suppress `align-self: stretch` and trigger shrink-to-fit**, which
+collapsed two 1180px columns to content width. In Tailwind terms: `mx-auto` on a
+flex child needs `w-full` beside it.
+
+#### Three of the "still open" questions are already answered
+
+Drop 8 repeats them, so the answers have not reached the designer. They should
+go back in the next reply:
+
+- **How autopick signs a transaction** — it does not. A pick is a database write
+  and nothing on that path signs anything; see CLAUDE.md, "Drafting signs
+  nothing". Draft room state 6 is designed for a failure that cannot happen.
+- **Which hero animation** — **A**, decided 2026-08-21.
+- **Kickoff** — the **9th**, confirmed against the synced schedule and by the
+  owner. The designs still say the 10th.
+
+Still genuinely open: when a week label flips, and whether escrow release can
+move a player whose game is in progress.
 
 ### What drop 7 changed
 
@@ -197,8 +272,8 @@ one of them will drift from the code that owns it.
 
 ## Do not build drop 6's landing copy — two sentences are retired
 
-**This is the trap in this directory right now, and drop 7 did not fix it —
-checked on 2026-08-21.** `screens/Rostr Landing.dc.html` still contains the
+**This is the trap in this directory right now. Drop 7 did not fix it and drop 8
+did not touch the file — both checked on 2026-08-21.** `screens/Rostr Landing.dc.html` still contains the
 roster-as-NFT claim, in two places, and the app deliberately does not. Anyone implementing that hero from the design will paste a false
 sentence back onto the front page, which is precisely how it got there the first
 time.

--- a/docs/design/screens/Rostr Leagues.dc.html
+++ b/docs/design/screens/Rostr Leagues.dc.html
@@ -1,0 +1,615 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="_ds/nocturne-2cbfcdf4-7e1c-4bfa-8626-a61405078160/styles.css">
+<script src="_ds/nocturne-2cbfcdf4-7e1c-4bfa-8626-a61405078160/_ds_bundle.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap">
+<style>
+  html, body { margin: 0; padding: 0; background: var(--color-bg); }
+  body { font-family: var(--font-body); color: var(--color-text); -webkit-font-smoothing: antialiased; }
+  * { box-sizing: border-box; }
+  a { color: var(--color-accent); text-decoration: none; }
+  a:hover { color: var(--color-accent-400); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+</style>
+</helmet>
+
+<div style="background: var(--color-bg); min-width: 1280px;">
+
+  <div style="display: flex; align-items: baseline; gap: 14px; padding: 30px 28px 14px;">
+    <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">STATE 1</span>
+    <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 500; letter-spacing: -0.02em;">A returning manager</span>
+    <span style="font-size: 13px; color: var(--color-neutral-500);">Two leagues, one invitation, and a draft clock running</span>
+  </div>
+
+  <div data-screen-label="Leagues" style="background: var(--color-bg); min-height: 100vh; padding-bottom: 56px;">
+
+    <header style="border-bottom: 1px solid var(--color-neutral-900);">
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 24px; max-width: 1180px; margin: 0 auto; padding: 14px 40px;">
+        <a href="#" style="display: flex; align-items: baseline; gap: 10px; color: inherit;">
+          <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+          <span style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
+        </a>
+        <div style="display: flex; align-items: center; gap: 22px;">
+          <a href="#" style="font-size: 13.5px; color: var(--color-neutral-400);" style-hover="color: var(--color-text);">How scoring works</a>
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <a href="#" style="font-size: 13.5px; color: var(--color-text); box-shadow: inset 0 -1px 0 var(--color-accent); padding-bottom: 3px;">Leagues</a>
+            <a href="#" aria-label="1 invitation" title="1 league has invited you" style="display: inline-flex; align-items: center; justify-content: center; min-width: 20px; padding: 1px 6px; border-radius: 999px; background: var(--color-accent); color: var(--color-bg); font-size: 11px; font-weight: 600;">1</a>
+          </span>
+          <span style="display: flex; align-items: center; gap: 8px;">
+          <button type="button" aria-label="Notifications, 4 unread" style="position: relative; display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-400); cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+            <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M221.8 175.94c-5.55-9.56-13.8-36.61-13.8-71.94a80 80 0 1 0-160 0c0 35.34-8.26 62.38-13.81 71.94A16 16 0 0 0 48 200h40.81a40 40 0 0 0 78.38 0H208a16 16 0 0 0 13.8-24.06ZM128 216a24 24 0 0 1-22.62-16h45.24A24 24 0 0 1 128 216Z"></path></svg>
+            <span style="position: absolute; top: 4px; right: 3px; display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--color-accent); color: #14162a; font-family: ui-monospace, monospace; font-size: 10px; font-weight: 600;">4</span>
+          </button>
+          <button type="button" style="display: inline-flex; align-items: center; gap: 9px; padding: 6px 10px 6px 7px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-300); font-family: inherit; font-size: 13.5px; cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+            <span style="display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 10px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+            <span>route66</span>
+            <svg width="11" height="11" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="m213.66 101.66-80 80a8 8 0 0 1-11.32 0l-80-80A8 8 0 0 1 48 88h160a8 8 0 0 1 5.66 13.66Z"></path></svg>
+          </button>
+          </span>
+        </div>
+      </div>
+    </header>
+
+    <sc-if value="{{ urgent }}" hint-placeholder-val="{{ true }}">
+    <div style="background: color-mix(in srgb, var(--color-accent) 14%, transparent); border-bottom: 1px solid var(--color-accent-800);">
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; width: 100%; max-width: 1180px; margin: 0 auto; padding: 9px 40px;">
+      <div style="display: flex; align-items: center; gap: 12px; min-width: 0;">
+        <span style="display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; flex: 0 0 auto; color: var(--color-accent-300);">
+          <svg width="15" height="15" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M128 40a96 96 0 1 0 96 96 96.11 96.11 0 0 0-96-96Zm8 96a8 8 0 0 1-8 8H88a8 8 0 0 1 0-16h32V80a8 8 0 0 1 16 0Z"></path></svg>
+        </span>
+        <span style="font-size: 13.5px; color: var(--color-accent-100);">You are on the clock in <span style="font-weight: 500;">Sunday Scaries</span></span>
+        <span style="font-family: ui-monospace, monospace; font-size: 13.5px; color: var(--color-accent-200); font-variant-numeric: tabular-nums;">1:12</span>
+        <span style="font-size: 12.5px; color: var(--color-accent-300);">Pick 5.09 &middot; autopick takes T. Higgins if it expires</span>
+      </div>
+      <div style="display: flex; align-items: center; gap: 10px; flex: 0 0 auto;">
+        <a class="btn btn-primary" href="#" style="font-size: 13px; padding: 6px 14px; border-color: var(--color-accent-300); color: var(--color-accent-100);">Go to the draft</a>
+      </div>
+      </div>
+    </div>
+    </sc-if>
+
+    <div style="width: 100%; max-width: 1180px; margin: 0 auto; padding: 48px 40px 0;">
+
+      <div style="display: grid; grid-template-columns: minmax(0, 1fr) 380px; gap: 40px; align-items: start;">
+        <div style="min-width: 0;">
+          <h1 style="font-family: var(--font-heading); font-size: 30px; font-weight: 500; letter-spacing: -0.026em; margin: 0;">Leagues</h1>
+          <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 11px 0 0; max-width: 620px; text-wrap: pretty;">Your leagues, anything waiting on you, and every public league still taking managers. Each one shows its whole rule set before you agree to anything, and those rules are frozen and hashed at creation, so what you read is what the season runs on.</p>
+        </div>
+        <div class="card" style="padding: 20px 22px; background: var(--color-surface);">
+          <h2 style="font-family: var(--font-heading); font-size: 18px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Start your own</h2>
+          <p style="font-size: 13.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 9px 0 0;">Set the name, the draft time and the pace. Everything else is fixed, and you will see all of it before it freezes.</p>
+          <a class="btn btn-primary btn-block" href="#" style="margin-top: 16px; font-size: 14px; min-height: 42px;">Create a league</a>
+          <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 11px 0 0;">Free. Two humans is enough to start &mdash; one bot squares an odd field.</p>
+        </div>
+      </div>
+
+      <section style="margin-top: 44px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 20px; margin-bottom: 16px;">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Your leagues</h2>
+          <span style="font-size: 12.5px; color: var(--color-neutral-500);">2 active</span>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px;">
+
+          <a href="#" class="card" style="display: block; padding: 0; overflow: hidden; background: var(--color-surface); border-left: 2px solid var(--color-accent); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding: 15px 18px 0;">
+              <span style="font-family: var(--font-heading); font-size: 16.5px; font-weight: 500; letter-spacing: -0.018em;">Sunday Scaries</span>
+              <span class="tag tag-accent" style="font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;">Drafting</span>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 16px; padding: 9px 18px 0; font-size: 12.5px; color: var(--color-neutral-500);">
+              <span>12 teams</span>
+              <span>Round 5 of 16</span>
+              <span>Fast &middot; 90s</span>
+            </div>
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 14px; margin: 14px 18px 16px; padding: 10px 13px; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--color-accent) 14%, transparent);">
+              <span style="font-size: 13px; color: var(--color-accent-100);">You are on the clock</span>
+              <span style="font-family: ui-monospace, monospace; font-size: 13px; color: var(--color-accent-200); font-variant-numeric: tabular-nums;">1:12</span>
+            </div>
+          </a>
+
+          <a href="#" class="card" style="display: block; padding: 0; overflow: hidden; background: var(--color-surface); border-left: 2px solid var(--color-neutral-800); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding: 15px 18px 0;">
+              <span style="font-family: var(--font-heading); font-size: 16.5px; font-weight: 500; letter-spacing: -0.018em;">Dynasty of Dropped Passes</span>
+              <span class="tag tag-neutral" style="font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;">Week 3</span>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 16px; padding: 9px 18px 0; font-size: 12.5px; color: var(--color-neutral-500);">
+              <span>12 teams</span>
+              <span style="color: var(--color-neutral-400);">2&ndash;0</span>
+              <span>4th of 12</span>
+            </div>
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 14px; margin: 14px 18px 16px; padding: 10px 13px; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--color-surface) 55%, transparent);">
+              <span style="font-size: 13px; color: var(--color-neutral-300);">Lineup not set &middot; 1 slot empty</span>
+              <span style="font-size: 12.5px; color: var(--color-neutral-500);">Locks Sun 1:00 PM</span>
+            </div>
+          </a>
+
+        </div>
+      </section>
+
+      <section style="margin-top: 40px;">
+        <div style="display: flex; align-items: baseline; gap: 12px; margin-bottom: 16px;">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Invitations</h2>
+          <span class="tag tag-accent" style="font-size: 10px;">1</span>
+        </div>
+        <div class="card" style="display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 24px; align-items: center; padding: 18px 20px; background: var(--color-surface); border-color: var(--color-accent-800);">
+          <div style="min-width: 0;">
+            <div style="display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;">
+              <span style="font-family: var(--font-heading); font-size: 16.5px; font-weight: 500; letter-spacing: -0.018em;">Bye Week Blues</span>
+              <span style="font-size: 12.5px; color: var(--color-neutral-500);">Private &middot; addressed to <span style="color: var(--color-neutral-400);">your username</span></span>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 18px; margin-top: 8px; font-size: 12.5px; color: var(--color-neutral-500);">
+              <span>9 of 12 seats</span>
+              <span>Drafts Sat 23 Aug, 8:00 PM</span>
+              <span>Fast &middot; 90s</span>
+              <span>Free</span>
+            </div>
+            <p style="font-size: 12.5px; line-height: 1.55; color: var(--color-neutral-500); margin: 9px 0 0;">Nothing is signed until you have read the rule set in full.</p>
+          </div>
+          <div style="display: flex; align-items: center; gap: 10px; flex: 0 0 auto;">
+            <button type="button" class="btn btn-ghost" style="font-size: 13.5px; padding: 9px 14px; min-height: 40px; color: var(--color-neutral-400); font-family: inherit; cursor: pointer;">Decline</button>
+            <a class="btn btn-primary" href="#" style="font-size: 13.5px; padding: 9px 16px; min-height: 40px;">Read the rules</a>
+          </div>
+        </div>
+      </section>
+
+      <section style="margin-top: 40px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 20px;">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Public leagues</h2>
+          <span style="font-size: 12.5px; color: var(--color-neutral-500);">6 open &middot; still forming</span>
+        </div>
+
+        <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 14px; padding-bottom: 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-accent); border-radius: 999px; background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent-200); font-family: inherit; font-size: 12.5px; cursor: pointer;">Drafting soonest</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Almost full</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Free only</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Newest</button>
+          </div>
+          <div class="field" style="margin: 0;">
+            <input class="input" id="league-search" placeholder="Search by name" style="width: 240px; font-size: 13px;">
+          </div>
+        </div>
+
+        <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin-top: 18px;">
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Open Field 12</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span style="color: var(--color-accent-300);">11 of 12 &middot; nearly full</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Fri 22 Aug, 19:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Fast &middot; 90s</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Zero RB Society</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>7 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Sat 23 Aug, 14:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Slow &middot; 8h</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Chalk Eaters</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>4 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Sat 23 Aug, 20:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Fast &middot; 120s</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">First Down Club</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>10 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Sun 24 Aug, 18:30</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Fast &middot; 90s</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">The Waiver Wire</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>3 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Mon 25 Aug, 20:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Slow &middot; 24h</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Autodraft Anonymous</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>2 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Tue 26 Aug, 19:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Slow &middot; 24h</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+
+        </div>
+
+        <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-500); margin: 18px 0 0; max-width: 760px; text-wrap: pretty;">Every league here is free. The escrow program is unwritten, so no league can take a deposit yet &mdash; the buy-in filter is here for when they can. Private leagues never appear in this list; they arrive as an invitation or a link.</p>
+      </section>
+    </div>
+    <footer style="max-width: 1180px; margin: 0 auto; padding: 32px 40px; font-size: 12.5px; color: var(--color-neutral-600);">Pre-alpha. Not audited. Do not use with funds you cannot lose.</footer>
+  </div>
+
+  <div style="height: 1px; margin: 46px 28px 0; background: linear-gradient(90deg, transparent, var(--color-neutral-800) 12%, var(--color-neutral-800) 88%, transparent);"></div>
+
+  <div style="display: flex; align-items: baseline; gap: 14px; padding: 30px 28px 14px;">
+    <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">STATE 2</span>
+    <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 500; letter-spacing: -0.02em;">Notifications open</span>
+    <span style="font-size: 13px; color: var(--color-neutral-500);">The bell holds everything; the strip holds only what is on a clock</span>
+  </div>
+
+  <div data-screen-label="Notifications" style="position: relative; display: flex; flex-direction: column; background: var(--color-bg); min-height: 840px; padding-bottom: 56px;">
+
+    <header style="border-bottom: 1px solid var(--color-neutral-900);">
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 24px; max-width: 1180px; margin: 0 auto; padding: 14px 40px;">
+        <a href="#" style="display: flex; align-items: baseline; gap: 10px; color: inherit;">
+          <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+          <span style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
+        </a>
+        <div style="display: flex; align-items: center; gap: 22px;">
+          <a href="#" style="font-size: 13.5px; color: var(--color-neutral-400);" style-hover="color: var(--color-text);">How scoring works</a>
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <a href="#" style="font-size: 13.5px; color: var(--color-text); box-shadow: inset 0 -1px 0 var(--color-accent); padding-bottom: 3px;">Leagues</a>
+            <a href="#" aria-label="1 invitation" title="1 league has invited you" style="display: inline-flex; align-items: center; justify-content: center; min-width: 20px; padding: 1px 6px; border-radius: 999px; background: var(--color-accent); color: var(--color-bg); font-size: 11px; font-weight: 600;">1</a>
+          </span>
+          <span style="display: flex; align-items: center; gap: 8px;">
+          <button type="button" aria-label="Notifications, 4 unread" aria-expanded="true" style="position: relative; display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: 0; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent-200); cursor: pointer;">
+            <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M221.8 175.94c-5.55-9.56-13.8-36.61-13.8-71.94a80 80 0 1 0-160 0c0 35.34-8.26 62.38-13.81 71.94A16 16 0 0 0 48 200h40.81a40 40 0 0 0 78.38 0H208a16 16 0 0 0 13.8-24.06ZM128 216a24 24 0 0 1-22.62-16h45.24A24 24 0 0 1 128 216Z"></path></svg>
+            <span style="position: absolute; top: 4px; right: 3px; display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--color-accent); color: #14162a; font-family: ui-monospace, monospace; font-size: 10px; font-weight: 600;">4</span>
+          </button>
+          <button type="button" style="display: inline-flex; align-items: center; gap: 9px; padding: 6px 10px 6px 7px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-300); font-family: inherit; font-size: 13.5px; cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+            <span style="display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 10px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+            <span>route66</span>
+            <svg width="11" height="11" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="m213.66 101.66-80 80a8 8 0 0 1-11.32 0l-80-80A8 8 0 0 1 48 88h160a8 8 0 0 1 5.66 13.66Z"></path></svg>
+          </button>
+          </span>
+        </div>
+      </div>
+    </header>
+
+    <div style="position: absolute; right: 90px; top: 64px; z-index: 20; width: 392px;">
+      <div class="card elev-lg" style="padding: 0; overflow: hidden; background: var(--color-surface);">
+
+        <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="font-family: var(--font-heading); font-size: 14.5px; font-weight: 500;">Notifications</span>
+          <button type="button" style="border: 0; background: transparent; color: var(--color-neutral-500); font-family: inherit; font-size: 12px; cursor: pointer; padding: 4px 2px;" style-hover="color: var(--color-accent-300);">Mark all read</button>
+        </div>
+
+        <div style="padding: 10px 16px 6px; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-400);">Needs you</div>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 9%, transparent); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 15%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-accent-300); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M216 64H56a8 8 0 0 1 0-16h136a8 8 0 0 0 0-16H56a24 24 0 0 0-24 24v128a24 24 0 0 0 24 24h160a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16Zm-36 84a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px; color: var(--color-accent-100);">You are on the clock &middot; pick 5.09</span>
+            <span style="font-size: 12px; color: var(--color-neutral-400);">Sunday Scaries &middot; autopick takes T. Higgins in 72 seconds</span>
+          </span>
+        </a>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 9%, transparent); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 15%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-accent-300); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M216 64H56a8 8 0 0 1 0-16h136a8 8 0 0 0 0-16H56a24 24 0 0 0-24 24v128a24 24 0 0 0 24 24h160a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16Zm-36 84a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px; color: var(--color-accent-100);">A trade is in its veto window</span>
+            <span style="font-size: 12px; color: var(--color-neutral-400);">Dynasty of Dropped Passes &middot; closes Thu 19 Nov, 8:16 PM &middot; not voting allows it</span>
+          </span>
+        </a>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-neutral-500); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M232 128a104 104 0 1 1-104-104 104.11 104.11 0 0 1 104 104Zm-40-8h-56V64a8 8 0 0 0-16 0v64a8 8 0 0 0 8 8h64a8 8 0 0 0 0-16Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px;">Lineup not set for Week 3</span>
+            <span style="font-size: 12px; color: var(--color-neutral-400);">One slot empty &middot; autofill starts T. Kraft at 1:00 PM Sunday</span>
+          </span>
+        </a>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-neutral-500); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M224 48H32a8 8 0 0 0-8 8v136a16 16 0 0 0 16 16h176a16 16 0 0 0 16-16V56a8 8 0 0 0-8-8Zm-96 85.15L52.57 64h150.86Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px;">Bye Week Blues invited you</span>
+            <span style="font-size: 12px; color: var(--color-neutral-400);">Private league &middot; drafts Sat 23 Aug, 8:00 PM</span>
+          </span>
+        </a>
+
+        <div style="padding: 12px 16px 6px; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Earlier</div>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-neutral-600); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M229.66 77.66l-128 128a8 8 0 0 1-11.32 0l-56-56a8 8 0 0 1 11.32-11.32L96 188.69 218.34 66.34a8 8 0 0 1 11.32 11.32Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px; color: var(--color-neutral-300);">Waivers ran &middot; you won D. Achane</span>
+            <span style="font-size: 12px; color: var(--color-neutral-500);">Dynasty of Dropped Passes &middot; priority moved to 12 of 12</span>
+          </span>
+        </a>
+
+        <a href="#" style="display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 11px; padding: 11px 16px; color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-neutral-600); padding-top: 1px;">
+            <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M229.66 77.66l-128 128a8 8 0 0 1-11.32 0l-56-56a8 8 0 0 1 11.32-11.32L96 188.69 218.34 66.34a8 8 0 0 1 11.32 11.32Z"></path></svg>
+          </span>
+          <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+            <span style="font-size: 13.5px; color: var(--color-neutral-300);">Week 2 finalised &middot; you won 86.2 to 71.9</span>
+            <span style="font-size: 12px; color: var(--color-neutral-500);">Dynasty of Dropped Passes &middot; 2&ndash;0, fourth of twelve</span>
+          </span>
+        </a>
+
+        <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 16px; border-top: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-surface) 50%, transparent);">
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);">A wallet mark means it needs a signature.</span>
+          <a href="#" style="font-size: 12px;">All invitations</a>
+        </div>
+      </div>
+    </div>
+
+    <div style="width: 100%; max-width: 1180px; margin: 0 auto; padding: 48px 40px 0; opacity: 0.5;">
+      <h1 style="font-family: var(--font-heading); font-size: 30px; font-weight: 500; letter-spacing: -0.026em; margin: 0;">Leagues</h1>
+      <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 11px 0 0; max-width: 620px;">The page behind the panel, dimmed here only so the panel reads. Nothing about it changes when notifications open.</p>
+    </div>
+    <footer style="width: 100%; max-width: 1180px; margin: auto auto 0; padding: 32px 40px; font-size: 12.5px; color: var(--color-neutral-600);">Pre-alpha. Not audited. Do not use with funds you cannot lose.</footer>
+  </div>
+
+  <div style="height: 1px; margin: 46px 28px 0; background: linear-gradient(90deg, transparent, var(--color-neutral-800) 12%, var(--color-neutral-800) 88%, transparent);"></div>
+
+  <div style="display: flex; align-items: baseline; gap: 14px; padding: 30px 28px 14px;">
+    <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">STATE 3</span>
+    <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 500; letter-spacing: -0.02em;">A brand-new account</span>
+    <span style="font-size: 13px; color: var(--color-neutral-500);">No leagues, no invitations, no strip &mdash; the two ways in carry the page</span>
+  </div>
+
+  <div data-screen-label="Leagues empty" style="background: var(--color-bg); min-height: 100vh; padding-bottom: 56px;">
+
+    <header style="border-bottom: 1px solid var(--color-neutral-900);">
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 24px; max-width: 1180px; margin: 0 auto; padding: 14px 40px;">
+        <a href="#" style="display: flex; align-items: baseline; gap: 10px; color: inherit;">
+          <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+          <span style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
+        </a>
+        <div style="display: flex; align-items: center; gap: 22px;">
+          <a href="#" style="font-size: 13.5px; color: var(--color-neutral-400);" style-hover="color: var(--color-text);">How scoring works</a>
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <a href="#" style="font-size: 13.5px; color: var(--color-text); box-shadow: inset 0 -1px 0 var(--color-accent); padding-bottom: 3px;">Leagues</a>
+          </span>
+          <span style="display: flex; align-items: center; gap: 8px;">
+          <button type="button" aria-label="Notifications, none unread" style="display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-500); cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+            <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M221.8 175.94c-5.55-9.56-13.8-36.61-13.8-71.94a80 80 0 1 0-160 0c0 35.34-8.26 62.38-13.81 71.94A16 16 0 0 0 48 200h40.81a40 40 0 0 0 78.38 0H208a16 16 0 0 0 13.8-24.06ZM128 216a24 24 0 0 1-22.62-16h45.24A24 24 0 0 1 128 216Z"></path></svg>
+          </button>
+          <button type="button" style="display: inline-flex; align-items: center; gap: 9px; padding: 6px 10px 6px 7px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-300); font-family: inherit; font-size: 13.5px; cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+            <span style="display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; background: color-mix(in srgb, var(--color-neutral-700) 60%, transparent); box-shadow: inset 0 0 0 1px var(--color-neutral-800); font-size: 10px; font-weight: 600; color: var(--color-neutral-300);">DK</span>
+            <span>dkerrigan</span>
+            <svg width="11" height="11" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="m213.66 101.66-80 80a8 8 0 0 1-11.32 0l-80-80A8 8 0 0 1 48 88h160a8 8 0 0 1 5.66 13.66Z"></path></svg>
+          </button>
+          </span>
+        </div>
+      </div>
+    </header>
+
+    <div style="width: 100%; max-width: 1180px; margin: 0 auto; padding: 48px 40px 0;">
+      <h1 style="font-family: var(--font-heading); font-size: 30px; font-weight: 500; letter-spacing: -0.026em; margin: 0;">Leagues</h1>
+      <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 11px 0 0; max-width: 640px; text-wrap: pretty;">You are not in a league yet. Start one and invite people, or join one of the public leagues below &mdash; each shows its whole rule set before you agree to anything.</p>
+
+      <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; margin-top: 26px;">
+        <div class="card" style="padding: 22px 24px; background: var(--color-surface); border-color: var(--color-accent-800);">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Create a league</h2>
+          <p style="font-size: 13.5px; line-height: 1.62; color: var(--color-neutral-400); margin: 10px 0 0;">You set the name, the draft time and the pace. Scoring, roster and payout are fixed, so there is no negotiating them mid-season &mdash; and you see all of it before it freezes.</p>
+          <a class="btn btn-primary" href="#" style="display: inline-flex; margin-top: 18px; font-size: 14px; padding: 11px 20px;">Create a league</a>
+          <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0;">Free. Two humans is enough to start.</p>
+        </div>
+        <div class="card" style="padding: 22px 24px; background: var(--color-surface);">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Been invited to one?</h2>
+          <p style="font-size: 13.5px; line-height: 1.62; color: var(--color-neutral-400); margin: 10px 0 0;">Most leagues are private, so most are joined by invitation. Anything addressed to your username or your wallet appears here automatically &mdash; private leagues never show up in the public list.</p>
+          <p style="font-size: 13px; line-height: 1.6; color: var(--color-neutral-500); margin: 14px 0 0;">Nothing is waiting for you right now. If somebody sent you a link, opening it works too.</p>
+        </div>
+      </div>
+
+      <section style="margin-top: 44px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 20px;">
+          <h2 style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.018em; margin: 0;">Public leagues</h2>
+          <span style="font-size: 12.5px; color: var(--color-neutral-500);">6 open &middot; still forming</span>
+        </div>
+
+        <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 14px; padding-bottom: 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-accent); border-radius: 999px; background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent-200); font-family: inherit; font-size: 12.5px; cursor: pointer;">Drafting soonest</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Almost full</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Free only</button>
+            <button type="button" style="padding: 7px 13px; border: 1px solid var(--color-neutral-800); border-radius: 999px; background: transparent; color: var(--color-neutral-400); font-family: inherit; font-size: 12.5px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Newest</button>
+          </div>
+          <div class="field" style="margin: 0;">
+            <input class="input" id="league-search-empty" placeholder="Search by name" style="width: 240px; font-size: 13px;">
+          </div>
+        </div>
+
+        <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin-top: 18px;">
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Open Field 12</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span style="color: var(--color-accent-300);">11 of 12 &middot; nearly full</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Fri 22 Aug, 19:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Fast &middot; 90s</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Zero RB Society</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>7 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Sat 23 Aug, 14:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Slow &middot; 8h</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+          <a href="#" class="card" style="display: flex; flex-direction: column; gap: 14px; padding: 18px; background: var(--color-surface); color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 7%, var(--color-surface));">
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-family: var(--font-heading); font-size: 16px; font-weight: 500; letter-spacing: -0.018em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Chalk Eaters</span>
+              <span style="font-size: 12px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; font-size: 12.5px;">
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Seats</span><span>4 of 12</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Draft</span><span>Sat 23 Aug, 20:00</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Pace</span><span>Fast &middot; 120s</span></span>
+              <span style="display: flex; flex-direction: column; gap: 3px;"><span style="color: var(--color-neutral-500);">Scoring</span><span>Full PPR</span></span>
+            </div>
+            <span style="font-size: 12.5px; color: var(--color-accent-400);">Read the rules and join &rarr;</span>
+          </a>
+        </div>
+
+        <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-500); margin: 18px 0 0; max-width: 760px; text-wrap: pretty;">Signing in is not required to look. The join control on a league page is where an account becomes necessary, and it says so there.</p>
+      </section>
+    </div>
+    <footer style="max-width: 1180px; margin: 0 auto; padding: 32px 40px; font-size: 12.5px; color: var(--color-neutral-600);">Pre-alpha. Not audited. Do not use with funds you cannot lose.</footer>
+  </div>
+
+</div>
+
+<div style="background: var(--color-bg); min-width: 1280px;">
+  <div style="height: 1px; margin: 46px 28px 0; background: linear-gradient(90deg, transparent, var(--color-neutral-800) 12%, var(--color-neutral-800) 88%, transparent);"></div>
+
+  <div style="display: flex; align-items: baseline; gap: 14px; padding: 30px 28px 14px;">
+    <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">STATE 4</span>
+    <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 500; letter-spacing: -0.02em;">The account menu</span>
+    <span style="font-size: 13px; color: var(--color-neutral-500);">Where <span style="font-family: ui-monospace, monospace; font-size: 12px;">SessionBar</span>&rsquo;s sign-out and unclaimed-username branch go</span>
+  </div>
+
+  <div data-screen-label="Account menu" style="position: relative; display: flex; flex-direction: column; background: var(--color-bg); min-height: 760px; padding-bottom: 56px;">
+    <header style="border-bottom: 1px solid var(--color-neutral-900);">
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 24px; max-width: 1180px; margin: 0 auto; padding: 14px 40px;">
+        <a href="#" style="display: flex; align-items: baseline; gap: 10px; color: inherit;">
+          <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+          <span style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
+        </a>
+        <div style="display: flex; align-items: center; gap: 22px;">
+          <a href="#" style="font-size: 13.5px; color: var(--color-neutral-400);" style-hover="color: var(--color-text);">How scoring works</a>
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <a href="#" style="font-size: 13.5px; color: var(--color-text); box-shadow: inset 0 -1px 0 var(--color-accent); padding-bottom: 3px;">Leagues</a>
+            <a href="#" aria-label="1 invitation" title="1 league has invited you" style="display: inline-flex; align-items: center; justify-content: center; min-width: 20px; padding: 1px 6px; border-radius: 999px; background: var(--color-accent); color: var(--color-bg); font-size: 11px; font-weight: 600;">1</a>
+          </span>
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <button type="button" aria-label="Notifications, 4 unread" style="position: relative; display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--color-neutral-400); cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">
+              <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M221.8 175.94c-5.55-9.56-13.8-36.61-13.8-71.94a80 80 0 1 0-160 0c0 35.34-8.26 62.38-13.81 71.94A16 16 0 0 0 48 200h40.81a40 40 0 0 0 78.38 0H208a16 16 0 0 0 13.8-24.06ZM128 216a24 24 0 0 1-22.62-16h45.24A24 24 0 0 1 128 216Z"></path></svg>
+              <span style="position: absolute; top: 4px; right: 3px; display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--color-accent); color: #14162a; font-family: ui-monospace, monospace; font-size: 10px; font-weight: 600;">4</span>
+            </button>
+            <button type="button" aria-expanded="true" style="display: inline-flex; align-items: center; gap: 9px; padding: 6px 10px 6px 7px; border: 0; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-text); font-family: inherit; font-size: 13.5px; cursor: pointer;">
+              <span style="display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 10px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+              <span>route66</span>
+              <svg width="11" height="11" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="m213.66 101.66-80 80a8 8 0 0 1-11.32 0l-80-80A8 8 0 0 1 48 88h160a8 8 0 0 1 5.66 13.66Z"></path></svg>
+            </button>
+          </span>
+        </div>
+      </div>
+    </header>
+
+    <div style="position: absolute; right: 90px; top: 64px; z-index: 20; width: 268px;">
+      <div class="card elev-lg" style="padding: 0; overflow: hidden; background: var(--color-surface);">
+        <div style="display: flex; flex-direction: column; gap: 3px; padding: 13px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="font-size: 13.5px;">route66</span>
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);">dana@example.com</span>
+        </div>
+        <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="display: flex; align-items: center; gap: 9px; min-width: 0;">
+            <span style="display: inline-flex; align-items: center; justify-content: center; color: var(--color-accent-400); flex: 0 0 auto;">
+              <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M216 64H56a8 8 0 0 1 0-16h136a8 8 0 0 0 0-16H56a24 24 0 0 0-24 24v128a24 24 0 0 0 24 24h160a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16Zm-36 84a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"></path></svg>
+            </span>
+            <span style="font-family: ui-monospace, monospace; font-size: 12px; color: var(--color-neutral-300);">7xKq&hellip;4vNb</span>
+          </span>
+          <span style="font-size: 11px; color: var(--color-neutral-500);">Linked</span>
+        </div>
+        <a href="#" style="display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding: 10px 16px; color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="font-size: 13.5px;">Invitations</span>
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);">1 waiting</span>
+        </a>
+        <a href="#" style="display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding: 10px 16px; color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="font-size: 13.5px;">Your teams</span>
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);">2 leagues</span>
+        </a>
+        <a href="#" style="display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding: 10px 16px; color: inherit;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+          <span style="font-size: 13.5px;">Settings</span>
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);"></span>
+        </a>
+        <div style="border-top: 1px solid var(--color-neutral-900);">
+          <button type="button" style="display: block; width: 100%; text-align: left; padding: 11px 16px; border: 0; background: transparent; color: var(--color-neutral-300); font-family: inherit; font-size: 13.5px; cursor: pointer;" style-hover="background: color-mix(in srgb, var(--color-accent) 10%, transparent); color: var(--color-text);">Sign out</button>
+        </div>
+      </div>
+
+      <div class="card" style="margin-top: 18px; padding: 0; overflow: hidden; background: var(--color-surface); border-color: var(--color-accent-800);">
+        <div style="padding: 10px 16px; border-bottom: 1px solid var(--color-neutral-900); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-400);">Variant &middot; no username yet</div>
+        <div style="display: flex; flex-direction: column; gap: 3px; padding: 13px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+          <a href="#" style="font-size: 13.5px; color: var(--color-accent-300);">Finish setting up</a>
+          <span style="font-size: 11.5px; color: var(--color-neutral-500);">dana@example.com</span>
+        </div>
+        <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-400); margin: 0; padding: 12px 16px;">An account with no username cannot be invited to anything, so the menu leads with the fix rather than quietly showing an email.</p>
+      </div>
+    </div>
+
+    <div style="width: 100%; max-width: 1180px; margin: 0 auto; padding: 48px 40px 0;">
+      <h1 style="font-family: var(--font-heading); font-size: 30px; font-weight: 500; letter-spacing: -0.026em; margin: 0; opacity: 0.5;">Leagues</h1>
+      <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 11px 0 0; max-width: 500px; text-wrap: pretty;">The menu absorbs what the shipped header showed inline &mdash; the username link and a bare Sign out button &mdash; and gives the linked wallet somewhere to live.</p>
+    </div>
+
+    <footer style="width: 100%; max-width: 1180px; margin: auto auto 0; padding: 32px 40px; font-size: 12.5px; color: var(--color-neutral-600);">Pre-alpha. Not audited. Do not use with funds you cannot lose.</footer>
+  </div>
+</div></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;urgentStrip&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Header&quot;}}">
+class Component extends DCLogic {
+  renderVals() {
+    return { urgent: this.props.urgentStrip !== false };
+  }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
One new file, `screens/Rostr Leagues.dc.html`. Every other screen and the whole brand kit are byte-identical to drop 7.

## What it proposes

Replacing **three shipped surfaces with one.** Today the shell carries "Join a league", a "Create a league" button and `InvitationBadge` side by side; `/leagues` browses public leagues with `InvitationsCorner` beside it; `/invitations` is a third page. The design is a single `Leagues` nav item ordered **your leagues → invitations → public leagues**.

**The gap it names is real and ours:** nothing on `/leagues` lists the leagues you're already in — the first thing a returning manager wants. This repo has known it since the commissioner's checklist landed.

## Grounded vs proposed

The designer read the shipped code and marks those parts **grounded — recreate from source, not from the pixels**: `InvitationBadge`, `INVITATIONS_KEY`, the deduplicated count that renders nothing at zero, `LeagueBrowser`'s PUBLIC-and-FORMING filter, seats against `maxTeams`, the buy-in by string surgery.

**Proposals with no backing route:** the urgent strip, the bell, the account menu, `Your leagues`. Only the invitation count has a real source today — so don't read the screen as a description of what exists.

## State 4 is a regression guard, and it's right

Collapsing `SessionBar` into an avatar would silently delete two shipped affordances: **Sign out**, and the `username === null` branch rendering **Finish setting up**. The second matters more than it looks — an account without a username can't be invited to anything and, as of yesterday, can't create or join either.

## Checked on install

No roster-as-NFT claim, no "held in your wallet", no join control in a list. The landing file is untouched, so that divergence still stands and `STATUS.md` says so.

Two CSS traps recorded, one of which applies to any Tailwind rebuild: `mx-auto` on a flex child needs `w-full` beside it, or auto side margins suppress `align-self: stretch` and collapse the column.

## Three "still open" questions are already answered

The repeat means our answers haven't reached the designer: **drafting signs nothing** (so draft room state 6 is designed for a failure that cannot happen), **hero animation A**, **kickoff is the 9th**. Worth sending back before the next drop.

Reference only — nothing is wired into `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)