### PR TITLE
A 429 that named the wrong tier, and a cron that threw away its error

### DIFF
--- a/apps/web/src/lib/jobs/season-sync.ts
+++ b/apps/web/src/lib/jobs/season-sync.ts
@@ -43,6 +43,17 @@ import type {
  * provider is behind it, which is what keeps swapping providers a one-file
  * change. Naming the concrete class here would put that back.
  */
+/**
+ * Cap a recorded outcome, keeping the front.
+ *
+ * The useful half of a provider error is its first sentence; the rest is a
+ * stack or a body echo. An ellipsis rather than a hard cut, so a reader can
+ * tell truncation from a message that simply ended.
+ */
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
 export async function runSeasonSyncJob(
   client: SqlClient,
   provider: AdpCapableProvider & ByeCapableProvider & ProjectionCapableProvider,
@@ -146,10 +157,33 @@ export async function runSeasonSyncJob(
   const failed = runs.filter((entry) => entry.error).length;
   const undated = runs.reduce((total, entry) => total + (entry.undatedGames ?? 0), 0);
 
+  /*
+    The message goes in, not just the count.
+
+    This recorded "1 of 1 seasons failed" and nothing else. The error was caught
+    per season, put in `runs[].error` and returned in the JSON — which nobody
+    reads, because a cron runs unattended and its response goes to a scheduler.
+    So the one durable record of a failure said that one had happened and
+    refused to say what it was, and `pnpm cron:status` could only repeat it.
+
+    A job that cannot say why it failed is a job nobody can fix. It cost a
+    session an hour of guessing at quotas.
+
+    Truncated, because a provider error can carry a stack and this column is
+    read by a status command that prints one line per job. The season is named
+    because a multi-season failure otherwise reads as one problem.
+  */
+  const problems = runs
+    .filter((entry) => entry.error)
+    .map((entry) => `${entry.season}: ${entry.error}`)
+    .join("; ");
+
   await recordCronRun(
     client,
     "season-sync",
-    failed > 0 ? `${failed} of ${seasons.length} seasons failed` : null,
+    failed > 0
+      ? truncate(`${failed} of ${seasons.length} seasons failed — ${problems}`, 400)
+      : null,
   );
 
   return NextResponse.json({

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -244,9 +244,24 @@ resolve, or the on-chain hash anchors nothing.
 **Done 2026-08-05.** Key is in `.env` as `TANK01_API_KEY`. Verify any time with
 `pnpm stats:check`, and inspect live response shapes with `pnpm stats:probe`.
 
-**Still to do: upgrade to Pro ($10/month) before Week 1.** Basic allows 1,000 calls a
-month and the estimate for a live season is ~700 — too close to the ceiling once real
-leagues are running, and exceeding it stops scoring mid-week.
+**The key is no longer on the free tier** — confirmed by the owner on 2026-08-22.
+This entry said an upgrade was still to do, and repeating that sent a session
+diagnosing a failed sync straight to the wrong conclusion.
+
+**Read the plan from the response, never from here.** Every Tank01 reply carries
+`X-RateLimit-Requests-Limit`, `-Remaining` and `-Reset`, and those are the only
+current statement of what the key may do:
+
+```
+curl -s -o /dev/null -D - "https://$TANK01_HOST/getNFLTeams" \
+  -H "X-RapidAPI-Key: $TANK01_API_KEY" -H "X-RapidAPI-Host: $TANK01_HOST" |
+  grep -i ratelimit
+```
+
+On 2026-08-22 that answered 998 of 1000 remaining with the window resetting in
+about fifteen hours — a **daily** allowance rather than the monthly one this file
+used to describe. Which plan that corresponds to is on the RapidAPI dashboard;
+it is not inferable from the headers and should not be guessed at here again.
 
 Both gaps flagged on first mapping are now **resolved** — two-point conversions and
 blocked kicks are both obtainable, from the play-by-play. See

--- a/packages/stats/src/tank01/client.test.ts
+++ b/packages/stats/src/tank01/client.test.ts
@@ -2,13 +2,23 @@ import { describe, expect, it, vi } from "vitest";
 import { ProviderError } from "../provider.js";
 import { Tank01Client } from "./client.js";
 
-function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+function mockFetch(
+  response: Omit<Partial<Response>, "headers"> & {
+    json?: () => Promise<unknown>;
+    /** Plain object for convenience; the client reads it through `.get`. */
+    headers?: Record<string, string>;
+  } = {},
+) {
+  const { headers, ...rest } = response;
   return vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
     text: () => Promise.resolve(""),
     json: () => Promise.resolve({ statusCode: 200, body: [] }),
-    ...response,
+    ...rest,
+    // A real `Headers`, because the client calls `.get` on it. A plain object
+    // would pass typing here and throw at the one line under test.
+    headers: new Headers(headers ?? {}),
   } as Response);
 }
 
@@ -58,11 +68,31 @@ describe("Tank01Client", () => {
     await expect(client.get("getNFLTeams")).rejects.toThrow(/own subscription/);
   });
 
-  it("names the free-tier ceiling when rate limited", async () => {
+  it("reports the rate-limit headers rather than a guess at the plan", async () => {
+    // It used to assert "the Basic tier allows 1,000 calls/month" on every 429,
+    // which sent somebody to check a monthly quota on an upgraded account when
+    // the real cause was a burst limit. The headers say which.
+    const fetchImpl = mockFetch({
+      ok: false,
+      status: 429,
+      headers: {
+        "x-ratelimit-requests-limit": "1000",
+        "x-ratelimit-requests-remaining": "0",
+        "x-ratelimit-requests-reset": "54213",
+      },
+    });
+    const client = new Tank01Client({ apiKey: "k", fetchImpl });
+
+    await expect(client.get("getNFLTeams")).rejects.toThrow(/0 of 1000 requests left/);
+  });
+
+  it("says so when a 429 carries no headers, because that is a different problem", async () => {
+    // No headers is the shape of a per-second burst limit, which needs a wait of
+    // a second rather than a wait for the quota window.
     const fetchImpl = mockFetch({ ok: false, status: 429 });
     const client = new Tank01Client({ apiKey: "k", fetchImpl });
 
-    await expect(client.get("getNFLTeams")).rejects.toThrow(/1,000 calls\/month/);
+    await expect(client.get("getNFLTeams")).rejects.toThrow(/burst limit/);
   });
 
   it("surfaces an error inside a 200 response", async () => {

--- a/packages/stats/src/tank01/client.ts
+++ b/packages/stats/src/tank01/client.ts
@@ -69,10 +69,32 @@ export class Tank01Client {
       );
     }
     if (response.status === 429) {
-      throw new ProviderError(
-        "Tank01 rate limit reached. The Basic tier allows 1,000 calls/month.",
-        "tank01",
-      );
+      /**
+       * Report what the response says, never what the plan was assumed to be.
+       *
+       * This used to read "The Basic tier allows 1,000 calls/month" on every
+       * 429, which is wrong twice. RapidAPI returns 429 for a **burst** limit as
+       * well as an exhausted quota, and the two need opposite responses — wait a
+       * second, or wait for the reset. And the tier is not this code's to know:
+       * the message sent somebody to check a monthly quota on an account that
+       * had been upgraded, when the request was simply too quick after the last.
+       *
+       * The headers carry the truth and cost nothing to read. `reset` is
+       * seconds until the window rolls, which is also what distinguishes a
+       * daily allowance from a monthly one without anybody guessing.
+       */
+      const limit = response.headers.get("x-ratelimit-requests-limit");
+      const remaining = response.headers.get("x-ratelimit-requests-remaining");
+      const reset = response.headers.get("x-ratelimit-requests-reset");
+
+      const detail =
+        remaining === null && limit === null
+          ? "No rate-limit headers came back, so this may be a per-second burst limit rather than an exhausted quota."
+          : `${remaining ?? "?"} of ${limit ?? "?"} requests left${
+              reset === null ? "" : `, window resets in ${reset}s`
+            }.`;
+
+      throw new ProviderError(`Tank01 refused the request (HTTP 429). ${detail}`, "tank01");
     }
     if (!response.ok) {
       throw new ProviderError(`Tank01 returned HTTP ${response.status}`, "tank01");


### PR DESCRIPTION
Started from `pnpm cron:status` reporting one unhealthy job. Three things came out of it, and one of them is a bug in the field.

## Tank01 is not out of calls

Read from the live response: `200 OK`, **998 of 1000 remaining**, window resetting in ~15 hours.

**The client asserted the plan.** Every 429 threw *"The Basic tier allows 1,000 calls/month"* — wrong twice: RapidAPI returns 429 for a **burst** limit as well as an exhausted quota, and those need opposite responses; and the tier isn't the code's to know, on an account that's been upgraded. It now reports the actual headers, or says "this looks like a burst limit" when a 429 carries none.

`SETUP-REQUIRED.md` still said *"still to do: upgrade to Pro"* — a stale to-do in the file whose job is listing what's outstanding, and exactly what a session reaches for when a sync fails. Replaced with the curl that reads the real limits.

## season-sync threw away the reason it failed

It recorded `1 of 1 seasons failed` and nothing else. The error was caught per season, put in `runs[].error` and returned in the JSON — which nobody reads, because a cron runs unattended. The one durable record said a failure happened and refused to say what it was.

The message now goes in, truncated to 400 characters with the season named. `last_outcome` stays a *state* — `cronJobState` returns FAILING for any non-null value — so this changes what a failure says, not what counts as one.

**The failure itself was transient.** Re-running all four steps by hand, every one passes:

```
syncPlayers      1,518 updated
syncGames           16 skipped   (undated week 16/17 flex games, by design)
syncRankings       480 ranked
syncProjections  2,571 updated
```

## The Washington fix is confirmed in production data

That re-run used the corrected adapter, so `DEF WSH` now carries the Sleeper key `WAS`, and **32 of 32** defences have one. It was 31 before today, and the missing one was invisible by construction.

2008 tests, lint, typecheck and format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)