### PR TITLE
Finish the second source, and fix a join that silently dropped Washington

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,6 +5,14 @@ export type { SqlClient } from "./client.js";
 // app entry point breaks the build. It lives at `@rostr/db/migrate`, for CLI and
 // setup code only.
 
+export {
+  compareSources,
+  ingestSecondSource,
+  SECOND_STAT_SOURCE,
+  type SecondSourceResult,
+  type SourceDisagreement,
+} from "./second-source.js";
+
 export { leaguesForUser, type MyLeague } from "./my-leagues.js";
 
 export {

--- a/packages/db/src/second-source.test.ts
+++ b/packages/db/src/second-source.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { NFL } from "@rostr/core";
+import { compareSources, ingestSecondSource, SECOND_STAT_SOURCE } from "./second-source.js";
+import { seedSport } from "./sports.js";
+import { createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+const SEASON = 2026;
+const WEEK = 1;
+const PRIMARY = "tank01";
+
+interface Fixture {
+  client: PGliteClient;
+  /** A receiver, joined to Sleeper by a numeric id. */
+  receiver: string;
+  /** Washington's D/ST, joined by a team abbreviation. */
+  washington: string;
+  statKeys: Map<string, string>;
+}
+
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const positions = new Map(
+    (
+      await db.query<{ id: string; key: string }>(
+        "SELECT id, key FROM positions WHERE sport_id = $1",
+        [sport!.id],
+      )
+    ).map((row) => [row.key, row.id]),
+  );
+  const statKeys = new Map(
+    (
+      await db.query<{ id: string; key: string }>(
+        "SELECT id, key FROM stat_keys WHERE sport_id = $1",
+        [sport!.id],
+      )
+    ).map((row) => [row.key, row.id]),
+  );
+
+  const [receiver] = await db.query<{ id: string }>(
+    `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref,
+                          second_source_ref)
+     VALUES ($1, '4262921', 'A. Receiver', $2, 'MIN', '5045')
+     RETURNING id`,
+    [sport!.id, positions.get("WR")!],
+  );
+
+  // Our abbreviation is `WSH`; Sleeper keys the unit under `WAS`, so the stored
+  // join key is Sleeper's — which is the adapter's job and the thing that was
+  // wrong until 2026-08-22.
+  const [washington] = await db.query<{ id: string }>(
+    `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref,
+                          second_source_ref)
+     VALUES ($1, 'DST_WSH', 'Washington Commanders', $2, 'WSH', 'WAS')
+     RETURNING id`,
+    [sport!.id, positions.get("DEF")!],
+  );
+
+  return { client: db, receiver: receiver!.id, washington: washington!.id, statKeys };
+}
+
+/** A primary-source row, so there is something to disagree with. */
+async function primary(
+  fx: Fixture,
+  playerId: string,
+  key: string,
+  value: number,
+): Promise<void> {
+  await fx.client.query(
+    `INSERT INTO stat_lines (player_id, season, week, stat_key_id, value, revision, source)
+     VALUES ($1, $2, $3, $4, $5, 0, $6)`,
+    [playerId, SEASON, WEEK, fx.statKeys.get(key)!, value, PRIMARY],
+  );
+}
+
+const storedValue = async (
+  fx: Fixture,
+  playerId: string,
+  key: string,
+): Promise<number | null> => {
+  const [row] = await fx.client.query<{ value: number }>(
+    `SELECT value FROM stat_lines_current
+      WHERE player_id = $1 AND season = $2 AND week = $3 AND stat_key_id = $4 AND source = $5`,
+    [playerId, SEASON, WEEK, fx.statKeys.get(key)!, SECOND_STAT_SOURCE],
+  );
+  return row ? Number(row.value) : null;
+};
+
+describe("ingestSecondSource", () => {
+  it("writes a player's week, joined by the provider's own id", async () => {
+    const fx = await setup();
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 7, rec_yd: 92, rec_td: 1 } },
+    });
+
+    expect(result.joined).toBe(1);
+    expect(result.unjoined).toBe(0);
+    expect(result.written).toBeGreaterThan(0);
+    expect(await storedValue(fx, fx.receiver, "rec")).toBe(7);
+    expect(await storedValue(fx, fx.receiver, "rec_yd")).toBe(92);
+  });
+
+  it("joins Washington's defence, which is the one team whose key differs", async () => {
+    // We carry `WSH` and Sleeper keys the unit `WAS`. Until the adapter applied
+    // the alias this unit never joined, and the failure was the quiet kind: the
+    // second source silently covered 31 of 32 defences, which looks exactly like
+    // two feeds that agree.
+    const fx = await setup();
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      // Sleeper's field is `sack`; `def_sack` is *our* key, and passing it
+      // would translate to nothing. Checked against a live week rather than
+      // assumed from the name.
+      stats: { WAS: { pts_allow: 17, sack: 3 } },
+    });
+
+    expect(result.joined).toBe(1);
+    expect(await storedValue(fx, fx.washington, "def_sack")).toBe(3);
+  });
+
+  it("counts a player it cannot join rather than dropping them", async () => {
+    // A join that quietly covers fewer players each week is indistinguishable
+    // from two sources that increasingly agree.
+    const fx = await setup();
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 7 }, "999999": { rec: 3 } },
+    });
+
+    expect(result.joined).toBe(1);
+    expect(result.unjoined).toBe(1);
+  });
+
+  it("re-running an unchanged week writes nothing", async () => {
+    // Revision numbers stay a record of real corrections rather than of how
+    // many times a job ran.
+    const fx = await setup();
+    const stats = { "5045": { rec: 7, rec_yd: 92 } };
+
+    const first = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats,
+    });
+    const second = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats,
+    });
+
+    expect(first.written).toBeGreaterThan(0);
+    expect(second.written).toBe(0);
+  });
+
+  it("a corrected value becomes a new revision, and the view shows it", async () => {
+    const fx = await setup();
+
+    await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 7 } },
+    });
+    await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 9 } },
+    });
+
+    expect(await storedValue(fx, fx.receiver, "rec")).toBe(9);
+  });
+
+  it("never touches the primary source's rows", async () => {
+    // Nothing scores from the second source, and this is what makes that true
+    // rather than merely intended.
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+
+    await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 9 } },
+    });
+
+    const [row] = await fx.client.query<{ value: number }>(
+      `SELECT value FROM stat_lines_current
+        WHERE player_id = $1 AND stat_key_id = $2 AND source = $3`,
+      [fx.receiver, fx.statKeys.get("rec")!, PRIMARY],
+    );
+    expect(Number(row?.value)).toBe(7);
+  });
+});
+
+describe("compareSources", () => {
+  it("reports a stat the two disagree on", async () => {
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 9 } },
+    });
+
+    expect(result.disagreements).toHaveLength(1);
+    expect(result.disagreements[0]).toMatchObject({
+      statKey: "rec",
+      primary: 7,
+      second: 9,
+    });
+  });
+
+  it("says nothing when they agree", async () => {
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 7 } },
+    });
+
+    expect(result.disagreements).toEqual([]);
+  });
+
+  it("a stat missing from one side that week is not a disagreement", async () => {
+    // Absence is not zero. The primary saw a reception; the second source's
+    // entry for this player carries no receiving fields at all, which is a gap
+    // in coverage rather than a contradiction.
+    //
+    // There is no stat key only one provider can produce — measured on
+    // 2026-08-22, the Sleeper translation emits all 26 — so the per-player,
+    // per-week gap is the only shape this case really takes.
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rush_yd: 12 } },
+    });
+
+    expect(result.disagreements).toEqual([]);
+  });
+  it("compares per stat, not per total", async () => {
+    // Two divergences that cancel in a total are two divergences. The corpus
+    // already paid for this: gating on totals hid `def_pts_allowed` gaps of six
+    // and two points because both readings fell in the same scoring tier.
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+    await primary(fx, fx.receiver, "rec_yd", 92);
+
+    const result = await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK,
+      stats: { "5045": { rec: 9, rec_yd: 90 } },
+    });
+
+    expect(result.disagreements.map((d) => d.statKey).sort()).toEqual(["rec", "rec_yd"]);
+  });
+
+  it("does not compare across weeks", async () => {
+    const fx = await setup();
+    await primary(fx, fx.receiver, "rec", 7);
+
+    await ingestSecondSource(fx.client, {
+      sportKey: NFL.key,
+      season: SEASON,
+      week: WEEK + 1,
+      stats: { "5045": { rec: 9 } },
+    });
+
+    expect(await compareSources(fx.client, NFL.key, SEASON, WEEK, PRIMARY)).toEqual([]);
+  });
+});

--- a/packages/db/src/second-source.ts
+++ b/packages/db/src/second-source.ts
@@ -1,0 +1,337 @@
+/**
+ * The second stats source, ingested and compared.
+ *
+ * `RULES.md` §7 wants two independent providers to agree before a week's scores
+ * finalise. This is the half that can be built correctly today: both providers'
+ * numbers land in `stat_lines` side by side, and every place they differ is
+ * reported. **It does not gate finalisation**, and the reason is written down
+ * rather than left to be inferred — see "What this deliberately does not do".
+ *
+ * Two functions, and both halves are real: {@link ingestSecondSource} writes the
+ * second provider's week, and {@link compareSources} reads the two back and
+ * reports every stat where they differ.
+ *
+ * ## Why the storage needed no change
+ *
+ * `stat_lines` has keyed on `source` since `0003` and `stat_lines_current` keys
+ * on it too, so two providers are two rows and always were. `CLAUDE.md` records
+ * that this was preserved on purpose: *"Collapsing them in the view or averaging
+ * them away would delete that comparison at the storage layer and have to be
+ * undone."* Nothing here undoes it, and nothing here changes a score — every
+ * read filters to {@link PRIMARY_STAT_SOURCE}.
+ *
+ * ## What this deliberately does not do
+ *
+ * §7 says disagreement *"freezes that week for review"*. That is not built, and
+ * building it today would be worse than not:
+ *
+ * - **Disagreement is common and mostly benign.** In the thirteen-game corpus
+ *   the two sources differ on 5 of 26 team-games, and four of those are correct
+ *   data — ESPN files a punt return by a defensive player in two places, and a
+ *   kickoff recovery is deliberately unmatched by our classifiers. A gate
+ *   freezing on any difference freezes most weeks.
+ * - **A gate switched off in week 2 is worse than none**, because it teaches an
+ *   operator to route around the mechanism that is supposed to stop week 14.
+ * - **The tolerance cannot be designed without data, and this is what generates
+ *   it.** The scoring table itself was settled by reconciling 11,507
+ *   player-weeks rather than by picking a number; the gate deserves the same.
+ * - **No money settles this season.** Pot leagues are closed for 2026, so §7's
+ *   gate currently protects a payout that is not happening. Stalling brackets to
+ *   protect nothing is a poor trade.
+ *
+ * So §7 remains partly unimplemented and this file says so plainly. It sits
+ * beside `settlement.requiredOracleSources`, which has always been in the frozen
+ * rule set and enforced nowhere.
+ */
+
+import type { StatLine } from "@rostr/core";
+import { sleeperPlayerStats, sleeperTeamDefenseStats } from "@rostr/stats";
+import type { SleeperWeek } from "@rostr/stats";
+import type { SqlClient } from "./client.js";
+import { PRIMARY_STAT_SOURCE } from "./lineups.js";
+import { loadSportIds } from "./sports.js";
+import { withTransaction } from "./transaction.js";
+
+/**
+ * Where second-source rows are filed.
+ *
+ * A sibling of {@link PRIMARY_STAT_SOURCE} rather than a variant of it: the two
+ * are separate opinions and the whole point is that they can differ.
+ */
+export const SECOND_STAT_SOURCE = "sleeper";
+
+/** One stat where the two providers disagree. */
+export interface SourceDisagreement {
+  readonly playerRef: string;
+  readonly playerName: string;
+  readonly statKey: string;
+  readonly primary: number;
+  readonly second: number;
+}
+
+export interface SecondSourceResult {
+  /** Rows written, counting a corrected revision as a write. */
+  readonly written: number;
+  /** Players in the provider's week we could join to one of ours. */
+  readonly joined: number;
+  /**
+   * Players in the provider's week we could not join.
+   *
+   * Reported rather than swallowed. A join that quietly covers fewer players
+   * each week is indistinguishable from two sources that increasingly agree,
+   * which is the failure mode that makes a second source worthless.
+   */
+  readonly unjoined: number;
+  readonly disagreements: readonly SourceDisagreement[];
+}
+
+/**
+ * Write a second provider's week into `stat_lines`.
+ *
+ * The week is **passed in rather than fetched**, exactly as `drawDraftOrder`
+ * takes a beacon: `@rostr/db` holds no HTTP client and should not gain one, and
+ * a caller that must supply real data cannot accidentally test against none.
+ *
+ * ## Joining
+ *
+ * `players.second_source_ref` is the whole join — Sleeper's numeric id for a
+ * player, and its **team abbreviation** for a D/ST, which is why Washington
+ * needs an alias (`WSH` here, `WAS` there) and gets one in the adapter.
+ * Nothing here matches on a name; a name match is how a D/ST ends up on the
+ * wrong roster.
+ *
+ * `unjoined` is returned rather than swallowed. A join that quietly covers
+ * fewer players each week is indistinguishable from two sources that
+ * increasingly agree, which is the failure that makes a second source
+ * worthless.
+ *
+ * ## Why there is no retraction
+ *
+ * The primary ingest retracts — it writes a zero when a stat it previously
+ * recorded disappears — because a stale stat there decides a matchup. **Nothing
+ * scores from this source.** Every scoring read filters to
+ * `PRIMARY_STAT_SOURCE`, so a stale second-source row can only ever cause a
+ * disagreement to be *reported*, and reporting one stat too many is the safe
+ * direction for a comparison whose entire job is to surface differences.
+ *
+ * Retraction here would also need the thing that makes it safe there: a list of
+ * players the response *covered*. A week endpoint returns whoever scored, so
+ * absence means "nothing happened", not "not covered" — and writing zeroes on
+ * that basis is how a truncated response wipes a week.
+ */
+export async function ingestSecondSource(
+  db: SqlClient,
+  input: {
+    readonly sportKey: string;
+    readonly season: number;
+    readonly week: number;
+    /** The provider's week, keyed by their player id or team abbreviation. */
+    readonly stats: SleeperWeek;
+    readonly source?: string;
+  },
+): Promise<SecondSourceResult> {
+  const source = input.source ?? SECOND_STAT_SOURCE;
+  const ids = await loadSportIds(db, input.sportKey);
+
+  const players = await db.query<{
+    id: string;
+    second_source_ref: string;
+    is_defense: boolean;
+  }>(
+    `SELECT p.id, p.second_source_ref, (pos.key = 'DEF') AS is_defense
+       FROM players p
+       JOIN positions pos ON pos.id = p.primary_position_id
+      WHERE p.sport_id = $1 AND p.second_source_ref IS NOT NULL`,
+    [ids.sportId],
+  );
+
+  const byRef = new Map(players.map((row) => [row.second_source_ref, row]));
+
+  const rowPlayer: string[] = [];
+  const rowStatKey: string[] = [];
+  const rowValue: number[] = [];
+  let joined = 0;
+  let unjoined = 0;
+
+  for (const [ref, raw] of Object.entries(input.stats)) {
+    const player = byRef.get(ref);
+    if (!player) {
+      unjoined++;
+      continue;
+    }
+    joined++;
+
+    // A D/ST and a player are different translations of the same shape — the
+    // provider's defensive fields mean nothing on a running back.
+    const lines: readonly StatLine[] = player.is_defense
+      ? sleeperTeamDefenseStats(raw)
+      : sleeperPlayerStats(raw);
+
+    for (const line of lines) {
+      const statKeyId = ids.statKeyIds.get(line.statKey);
+      if (!statKeyId) {
+        // Loud, like the primary ingest. The registry and a provider map
+        // having diverged should fail rather than drop a stat silently.
+        throw new Error(
+          `Second source references unknown stat key "${line.statKey}". ` +
+            `The sport registry and the provider map have diverged.`,
+        );
+      }
+      rowPlayer.push(player.id);
+      rowStatKey.push(statKeyId);
+      rowValue.push(line.value);
+    }
+  }
+
+  const written =
+    rowValue.length === 0
+      ? 0
+      : await writeRows(db, {
+          season: input.season,
+          week: input.week,
+          source,
+          rowPlayer,
+          rowStatKey,
+          rowValue,
+        });
+
+  return {
+    written,
+    joined,
+    unjoined,
+    disagreements: await compareSources(
+      db,
+      input.sportKey,
+      input.season,
+      input.week,
+      PRIMARY_STAT_SOURCE,
+      source,
+    ),
+  };
+}
+
+/**
+ * Insert a revision for every value that is new or has changed.
+ *
+ * `box-scores.ts`' idiom, minus the retraction: three arrays and three scalars,
+ * so it is **six bind parameters however many rows** and the 65535 parameter cap
+ * is structurally unreachable rather than avoided by chunking.
+ *
+ * A value identical to the one already stored writes nothing, so re-running a
+ * week is free and the revision number stays a record of actual corrections.
+ */
+async function writeRows(
+  db: SqlClient,
+  input: {
+    readonly season: number;
+    readonly week: number;
+    readonly source: string;
+    readonly rowPlayer: readonly string[];
+    readonly rowStatKey: readonly string[];
+    readonly rowValue: readonly number[];
+  },
+): Promise<number> {
+  return withTransaction(db, async (tx) => {
+    const rows = await tx.query<{ id: string }>(
+      `WITH incoming (player_id, stat_key_id, value) AS (
+         SELECT * FROM unnest($4::uuid[], $5::uuid[], $6::integer[])
+       ),
+       cur AS (
+         SELECT c.player_id, c.stat_key_id, c.value, c.revision
+           FROM stat_lines_current c
+          WHERE c.season = $1 AND c.week = $2 AND c.source = $3
+            AND c.player_id = ANY($4::uuid[])
+       )
+       INSERT INTO stat_lines
+              (player_id, season, week, stat_key_id, value, source, revision)
+       SELECT i.player_id, $1, $2, i.stat_key_id, i.value, $3,
+              COALESCE(c.revision + 1, 0)
+         FROM incoming i
+         LEFT JOIN cur c
+           ON c.player_id = i.player_id AND c.stat_key_id = i.stat_key_id
+        WHERE c.player_id IS NULL OR c.value IS DISTINCT FROM i.value
+       RETURNING id`,
+      [
+        input.season,
+        input.week,
+        input.source,
+        input.rowPlayer,
+        input.rowStatKey,
+        input.rowValue,
+      ],
+    );
+
+    // `PostgresClient.query` discards `rowCount`, so the count is only knowable
+    // because the statement ends in `RETURNING` — the same reason
+    // `resolveLeagueWeek` returns ids it does not use.
+    return rows.length;
+  });
+}
+/**
+ * Compare the two sources for a week, from what is already stored.
+ *
+ * **Per stat, never per total.** The conformance corpus already paid for this
+ * lesson: gating on totals hid two real `def_pts_allowed` divergences of six and
+ * two points, because both readings fell in the same scoring tier and paid the
+ * same. A tier is a range, so a gap worth nothing this week is worth six the
+ * week it straddles a boundary.
+ *
+ * Only stats **both** sources reported **for that player, that week** are
+ * compared. Absence is not zero, and treating it as zero would invent a
+ * disagreement out of a gap in coverage.
+ *
+ * The example this comment used to give was wrong and is worth correcting rather
+ * than deleting: it said Sleeper carries no `def_yds_allowed`. It does —
+ * `yds_allow`, 231 for Washington in week 1 of 2025 — and measured against the
+ * live endpoint on 2026-08-22 the Sleeper translation emits **all 26** of the
+ * sport's stat keys. There is no key only one provider can produce.
+ *
+ * What is real is the per-player gap: a provider that did not report a receiver
+ * at all, or reported him with no receiving fields, leaves those stats absent on
+ * one side. The inner join skips them. That matters most for
+ * `def_pts_allowed`, where absent means a **shutout** rather than nothing — the
+ * translator makes the same correction for the same reason.
+ */
+export async function compareSources(
+  db: SqlClient,
+  sportKey: string,
+  season: number,
+  week: number,
+  primarySource: string,
+  secondSource: string = SECOND_STAT_SOURCE,
+): Promise<readonly SourceDisagreement[]> {
+  const ids = await loadSportIds(db, sportKey);
+
+  const rows = await db.query<{
+    external_ref: string;
+    full_name: string;
+    stat_key: string;
+    primary_value: string;
+    second_value: string;
+  }>(
+    `SELECT p.external_ref, p.full_name, sk.key AS stat_key,
+            a.value::text AS primary_value, b.value::text AS second_value
+       FROM stat_lines_current a
+       JOIN stat_lines_current b
+         ON b.player_id = a.player_id
+        AND b.season = a.season AND b.week = a.week
+        AND b.stat_key_id = a.stat_key_id
+        AND b.source = $5
+       JOIN players p ON p.id = a.player_id
+       JOIN stat_keys sk ON sk.id = a.stat_key_id
+      WHERE p.sport_id = $1
+        AND a.season = $2 AND a.week = $3
+        AND a.source = $4
+        AND a.value IS DISTINCT FROM b.value
+      ORDER BY p.full_name, sk.key`,
+    [ids.sportId, season, week, primarySource, secondSource],
+  );
+
+  return rows.map((row) => ({
+    playerRef: row.external_ref,
+    playerName: row.full_name,
+    statKey: row.stat_key,
+    primary: Number(row.primary_value),
+    second: Number(row.second_value),
+  }));
+}

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -36,3 +36,21 @@ export {
   TANK01_STAT_MAP,
   TANK01_UNAVAILABLE_STATS,
 } from "./tank01/stat-map.js";
+
+/**
+ * The second source.
+ *
+ * `@rostr/db`'s `second-source.ts` translates a Sleeper week with these before
+ * writing it, so they have to leave the package. The client goes with them
+ * because the caller that fetches a week is the one that ingests it.
+ */
+export {
+  SleeperClient,
+  type SleeperClientOptions,
+  type SleeperWeek,
+} from "./sleeper/client.js";
+export {
+  sleeperPlayerStats,
+  sleeperTeamDefenseStats,
+  type SleeperStats,
+} from "./sleeper/stats.js";

--- a/packages/stats/src/tank01/adapter.ts
+++ b/packages/stats/src/tank01/adapter.ts
@@ -61,6 +61,16 @@ const POSITION_MAP: Readonly<Record<string, string>> = {
  */
 export const DST_REF_PREFIX = "DST_";
 
+/**
+ * Where Sleeper's team abbreviations differ from ours.
+ *
+ * A table rather than a fuzzy match, for the reason the corpus records: a
+ * D/ST joined to the wrong team is a swing between two rosters. Only
+ * Washington differs — `LAR`, `LV` and `JAX`, the ones that usually vary
+ * between feeds, are identical here.
+ */
+const SLEEPER_TEAM_ALIASES: Readonly<Record<string, string>> = { WSH: "WAS" };
+
 export interface AdpEntry {
   readonly externalRef: string;
   readonly fullName: string;
@@ -374,7 +384,15 @@ export class Tank01Provider implements StatsProvider {
         profile: { ...EMPTY_PROFILE, imageUrl: imageUrl(team.espnLogo1) },
         // Sleeper identifies a team unit by its abbreviation rather than by a
         // numeric id, so the join key for a defence is the team ref itself.
-        secondSourceRef: team.teamAbv,
+        // Sleeper's own abbreviation, not ours. The two agree for 31 teams and
+        // disagree for Washington: we carry `WSH` and Sleeper keys the D/ST
+        // under `WAS` — verified against the live week endpoint on 2026-08-22,
+        // whose 32 team keys include `WAS` and no `WSH`.
+        //
+        // Without the alias that one unit never joins, and the failure is the
+        // quiet kind: the second source simply covers 31 of 32 defences, which
+        // is indistinguishable from two feeds that agree.
+        secondSourceRef: SLEEPER_TEAM_ALIASES[team.teamAbv] ?? team.teamAbv,
       });
     }
 


### PR DESCRIPTION
`second-source.ts` had been sitting **untracked** since 2026-08-19 with the comparison half written and the ingest half missing. It read `stat_lines` for rows tagged `sleeper`; nothing has ever written one, so it returned `[]` and always would. `SecondSourceResult` — `written`, `joined`, `unjoined` — was exported and produced by nothing: the signature of the function that wasn't there.

`ingestSecondSource` is that function. The week is **passed in rather than fetched**, as `drawDraftOrder` takes a beacon: `@rostr/db` holds no HTTP client, and a caller obliged to supply real data can't accidentally test against none.

## A real defect found on the way, and it's the quiet kind

`players.second_source_ref` is the whole join — Sleeper's numeric id for a player, its **team abbreviation** for a D/ST. The adapter stored `team.teamAbv` raw, so Washington was filed as `WSH`.

**Sleeper keys that unit `WAS`.** Verified against the live week endpoint rather than the comment that predicted it — the 32 team keys include `WAS` and no `WSH`. One defence in thirty-two would never have joined, and the failure is invisible by construction: a second source silently covering 31 of 32 units looks exactly like two feeds that agree.

## Two things the inherited file asserted that aren't true

It claimed Sleeper carries no `def_yds_allowed`, so comparing would report every defence as disputed. Sleeper carries it — `yds_allow`, 231 for Washington in week 1 of 2025 — and measured against the live endpoint the Sleeper translation emits **all 26** of the sport's stat keys. There is no key only one provider can produce.

The inner join is still right, for the real reason: a stat absent for *that player, that week* is a gap in coverage, not a contradiction, and absence isn't zero — most sharply for `def_pts_allowed`, where absent means a shutout.

## No retraction, deliberately

The primary ingest writes a zero when a recorded stat disappears, because a stale stat there decides a matchup. Nothing scores from this source, so a stale row can only cause a disagreement to be *reported* — the safe direction. Retraction would also need the list of players a response covered, and a week endpoint returns whoever scored: absence means "nothing happened", not "not covered".

Eleven tests, including the Washington join, that re-running an unchanged week writes nothing, and that the primary's rows are never touched.

§7's gate is still not built and the file still says so plainly.

2007 tests, lint, typecheck and format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)