### PR TITLE
feat(web): the lineup screen says what the autofill is about to do

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -7,9 +7,10 @@ import {
   slotLocksAt,
   startingSlots,
 } from "@rostr/core";
-import { buildRosterShape, NFL } from "@rostr/core";
+import { autolineupChoices, buildRosterShape, NFL } from "@rostr/core";
 import type { LineupAssignment } from "@rostr/core";
 import {
+  autolineupCandidate,
   getAutofillEnabled,
   LineupError,
   loadAverages,
@@ -104,10 +105,69 @@ export async function GET(
 
     const now = Math.floor(Date.now() / 1000);
 
+    /*
+      What the autofill would do, computed here rather than in the browser.
+
+      The screen used to offer a checkbox and no account of what turning it on
+      does — which is the one thing worth knowing before trusting it with a week
+      that counts. `autolineupChoices` is the same function `autoFillLineup`
+      fills with, so the preview cannot name a different player from the write.
+
+      **Locked slots are passed in, not filtered out.** A locked player is
+      unavailable to every other slot, so omitting them would let the preview
+      offer somebody who is already playing — and the FLEX preview in particular
+      would be wrong every Sunday afternoon.
+    */
+    const shape = buildRosterShape(context.rules.roster, NFL);
+    const currentAssignments: LineupAssignment[] = startingSlots(shape).map((slot) => {
+      const found = assignments.find(
+        (entry) => entry.slotType === slot.slotType && entry.slotIndex === slot.slotIndex,
+      );
+      return found ?? { slotType: slot.slotType, slotIndex: slot.slotIndex, playerId: null };
+    });
+
+    const choices = autolineupChoices({
+      shape,
+      roster: [...roster.values()].map((player) =>
+        autolineupCandidate(player, {
+          averageMilliPoints: averages.get(player.playerId) ?? null,
+          projectedMilliPoints: projected.get(player.playerId) ?? null,
+        }),
+      ),
+      mode: context.rules.roster.autofill,
+      locked: currentAssignments.filter((entry) => slotIsLocked(entry, kickoffs, now)),
+    });
+
+    /*
+      Only slots the manager has left empty.
+
+      The autofill "only touches slots you leave empty" — the label already says
+      so — and a preview covering filled slots would read as a threat to replace
+      a starter somebody deliberately chose.
+    */
+    const preview = choices.filter((choice) => {
+      const current = currentAssignments.find(
+        (entry) => entry.slotType === choice.slotType && entry.slotIndex === choice.slotIndex,
+      );
+      return current?.playerId == null && choice.playerId !== null;
+    });
+
     return NextResponse.json({
       week,
       autofill: {
         enabled: autofillEnabled ?? true,
+        /**
+         * Per empty slot: who it would start, and the best player left on the
+         * bench that it passed over. Empty when nothing is outstanding, which is
+         * the ordinary state of a lineup somebody has set.
+         */
+        preview: preview.map((choice) => ({
+          slotType: choice.slotType,
+          slotIndex: choice.slotIndex,
+          playerId: choice.playerId,
+          runnerUpId: choice.runnerUpId,
+          runnerUpReason: choice.runnerUpReason,
+        })),
         /** Frozen in the league's rules, so it is the same for everybody. */
         mode: context.rules.roster.autofill,
       },

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { previewHeading, whyNot } from "@/lib/autofill";
 import useSWR from "swr";
 import { PlayerAvatar } from "./PlayerAvatar";
 import { PlayerCard } from "./PlayerCard";
@@ -59,7 +60,18 @@ interface RosterPlayer {
 
 interface LineupResponse {
   week: number;
-  autofill: { enabled: boolean; mode: "WEEKLY_PROJECTION" | "SEASON_AVERAGE" };
+  autofill: {
+    enabled: boolean;
+    mode: "WEEKLY_PROJECTION" | "SEASON_AVERAGE";
+    /** Per empty slot: who it would start, and who it left on the bench. */
+    preview: {
+      slotType: string;
+      slotIndex: number;
+      playerId: string;
+      runnerUpId: string | null;
+      runnerUpReason: "LOWER_RANKED" | "UNAVAILABLE" | "NO_DATA" | null;
+    }[];
+  };
   slots: Slot[];
   roster: RosterPlayer[];
 }
@@ -214,6 +226,17 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
     void save(next);
   }
 
+  /*
+    Counted from the slots, not from the preview's length.
+
+    The preview only covers slots the autofill can actually fill; a slot with no
+    eligible player left produces no entry. Deriving the count from it would
+    quietly under-report — the manager would be told two slots are empty while
+    three score nothing.
+  */
+  const emptySlots = data.slots.filter((slot) => slot.playerId === null).length;
+  const heading = previewHeading({ enabled: data.autofill.enabled, emptySlots });
+
   const starterPoints = data.slots.reduce(
     (total, slot) => total + (slot.playerId ? (byId.get(slot.playerId)?.milliPoints ?? 0) : 0),
     0,
@@ -248,6 +271,52 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
           </span>
         </span>
       </label>
+
+      {/*
+        What the autofill will actually do, named.
+
+        The checkbox alone asks a manager to trust a decision taken while they
+        are asleep, on a week that counts. This is the same `autolineupChoices`
+        the write uses, so the names here are the names that get started.
+
+        Rendered whether autofill is on or off, and saying different things: on,
+        it is a prediction; off, an empty slot scores nothing and that is the
+        more useful warning.
+      */}
+      {heading && (
+        <div className="space-y-2 rounded border border-nocturne-neutral-900 px-4 py-3 text-sm">
+          <p className={data.autofill.enabled ? "text-nocturne-neutral-400" : "text-amber-300"}>
+            {heading}
+          </p>
+
+          {data.autofill.enabled && (
+            <ul className="space-y-1.5">
+              {data.autofill.preview.map((choice) => {
+                const starter = byId.get(choice.playerId);
+                const passed = choice.runnerUpId ? byId.get(choice.runnerUpId) : null;
+                if (!starter) return null;
+
+                return (
+                  <li key={`${choice.slotType}#${choice.slotIndex}`} className="text-[13px]">
+                    <span className="text-nocturne-neutral-600">{choice.slotType}</span>{" "}
+                    <span className="text-nocturne-text">{starter.name}</span>
+                    {passed && choice.runnerUpReason && (
+                      // The road not taken. Without it the preview is an
+                      // assertion; with it, a manager can tell whether the
+                      // autofill understood something they did not.
+                      <span className="text-nocturne-neutral-600">
+                        {" "}
+                        — over {passed.name},{" "}
+                        {whyNot(choice.runnerUpReason, data.autofill.mode)}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
 
       {(saveError || problems.length > 0) && (
         <div className="space-y-1 rounded border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">

--- a/apps/web/src/lib/autofill.test.ts
+++ b/apps/web/src/lib/autofill.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { previewHeading, whyNot } from "./autofill";
+
+describe("whyNot", () => {
+  it("names the ranking the league actually froze", () => {
+    // "Projected lower" and "averaging lower" are different claims, and a
+    // SEASON_AVERAGE league making the first one would be describing a number
+    // its autofill does not consult.
+    expect(whyNot("LOWER_RANKED", "WEEKLY_PROJECTION")).toBe("projected lower");
+    expect(whyNot("LOWER_RANKED", "SEASON_AVERAGE")).toBe("averaging lower");
+  });
+
+  it("says unavailable without reference to the ranking", () => {
+    // A player on a bye did not lose on points, and saying so would invite a
+    // manager to argue with a comparison that never happened.
+    expect(whyNot("UNAVAILABLE", "WEEKLY_PROJECTION")).toBe("on a bye or out this week");
+    expect(whyNot("UNAVAILABLE", "SEASON_AVERAGE")).toBe("on a bye or out this week");
+  });
+
+  it("admits when there is nothing to rank on", () => {
+    expect(whyNot("NO_DATA", "WEEKLY_PROJECTION")).toBe("has no projection this week");
+    expect(whyNot("NO_DATA", "SEASON_AVERAGE")).toBe("has not played yet this season");
+  });
+});
+
+describe("previewHeading", () => {
+  it("says nothing when the lineup is complete", () => {
+    expect(previewHeading({ enabled: true, emptySlots: 0 })).toBeNull();
+    expect(previewHeading({ enabled: false, emptySlots: 0 })).toBeNull();
+  });
+
+  it("describes what will happen when autofill is on", () => {
+    expect(previewHeading({ enabled: true, emptySlots: 2 })).toBe(
+      "Autofill will fill 2 empty slots at kickoff:",
+    );
+  });
+
+  it("warns rather than predicts when autofill is off", () => {
+    // The mutation this exists to catch. Describing what the autofill "would"
+    // do on a team that has it switched off is describing something that is not
+    // going to happen — and the slot scores zero instead.
+    const heading = previewHeading({ enabled: false, emptySlots: 2 });
+    expect(heading).toBe("2 slots are empty and will score nothing — autofill is off.");
+    expect(heading).not.toContain("will fill");
+  });
+
+  it("counts one slot in the singular, both ways round", () => {
+    expect(previewHeading({ enabled: true, emptySlots: 1 })).toContain("1 empty slot at");
+    expect(previewHeading({ enabled: false, emptySlots: 1 })).toContain("1 slot is empty");
+  });
+});

--- a/apps/web/src/lib/autofill.ts
+++ b/apps/web/src/lib/autofill.ts
@@ -1,0 +1,66 @@
+/**
+ * How the autofill preview reads.
+ *
+ * In `lib` rather than in `LineupEditor` for the reason `field.ts` and
+ * `chrome.ts` record: `apps/web` has no jsdom in either vitest project, so a
+ * sentence composed inside a `.tsx` is verified only by being run in
+ * production. The wording here has a wrong answer worth catching — this is the
+ * screen explaining a decision nobody was present for.
+ */
+
+export type RunnerUpReason = "LOWER_RANKED" | "UNAVAILABLE" | "NO_DATA";
+
+export type AutofillMode = "WEEKLY_PROJECTION" | "SEASON_AVERAGE";
+
+/**
+ * "Projected lower", "On a bye or out", "No games played yet".
+ *
+ * Three sentences because they are three different instructions. Lower-ranked
+ * says the autofill worked and you may disagree with it. Unavailable says the
+ * alternative was never really one. No data says the autofill is guessing, and
+ * your own opinion outranks its ordering — which is the case where a manager
+ * most needs to be told rather than reassured.
+ *
+ * The mode is named in the first, because "projected lower" and "averaged
+ * lower" are different claims and the league froze which one it makes.
+ */
+export function whyNot(reason: RunnerUpReason, mode: AutofillMode): string {
+  switch (reason) {
+    case "UNAVAILABLE":
+      return "on a bye or out this week";
+    case "NO_DATA":
+      return mode === "WEEKLY_PROJECTION"
+        ? "has no projection this week"
+        : "has not played yet this season";
+    case "LOWER_RANKED":
+      return mode === "WEEKLY_PROJECTION" ? "projected lower" : "averaging lower";
+  }
+}
+
+/**
+ * The headline above the preview list.
+ *
+ * **Says nothing when the autofill is off**, which is the whole point of the
+ * distinction: an empty slot with autofill off is a slot that scores zero, and
+ * describing what the autofill "would" do there would be describing something
+ * that is not going to happen.
+ */
+export function previewHeading(input: {
+  readonly enabled: boolean;
+  readonly emptySlots: number;
+}): string | null {
+  if (input.emptySlots === 0) return null;
+
+  if (!input.enabled) {
+    // The honest version of the same fact. A manager who turned autofill off and
+    // then left a slot empty has made two separate decisions, and only the
+    // second one is likely to be an accident.
+    return input.emptySlots === 1
+      ? "1 slot is empty and will score nothing — autofill is off."
+      : `${input.emptySlots} slots are empty and will score nothing — autofill is off.`;
+  }
+
+  return input.emptySlots === 1
+    ? "Autofill will fill 1 empty slot at kickoff:"
+    : `Autofill will fill ${input.emptySlots} empty slots at kickoff:`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,9 @@ export {
 
 export {
   autolineup,
+  autolineupChoices,
+  type AutolineupChoice,
+  type RunnerUpReason,
   rankingValue,
   seasonAverage,
   type AutofillMode,

--- a/packages/core/src/season/autolineup-choices.test.ts
+++ b/packages/core/src/season/autolineup-choices.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { buildRosterShape } from "../draft/roster.js";
+import { NFL } from "../sports/nfl.js";
+import { NFL_PPR_ROSTER } from "../rules/nfl-ppr.js";
+import { autolineup, autolineupChoices } from "./autolineup.js";
+import type { AutolineupCandidate } from "./autolineup.js";
+
+const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
+const SUNDAY = 1_757_782_800;
+
+function candidate(
+  playerId: string,
+  positions: string[],
+  averageMilliPoints: number | null,
+  extra: { unavailable?: boolean } = {},
+): AutolineupCandidate {
+  return {
+    playerId,
+    positions,
+    averageMilliPoints,
+    kickoffAt: SUNDAY,
+    ...(extra.unavailable !== undefined ? { unavailable: extra.unavailable } : {}),
+  };
+}
+
+const ROSTER: AutolineupCandidate[] = [
+  candidate("qb-good", ["QB"], 22_000),
+  candidate("qb-bad", ["QB"], 14_000),
+  candidate("rb1", ["RB"], 18_000),
+  candidate("rb2", ["RB"], 16_000),
+  candidate("rb3", ["RB"], 9_000),
+  candidate("wr1", ["WR"], 17_000),
+  candidate("wr2", ["WR"], 15_000),
+  candidate("wr3", ["WR"], 8_000),
+  candidate("te1", ["TE"], 11_000),
+  candidate("k1", ["K"], 7_000),
+  candidate("dst1", ["DST"], 6_000),
+];
+
+function choiceFor(choices: readonly { slotType: string; slotIndex: number }[], slot: string) {
+  const [slotType, index] = slot.split("#");
+  return choices.find((c) => c.slotType === slotType && c.slotIndex === Number(index));
+}
+
+describe("autolineupChoices", () => {
+  it("fills exactly as autolineup does", () => {
+    // The property that makes a preview safe to show: the screen and the
+    // Sunday-morning write cannot name different players, because one is a
+    // projection of the other rather than a second implementation.
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+
+    expect(
+      choices.map(({ slotType, slotIndex, playerId }) => ({ slotType, slotIndex, playerId })),
+    ).toEqual(lineup);
+  });
+
+  it("names the runner-up it passed over", () => {
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const qb = choiceFor(choices, "QB#0") as { playerId: string; runnerUpId: string | null };
+
+    expect(qb.playerId).toBe("qb-good");
+    expect(qb.runnerUpId).toBe("qb-bad");
+  });
+
+  it("says the runner-up was ranked lower when that is the reason", () => {
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    expect(choiceFor(choices, "QB#0")).toMatchObject({ runnerUpReason: "LOWER_RANKED" });
+  });
+
+  it("says unavailable ahead of lower-ranked, because that is the actionable fact", () => {
+    // A backup on a bye is not a judgement the manager can second-guess. Saying
+    // "projected lower" here is true and useless.
+    const roster = ROSTER.map((player) =>
+      player.playerId === "qb-bad" ? { ...player, unavailable: true } : player,
+    );
+    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+      runnerUpId: "qb-bad",
+      runnerUpReason: "UNAVAILABLE",
+    });
+  });
+
+  it("does not blame unavailability when the winner is unavailable too", () => {
+    // Both on a bye: the choice really was made on the ranking, and claiming
+    // otherwise would tell a manager to go and find a replacement who is no
+    // better off than the starter.
+    const roster = ROSTER.map((player) =>
+      player.positions[0] === "QB" ? { ...player, unavailable: true } : player,
+    );
+    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+      runnerUpReason: "LOWER_RANKED",
+    });
+  });
+
+  it("says NO_DATA rather than lower-ranked for an unranked runner-up", () => {
+    // A null ranking sorts last by construction, so "projected lower" implies a
+    // comparison that never took place.
+    const roster = ROSTER.map((player) =>
+      player.playerId === "qb-bad" ? { ...player, averageMilliPoints: null } : player,
+    );
+    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+      runnerUpId: "qb-bad",
+      runnerUpReason: "NO_DATA",
+    });
+  });
+
+  it("reports no runner-up when the slot had only one candidate", () => {
+    const roster = ROSTER.filter((player) => player.playerId !== "qb-bad");
+    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+      playerId: "qb-good",
+      runnerUpId: null,
+      runnerUpReason: null,
+    });
+  });
+
+  it("never offers a player another slot already took", () => {
+    // The reason the runner-up is computed inside the fill loop. Scarcest slot
+    // first means TE takes the only tight end before FLEX is considered, so
+    // naming him as FLEX's alternative would describe a choice nobody can make.
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const taken = new Set(choices.map((c) => c.playerId).filter(Boolean));
+
+    for (const choice of choices) {
+      if (choice.runnerUpId === null) continue;
+      expect(taken.has(choice.runnerUpId)).toBe(false);
+    }
+  });
+
+  it("never names a player who starts in another slot", () => {
+    // The flaw that produced the second pass. Computed inside the fill loop,
+    // RB#0's runner-up is rb2 — who RB#1 then starts. The screen would have
+    // offered the manager somebody already in their own lineup, described as an
+    // alternative to it.
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const rb0 = choiceFor(choices, "RB#0") as { playerId: string; runnerUpId: string | null };
+    const rb1 = choiceFor(choices, "RB#1") as { playerId: string };
+
+    expect(rb0.playerId).toBe("rb1");
+    expect(rb1.playerId).toBe("rb2");
+    expect(rb0.runnerUpId).not.toBe("rb2");
+  });
+
+  it("reports nothing for a locked slot", () => {
+    // A locked slot was not chosen by the autofill — its player is a fact about
+    // a game that has already started, and there was no alternative to weigh.
+    const choices = autolineupChoices({
+      shape: SHAPE,
+      roster: ROSTER,
+      locked: [{ slotType: "QB", slotIndex: 0, playerId: "qb-bad" }],
+    });
+    expect(choiceFor(choices, "QB#0")).toMatchObject({
+      playerId: "qb-bad",
+      runnerUpId: null,
+      runnerUpReason: null,
+    });
+  });
+});

--- a/packages/core/src/season/autolineup.ts
+++ b/packages/core/src/season/autolineup.ts
@@ -144,18 +144,62 @@ function compare(a: AutolineupCandidate, b: AutolineupCandidate, mode: AutofillM
  * Returns an assignment for every starting slot, with `null` where nobody on the
  * roster could fill it.
  */
-export function autolineup(input: AutolineupInput): readonly LineupAssignment[] {
+/**
+ * Why the runner-up did not get the slot.
+ *
+ * Three reasons rather than one number, because they are different instructions
+ * to a manager. "Projected lower" says the autofill is working and you may
+ * disagree with it; "on a bye or out" says the alternative was never really an
+ * alternative; "nothing to rank him on" says the autofill is guessing and your
+ * own opinion is worth more than its ordering.
+ */
+export type RunnerUpReason = "LOWER_RANKED" | "UNAVAILABLE" | "NO_DATA";
+
+export interface AutolineupChoice extends LineupAssignment {
+  /**
+   * The best eligible player this slot did **not** take, if there was one.
+   *
+   * Null when the slot had exactly one candidate, or none — in which case the
+   * autofill made no choice worth explaining.
+   */
+  readonly runnerUpId: string | null;
+  readonly runnerUpReason: RunnerUpReason | null;
+}
+
+/**
+ * The fill, with the road not taken.
+ *
+ * **`autolineup` delegates to this**, rather than the preview reimplementing
+ * the fill. A preview that ranked players itself would be the same decision
+ * authored twice, and the failure mode is the worst kind: the screen names one
+ * player all week and a different one gets started on Sunday, silently, in the
+ * league's own records.
+ *
+ * The runner-up is computed inside the loop because it is only knowable there —
+ * it depends on `used`, which changes as scarcer slots are filled first. A tight
+ * end taken by TE is genuinely not available to FLEX, and reporting him as
+ * FLEX's runner-up would describe a choice nobody could make.
+ */
+export function autolineupChoices(input: AutolineupInput): readonly AutolineupChoice[] {
   const { shape, roster, locked, mode = "SEASON_AVERAGE" } = input;
 
   const slots = startingSlots(shape);
 
-  const assignments = new Map<string, LineupAssignment>();
+  const assignments = new Map<string, AutolineupChoice>();
   const used = new Set<string>();
 
   // Locked slots are fixed points: preserved exactly, and their players are
   // unavailable to everything else.
+  const lockedKeys = new Set((locked ?? []).map((e) => `${e.slotType}#${e.slotIndex}`));
+
   for (const entry of locked ?? []) {
-    assignments.set(`${entry.slotType}#${entry.slotIndex}`, entry);
+    // A locked slot was not chosen by the autofill and has no alternative to
+    // report — its player is a fact about a game that has started.
+    assignments.set(`${entry.slotType}#${entry.slotIndex}`, {
+      ...entry,
+      runnerUpId: null,
+      runnerUpReason: null,
+    });
     if (entry.playerId) used.add(entry.playerId);
   }
 
@@ -193,26 +237,104 @@ export function autolineup(input: AutolineupInput): readonly LineupAssignment[] 
         slotType: slot.slotType,
         slotIndex: slot.slotIndex,
         playerId: best.playerId,
+        runnerUpId: null,
+        runnerUpReason: null,
       });
     } else {
       assignments.set(key, {
         slotType: slot.slotType,
         slotIndex: slot.slotIndex,
         playerId: null,
+        runnerUpId: null,
+        runnerUpReason: null,
       });
     }
   }
 
   // Returned in roster order, not fill order — the caller is writing a lineup a
   // human will read.
-  return slots.map(
-    (slot) =>
-      assignments.get(`${slot.slotType}#${slot.slotIndex}`) ?? {
-        slotType: slot.slotType,
-        slotIndex: slot.slotIndex,
-        playerId: null,
-      },
+  /*
+    The runner-up, in a second pass and against the **finished** lineup.
+
+    Computing it inside the fill loop is the obvious approach and is wrong: the
+    best player a slot passes over is usually the one the *next* slot of the same
+    type takes. RB#0 would report RB#1's starter as "also eligible", so the
+    screen would offer a manager somebody already in their own lineup.
+
+    What a manager wants named is the best player who ends up on the **bench** —
+    the alternative that really was foregone. That is only knowable once every
+    slot is filled, which is why this cannot live in the loop.
+  */
+  const started = new Set(
+    [...assignments.values()]
+      .map((entry) => entry.playerId)
+      .filter((id): id is string => id !== null),
   );
+  const bench = roster.filter((player) => !started.has(player.playerId));
+
+  return slots.map((slot) => {
+    const entry = assignments.get(`${slot.slotType}#${slot.slotIndex}`) ?? {
+      slotType: slot.slotType,
+      slotIndex: slot.slotIndex,
+      playerId: null,
+      runnerUpId: null,
+      runnerUpReason: null,
+    };
+
+    // A locked slot was not chosen by the autofill, and an empty one had nobody
+    // to pass over. Neither has an alternative worth reporting.
+    if (entry.playerId === null) return entry;
+    if (lockedKeys.has(`${slot.slotType}#${slot.slotIndex}`)) return entry;
+
+    const winner = roster.find((player) => player.playerId === entry.playerId);
+    const runnerUp = bench
+      .filter((player) =>
+        player.positions.some((position) => slot.eligiblePositions.includes(position)),
+      )
+      .sort((a, b) => compare(a, b, mode))[0];
+
+    if (!winner || !runnerUp) return entry;
+
+    return {
+      ...entry,
+      runnerUpId: runnerUp.playerId,
+      runnerUpReason: reasonAgainst(winner, runnerUp, mode),
+    };
+  });
+}
+
+/**
+ * Why `loser` lost to `winner`.
+ *
+ * Order matters. Unavailability is checked first because it is the reason a
+ * manager can act on — an alternative who is on a bye is not a judgement call,
+ * and reporting "projected lower" for a player with no game would be true and
+ * useless. `NO_DATA` comes next: a null ranking sorts last by construction, so
+ * "projected lower" would imply a comparison that never happened.
+ */
+function reasonAgainst(
+  winner: AutolineupCandidate,
+  loser: AutolineupCandidate,
+  mode: AutofillMode,
+): RunnerUpReason {
+  if (loser.unavailable === true && winner.unavailable !== true) return "UNAVAILABLE";
+  if (rankingValue(loser, mode) === null) return "NO_DATA";
+  return "LOWER_RANKED";
+}
+
+/**
+ * The fill alone.
+ *
+ * Kept as the public entry point every existing caller uses, so adding the
+ * preview cannot change what gets written. It is a projection of
+ * `autolineupChoices`, not a second implementation.
+ */
+export function autolineup(input: AutolineupInput): readonly LineupAssignment[] {
+  return autolineupChoices(input).map(({ slotType, slotIndex, playerId }) => ({
+    slotType,
+    slotIndex,
+    playerId,
+  }));
 }
 
 /**

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -135,6 +135,7 @@ export {
   loadByeWeeks,
   loadLineup,
   loadKickoffs,
+  autolineupCandidate,
   loadRosterForWeek,
   loadTbdKickoffs,
   type RosterPlayer,

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -730,6 +730,40 @@ export async function loadProjectedPoints(
 const OUT_STATUSES = new Set(["OUT", "IR", "INACTIVE", "SUSPENDED", "DOUBTFUL", "PUP", "NFI"]);
 
 /**
+ * One roster row, as the autofill sees it.
+ *
+ * **Exported so the preview cannot describe a different player from the write.**
+ * The lineup route has every input already loaded and would otherwise restate
+ * the `unavailable` rule inline — a bye and an out designation both meaning
+ * "will not appear", neither being a hard exclusion. That rule sitting in two
+ * files is how a screen ends up promising one starter while Sunday produces
+ * another.
+ */
+export function autolineupCandidate(
+  player: {
+    readonly playerId: string;
+    readonly positions: readonly string[];
+    readonly kickoffAt: number | null;
+    readonly status: string;
+  },
+  ranking: {
+    readonly averageMilliPoints: number | null;
+    readonly projectedMilliPoints: number | null;
+  },
+): AutolineupCandidate {
+  return {
+    playerId: player.playerId,
+    positions: player.positions,
+    kickoffAt: player.kickoffAt,
+    averageMilliPoints: ranking.averageMilliPoints,
+    projectedMilliPoints: ranking.projectedMilliPoints,
+    // A bye and an injury designation both mean "will not appear". Neither is a
+    // hard exclusion — a team with nobody else still has to field someone.
+    unavailable: player.kickoffAt === null || OUT_STATUSES.has(player.status.toUpperCase()),
+  };
+}
+
+/**
  * Fill a team's lineup automatically.
  *
  * Preserves any slot that has already locked and any slot the manager has
@@ -775,16 +809,12 @@ export async function autoFillLineup(
       ? await loadProjectedPoints(db, season, week, stored.rules)
       : new Map<string, number>();
 
-  const candidates: AutolineupCandidate[] = [...roster.values()].map((player) => ({
-    playerId: player.playerId,
-    positions: player.positions,
-    kickoffAt: player.kickoffAt,
-    averageMilliPoints: averages.get(player.playerId) ?? null,
-    projectedMilliPoints: projected.get(player.playerId) ?? null,
-    // A bye and an injury designation both mean "will not appear". Neither is a
-    // hard exclusion — a team with nobody else still has to field someone.
-    unavailable: player.kickoffAt === null || OUT_STATUSES.has(player.status.toUpperCase()),
-  }));
+  const candidates: AutolineupCandidate[] = [...roster.values()].map((player) =>
+    autolineupCandidate(player, {
+      averageMilliPoints: averages.get(player.playerId) ?? null,
+      projectedMilliPoints: projected.get(player.playerId) ?? null,
+    }),
+  );
 
   const slotTypeIds = await loadSlotTypeIds(db, stored.rules);
 


### PR DESCRIPTION
The autofill sets lineups for anyone who doesn't, and the screen offered **a checkbox and nothing else** — no account of what turning it on would actually do. The design calls this the lineup screen's headline feature; it was never built.

Per empty slot it now names the player it will start, the best player it left on the bench, and why.

## It cannot disagree with the write

The preview comes from `autolineupChoices` — the same function `autoFillLineup` fills with. `autolineup` is now a projection of it rather than a sibling, and the existing 29 engine tests pass unchanged, which is what says the fill did not move.

A browser-side ranking would have been the same decision authored twice, and the divergence is the expensive kind: the screen names one player all week and a different one starts on Sunday, in the league's own records.

## The runner-up is computed against the *finished* lineup

The obvious implementation records it inside the fill loop, and a test written for the invariant caught it: **the player a slot passes over is usually the one the next slot of the same type takes.** RB#0's runner-up came out as rb2 — who RB#1 then starts. The screen would have offered a manager somebody already in their own lineup, presented as an alternative to it.

What's worth naming is the best player who ends up on the **bench**, which is only knowable once every slot is filled.

## Three more that would each have shipped wrong

- **Locked slots are passed in, not filtered out.** A locked player is unavailable to every other slot; omitting them would let the preview offer someone already playing. The FLEX line would have been wrong every Sunday afternoon.
- **The empty count comes from the slots, not the preview's length.** A slot with no eligible player produces no entry — counting entries would say two slots are empty while three score nothing.
- **With autofill off it warns rather than predicts.** Describing what the autofill "would" do on a team that has it off describes something that isn't going to happen. A test asserts the off heading never says "will fill".

## Reasons, not a number

`LOWER_RANKED` / `UNAVAILABLE` / `NO_DATA` are different instructions. Unavailability is reported first because it's the fact a manager can act on — and only when the winner is available, or a lineup of players all on a bye would blame the bye for a choice the ranking made.

`whyNot` names the ranking the league actually froze: "projected lower" vs "averaging lower" are different claims, and a SEASON_AVERAGE league making the first would describe a number its autofill never consults.

## Checks

`pnpm test` (2055 passed, 2 skipped), typecheck, lint, prettier, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)