### PR TITLE
feat(web): the Leagues hub knows when an account is new

### DIFF
--- a/apps/web/src/app/(app)/leagues/page.tsx
+++ b/apps/web/src/app/(app)/leagues/page.tsx
@@ -1,6 +1,9 @@
 import { InvitationsCorner } from "@/components/InvitationsCorner";
 import { LeagueBrowser } from "@/components/LeagueBrowser";
 import { YourLeagues } from "@/components/YourLeagues";
+import { invitationsForUser, leaguesForUser } from "@rostr/db";
+import { db } from "@/lib/db";
+import { hubView } from "@/lib/hub";
 import { currentUser } from "@/lib/session";
 
 /**
@@ -38,41 +41,127 @@ import { currentUser } from "@/lib/session";
 export default async function LeaguesPage() {
   const user = await currentUser().catch(() => null);
 
+  /*
+    Counted on the server so the page can choose its own shape.
+
+    `YourLeagues` and `InvitationsCorner` each self-fetch and render null when
+    empty, which is right for them and leaves the page unable to tell an account
+    with nothing from an account it has not loaded yet. A new user therefore got
+    the returning manager's heading above two blank gaps and a directory that is
+    usually empty as well — the first screen of the product, describing somebody
+    else.
+
+    The duplicate fetch is deliberate and cheap: both are indexed reads on one
+    user id, and the alternative is threading server data through two client
+    components that already know how to get it.
+  */
+  const [leagues, invitations] = user
+    ? await Promise.all([
+        leaguesForUser(db(), user.id).catch(() => []),
+        invitationsForUser(db(), user.id).catch(() => []),
+      ])
+    : [[], []];
+
+  const view = hubView({
+    signedIn: user !== null,
+    leagueCount: leagues.length,
+    invitationCount: invitations.length,
+  });
+
   return (
     <div className="space-y-10">
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Leagues</h1>
-          <p className="max-w-2xl text-sm text-nocturne-neutral-400">
-            Your leagues, anything waiting on you, and every public league still taking
-            managers. Each one shows its whole rule set before you agree to anything, and those
-            rules are frozen and hashed at creation — so what you read is what the season runs
-            on.
-          </p>
-        </div>
+      {view === "EMPTY" ? (
+        /*
+          The brand-new account.
 
-        {/*
-          Create is a card with equal weight rather than a button in the nav.
-          Drop 8's change, and it is right: starting a league and joining one are
-          the same size of decision, and the nav made one of them an afterthought.
-        */}
-        <aside className="space-y-3 rounded-lg border border-nocturne-neutral-900 p-5">
-          <h2 className="text-base font-medium">Start your own</h2>
-          <p className="text-xs leading-[1.55] text-nocturne-neutral-500">
-            Set the name, the draft time and the pace. Everything else is fixed, and you will
-            see all of it before it freezes.
-          </p>
-          <a
-            href="/leagues/new"
-            className="inline-block rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
-          >
-            Create a league
-          </a>
-          <p className="text-[11px] text-nocturne-neutral-600">
-            Free. Two humans is enough to start — one bot squares an odd field.
-          </p>
-        </aside>
-      </div>
+          Two cards of equal weight, because at this moment creating and being
+          invited are the only two ways in and neither is the obvious one. The
+          returning-manager head is wrong here in a way that is worse than plain:
+          it describes leagues, invitations and a directory, and this person has
+          none of the first two and usually sees none of the third.
+        */
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-tight">Leagues</h1>
+            <p className="max-w-2xl text-sm text-nocturne-neutral-400">
+              You are not in a league yet. Start one and invite people, or join one of the
+              public leagues below — each shows its whole rule set before you agree to anything.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-3 rounded-lg border border-nocturne-accent/40 p-5">
+              <h2 className="text-base font-medium">Create a league</h2>
+              <p className="text-xs leading-[1.55] text-nocturne-neutral-500">
+                You set the name, the draft time and the pace. Scoring, roster and payout are
+                fixed, so there is no negotiating them mid-season — and you see all of it before
+                it freezes.
+              </p>
+              <a
+                href="/leagues/new"
+                className="inline-block rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
+              >
+                Create a league
+              </a>
+              <p className="text-[11px] text-nocturne-neutral-600">
+                Free. Two humans is enough to start.
+              </p>
+            </div>
+
+            {/*
+              The second way in, which has no control because there is nothing
+              to press. It exists to answer "where would an invitation even
+              appear" before somebody concludes the answer is nowhere.
+            */}
+            <div className="space-y-3 rounded-lg border border-nocturne-neutral-900 p-5">
+              <h2 className="text-base font-medium">Been invited to one?</h2>
+              <p className="text-xs leading-[1.55] text-nocturne-neutral-500">
+                Most leagues are private, so most are joined by invitation. Anything addressed
+                to your username or your wallet appears here automatically — private leagues
+                never show up in the public list.
+              </p>
+              <p className="text-[11px] text-nocturne-neutral-600">
+                Nothing is waiting for you right now. If somebody sent you a link, opening it
+                works too.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-tight">Leagues</h1>
+            <p className="max-w-2xl text-sm text-nocturne-neutral-400">
+              Your leagues, anything waiting on you, and every public league still taking
+              managers. Each one shows its whole rule set before you agree to anything, and
+              those rules are frozen and hashed at creation — so what you read is what the
+              season runs on.
+            </p>
+          </div>
+
+          {/*
+            Create is a card with equal weight rather than a button in the nav.
+            Drop 8's change, and it is right: starting a league and joining one
+            are the same size of decision, and the nav made one an afterthought.
+          */}
+          <aside className="space-y-3 rounded-lg border border-nocturne-neutral-900 p-5">
+            <h2 className="text-base font-medium">Start your own</h2>
+            <p className="text-xs leading-[1.55] text-nocturne-neutral-500">
+              Set the name, the draft time and the pace. Everything else is fixed, and you will
+              see all of it before it freezes.
+            </p>
+            <a
+              href="/leagues/new"
+              className="inline-block rounded-[4px] border border-nocturne-accent px-4 py-2 text-[13.5px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10"
+            >
+              Create a league
+            </a>
+            <p className="text-[11px] text-nocturne-neutral-600">
+              Free. Two humans is enough to start — one bot squares an odd field.
+            </p>
+          </aside>
+        </div>
+      )}
 
       <YourLeagues />
 

--- a/apps/web/src/lib/hub.test.ts
+++ b/apps/web/src/lib/hub.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { hubView } from "./hub";
+
+describe("hubView", () => {
+  it("gives a signed-in manager with leagues the populated page", () => {
+    expect(hubView({ signedIn: true, leagueCount: 2, invitationCount: 0 })).toBe("POPULATED");
+  });
+
+  it("gives a signed-in account with nothing the empty page", () => {
+    expect(hubView({ signedIn: true, leagueCount: 0, invitationCount: 0 })).toBe("EMPTY");
+  });
+
+  it("treats an invitation as something, not nothing", () => {
+    // The empty state asks "been invited to one?" — a question this account can
+    // already see answered on the same screen.
+    expect(hubView({ signedIn: true, leagueCount: 0, invitationCount: 1 })).toBe("POPULATED");
+  });
+
+  it("never calls a signed-out visitor empty", () => {
+    // The mutation this file exists to catch. A signed-out visitor has zero of
+    // both, so a bare count test tells them "you are not in a league yet" — a
+    // claim about a person we have not identified, who may have eleven.
+    expect(hubView({ signedIn: false, leagueCount: 0, invitationCount: 0 })).toBe("ANONYMOUS");
+  });
+
+  it("stays anonymous even if counts somehow arrive non-zero", () => {
+    // Defensive: identity decides first. Counts belonging to nobody must never
+    // promote a stranger into somebody's page.
+    expect(hubView({ signedIn: false, leagueCount: 3, invitationCount: 2 })).toBe("ANONYMOUS");
+  });
+});

--- a/apps/web/src/lib/hub.ts
+++ b/apps/web/src/lib/hub.ts
@@ -1,0 +1,49 @@
+/**
+ * Which version of the Leagues hub a visitor gets.
+ *
+ * Three audiences arrive at one URL and need different pages. The design draws
+ * two of them (a returning manager, and a brand-new account) and the third — a
+ * signed-out visitor — falls out of the same question.
+ *
+ * **In `lib` rather than inline in the page** for the reason `field.ts` records:
+ * `apps/web` has no jsdom in either vitest project, so a branch written inside
+ * the component is verified only by being run in production.
+ */
+
+export type HubView =
+  /**
+   * Signed out. The browse list is public and the two personal sections render
+   * nothing, so this is the returning-manager layout minus the parts that need
+   * an account — plus the line explaining where private leagues actually go.
+   *
+   * **Not the empty state**, and the distinction is the whole reason this is a
+   * function. A signed-out visitor genuinely has no leagues, so a naive "is it
+   * empty" test would tell them *"You are not in a league yet"* — a statement
+   * about a person we cannot make, because we do not know who they are. They
+   * may have eleven.
+   */
+  | "ANONYMOUS"
+  /**
+   * Signed in, in nothing, invited to nothing. The one screen every new account
+   * sees first, and the one the shipped page never had — a new user was handed
+   * the returning-manager heading and a directory that is usually empty too.
+   */
+  | "EMPTY"
+  /** Signed in with at least one league or one invitation. */
+  | "POPULATED";
+
+export function hubView(input: {
+  readonly signedIn: boolean;
+  readonly leagueCount: number;
+  readonly invitationCount: number;
+}): HubView {
+  if (!input.signedIn) return "ANONYMOUS";
+
+  // An invitation counts as having something. Somebody asked for you
+  // specifically, so "you are not in a league yet" is true and beside the point
+  // — and the empty state's own "been invited to one?" card would be answering
+  // a question the page can already see the answer to.
+  if (input.leagueCount > 0 || input.invitationCount > 0) return "POPULATED";
+
+  return "EMPTY";
+}


### PR DESCRIPTION
## The bug

Every new account landed on the **returning manager's** page. The heading promises "your leagues, anything waiting on you, and every public league still taking managers" — a fresh account has none of the first two, and since every league here is private, usually sees none of the third either.

So the first screen of the product described somebody else's, above two blank gaps. The design draws this state; it was never built.

## Why the page couldn't tell

`YourLeagues` and `InvitationsCorner` each self-fetch and render `null` when empty. Right for them, and it left the page with nothing to branch on. Both counts are now read on the server.

`invitationsForUser` already filters to pending, non-withdrawn, still-FORMING and not-already-a-member — so a withdrawn invitation cannot make an empty account look populated.

## The branch lives in `lib/hub.ts`

No jsdom in either vitest project, so a branch written in the component is verified only by being run in production.

**The mutation the tests exist to catch: calling a signed-out visitor empty.** They have zero leagues and zero invitations, exactly like a new account — so a bare count test greets them with *"You are not in a league yet"*, a claim about a person nobody has identified, who may have eleven. Identity decides first; a test keeps a stranger anonymous even with non-zero counts.

**An invitation counts as something**, so an account with one pending gets the populated view — the empty state's "been invited to one?" card would otherwise ask a question the same screen already answers.

## Checks

typecheck, lint, prettier, `apps/web/src/lib` (240 passed), production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)