### PR TITLE
feat(web): the league nav on every league screen, and a door to the lobby

### DIFF
--- a/apps/web/src/app/(app)/leagues/[id]/bracket/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/bracket/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { getLeagueRules, loadWeekResults, playoffState } from "@rostr/db";
 import type { BracketGame, BracketRound } from "@rostr/core";
 import { db } from "@/lib/db";
@@ -31,6 +33,10 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
   // `notFound` rather than a notice: a "this league is private" page confirms
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
+
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();
@@ -143,13 +149,8 @@ export default async function BracketPage({ params }: { params: Promise<{ id: st
 
   return (
     <div className="space-y-8">
+      {chrome && <LeagueChrome {...chrome} active="NONE" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Bracket</h1>
         <p className="text-sm text-nocturne-neutral-500">
           Top {stored.rules.schedule.playoffTeams} qualify; the top{" "}

--- a/apps/web/src/app/(app)/leagues/[id]/lineup/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/lineup/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { LineupEditor } from "@/components/LineupEditor";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
@@ -25,19 +27,18 @@ export default async function LineupPage({
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
 
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
+
   const user = await currentUser();
   const parsed = Number.parseInt(week ?? "1", 10);
   const current = Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 
   return (
     <div className="space-y-6">
+      {chrome && <LeagueChrome {...chrome} active="/lineup" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Lineup</h1>
       </header>
 

--- a/apps/web/src/app/(app)/leagues/[id]/matchup/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/matchup/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { getLeagueRules } from "@rostr/db";
 import { Scoreboard } from "@/components/Scoreboard";
 import { db } from "@/lib/db";
@@ -20,6 +22,10 @@ export default async function MatchupPage({ params }: { params: Promise<{ id: st
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
 
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
+
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();
 
@@ -27,13 +33,8 @@ export default async function MatchupPage({ params }: { params: Promise<{ id: st
 
   return (
     <div className="space-y-6">
+      {chrome && <LeagueChrome {...chrome} active="/matchup" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Scoreboard</h1>
         <p className="text-sm text-nocturne-neutral-500">
           Scored live from the same rules that decide the standings. A week is final{" "}

--- a/apps/web/src/app/(app)/leagues/[id]/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/page.tsx
@@ -167,6 +167,23 @@ export default async function LeaguePage({ params }: { params: Promise<{ id: str
       */}
       {navOpen ? (
         <div className="flex flex-wrap gap-3">
+          {/*
+            **The lobby had no inbound link from anywhere in the app.** Nearly
+            900 lines of `DraftLobby` — the countdown, the field, and the
+            order-draw explainer with its slot, blockhash and seed — plus
+            `SettlementPanel`, reachable only by typing the URL. It was built to
+            drop 8 and then never connected, so the one screen that shows the
+            draw is verifiable was the one screen nobody could reach.
+
+            First in the row because it comes first in time: the lobby is where
+            a league waits, and the room is where it drafts.
+          */}
+          <a
+            href={`/leagues/${league.id}/lobby`}
+            className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"
+          >
+            Draft lobby
+          </a>
           <a
             href={`/leagues/${league.id}/draft`}
             className="rounded-[4px] border border-nocturne-neutral-800 px-[14px] py-2 text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"

--- a/apps/web/src/app/(app)/leagues/[id]/players/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/players/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { getLeagueRules, nextWaiverRun } from "@rostr/db";
 import { PlayerMarket } from "@/components/PlayerMarket";
 import { db } from "@/lib/db";
@@ -20,6 +22,10 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
 
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
+
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();
 
@@ -28,13 +34,8 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
 
   return (
     <div className="space-y-6">
+      {chrome && <LeagueChrome {...chrome} active="/players" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Players</h1>
         <p className="text-sm text-nocturne-neutral-500">
           Next waiver run {nextRun.toLocaleString()}. A claim is resolved by priority at the run

--- a/apps/web/src/app/(app)/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/standings/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { computeStandings, consolationField, playoffField } from "@rostr/core";
 import type { StandingsRow } from "@rostr/core";
 import { getLeagueRules, loadWeekResults, teamForUser } from "@rostr/db";
@@ -35,6 +37,10 @@ export default async function StandingsPage({ params }: { params: Promise<{ id: 
   // `notFound` rather than a notice: a "this league is private" page confirms
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
+
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
 
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();
@@ -112,13 +118,8 @@ export default async function StandingsPage({ params }: { params: Promise<{ id: 
 
   return (
     <div className="space-y-6">
+      {chrome && <LeagueChrome {...chrome} active="/standings" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Standings</h1>
         <p className="text-sm text-nocturne-neutral-500">
           {weeksPlayed === 0

--- a/apps/web/src/app/(app)/leagues/[id]/trades/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/trades/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { leagueReadAccess } from "@/lib/visibility";
+import { chromeProps } from "@/lib/chrome";
+import { LeagueChrome } from "@/components/LeagueChrome";
 import { getLeagueRules } from "@rostr/db";
 import { TradeBlock } from "@/components/TradeBlock";
 import { db } from "@/lib/db";
@@ -20,6 +22,10 @@ export default async function TradesPage({ params }: { params: Promise<{ id: str
   // the league exists, which is the fact an unguessable id is protecting.
   if (!(await leagueReadAccess(id)).ok) notFound();
 
+  // After the gate, never before: the chrome carries the league's name, size and
+  // rules hash, which is exactly what a private league owes a stranger none of.
+  const chrome = await chromeProps(id);
+
   const stored = await getLeagueRules(client, id);
   if (!stored) notFound();
 
@@ -28,13 +34,8 @@ export default async function TradesPage({ params }: { params: Promise<{ id: str
 
   return (
     <div className="space-y-6">
+      {chrome && <LeagueChrome {...chrome} active="/trades" />}
       <header className="space-y-1">
-        <a
-          href={`/leagues/${id}`}
-          className="text-xs text-nocturne-neutral-600 hover:text-nocturne-text"
-        >
-          ← {league.name}
-        </a>
         <h1 className="text-2xl font-semibold tracking-tight">Trades</h1>
         <p className="text-sm text-nocturne-neutral-500">
           Deadline: end of week {trades.deadlineWeek}. An accepted trade waits{" "}

--- a/apps/web/src/components/LeagueChrome.tsx
+++ b/apps/web/src/components/LeagueChrome.tsx
@@ -41,8 +41,16 @@ export function LeagueChrome({
   /** "Week 3 · 12 teams · full PPR" — composed by the caller, which knows. */
   readonly subtitle: string;
   readonly rulesHash: string;
-  /** The tab to mark current, as its `href` suffix. `""` is Home. */
-  readonly active: (typeof TABS)[number]["href"];
+  /**
+   * The tab to mark current, as its `href` suffix. `""` is Home.
+   *
+   * `"NONE"` for a screen the nav does not contain — the bracket and the draft
+   * room, which are deliberately not tabs. Borrowing a neighbouring tab was the
+   * obvious alternative and is wrong: the marker sets `aria-current="page"`, so
+   * it would tell a screen reader the visitor is on Standings while they are on
+   * the bracket. A screen with no tab should light no tab.
+   */
+  readonly active: (typeof TABS)[number]["href"] | "NONE";
   /**
    * Whether these tabs lead anywhere for this viewer — `leagueNavOpen`.
    *

--- a/apps/web/src/lib/chrome.test.ts
+++ b/apps/web/src/lib/chrome.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { leagueSubtitle } from "./chrome";
+
+describe("leagueSubtitle", () => {
+  it("reads as a sentence about the league", () => {
+    expect(leagueSubtitle({ season: 2026, taken: 5, maxTeams: 12, state: "FORMING" })).toBe(
+      "2026 season · 5/12 teams · forming",
+    );
+  });
+
+  it("replaces every underscore, not only the first", () => {
+    // `replace` without a global flag takes the first occurrence only. No state
+    // in the enum has two today, so this pins the behaviour before one does —
+    // the league home's inline version used single `replace` and would not.
+    expect(leagueSubtitle({ season: 2026, taken: 12, maxTeams: 12, state: "A_B_C" })).toContain(
+      "a b c",
+    );
+  });
+
+  it("renders IN_SEASON as words rather than an enum", () => {
+    expect(leagueSubtitle({ season: 2026, taken: 12, maxTeams: 12, state: "IN_SEASON" })).toBe(
+      "2026 season · 12/12 teams · in season",
+    );
+  });
+
+  it("says a full league is full rather than hiding the count", () => {
+    expect(
+      leagueSubtitle({ season: 2026, taken: 12, maxTeams: 12, state: "DRAFTING" }),
+    ).toContain("12/12 teams");
+  });
+
+  it("says zero rather than omitting an empty league's count", () => {
+    // A league with no teams is the commissioner's own first view of it.
+    expect(
+      leagueSubtitle({ season: 2026, taken: 0, maxTeams: 10, state: "FORMING" }),
+    ).toContain("0/10 teams");
+  });
+});

--- a/apps/web/src/lib/chrome.ts
+++ b/apps/web/src/lib/chrome.ts
@@ -1,0 +1,88 @@
+import { getLeagueRules } from "@rostr/db";
+import { db } from "@/lib/db";
+import { leagueNavOpen } from "@/lib/visibility";
+
+/**
+ * Everything `LeagueChrome` needs, loaded once.
+ *
+ * **Six of the eight league screens had no chrome at all.** Lineup, players,
+ * trades, matchup, standings and bracket each rendered a bare "← league name"
+ * link instead, so clicking into any of them ended the nav: getting from your
+ * lineup to trades meant going back first, on every screen, all season.
+ *
+ * They did not have the parts. Each loads `id, name` and nothing else, while the
+ * chrome wants the rules hash and a subtitle — so adding it page by page meant
+ * six copies of the same query and six chances for the subtitle to disagree
+ * about what a league is. `CLAUDE.md`'s recurring lesson is that a fact authored
+ * twice diverges; this is the same fact authored six times.
+ *
+ * **The subtitle is composed here on purpose.** The league home built it inline
+ * and it is the one string on the chrome that can lie — a stale team count or a
+ * wrong state reads as authoritative because it sits beside the rules hash.
+ */
+export interface ChromeProps {
+  readonly leagueId: string;
+  readonly name: string;
+  readonly subtitle: string;
+  readonly rulesHash: string;
+  readonly navOpen: boolean;
+}
+
+/**
+ * `null` when the league does not exist, so the caller can `notFound()`.
+ *
+ * It answers nothing about *visibility* — `leagueReadAccess` is that check and
+ * every caller runs it already. Folding the two together would make one
+ * function decide both "is there a league" and "may you see it", and the second
+ * has to 404 rather than 403 for reasons `visibility.ts` records.
+ */
+export async function chromeProps(leagueId: string): Promise<ChromeProps | null> {
+  const client = db();
+
+  const [league] = await client.query<{
+    id: string;
+    name: string;
+    season: number;
+    state: string;
+  }>("SELECT id, name, season, state FROM leagues WHERE id = $1", [leagueId]);
+  if (!league) return null;
+
+  const stored = await getLeagueRules(client, leagueId);
+  if (!stored) return null;
+
+  const [count] = await client.query<{ taken: number }>(
+    "SELECT count(*)::int AS taken FROM teams WHERE league_id = $1",
+    [leagueId],
+  );
+  const taken = Number(count?.taken ?? 0);
+
+  return {
+    leagueId: league.id,
+    name: league.name,
+    subtitle: leagueSubtitle({
+      season: league.season,
+      taken,
+      maxTeams: stored.rules.league.maxTeams,
+      state: league.state,
+    }),
+    rulesHash: stored.hash,
+    navOpen: await leagueNavOpen(leagueId),
+  };
+}
+
+/**
+ * "2026 season · 5/12 teams · forming".
+ *
+ * Separated from the query so it can be tested without a database — the shape
+ * of the string is the part with a wrong answer worth catching, and `IN_SEASON`
+ * rendering as `in_season` is exactly the kind that ships.
+ */
+export function leagueSubtitle(input: {
+  readonly season: number;
+  readonly taken: number;
+  readonly maxTeams: number;
+  readonly state: string;
+}): string {
+  const state = input.state.toLowerCase().replaceAll("_", " ");
+  return `${input.season} season · ${input.taken}/${input.maxTeams} teams · ${state}`;
+}


### PR DESCRIPTION
Two routing gaps from the design audit. Neither needs new logic — both are things that already exist and were not connected.

## 1. Six of eight league screens ended the nav

`LeagueChrome` defines the six tabs the design puts on every league screen. It was imported by **two** pages. Lineup, players, trades, matchup, standings and bracket each rendered a bare `← league name` link instead.

So clicking into any of them was a dead end. Getting from your lineup to trades meant going back first — on every screen, all season.

They didn't have the parts to render it: each loads `id, name` and nothing else, while the chrome wants the rules hash and a subtitle. Doing it page-by-page meant six copies of one query and six chances for the subtitle to disagree about what a league is. `chromeProps` loads it once.

`leagueSubtitle` is split out so it can be tested without a database, and one test pins a bug the inline version had — `replace` with no global flag renders only the first underscore. No state in today's enum exposes it; the next one would.

**Loaded after the visibility gate, never before** — the chrome carries the league's name, size and hash, which is what a private league owes a stranger none of.

## 2. The bracket lights no tab

Marking Standings was the obvious move and is wrong: the marker sets `aria-current="page"`, so it would tell a screen reader you're on Standings while you're on the bracket. `active` now accepts `"NONE"`.

The bracket is **not** added as a tab, and the draft room stays out — that's `LeagueChrome`'s own recorded decision. A permanent tab to a screen empty for most of a season is the "invention" `CLAUDE.md` forbids. Both stay surfaced from the body of the league page.

## 3. The lobby had no inbound link from anywhere

Nearly 900 lines of `DraftLobby` — the countdown, the field, the order-draw explainer with its slot, blockhash and seed — plus `SettlementPanel`, reachable only by typing the URL. Built to drop 8 and never connected, so the one screen proving the draw is verifiable was the one screen nobody could reach.

It joins the same body row as the draft room, ahead of it: the lobby is where a league waits, the room is where it drafts.

## Checks

`pnpm test` (2038 passed, 2 skipped), typecheck, lint, prettier, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)