### PR TITLE
The Leagues hub

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -48,32 +48,27 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               How scoring works
             </Link>
             {/*
-              Joining and creating sit side by side, and joining is first.
-              Creating a league has had a front door since A10; joining one has
-              never had anywhere to start, so a league was reachable only by
-              holding its URL. Most people arrive wanting to be in a league
-              rather than to run one.
+              One `Leagues` item, not three — drop 8.
+
+              The shell carried "Join a league", a "Create a league" button and
+              the invitation badge side by side, and none of them led to the
+              leagues you are already in. `/leagues` is now the hub — your
+              leagues, your invitations, the public list — and create is a card
+              in its head with equal weight rather than a button competing with
+              the nav.
+
+              The badge stays beside the link. It renders nothing at zero, so
+              this is a bare word until something is actually waiting.
             */}
             <span className="flex items-center gap-2">
               <Link
                 href="/leagues"
                 className="text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
               >
-                Join a league
+                Leagues
               </Link>
-              {/*
-                Rendered only when something is waiting, and only for a signed-in
-                visitor — the route answers an empty list to anyone else, so a
-                logged-out header makes one cheap request and draws nothing.
-              */}
               {user && <InvitationBadge />}
             </span>
-            <Link
-              href="/leagues/new"
-              className="rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
-            >
-              Create a league
-            </Link>
             <SessionBar email={user?.email ?? null} username={user?.username ?? null} />
           </div>
         </nav>

--- a/apps/web/src/app/(app)/leagues/page.tsx
+++ b/apps/web/src/app/(app)/leagues/page.tsx
@@ -1,63 +1,111 @@
 import { InvitationsCorner } from "@/components/InvitationsCorner";
 import { LeagueBrowser } from "@/components/LeagueBrowser";
+import { YourLeagues } from "@/components/YourLeagues";
 import { currentUser } from "@/lib/session";
 
 /**
- * Join a league.
+ * The Leagues hub — drop 8.
  *
- * The other half of the front door — creating one has had a page since A10 and
- * joining one has never had anywhere to start. Until now a league was reachable
- * only by holding its URL, which is fine for the private leagues invitations
- * exist for and leaves a public league findable by nobody.
+ * One page ordered **your leagues → invitations → public leagues**, which is the
+ * order a returning manager needs them in: the thing they came back for, the
+ * thing waiting on them, then what to do if neither applies.
  *
- * Signing in is **not** required to look. `RULES.md` requires the full rule set
- * to be readable before anyone joins, and that argument does not begin at the
- * league page — somebody deciding whether this product is for them should be
- * able to see what is on offer first. The join control on the league page is
- * where an account becomes necessary, and it says so there.
+ * It replaces a browse-only page that listed *public* leagues — by definition
+ * the ones you are not in — so somebody with two leagues and an invitation had
+ * no route to any of the three except browser history.
+ *
+ * ## Built to the design, minus what has no source
+ *
+ * Drop 8 marks its own parts as grounded or proposed and that line is honoured
+ * here. The invitation count and the browse cards are grounded, and are the
+ * shipped `InvitationsCorner` and `LeagueBrowser` rather than rebuilt.
+ *
+ * **The urgent strip, the notification bell and the account menu are proposals
+ * with no backing route**, so they are not drawn. The one urgent fact that does
+ * have a source — being on the clock — rides on the league's own card in
+ * `YourLeagues`, which links straight into the draft. A 90-second clock cannot
+ * live behind a click, which is the design's own argument for the strip; this
+ * satisfies it without inventing the other five things the strip would carry.
+ *
+ * **No join control anywhere on this page.** Both card types lead to the
+ * league, where the whole rule set renders above the join button. `RULES.md`
+ * requires the full document before anyone joins, and a join button in a
+ * directory is a way to agree to a rule set nobody read.
+ *
+ * Signing in is not required to look: the browse list is public, and the two
+ * signed-in sections render nothing for a visitor.
  */
 export default async function LeaguesPage() {
   const user = await currentUser().catch(() => null);
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Join a league</h1>
-        <p className="max-w-2xl text-sm text-nocturne-neutral-400">
-          Public leagues still taking managers. Every one shows you its whole rule set — the
-          scoring, the roster, the draft, the payout — before you agree to anything, and those
-          rules are frozen and hashed at creation, so what you read is what the season runs on.
-        </p>
+    <div className="space-y-10">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Leagues</h1>
+          <p className="max-w-2xl text-sm text-nocturne-neutral-400">
+            Your leagues, anything waiting on you, and every public league still taking
+            managers. Each one shows its whole rule set before you agree to anything, and those
+            rules are frozen and hashed at creation — so what you read is what the season runs
+            on.
+          </p>
+        </div>
+
+        {/*
+          Create is a card with equal weight rather than a button in the nav.
+          Drop 8's change, and it is right: starting a league and joining one are
+          the same size of decision, and the nav made one of them an afterthought.
+        */}
+        <aside className="space-y-3 rounded-lg border border-nocturne-neutral-900 p-5">
+          <h2 className="text-base font-medium">Start your own</h2>
+          <p className="text-xs leading-[1.55] text-nocturne-neutral-500">
+            Set the name, the draft time and the pace. Everything else is fixed, and you will
+            see all of it before it freezes.
+          </p>
+          <a
+            href="/leagues/new"
+            className="inline-block rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
+          >
+            Create a league
+          </a>
+          <p className="text-[11px] text-nocturne-neutral-600">
+            Free. Two humans is enough to start — one bot squares an odd field.
+          </p>
+        </aside>
       </div>
+
+      <YourLeagues />
 
       {/*
-        The browse list, and anything waiting for you beside it.
-
-        Two columns rather than a banner above the list, because they answer
-        different questions — "what is on offer" and "who asked for me" — and a
-        private league can only ever arrive through the second. The corner
-        renders nothing when there is nothing waiting, so the ordinary visit is
-        a single column.
+        Invitations sit between what you have and what is open, because that is
+        where they belong in the decision: somebody asked for you specifically,
+        which outranks a directory and does not outrank a draft already running.
       */}
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <LeagueBrowser />
-        <InvitationsCorner />
-      </div>
+      <InvitationsCorner />
 
-      <section className="space-y-2 border-t border-nocturne-neutral-900 pt-6">
-        <h2 className="text-sm font-medium text-nocturne-neutral-400">Been invited to one?</h2>
-        <p className="text-sm text-nocturne-neutral-600">
-          {user
-            ? "Invitations to private leagues appear under Invitations, addressed to your username or your wallet."
-            : "Sign in and any invitations waiting for you appear under Invitations — private leagues never show up in this list."}
-        </p>
-        <a
-          href={user ? "/invitations" : "/signin?next=%2Finvitations"}
-          className="inline-block text-sm text-nocturne-accent-300 hover:underline"
-        >
-          {user ? "See your invitations" : "Sign in"}
-        </a>
+      <section className="space-y-3">
+        <header className="flex items-baseline justify-between gap-3">
+          <h2 className="text-sm font-medium tracking-wide text-nocturne-neutral-500 uppercase">
+            Public leagues
+          </h2>
+          <span className="text-xs text-nocturne-neutral-600">still forming</span>
+        </header>
+
+        <LeagueBrowser />
       </section>
+
+      {!user && (
+        <p className="border-t border-nocturne-neutral-900 pt-6 text-sm text-nocturne-neutral-600">
+          Private leagues never appear here — they arrive as an invitation or a link.{" "}
+          <a
+            href="/signin?next=%2Fleagues"
+            className="text-nocturne-accent-300 hover:underline"
+          >
+            Sign in
+          </a>{" "}
+          to see yours and anything waiting on you.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/api/me/leagues/route.ts
+++ b/apps/web/src/app/api/me/leagues/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { leaguesForUser } from "@rostr/db";
+import { db } from "@/lib/db";
+import { currentUser } from "@/lib/session";
+
+/**
+ * The leagues you are in.
+ *
+ * Scoped to **you**, from the session cookie — which is why it lives under
+ * `/api/me` rather than `/api/leagues/[id]`, and why it needs no
+ * `leagueReadForbidden`. Every row it can return is a league this account holds
+ * a membership in, and a member may read their own league whatever its
+ * visibility.
+ *
+ * A signed-out caller gets an empty list rather than a 401, so the hub can ask
+ * without putting an error in the console of every logged-out visit.
+ */
+export async function GET(): Promise<NextResponse> {
+  const user = await currentUser();
+  if (!user) return NextResponse.json({ leagues: [] });
+
+  const leagues = await leaguesForUser(db(), user.id);
+
+  return NextResponse.json({
+    leagues: leagues.map((league) => ({
+      id: league.leagueId,
+      name: league.name,
+      state: league.state,
+      teamCount: league.teamCount,
+      teamName: league.teamName,
+      /** Unix seconds, rendered against the reader's own clock. */
+      draftScheduledAt: league.draftScheduledAt,
+      draftStatus: league.draftStatus,
+      rounds: league.rounds,
+      currentRound: league.currentRound,
+      onTheClock: league.onTheClock,
+    })),
+  });
+}

--- a/apps/web/src/components/InvitationsCorner.tsx
+++ b/apps/web/src/components/InvitationsCorner.tsx
@@ -41,8 +41,12 @@ export function InvitationsCorner() {
   if (invitations.length === 0) return null;
 
   return (
-    <aside
-      className="space-y-3 rounded-lg border border-nocturne-accent/30 bg-nocturne-accent/5 p-4 lg:sticky lg:top-6"
+    // Full width in the hub, where it is a section between your leagues and the
+    // public list rather than a sidebar beside one. It was `lg:sticky lg:top-6`
+    // when it sat in a column; sticky on a full-width band does nothing but
+    // promise something the layout no longer has.
+    <section
+      className="space-y-3 rounded-lg border border-nocturne-accent/30 bg-nocturne-accent/5 p-4"
       aria-label="Invitations waiting for you"
     >
       <header className="flex items-baseline justify-between gap-2">
@@ -64,7 +68,7 @@ export function InvitationsCorner() {
         Private leagues never appear in the list — this is where they reach you.
       </p>
 
-      <ul className="space-y-2">
+      <ul className="grid gap-2 sm:grid-cols-2">
         {invitations.slice(0, 4).map((invitation) => (
           <li key={invitation.id}>
             <a
@@ -88,7 +92,7 @@ export function InvitationsCorner() {
           and {invitations.length - 4} more
         </a>
       )}
-    </aside>
+    </section>
   );
 }
 

--- a/apps/web/src/components/YourLeagues.tsx
+++ b/apps/web/src/components/YourLeagues.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import useSWR from "swr";
+
+/**
+ * The leagues you are already in.
+ *
+ * The gap drop 8 named: `/leagues` browsed *public* leagues, which are by
+ * definition the ones you are not in, so a returning manager's only route back
+ * to their own league was browser history.
+ *
+ * ## What each row says, and what it does not
+ *
+ * One line per league, and the line is chosen by state — seats and a draft time
+ * while forming, the round while drafting, the week once playing. The design
+ * also draws a record, a standings position and whether your lineup is set;
+ * those cost a standings computation or a kickoff lookup per league on a page
+ * that renders every visit, so they are left to the screens that own them
+ * rather than approximated here.
+ *
+ * **`onTheClock` is the one urgent fact with a real source.** The design's
+ * urgent strip also wants a closing veto window, an unset lineup near kickoff
+ * and a waiver run; none of those has a route today. Drawing them would be
+ * inventing state on a page whose whole job is to tell you what is true.
+ */
+
+interface MyLeague {
+  id: string;
+  name: string;
+  state: string;
+  teamCount: number;
+  teamName: string;
+  draftScheduledAt: number | null;
+  draftStatus: string | null;
+  rounds: number | null;
+  currentRound: number | null;
+  onTheClock: boolean;
+}
+
+const fetcher = async (url: string): Promise<MyLeague[]> => {
+  const response = await fetch(url);
+  if (!response.ok) return [];
+  const body = (await response.json()) as { leagues?: MyLeague[] };
+  return body.leagues ?? [];
+};
+
+/** "Sat 23 Aug, 20:00" in the reader's own timezone. */
+function when(seconds: number | null): string {
+  if (seconds === null) return "not scheduled";
+  return new Date(seconds * 1000).toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * The one line worth showing for a league in this state.
+ *
+ * Written as a switch over the state machine rather than a pile of conditionals
+ * so an unhandled state renders something honest instead of an empty row —
+ * `SETTLED` and `DISSOLVED` are real states this hub will meet.
+ */
+function status(league: MyLeague): string {
+  switch (league.state) {
+    case "FORMING":
+      return `${league.teamCount} in · drafts ${when(league.draftScheduledAt)}`;
+    case "DRAFTING":
+      return league.currentRound !== null && league.rounds !== null
+        ? `Drafting · round ${league.currentRound} of ${league.rounds}`
+        : `Drafting · starts ${when(league.draftScheduledAt)}`;
+    case "IN_SEASON":
+      return `In season · ${league.teamCount} teams`;
+    case "PLAYOFFS":
+      return `Playoffs · ${league.teamCount} teams`;
+    case "SETTLED":
+      return "Settled";
+    case "DISSOLVED":
+      return "Dissolved";
+    default:
+      return league.state;
+  }
+}
+
+export function YourLeagues() {
+  const { data, isLoading } = useSWR<MyLeague[]>("/api/me/leagues", fetcher, {
+    revalidateOnFocus: true,
+  });
+
+  const leagues = data ?? [];
+
+  // Nothing at all while loading and nothing when empty — the hub's other two
+  // sections say what to do next, and an empty "you have no leagues" card above
+  // a list of leagues you could join would be saying it twice.
+  if (isLoading || leagues.length === 0) return null;
+
+  return (
+    <section className="space-y-3">
+      <header className="flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium tracking-wide text-nocturne-neutral-500 uppercase">
+          Your leagues
+        </h2>
+        <span className="text-xs text-nocturne-neutral-600">
+          {leagues.length} {leagues.length === 1 ? "league" : "leagues"}
+        </span>
+      </header>
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {leagues.map((league) => (
+          <li key={league.id}>
+            <a
+              href={league.onTheClock ? `/leagues/${league.id}/draft` : `/leagues/${league.id}`}
+              className={`block h-full space-y-2 rounded-lg border p-5 transition-colors ${
+                league.onTheClock
+                  ? "border-nocturne-accent bg-nocturne-accent/5"
+                  : "border-nocturne-neutral-900 hover:border-nocturne-neutral-800 hover:bg-nocturne-surface/30"
+              }`}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <h3 className="truncate text-base font-medium">{league.name}</h3>
+                <span className="shrink-0 text-xs text-nocturne-neutral-600">
+                  {league.teamName}
+                </span>
+              </div>
+
+              <p className="text-xs text-nocturne-neutral-500">{status(league)}</p>
+
+              {league.onTheClock && (
+                // The only urgent state with a real source. A 90-second clock
+                // cannot live behind a click, so it is on the card and the card
+                // links straight into the draft rather than the league page.
+                <p className="text-sm font-medium text-nocturne-accent-200">
+                  You are on the clock &rarr;
+                </p>
+              )}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,6 +5,8 @@ export type { SqlClient } from "./client.js";
 // app entry point breaks the build. It lives at `@rostr/db/migrate`, for CLI and
 // setup code only.
 
+export { leaguesForUser, type MyLeague } from "./my-leagues.js";
+
 export {
   InvitationError,
   invitationsForLeague,

--- a/packages/db/src/my-leagues.test.ts
+++ b/packages/db/src/my-leagues.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNflPprRules, NFL, teamOnClock } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import { createDraftRecord } from "./draft.js";
+import { createUser } from "./identity.js";
+import { createLeague } from "./leagues.js";
+import { leaguesForUser } from "./my-leagues.js";
+import { seedSport } from "./sports.js";
+import { addTestTeam, createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+};
+
+interface Fixture {
+  client: PGliteClient;
+  leagueId: string;
+  /** Four seats, in draft order 1..4, with their owning users. */
+  seats: { teamId: string; userId: string }[];
+}
+
+/** A league with four seated members and a scheduled draft. */
+async function fixture(name = "Sunday Scaries"): Promise<Fixture> {
+  db ??= await createTestDatabase();
+  const client = db;
+  await seedSport(client, NFL).catch(() => undefined);
+
+  const commissioner = await createUser(client, `${name}@example.test`, "Commish");
+  const league = await createLeague(client, NFL, {
+    name,
+    commissionerId: commissioner.id,
+    rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+  });
+
+  const seats: { teamId: string; userId: string }[] = [];
+  for (let i = 0; i < 4; i++) {
+    const seat = await addTestTeam(client, league.id, `${name} Team ${i + 1}`);
+    seats.push({ teamId: seat.teamId, userId: seat.userId });
+
+    await client.query(
+      `INSERT INTO wallets (user_id, address, verified_at)
+       VALUES ($1::uuid, 'w-' || $1::text || '-' || $2::text, now())`,
+      [seat.userId, String(i)],
+    );
+    await client.query(
+      `INSERT INTO league_memberships (league_id, user_id, team_id, wallet_id, rules_hash, signature)
+       SELECT $1::uuid, $2::uuid, $3::uuid, w.id, repeat('a', 64), 'sig'
+         FROM wallets w WHERE w.user_id = $2::uuid LIMIT 1`,
+      [league.id, seat.userId, seat.teamId],
+    );
+    // Draft order 1..4, so `onTheClock` has something to compare against.
+    await client.query("UPDATE teams SET draft_position = $2 WHERE id = $1", [
+      seat.teamId,
+      i + 1,
+    ]);
+  }
+
+  await createDraftRecord(client, {
+    leagueId: league.id,
+    rounds: 15,
+    pickSeconds: DRAFT.pickSeconds,
+    scheduledAt: new Date(DRAFT.scheduledAt * 1000),
+  });
+
+  return { client, leagueId: league.id, seats };
+}
+
+/** Put the draft in progress with `picks` already made. */
+async function withPicks(fx: Fixture, picks: number): Promise<void> {
+  const [draft] = await fx.client.query<{ id: string }>(
+    "SELECT id FROM drafts WHERE league_id = $1",
+    [fx.leagueId],
+  );
+  // Both together: `clock_only_while_running` in `0009` makes IN_PROGRESS and a
+  // running clock the same fact, so setting one without the other is a state the
+  // app cannot produce and the database will not hold.
+  await fx.client.query(
+    "UPDATE drafts SET status = 'IN_PROGRESS', clock_started_at = now() WHERE id = $1",
+    [draft!.id],
+  );
+
+  // `seedSport` seeds the registry — sports, positions, stat keys — and not a
+  // player pool, so the picks need somebody to be picked.
+  const players: { id: string }[] = [];
+  for (let i = 0; i < picks; i++) {
+    const [player] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id)
+       SELECT s.id, $1, $2, p.id
+         FROM sports s
+         JOIN positions p ON p.sport_id = s.id AND p.key = 'RB'
+        WHERE s.key = 'nfl'
+       RETURNING id`,
+      [`pick-${fx.leagueId}-${i}`, `Player ${i + 1}`],
+    );
+    players.push(player!);
+  }
+
+  for (let i = 0; i < picks; i++) {
+    // The order is 1..4 by `draft_position`, so the snake decides which seat
+    // owns pick i+1 — asked of the engine rather than restated here.
+    const order = fx.seats.map((seat) => seat.teamId);
+    await fx.client.query(
+      `INSERT INTO draft_picks (draft_id, pick_number, round, team_id, player_id, source)
+       VALUES ($1, $2, $3, $4, $5, 'MANUAL')`,
+      [
+        draft!.id,
+        i + 1,
+        Math.floor(i / order.length) + 1,
+        teamOnClock(i + 1, order),
+        players[i]!.id,
+      ],
+    );
+  }
+}
+
+describe("leaguesForUser", () => {
+  it("lists a league you joined, with your team", async () => {
+    const fx = await fixture();
+    const mine = await leaguesForUser(fx.client, fx.seats[0]!.userId);
+
+    expect(mine).toHaveLength(1);
+    expect(mine[0]).toMatchObject({
+      leagueId: fx.leagueId,
+      name: "Sunday Scaries",
+      state: "FORMING",
+      teamCount: 4,
+      teamId: fx.seats[0]!.teamId,
+      onTheClock: false,
+    });
+  });
+
+  it("shows nothing to somebody who is in no league", async () => {
+    const fx = await fixture();
+    const stranger = await createUser(fx.client, "stranger@example.test", "Stranger");
+
+    expect(await leaguesForUser(fx.client, stranger.id)).toEqual([]);
+  });
+
+  it("does not list a league you were only invited to", async () => {
+    // Membership is the source, and an invitation grants nothing. A hub that
+    // listed invitations as leagues would be claiming you are in them.
+    const fx = await fixture();
+    const invitee = await createUser(fx.client, "invited@example.test", "Invited");
+    await fx.client.query(
+      `INSERT INTO league_invitations (league_id, invited_user_id, invited_by_user_id, addressed_as)
+       VALUES ($1::uuid, $2::uuid, $3::uuid, 'USERNAME')`,
+      [fx.leagueId, invitee.id, fx.seats[0]!.userId],
+    );
+
+    expect(await leaguesForUser(fx.client, invitee.id)).toEqual([]);
+  });
+
+  it("names the round from the picks, not from a stored counter", async () => {
+    // Four teams, five picks made, so pick six is the next one — round two.
+    const fx = await fixture();
+    await withPicks(fx, 5);
+
+    const [league] = await leaguesForUser(fx.client, fx.seats[0]!.userId);
+    expect(league?.currentRound).toBe(2);
+    expect(league?.draftStatus).toBe("IN_PROGRESS");
+  });
+
+  it("says who is on the clock, and agrees with the engine", async () => {
+    // Five picks made means pick six is next. Round two runs backwards, so pick
+    // six belongs to seat three — which is `teamOnClock`'s answer, and the whole
+    // point is that this module asks rather than restates.
+    const fx = await fixture();
+    await withPicks(fx, 5);
+
+    const order = fx.seats.map((seat) => seat.teamId);
+    const expected = teamOnClock(6, order);
+
+    for (const seat of fx.seats) {
+      const [league] = await leaguesForUser(fx.client, seat.userId);
+      expect(league?.onTheClock).toBe(seat.teamId === expected);
+    }
+  });
+
+  it("nobody is on the clock before the draft starts", async () => {
+    const fx = await fixture();
+    const [league] = await leaguesForUser(fx.client, fx.seats[0]!.userId);
+
+    expect(league?.onTheClock).toBe(false);
+    expect(league?.currentRound).toBeNull();
+  });
+
+  it("carries the draft time so a row can say when it starts", async () => {
+    const fx = await fixture();
+    const [league] = await leaguesForUser(fx.client, fx.seats[0]!.userId);
+
+    expect(league?.draftScheduledAt).toBe(DRAFT.scheduledAt);
+    expect(league?.rounds).toBe(15);
+  });
+});

--- a/packages/db/src/my-leagues.ts
+++ b/packages/db/src/my-leagues.ts
@@ -1,0 +1,157 @@
+/**
+ * The leagues you are in.
+ *
+ * The gap drop 8 named, and it has been open since the commissioner's checklist
+ * landed: nothing anywhere listed the leagues you had already joined, so a
+ * returning manager's only route back was browser history. `/leagues` browsed
+ * *public* leagues, which are by definition the ones you are not in.
+ *
+ * ## What this returns and what it deliberately does not
+ *
+ * Every field here is one cheap join away from `league_memberships`. The design
+ * also draws a record, a standings position, and whether your lineup is set —
+ * all three are real facts, and all three cost a standings computation or a
+ * kickoff lookup **per league** on a page that renders on every visit.
+ *
+ * They are left out rather than approximated. A hub that showed a stale or
+ * guessed record would be worse than one that shows none: the standings screen
+ * is one click away and is the thing that owns that number.
+ *
+ * What is here is what the row needs to be useful — which league, what state,
+ * how big, and the single most pressing thing about it.
+ */
+
+import { pickPosition } from "@rostr/core";
+import type { SqlClient } from "./client.js";
+
+export interface MyLeague {
+  readonly leagueId: string;
+  readonly name: string;
+  readonly season: number;
+  /** `FORMING`, `DRAFTING`, `IN_SEASON`, `PLAYOFFS`, `SETTLED`, `DISSOLVED`. */
+  readonly state: string;
+  readonly teamCount: number;
+  /** This user's team in that league. */
+  readonly teamId: string;
+  readonly teamName: string;
+  /** Unix seconds, from the frozen rules by way of the draft row. */
+  readonly draftScheduledAt: number | null;
+  readonly draftStatus: string | null;
+  readonly rounds: number | null;
+  /** 1-based, or null when the draft has not started. */
+  readonly currentRound: number | null;
+  /**
+   * Whether the pick on the clock is this user's.
+   *
+   * The one urgent fact on this page with a real source behind it. The design's
+   * urgent strip also wants "veto window closing", "lineup unset near kickoff"
+   * and "waivers running"; none of those has a route today, and this one does —
+   * so it is the only one built.
+   */
+  readonly onTheClock: boolean;
+}
+
+/**
+ * Whether the pick on the clock belongs to this team.
+ *
+ * **Asked of `pickPosition`, never worked out here.** The draft has one
+ * implementation of the snake and it lives in `@rostr/core`; a second one — in
+ * SQL or in this file — is the failure this repo names by hand, because the
+ * first time the two disagreed a hub would tell somebody their pick was live
+ * while the draft room said otherwise.
+ *
+ * `draft_position` is 1-based and `orderIndex` is 0-based, which is the only
+ * arithmetic here.
+ */
+function onTheClock(
+  status: string | null,
+  picksMade: number | null,
+  teamCount: number,
+  draftPosition: number | null,
+): boolean {
+  if (status !== "IN_PROGRESS") return false;
+  if (picksMade === null || draftPosition === null || teamCount === 0) return false;
+
+  const { orderIndex } = pickPosition(picksMade + 1, teamCount);
+  return orderIndex === draftPosition - 1;
+}
+
+/**
+ * Leagues this user has joined, most recently joined first.
+ *
+ * Membership rather than team ownership is the source: a `league_memberships`
+ * row is the record of consent — the signature over the rules hash — and it is
+ * what every other league-scoped read keys on. A team with an `owner_id` and no
+ * membership row is not a state this app can produce.
+ */
+export async function leaguesForUser(
+  db: SqlClient,
+  userId: string,
+): Promise<readonly MyLeague[]> {
+  const rows = await db.query<{
+    league_id: string;
+    name: string;
+    season: number;
+    state: string;
+    team_count: number;
+    team_id: string;
+    team_name: string;
+    scheduled_at: string | null;
+    draft_status: string | null;
+    rounds: number | null;
+    picks_made: number | null;
+    draft_position: number | null;
+  }>(
+    `SELECT l.id AS league_id,
+            l.name,
+            l.season,
+            l.state,
+            (SELECT count(*)::int FROM teams t WHERE t.league_id = l.id) AS team_count,
+            m.team_id,
+            mt.name AS team_name,
+            d.scheduled_at,
+            d.status AS draft_status,
+            d.rounds,
+            -- The round is derived from how many picks exist, not stored. One
+            -- fewer thing that can disagree with the picks themselves.
+            (SELECT count(*)::int FROM draft_picks p WHERE p.draft_id = d.id) AS picks_made,
+            mt.draft_position
+       FROM league_memberships m
+       JOIN leagues l ON l.id = m.league_id
+       JOIN teams mt ON mt.id = m.team_id
+       LEFT JOIN drafts d ON d.league_id = l.id
+      WHERE m.user_id = $1
+      ORDER BY m.joined_at DESC`,
+    [userId],
+  );
+
+  return rows.map((row) => {
+    const teamCount = Number(row.team_count);
+    const picksMade = row.picks_made === null ? null : Number(row.picks_made);
+    const rounds = row.rounds === null ? null : Number(row.rounds);
+
+    return {
+      leagueId: row.league_id,
+      name: row.name,
+      season: Number(row.season),
+      state: row.state,
+      teamCount,
+      teamId: row.team_id,
+      teamName: row.team_name,
+      draftScheduledAt: row.scheduled_at
+        ? Math.floor(new Date(row.scheduled_at).getTime() / 1000)
+        : null,
+      draftStatus: row.draft_status,
+      rounds,
+      // The engine's answer for the pick about to be made, rather than
+      // arithmetic repeated here. Guarded on a non-empty field: `pickPosition`
+      // throws below one team, and a league whose seats were all removed before
+      // the draw should read as "no round yet" rather than raise.
+      currentRound:
+        picksMade === null || teamCount === 0 || row.draft_status !== "IN_PROGRESS"
+          ? null
+          : pickPosition(picksMade + 1, teamCount).round,
+      onTheClock: onTheClock(row.draft_status, picksMade, teamCount, row.draft_position),
+    };
+  });
+}


### PR DESCRIPTION
Drop 8's gap, open since the commissioner's checklist landed: **nothing anywhere listed the leagues you had already joined.** `/leagues` browsed *public* leagues — by definition the ones you are not in — so a returning manager's only route back was browser history.

One page now, ordered the way a returning manager needs it — **your leagues → invitations → public leagues** — and one `Leagues` nav item where three surfaces competed. Create moves into the page head as a card with equal weight, which is the design's change and is right: starting a league and joining one are the same size of decision.

## Built to the design, minus what has no source

Drop 8 marks its own parts grounded or proposed, and that line is honoured. `InvitationsCorner` and `LeagueBrowser` are the shipped components, not rebuilds.

**The urgent strip, the bell and the account menu are proposals with no backing route and are not drawn.** The one urgent fact that does have a source — being on the clock — rides on the league's own card and links straight into the draft. That satisfies the design's own argument for the strip (a 90-second clock cannot live behind a click) without inventing the five other things it would carry.

## `leaguesForUser`, and what it refuses to guess

- **Membership is the source**, not team ownership: a `league_memberships` row is the record of consent, and an invitation grants nothing. There's a test that an invitee's league does not appear.
- **The round and the team on the clock are asked of the engine.** `drafts` stores no current team — it is derived from the pick number and the drawn order, and `pickPosition` is the only implementation of that. A second one in SQL is the failure this repo names by hand: the first time they disagreed, the hub would say your pick was live while the draft room disagreed. A test asserts they match for every seat.
- **The record, standings position and lineup state are left out.** Each costs a standings computation or a kickoff lookup *per league* on a page that renders every visit, and a guessed record is worse than none when the standings screen is one click away.

Seven tests. Two cost a fixture correction worth recording: `IN_PROGRESS` and a running clock are the same fact to `clock_only_while_running`, and `seedSport` seeds the registry rather than a player pool.

1996 tests, lint, typecheck and format green; production build compiles.

**Not seen in a browser** — `apps/web` has no jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)