### PR TITLE
feat(web): an invitation can be refused

### DIFF
--- a/apps/web/src/app/(app)/invitations/page.tsx
+++ b/apps/web/src/app/(app)/invitations/page.tsx
@@ -3,6 +3,7 @@ import { getWallets, invitationsForUser } from "@rostr/db";
 import { db } from "@/lib/db";
 import { accountGaps } from "@/lib/account";
 import { currentUser } from "@/lib/session";
+import { DeclineInvitation } from "@/components/DeclineInvitation";
 
 /**
  * Leagues you have been asked to join.
@@ -77,22 +78,27 @@ export default async function InvitationsPage() {
         <ul className="space-y-3">
           {invitations.map((invitation) => (
             <li key={invitation.id}>
-              <a
-                href={`/leagues/${invitation.leagueId}`}
-                className="block space-y-2 rounded-lg border border-nocturne-neutral-900 p-5 transition-colors hover:border-nocturne-neutral-800 hover:bg-nocturne-surface/30"
-              >
-                <div className="flex items-baseline justify-between gap-3">
-                  <h2 className="truncate text-base font-medium">{invitation.leagueName}</h2>
-                  <span className="shrink-0 text-xs text-nocturne-neutral-600">
-                    {invitation.addressedAs === "WALLET"
-                      ? "addressed to your wallet address"
-                      : "addressed to your username"}
-                  </span>
-                </div>
-                <p className="text-xs text-nocturne-neutral-600">
-                  Read the rules and join &rarr;
-                </p>
-              </a>
+              <div className="space-y-2 rounded-lg border border-nocturne-neutral-900 p-5 transition-colors hover:border-nocturne-neutral-800">
+                <a href={`/leagues/${invitation.leagueId}`} className="block space-y-2">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <h2 className="truncate text-base font-medium">{invitation.leagueName}</h2>
+                    <span className="shrink-0 text-xs text-nocturne-neutral-600">
+                      {invitation.addressedAs === "WALLET"
+                        ? "addressed to your wallet address"
+                        : "addressed to your username"}
+                    </span>
+                  </div>
+                  <p className="text-xs text-nocturne-neutral-600">
+                    Read the rules and join &rarr;
+                  </p>
+                </a>
+                {/*
+                  Outside the anchor. An action nested inside a navigation target
+                  is how declining becomes an accidental click on the way to
+                  reading the rules.
+                */}
+                <DeclineInvitation invitationId={invitation.id} />
+              </div>
             </li>
           ))}
         </ul>

--- a/apps/web/src/app/api/invitations/route.ts
+++ b/apps/web/src/app/api/invitations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { invitationsForUser } from "@rostr/db";
+import { declineInvitation, invitationsForUser } from "@rostr/db";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 
@@ -38,4 +38,37 @@ export async function GET(): Promise<NextResponse> {
       createdAt: invitation.createdAt.toISOString(),
     })),
   });
+}
+
+/**
+ * Refuse an invitation.
+ *
+ * **Scoped to you, like the GET above**, and that is the whole authorisation
+ * story: the account comes from the session cookie and `declineInvitation` is
+ * scoped by the invitee, so a caller has no way to *name* another person and
+ * therefore no way to act as them. The mirror of `withdrawInvitation`, which is
+ * scoped by league because a commissioner acts on their league's invitations.
+ *
+ * A 401 for a signed-out caller rather than the GET's empty list: reading
+ * nothing is a reasonable answer to "what am I invited to", and declining
+ * nothing is not a request that can succeed.
+ *
+ * `declined: false` is returned with a 200, not an error. It means the row was
+ * already declined, already withdrawn, or was never this caller's — and all
+ * three end with the invitation gone from their list, which is what they asked
+ * for. Distinguishing them in the response would report on invitations
+ * belonging to other people.
+ */
+export async function DELETE(request: Request): Promise<NextResponse> {
+  const user = await currentUser();
+  if (!user) return NextResponse.json({ error: "Sign in first" }, { status: 401 });
+
+  const body = (await request.json().catch(() => ({}))) as { invitationId?: unknown };
+  if (typeof body.invitationId !== "string") {
+    return NextResponse.json({ error: "invitationId is required" }, { status: 400 });
+  }
+
+  const result = await declineInvitation(db(), body.invitationId, user.id);
+
+  return NextResponse.json(result);
 }

--- a/apps/web/src/components/DeclineInvitation.tsx
+++ b/apps/web/src/components/DeclineInvitation.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { mutate } from "swr";
+import { INVITATIONS_KEY } from "@/components/InvitationsCorner";
+
+/**
+ * Refuse an invitation, from a server-rendered list.
+ *
+ * A client island rather than a form action because the page around it is a
+ * server component and the row has to disappear without a full navigation —
+ * `router.refresh()` re-runs the page's own query, which is the same list this
+ * button just changed.
+ *
+ * **It also invalidates `INVITATIONS_KEY`**, and that is not incidental. The
+ * header's corner reads the same invitations through SWR, so declining here
+ * while leaving that cache alone would show the invitation gone from the page
+ * and still present in the corner — the two disagreeing about the same fact on
+ * the same screen.
+ *
+ * Not confirmed. A decline removes the invitation and tells the commissioner;
+ * it does not bar anybody, and they can ask again — so a dialog would guard
+ * something reversible and train people to click through the ones that are not.
+ */
+export function DeclineInvitation({ invitationId }: { invitationId: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function decline(): Promise<void> {
+    setBusy(true);
+    try {
+      await fetch("/api/invitations", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invitationId }),
+      });
+      await mutate(INVITATIONS_KEY);
+      router.refresh();
+    } finally {
+      // Left busy on success would leave a dead control if the refresh is slow,
+      // and the row is about to be removed either way.
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={() => void decline()}
+      disabled={busy}
+      className="text-xs text-nocturne-neutral-600 transition-colors hover:text-red-400 disabled:opacity-40"
+    >
+      {busy ? "Declining…" : "Decline"}
+    </button>
+  );
+}

--- a/apps/web/src/components/InvitationsCorner.tsx
+++ b/apps/web/src/components/InvitationsCorner.tsx
@@ -36,9 +36,41 @@ export const invitationsFetcher = async (url: string): Promise<PendingInvitation
 };
 
 export function InvitationsCorner() {
-  const { data } = useSWR<PendingInvitation[]>(INVITATIONS_KEY, invitationsFetcher, {
+  const { data, mutate } = useSWR<PendingInvitation[]>(INVITATIONS_KEY, invitationsFetcher, {
     revalidateOnFocus: true,
   });
+
+  /**
+   * Refuse it.
+   *
+   * **The list is optimistic and revalidates**, because the alternative reads
+   * as a dead button: the row is the only feedback there is, and waiting a
+   * round trip to remove it invites a second click on an invitation that is
+   * already gone.
+   *
+   * Not confirmed. A decline removes the invitation and tells the commissioner;
+   * it does not bar anybody, and they can ask again — so a dialog here would be
+   * guarding something reversible and would train people to click through the
+   * ones that are not.
+   */
+  async function decline(invitationId: string): Promise<void> {
+    await mutate(
+      async (current) => {
+        await fetch("/api/invitations", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ invitationId }),
+        });
+        return (current ?? []).filter((invitation) => invitation.id !== invitationId);
+      },
+      {
+        optimisticData: (current: PendingInvitation[] | undefined) =>
+          (current ?? []).filter((invitation) => invitation.id !== invitationId),
+        rollbackOnError: true,
+        revalidate: true,
+      },
+    );
+  }
 
   const invitations = data ?? [];
   if (invitations.length === 0) return null;
@@ -74,16 +106,26 @@ export function InvitationsCorner() {
       <ul className="grid gap-2 sm:grid-cols-2">
         {invitations.slice(0, 4).map((invitation) => (
           <li key={invitation.id}>
-            <a
-              href={`/leagues/${invitation.leagueId}`}
-              className="block rounded border border-nocturne-neutral-900 bg-nocturne-bg/40 px-3 py-2 transition-colors hover:border-nocturne-neutral-800"
-            >
-              <span className="block truncate text-sm">{invitation.leagueName}</span>
-              <span className="block text-[11px] text-nocturne-neutral-600">
-                addressed to your{" "}
-                {invitation.addressedAs === "WALLET" ? "wallet address" : "username"}
-              </span>
-            </a>
+            <div className="rounded border border-nocturne-neutral-900 bg-nocturne-bg/40 px-3 py-2 transition-colors hover:border-nocturne-neutral-800">
+              <a href={`/leagues/${invitation.leagueId}`} className="block">
+                <span className="block truncate text-sm">{invitation.leagueName}</span>
+                <span className="block text-[11px] text-nocturne-neutral-600">
+                  addressed to your{" "}
+                  {invitation.addressedAs === "WALLET" ? "wallet address" : "username"}
+                </span>
+              </a>
+              {/*
+                A button, not a link, and outside the anchor — nesting an action
+                inside a navigation target is how a decline becomes an accidental
+                click on the way to reading the rules.
+              */}
+              <button
+                onClick={() => void decline(invitation.id)}
+                className="mt-1.5 text-[11px] text-nocturne-neutral-600 transition-colors hover:text-red-400"
+              >
+                Decline
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/packages/db/migrations/0037_decline_invitation.sql
+++ b/packages/db/migrations/0037_decline_invitation.sql
@@ -1,0 +1,25 @@
+-- An invitation can be refused.
+--
+-- `0036` stored withdrawal and not decline, so the only way out of an invitation
+-- was for the commissioner to take it back. An invitee who was never going to
+-- join carried it in their list indefinitely, and the commissioner had no way to
+-- tell "has not looked yet" from "has decided against it" — which is exactly the
+-- fact that tells them to invite somebody else.
+--
+-- Separate from `withdrawn_at`, not a shared "cancelled_at". They are different
+-- acts by different people and the commissioner's screen has to distinguish
+-- them: an invitation you withdrew is one you may want to re-send, and one that
+-- was declined is one you probably should not. Collapsing them would make the
+-- invite panel unable to say which happened, and there is no second place that
+-- records it.
+ALTER TABLE league_invitations
+  ADD COLUMN declined_at timestamptz;
+
+-- Both cannot be true at once. They are mutually exclusive events — a
+-- commissioner cannot withdraw an invitation that has already been refused and
+-- an invitee cannot refuse one that is no longer offered — and the routes each
+-- check for the other. This is what makes that a fact rather than a convention
+-- two call sites happen to keep.
+ALTER TABLE league_invitations
+  ADD CONSTRAINT league_invitations_one_ending
+  CHECK (withdrawn_at IS NULL OR declined_at IS NULL);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27,6 +27,7 @@ export {
   invitationsForLeague,
   invitationsForUser,
   inviteToLeague,
+  declineInvitation,
   withdrawInvitation,
   type AddressedAs,
   type Invitation,

--- a/packages/db/src/invitations.test.ts
+++ b/packages/db/src/invitations.test.ts
@@ -3,6 +3,7 @@ import { buildNflPprRules, NFL } from "@rostr/core";
 import type { DraftRules, LeagueRules } from "@rostr/core";
 import { createUser, linkWallet } from "./identity.js";
 import {
+  declineInvitation,
   invitationsForLeague,
   invitationsForUser,
   inviteToLeague,
@@ -293,5 +294,112 @@ describe("invitationsForUser", () => {
     await fx.client.query("UPDATE leagues SET state = 'DRAFTING' WHERE id = $1", [fx.leagueId]);
 
     expect(await invitationsForUser(fx.client, fx.invitee)).toHaveLength(0);
+  });
+});
+
+describe("declineInvitation", () => {
+  it("takes the invitation out of the invitee's list", async () => {
+    const fx = await setup();
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+
+    expect(await invitationsForUser(fx.client, fx.invitee)).toHaveLength(1);
+
+    await declineInvitation(fx.client, invitation.id, fx.invitee);
+
+    // The list is a to-do. A declined invitation left on it would make the
+    // button look broken rather than recorded.
+    expect(await invitationsForUser(fx.client, fx.invitee)).toHaveLength(0);
+  });
+
+  it("still shows the commissioner that they were refused", async () => {
+    const fx = await setup();
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+    await declineInvitation(fx.client, invitation.id, fx.invitee);
+
+    // The fact that tells a commissioner to ask somebody else. Dropping it from
+    // both lists would make a decline indistinguishable from silence.
+    const [row] = await invitationsForLeague(fx.client, fx.leagueId);
+    expect(row?.declinedAt).toBeInstanceOf(Date);
+    expect(row?.withdrawnAt).toBeNull();
+  });
+
+  it("refuses to decline somebody else's invitation", async () => {
+    const fx = await setup();
+    const stranger = await createUser(fx.client, "stranger@example.test", "Stranger");
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+
+    // Scoped by the invitee, not the league. A caller with no way to name
+    // another person has no way to act as them.
+    expect(await declineInvitation(fx.client, invitation.id, stranger.id)).toEqual({
+      declined: false,
+    });
+    expect(await invitationsForUser(fx.client, fx.invitee)).toHaveLength(1);
+  });
+
+  it("is idempotent", async () => {
+    const fx = await setup();
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+
+    expect(await declineInvitation(fx.client, invitation.id, fx.invitee)).toEqual({
+      declined: true,
+    });
+    // Pressing twice is not a failure — saying so would suggest they are still
+    // invited.
+    expect(await declineInvitation(fx.client, invitation.id, fx.invitee)).toEqual({
+      declined: false,
+    });
+  });
+
+  it("will not decline an invitation the commissioner already withdrew", async () => {
+    const fx = await setup();
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+    await withdrawInvitation(fx.client, fx.leagueId, invitation.id);
+
+    // There is nothing left to decline, and writing both would violate `0037`'s
+    // check constraint.
+    expect(await declineInvitation(fx.client, invitation.id, fx.invitee)).toEqual({
+      declined: false,
+    });
+  });
+
+  it("comes back when the commissioner asks again", async () => {
+    const fx = await setup();
+    const invitation = await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+    await declineInvitation(fx.client, invitation.id, fx.invitee);
+
+    // "We spoke and they changed their mind" is the ordinary reason to re-send.
+    // A decline removes the invitation and reports the refusal; it does not bar
+    // the person, and this test is what says so out loud.
+    await inviteToLeague(fx.client, {
+      leagueId: fx.leagueId,
+      invitedBy: fx.commissioner,
+      identifier: "route66",
+    });
+
+    expect(await invitationsForUser(fx.client, fx.invitee)).toHaveLength(1);
   });
 });

--- a/packages/db/src/invitations.ts
+++ b/packages/db/src/invitations.ts
@@ -46,6 +46,15 @@ export interface Invitation {
   readonly createdAt: Date;
   readonly withdrawnAt: Date | null;
   /**
+   * When the invitee refused, if they did.
+   *
+   * Distinct from `withdrawnAt` because the commissioner's next move differs:
+   * an invitation they withdrew is one they may want to re-send, and one that
+   * was declined is one they probably should not. A shared "cancelled" would
+   * leave the panel unable to say which happened, and nothing else records it.
+   */
+  readonly declinedAt: Date | null;
+  /**
    * Whether the invitee has since joined.
    *
    * **Derived from `league_memberships`, never stored.** A member is a member
@@ -142,7 +151,20 @@ export async function inviteToLeague(
            -- Re-inviting revives a withdrawn invitation. The alternative is a
            -- commissioner who changed their mind being permanently unable to
            -- change it back, with nothing on screen explaining why.
-           withdrawn_at = NULL
+           withdrawn_at = NULL,
+           -- And a declined one, deliberately, though it is the less obvious
+           -- half. "We spoke and they changed their mind" is the ordinary
+           -- reason a commissioner re-sends after a decline, and a permanent
+           -- block would have no way to express it.
+           --
+           -- The cost is that a decline can be overridden by asking again, so
+           -- it does not *bar* anyone. What it does is remove the invitation
+           -- from the invitee's list and tell the commissioner they were
+           -- refused — and each fresh decline is recorded in turn. Barring
+           -- would need a separate opt-out belonging to the invitee rather
+           -- than to one invitation; nothing here is that, and this comment is
+           -- not claiming it is.
+           declined_at = NULL
      RETURNING id, created_at, addressed_as`,
     [input.leagueId, invitee.id, input.invitedBy, addressedAs],
   );
@@ -155,6 +177,7 @@ export async function inviteToLeague(
     addressedAs: row!.addressed_as as AddressedAs,
     createdAt: new Date(row!.created_at),
     withdrawnAt: null,
+    declinedAt: null,
     accepted: false,
   };
 }
@@ -176,6 +199,44 @@ export async function withdrawInvitation(
   );
 }
 
+/**
+ * Refuse an invitation.
+ *
+ * **Scoped by the invitee, never by the league**, which is the mirror image of
+ * `withdrawInvitation` and the reason the two cannot share an implementation.
+ * A commissioner acts on invitations belonging to their league; an invitee acts
+ * on invitations belonging to *them*. Taking a league id here would let a
+ * caller decline on somebody else's behalf by naming a league they happen to
+ * run, and taking neither would let anyone decline anything with a UUID.
+ *
+ * The wallet-derivation rule elsewhere in this repo is the same idea: a caller
+ * with no way to *name* another person has no way to act as them.
+ *
+ * Idempotent. A second decline matches no row and is not an error — the invitee
+ * pressed a button twice, and telling them it failed would suggest they are
+ * still invited.
+ *
+ * `withdrawn_at IS NULL` is not merely tidiness. Declining an invitation the
+ * commissioner already took back would write a state the `0037` check
+ * constraint refuses, and the honest answer is that there is nothing left to
+ * decline.
+ */
+export async function declineInvitation(
+  db: SqlClient,
+  invitationId: string,
+  invitedUserId: string,
+): Promise<{ declined: boolean }> {
+  const rows = await db.query<{ id: string }>(
+    `UPDATE league_invitations SET declined_at = now()
+      WHERE id = $1 AND invited_user_id = $2
+        AND declined_at IS NULL AND withdrawn_at IS NULL
+      RETURNING id`,
+    [invitationId, invitedUserId],
+  );
+
+  return { declined: rows.length > 0 };
+}
+
 /** Everyone this league has asked, newest first. */
 export async function invitationsForLeague(
   db: SqlClient,
@@ -190,10 +251,12 @@ export async function invitationsForLeague(
     addressed_as: string;
     created_at: string;
     withdrawn_at: string | null;
+    declined_at: string | null;
     accepted: boolean;
   }>(
     `SELECT i.id, i.league_id, l.name AS league_name, i.invited_user_id,
             u.username AS invited_username, i.addressed_as, i.created_at, i.withdrawn_at,
+            i.declined_at,
             EXISTS (
               SELECT 1 FROM league_memberships m
                WHERE m.league_id = i.league_id AND m.user_id = i.invited_user_id
@@ -242,6 +305,10 @@ export async function invitationsForUser(
        JOIN leagues l ON l.id = i.league_id
       WHERE i.invited_user_id = $1
         AND i.withdrawn_at IS NULL
+        -- Declined is an answer, and this list is a to-do. Leaving it here would
+        -- make the button do nothing visible, which reads as a broken control
+        -- rather than a recorded decision.
+        AND i.declined_at IS NULL
         AND l.state = 'FORMING'
         AND NOT EXISTS (
           SELECT 1 FROM league_memberships m
@@ -262,6 +329,7 @@ function toInvitation(row: {
   addressed_as: string;
   created_at: string;
   withdrawn_at: string | null;
+  declined_at?: string | null;
   accepted: boolean;
 }): Invitation {
   return {
@@ -272,6 +340,7 @@ function toInvitation(row: {
     addressedAs: row.addressed_as as AddressedAs,
     createdAt: new Date(row.created_at),
     withdrawnAt: row.withdrawn_at ? new Date(row.withdrawn_at) : null,
+    declinedAt: row.declined_at ? new Date(row.declined_at) : null,
     accepted: row.accepted,
   };
 }


### PR DESCRIPTION
`0036` stored withdrawal and not decline, so the only way out of an invitation was for the **commissioner** to take it back. Somebody who was never going to join carried it in their list indefinitely, and the commissioner couldn't tell "hasn't looked yet" from "has decided against it" — which is the fact that tells them to ask someone else.

## `declined_at` is its own column

Not a shared `cancelled_at`. They're different acts by different people, and the commissioner's next move differs: an invitation they withdrew is one they may want to re-send; one that was refused is one they probably shouldn't. Collapsing them would leave the invite panel unable to say which happened.

`0037` adds a check constraint refusing both at once — the two routes each check for the other, and the constraint is what makes that a fact rather than a convention two call sites happen to keep.

Migration numbering checked: `0036` is main's highest and all are applied, so `db:status` reports `0037` as **PENDING** rather than the false `applied` a collision produces.

## Scoped by the invitee, never by the league

The mirror of `withdrawInvitation`, and why the two can't share an implementation. A commissioner acts on their league's invitations; an invitee acts on **theirs**. A league id here would let a caller decline on someone else's behalf by naming a league they happen to run; neither would let anyone decline anything with a UUID.

## What a decline does and doesn't do

Removes it from the invitee's list, shows the commissioner they were refused. **It does not bar anybody** — re-inviting revives it, exactly as it revives a withdrawal, because "we spoke and they changed their mind" is the ordinary reason to re-send. Each fresh decline is recorded in turn. Barring would need an opt-out belonging to the person rather than to one invitation, and the comment says plainly that this isn't that.

Idempotent; a second press isn't an error, since saying so would suggest they're still invited.

## Two rendering details

- **The button sits outside the anchor**, both places — an action nested in a navigation target is how declining becomes an accidental click on the way to reading the rules.
- **The page's island invalidates `INVITATIONS_KEY`, not just `router.refresh()`.** The header corner reads the same invitations through SWR; without it the invitation would vanish from the list and remain in the corner.

## Checks

`pnpm test` (2061 passed, 2 skipped) including 6 new decline tests, typecheck, lint, prettier, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)