### PR TITLE
feat: injured reserve, which the rules have promised since the schema was written

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/ir/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/ir/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { activateFromIr, IrError, moveToIr } from "@rostr/db";
+import { db } from "@/lib/db";
+import { draftContext, DraftContextError } from "@/lib/draft-context";
+
+/**
+ * Injured reserve, on and off.
+ *
+ * **Your own team only.** The team is derived from the caller's membership, not
+ * taken from the request — a caller with no way to *name* another team has no
+ * way to act on one. Same shape as the lineup route beside it, and the same
+ * reason.
+ *
+ * The rules half lives in `@rostr/core`; the transaction half in `@rostr/db`.
+ * This route does nothing but establish who is asking and map a refusal to a
+ * status, which is why there is no capacity arithmetic anywhere in it.
+ */
+
+const STATUS: Record<string, number> = {
+  LEAGUE_NOT_FOUND: 404,
+  NOT_ON_ROSTER: 404,
+  NOT_ON_IR: 404,
+  // The league's own frozen rules refuse it. Well-formed requests against a
+  // state that does not permit them, so 409 rather than 422.
+  NOT_INJURED: 409,
+  IR_FULL: 409,
+  GAME_STARTED: 409,
+};
+
+function fail(error: unknown): NextResponse {
+  if (error instanceof IrError) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: STATUS[error.code] ?? 400 },
+    );
+  }
+  if (error instanceof DraftContextError) {
+    return NextResponse.json(
+      { error: error.message, code: "CONTEXT" },
+      { status: error.status },
+    );
+  }
+  throw error;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  try {
+    const context = await draftContext(id);
+    if (!context.myTeamId) {
+      return NextResponse.json({ error: "You are not in this league" }, { status: 403 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      playerId?: unknown;
+      week?: unknown;
+      action?: unknown;
+    };
+    if (typeof body.playerId !== "string") {
+      return NextResponse.json({ error: "playerId is required" }, { status: 400 });
+    }
+
+    if (body.action === "ACTIVATE") {
+      const result = await activateFromIr(db(), {
+        leagueId: id,
+        teamId: context.myTeamId,
+        playerId: body.playerId,
+      });
+      return NextResponse.json(result);
+    }
+
+    /*
+      The week comes from the client here, and that is safe in a way it is not
+      on the trades route.
+
+      It selects which fixture the kickoff check looks at, and the check only
+      ever *refuses*. Naming a week with no fixture finds no kickoff and lets
+      the move through — which is the same answer a bye gives, and a bye is a
+      legitimate time to stash somebody. Nothing here is a deadline a wrong week
+      could move.
+    */
+    const week = typeof body.week === "number" && body.week > 0 ? body.week : 1;
+
+    const result = await moveToIr(db(), {
+      leagueId: id,
+      teamId: context.myTeamId,
+      playerId: body.playerId,
+      week,
+      now: new Date(),
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    return fail(error);
+  }
+}

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -128,12 +128,16 @@ export async function GET(
 
     const choices = autolineupChoices({
       shape,
-      roster: [...roster.values()].map((player) =>
-        autolineupCandidate(player, {
-          averageMilliPoints: averages.get(player.playerId) ?? null,
-          projectedMilliPoints: projected.get(player.playerId) ?? null,
-        }),
-      ),
+      // Stashed players are out of the rotation, exactly as in `autoFillLineup`.
+      // A preview that offered one would name a starter the write will not make.
+      roster: [...roster.values()]
+        .filter((player) => !player.onIr)
+        .map((player) =>
+          autolineupCandidate(player, {
+            averageMilliPoints: averages.get(player.playerId) ?? null,
+            projectedMilliPoints: projected.get(player.playerId) ?? null,
+          }),
+        ),
       mode: context.rules.roster.autofill,
       locked: currentAssignments.filter((entry) => slotIsLocked(entry, kickoffs, now)),
     });
@@ -154,6 +158,8 @@ export async function GET(
 
     return NextResponse.json({
       week,
+      /** From the frozen rules, so the screen cannot invent an allowance. */
+      irSlots: context.rules.roster.irSlots,
       autofill: {
         enabled: autofillEnabled ?? true,
         /**
@@ -203,6 +209,12 @@ export async function GET(
         imageUrl: player.imageUrl,
         teamRef: player.teamRef,
         injuryDesignation: player.injuryDesignation,
+        /**
+         * On injured reserve. Unlike the designation above this is **not**
+         * display-only: it decides whether he counts against the roster limit
+         * and keeps him out of the autofill.
+         */
+        onIr: player.onIr,
         kickoffAt: player.kickoffAt,
         /**
          * How settled this player's week is. A bye, a fixture whose kickoff

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { isIrEligible as irEligible } from "@rostr/core";
 import { previewHeading, whyNot } from "@/lib/autofill";
 import useSWR from "swr";
 import { PlayerAvatar } from "./PlayerAvatar";
@@ -41,6 +42,8 @@ interface RosterPlayer {
    * `UNSCHEDULED` is the same news with less of it: no fixture stored at all.
    */
   availability: "SCHEDULED" | "TIME_TBD" | "BYE" | "UNSCHEDULED";
+  /** Stashed on injured reserve: on the roster, out of the rotation. */
+  onIr: boolean;
   milliPoints: number;
   /** This week's projection under this league's scoring. Null if unpublished. */
   projectedMilliPoints: number | null;
@@ -74,6 +77,8 @@ interface LineupResponse {
   };
   slots: Slot[];
   roster: RosterPlayer[];
+  /** From the frozen rules. Zero means the league has no injured reserve. */
+  irSlots: number;
 }
 
 /**
@@ -242,7 +247,42 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
     0,
   );
 
-  const bench = data.roster.filter((player) => !started.has(player.playerId));
+  /*
+    Three places a player can be, not two.
+
+    A stashed player is neither started nor on the bench — he is out of the
+    rotation, and listing him among the bench would offer him in every slot's
+    dropdown, which is precisely what injured reserve exists to stop.
+  */
+  const stashed = data.roster.filter((player) => player.onIr);
+  const bench = data.roster.filter((player) => !started.has(player.playerId) && !player.onIr);
+
+  /**
+   * Move a player on or off injured reserve.
+   *
+   * The server decides. This sends the intent and re-reads — every rule that
+   * matters (is he injured, is there room, has his game started) lives in
+   * `@rostr/core` and `@rostr/db`, and duplicating any of it here would be a
+   * screen that permits what the server refuses.
+   */
+  async function ir(playerId: string, action: "STASH" | "ACTIVATE"): Promise<void> {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const response = await fetch(`/api/leagues/${leagueId}/ir`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ playerId, week, action }),
+      });
+      const body = (await response.json()) as { error?: string };
+      if (!response.ok) throw new Error(body.error ?? "Could not change injured reserve");
+      await mutate();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -504,6 +544,22 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
               {OUT_STATUSES.has(player.status.toUpperCase()) && (
                 <span className="text-amber-400/70">{player.status}</span>
               )}
+              {/*
+                Offered only to a player the server would actually accept. The
+                rule is enforced there; this just avoids a button whose only
+                outcome is a refusal.
+              */}
+              {data.irSlots > 0 &&
+                stashed.length < data.irSlots &&
+                irEligible(player.injuryDesignation) && (
+                  <button
+                    onClick={() => void ir(player.playerId, "STASH")}
+                    disabled={saving}
+                    className="text-[10px] text-nocturne-neutral-600 hover:text-nocturne-accent-300 disabled:opacity-40"
+                  >
+                    To IR
+                  </button>
+                )}
               {player.availability === "BYE" && (
                 <span className="text-nocturne-neutral-600">bye</span>
               )}
@@ -543,6 +599,81 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
           ))}
         </ul>
       </section>
+
+      {/*
+        Injured reserve.
+
+        Rendered whenever the league has slots, even when empty, because unlike
+        the bell's badge this is a *rule members signed* — `roster.irSlots` is in
+        the frozen document and `RulesView` shows it above the join control. A
+        section that only appeared once used would leave a manager unable to find
+        out the allowance existed.
+      */}
+      {data.irSlots > 0 && (
+        <section className="space-y-2">
+          <h3 className="text-sm font-medium text-nocturne-neutral-400">
+            Injured reserve{" "}
+            <span className="text-xs font-normal text-nocturne-neutral-600">
+              {stashed.length} of {data.irSlots}
+            </span>
+          </h3>
+
+          {stashed.length === 0 ? (
+            <p className="text-[11px] text-nocturne-neutral-600">
+              Holds players carrying an official out designation. They do not count against your
+              roster limit and the autofill will never start them.
+            </p>
+          ) : (
+            <ul className="space-y-1 text-xs">
+              {stashed.map((player) => {
+                // The owner's rule made visible: a player on IR must actually be
+                // injured. When he recovers nothing is dropped or moved — he
+                // simply stops being exempt, so the roster is over its limit
+                // until the manager acts. Saying so is the whole remedy.
+                const recovered = !irEligible(player.injuryDesignation);
+
+                return (
+                  <li key={player.playerId} className="flex items-center gap-3">
+                    <button
+                      onClick={() => setOpenPlayerId(player.playerId)}
+                      className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                    >
+                      <PlayerAvatar
+                        name={player.name}
+                        positions={player.positions}
+                        imageUrl={player.imageUrl}
+                        size={28}
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs">{player.name}</span>
+                        <span className="block text-[10px] text-nocturne-neutral-600">
+                          {positionGroup(player.positions)}
+                          {player.teamRef ? ` · ${player.teamRef}` : ""}
+                          {player.injuryDesignation ? ` · ${player.injuryDesignation}` : ""}
+                        </span>
+                      </span>
+                    </button>
+
+                    {recovered && (
+                      <span className="text-[10px] text-amber-300">
+                        no longer out — counts against your roster
+                      </span>
+                    )}
+
+                    <button
+                      onClick={() => void ir(player.playerId, "ACTIVATE")}
+                      disabled={saving}
+                      className="text-[10px] text-nocturne-neutral-600 hover:text-nocturne-accent-300 disabled:opacity-40"
+                    >
+                      Activate
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      )}
 
       <p className="text-xs text-nocturne-neutral-600">
         Each slot locks when that player&rsquo;s game kicks off, not all at once — so a Thursday

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -272,3 +272,13 @@ export {
   type DraftState,
   type MakePickInput,
 } from "./draft/state.js";
+
+export {
+  countedRosterSize,
+  irExemptCount,
+  IR_ELIGIBLE_DESIGNATIONS,
+  isIrEligible,
+  refuseIrPlacement,
+  type IrPlacementRefusal,
+  type IrRosterEntry,
+} from "./season/injured-reserve.js";

--- a/packages/core/src/season/injured-reserve.test.ts
+++ b/packages/core/src/season/injured-reserve.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  countedRosterSize,
+  irExemptCount,
+  isIrEligible,
+  refuseIrPlacement,
+} from "./injured-reserve.js";
+import type { IrRosterEntry } from "./injured-reserve.js";
+
+function entry(
+  playerId: string,
+  onIr: boolean,
+  injuryDesignation: string | null,
+): IrRosterEntry {
+  return { playerId, onIr, injuryDesignation };
+}
+
+describe("isIrEligible", () => {
+  it("accepts the designations that mean a player will not appear", () => {
+    for (const designation of ["OUT", "IR", "PUP", "NFI", "SUSPENDED", "INACTIVE"]) {
+      expect(isIrEligible(designation)).toBe(true);
+    }
+  });
+
+  it("treats a healthy player as ineligible however the absence is spelt", () => {
+    // Three shapes the column actually takes. An empty string reading as
+    // eligible would put every healthy player on the list.
+    expect(isIrEligible(null)).toBe(false);
+    expect(isIrEligible(undefined)).toBe(false);
+    expect(isIrEligible("")).toBe(false);
+    expect(isIrEligible("   ")).toBe(false);
+  });
+
+  it("normalises case and whitespace, because the column is provider text", () => {
+    expect(isIrEligible(" out ")).toBe(true);
+    expect(isIrEligible("Questionable")).toBe(false);
+  });
+});
+
+describe("irExemptCount", () => {
+  it("exempts a genuinely injured player who is on IR", () => {
+    const roster = [entry("a", true, "OUT"), entry("b", false, null)];
+    expect(irExemptCount(roster, 2)).toBe(1);
+  });
+
+  it("stops exempting a player the moment he recovers", () => {
+    // The owner's rule: a player on IR must actually be injured. Nothing is
+    // forced off and nothing is dropped — the exemption simply evaporates, so a
+    // healthy player can never buy his team an extra roster spot.
+    const roster = [entry("a", true, null), entry("b", false, null)];
+    expect(irExemptCount(roster, 2)).toBe(0);
+  });
+
+  it("never exempts more than the league's own irSlots", () => {
+    const roster = [entry("a", true, "OUT"), entry("b", true, "IR"), entry("c", true, "PUP")];
+    // Being injured is a condition of occupying a slot, not a way to make more.
+    expect(irExemptCount(roster, 2)).toBe(2);
+  });
+
+  it("exempts nobody in a league with no IR slots", () => {
+    expect(irExemptCount([entry("a", true, "OUT")], 0)).toBe(0);
+  });
+
+  it("ignores an injured player who is not on IR", () => {
+    // Being hurt is not the same as being stashed. A manager who keeps an
+    // injured starter on the bench has made a choice and still owes the spot.
+    expect(irExemptCount([entry("a", false, "OUT")], 2)).toBe(0);
+  });
+});
+
+describe("countedRosterSize", () => {
+  it("subtracts only the genuine occupants", () => {
+    const roster = [entry("a", true, "OUT"), entry("b", true, null), entry("c", false, null)];
+    // Three players, one genuinely stashed: two count.
+    expect(countedRosterSize(roster, 2)).toBe(2);
+  });
+
+  it("counts a full healthy roster in full", () => {
+    const roster = Array.from({ length: 14 }, (_, i) => entry(`p${i}`, false, null));
+    expect(countedRosterSize(roster, 2)).toBe(14);
+  });
+});
+
+describe("refuseIrPlacement", () => {
+  const injured = entry("hurt", false, "OUT");
+  const healthy = entry("fit", false, null);
+
+  it("allows an injured player onto an empty IR", () => {
+    expect(
+      refuseIrPlacement({ roster: [injured, healthy], playerId: "hurt", irSlots: 2 }),
+    ).toBeNull();
+  });
+
+  it("refuses a healthy player", () => {
+    expect(refuseIrPlacement({ roster: [injured, healthy], playerId: "fit", irSlots: 2 })).toBe(
+      "NOT_INJURED",
+    );
+  });
+
+  it("refuses somebody who is not on the roster", () => {
+    expect(refuseIrPlacement({ roster: [injured], playerId: "stranger", irSlots: 2 })).toBe(
+      "NOT_ON_ROSTER",
+    );
+  });
+
+  it("refuses when every slot is genuinely occupied", () => {
+    const roster = [entry("a", true, "OUT"), entry("b", true, "IR"), injured];
+    expect(refuseIrPlacement({ roster, playerId: "hurt", irSlots: 2 })).toBe("IR_FULL");
+  });
+
+  it("lets a recovered occupant's slot be taken", () => {
+    // He is on IR and no longer entitled to be, so he is not holding the slot
+    // against anybody. This is the other half of the exemption being
+    // conditional: it frees the room as well as removing the benefit.
+    const roster = [entry("a", true, null), entry("b", true, "IR"), injured];
+    expect(refuseIrPlacement({ roster, playerId: "hurt", irSlots: 2 })).toBeNull();
+  });
+
+  it("refuses everybody in a league with no IR slots", () => {
+    expect(refuseIrPlacement({ roster: [injured], playerId: "hurt", irSlots: 0 })).toBe(
+      "IR_FULL",
+    );
+  });
+});

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -1,0 +1,130 @@
+/**
+ * Injured reserve: who may occupy it, and what it does to roster capacity.
+ *
+ * `roster.irSlots` has sat in the frozen, hashed, member-signed rule set since
+ * the schema was written and was **read by nothing**. `RulesView` renders it
+ * above the join control, so every member has agreed to a number that did not
+ * exist anywhere else in the system — the `botsAllowed` failure exactly, and the
+ * reason that field was deleted rather than left lying.
+ *
+ * Pure, and in `@rostr/core` rather than in the database layer, because it is a
+ * rule rather than a query: the same answer has to govern a manager's own
+ * placement, an add that needs the room, and whatever screen explains why.
+ */
+
+/**
+ * Designations that mean a player is genuinely unavailable.
+ *
+ * The same set the autofill treats as unavailable, restated here rather than
+ * imported from `@rostr/db` — this package must not depend on that one, and the
+ * two are the same list for the same reason rather than by coincidence. If they
+ * drift, the symptom is a player the autofill benches but IR refuses to hold.
+ *
+ * `DOUBTFUL` is included, and is the debatable one. It is kept because the whole
+ * set answers "will not appear this week", and a manager should not have to
+ * re-litigate a designation the provider already made.
+ */
+export const IR_ELIGIBLE_DESIGNATIONS = new Set([
+  "OUT",
+  "IR",
+  "INACTIVE",
+  "SUSPENDED",
+  "DOUBTFUL",
+  "PUP",
+  "NFI",
+]);
+
+/**
+ * Whether this designation permits a player to occupy an IR slot.
+ *
+ * **Decided by the owner, 2026-08-23: "whenever a player is on IR they need to
+ * be actually injured."** So this is asked continuously rather than only at the
+ * moment somebody is placed there.
+ *
+ * A null or empty designation is a healthy player. Note this reads the
+ * designation column, which `CLAUDE.md` records as *shown and never enforced* —
+ * that rule exists so a designation arriving on a Sunday cannot invalidate a
+ * lineup that was legal when it was set, and nothing here touches a lineup.
+ * See {@link irExemptCount} for how the continuous check avoids doing anything
+ * destructive when a player recovers.
+ */
+export function isIrEligible(designation: string | null | undefined): boolean {
+  if (designation === null || designation === undefined) return false;
+  const normalised = designation.trim().toUpperCase();
+  if (normalised === "") return false;
+  return IR_ELIGIBLE_DESIGNATIONS.has(normalised);
+}
+
+export interface IrRosterEntry {
+  readonly playerId: string;
+  readonly onIr: boolean;
+  /** The provider's current designation, or null for a healthy player. */
+  readonly injuryDesignation: string | null;
+}
+
+/**
+ * How many of this team's players are genuinely exempt from the roster limit.
+ *
+ * **The exemption is conditional, and that is what makes continuous enforcement
+ * safe.** A player who recovers while on IR is not forced off, auto-dropped, or
+ * silently moved — all three are destructive, and this repo does not do
+ * destructive things to a roster on a provider's say-so. He simply stops being
+ * exempt, so he counts against the limit again from that moment.
+ *
+ * The team is then in the ordinary "roster full" state: they cannot add anybody
+ * until they activate him and drop somebody, which is a decision only they
+ * should make. No new rule is needed for it, and no state is reachable in which
+ * a healthy player is quietly buying his team an extra roster spot.
+ *
+ * Capped at `irSlots` regardless. Being injured is a condition of occupying the
+ * slot, not a way to conjure more of them.
+ */
+export function irExemptCount(roster: readonly IrRosterEntry[], irSlots: number): number {
+  const genuine = roster.filter(
+    (entry) => entry.onIr && isIrEligible(entry.injuryDesignation),
+  ).length;
+
+  return Math.min(genuine, Math.max(0, irSlots));
+}
+
+/**
+ * How many players this team counts as holding, for the roster limit.
+ *
+ * `totalSlots` already excludes IR (`starters + bench`), so the comparison this
+ * feeds is unchanged — what changes is that genuinely-stashed players are
+ * subtracted before it.
+ */
+export function countedRosterSize(roster: readonly IrRosterEntry[], irSlots: number): number {
+  return roster.length - irExemptCount(roster, irSlots);
+}
+
+export type IrPlacementRefusal =
+  /** The player is healthy, or carries a designation that does not qualify. */
+  | "NOT_INJURED"
+  /** Every IR slot the league's rules provide is already genuinely occupied. */
+  | "IR_FULL"
+  /** He is on this roster twice, or not on it at all. */
+  | "NOT_ON_ROSTER";
+
+/**
+ * Whether this player may be moved onto IR right now.
+ *
+ * Returns the refusal rather than throwing, so a caller can render it. `null`
+ * means the move is legal.
+ */
+export function refuseIrPlacement(input: {
+  readonly roster: readonly IrRosterEntry[];
+  readonly playerId: string;
+  readonly irSlots: number;
+}): IrPlacementRefusal | null {
+  const player = input.roster.find((entry) => entry.playerId === input.playerId);
+  if (!player) return "NOT_ON_ROSTER";
+
+  if (!isIrEligible(player.injuryDesignation)) return "NOT_INJURED";
+
+  // Counted against the *genuine* occupancy, so a recovered player sitting on
+  // IR does not block the slot he is no longer entitled to.
+  if (irExemptCount(input.roster, input.irSlots) >= input.irSlots) return "IR_FULL";
+
+  return null;
+}

--- a/packages/db/migrations/0038_injured_reserve.sql
+++ b/packages/db/migrations/0038_injured_reserve.sql
@@ -1,0 +1,34 @@
+-- Injured reserve, which the rules have always promised and nothing implemented.
+--
+-- `roster.irSlots` is 2 in the default rule set, sits in the frozen hashed
+-- document every member signs, and is rendered by `RulesView` above the join
+-- control. Nothing else in the repo read it. That is the same defect
+-- `botsAllowed` was removed over — a guarantee members signed that did nothing —
+-- except that here the answer is to implement it rather than delete it.
+--
+-- **A designation, not a lineup slot.** IR is a property of the roster, not of
+-- one week: a player put on IR in week 3 is still on it in week 4 without
+-- anybody re-stating it, and roster capacity must not vary week to week. So it
+-- lives on `roster_entries` rather than in `lineups`.
+--
+-- **This column is mutable, and `roster_entries` is otherwise append-only.**
+-- That is deliberate and worth naming, because the append-only shape exists so
+-- any past week's roster can be reconstructed. IR reaches no past week: it
+-- decides transactions and capacity, never who started or what anyone scored, so
+-- a settled week stays exactly as provable as it was. What is genuinely lost is
+-- the ability to say *when* somebody went on IR, and nothing needs to know.
+ALTER TABLE roster_entries
+  ADD COLUMN on_ir boolean NOT NULL DEFAULT false;
+
+-- A released player is not on anybody's injured reserve. Without this a drop
+-- would leave `on_ir` true on a historical row, and any future count that
+-- forgot to filter on `released_at` would exempt a player who left months ago.
+ALTER TABLE roster_entries
+  ADD CONSTRAINT roster_entries_ir_requires_active
+  CHECK (NOT on_ir OR released_at IS NULL);
+
+-- The count of players a team has stashed, which both the capacity rule and the
+-- IR limit consult on every transaction.
+CREATE INDEX roster_entries_ir_idx
+  ON roster_entries (team_id)
+  WHERE on_ir AND released_at IS NULL;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -331,3 +331,5 @@ export {
   type OnChainJoin,
   type OnChainStake,
 } from "./membership.js";
+
+export { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";

--- a/packages/db/src/injured-reserve.test.ts
+++ b/packages/db/src/injured-reserve.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNflPprRules, NFL } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import { createLeague } from "./leagues.js";
+import { createUser } from "./identity.js";
+import { seedSport } from "./sports.js";
+import { addTestTeam, createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: 1_756_400_000,
+};
+
+const NOW = new Date("2026-09-16T12:00:00Z");
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+interface Fixture {
+  client: PGliteClient;
+  leagueId: string;
+  teamId: string;
+  players: Map<string, string>;
+}
+
+/** One team holding four players: three carrying an OUT designation, one fit. */
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const commissioner = await createUser(db, "commish@example.com", "Commish");
+  const league = await createLeague(db, NFL, {
+    name: "IR League",
+    commissionerId: commissioner.id,
+    rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+  });
+
+  const { teamId } = await addTestTeam(db, league.id, "The Stashers");
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const [rb] = await db.query<{ id: string }>(
+    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+    [sport!.id],
+  );
+
+  const players = new Map<string, string>();
+  for (const handle of ["hurt", "fit", "alsohurt", "third"]) {
+    const [row] = await db.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, rb!.id],
+    );
+    players.set(handle, row!.id);
+    await db.query(
+      "INSERT INTO roster_entries (team_id, player_id, acquired_via) VALUES ($1, $2, 'DRAFT')",
+      [teamId, row!.id],
+    );
+  }
+
+  await db.query("UPDATE players SET injury_designation = 'OUT' WHERE id = ANY($1)", [
+    [players.get("hurt"), players.get("alsohurt"), players.get("third")],
+  ]);
+
+  return { client: db, leagueId: league.id, teamId, players };
+}
+
+describe("moveToIr", () => {
+  it("stashes an injured player without releasing him", async () => {
+    const fx = await setup();
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get("hurt")!,
+      week: 2,
+      now: NOW,
+    });
+
+    // Still owned. IR is where a player sits, not whether he is on the roster —
+    // nobody else may add him and every ownership check still sees him.
+    const [row] = await fx.client.query<{ on_ir: boolean; released_at: string | null }>(
+      "SELECT on_ir, released_at FROM roster_entries WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("hurt")],
+    );
+    expect(row?.on_ir).toBe(true);
+    expect(row?.released_at).toBeNull();
+  });
+
+  it("refuses a healthy player", async () => {
+    const fx = await setup();
+    // The owner's rule, at the door: a player on IR must actually be injured.
+    await expect(
+      moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("fit")!,
+        week: 2,
+        now: NOW,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_INJURED" });
+  });
+
+  it("refuses once every slot is genuinely occupied", async () => {
+    const fx = await setup();
+    for (const handle of ["hurt", "alsohurt"]) {
+      await moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get(handle)!,
+        week: 2,
+        now: NOW,
+      });
+    }
+
+    // Two slots in the default rules, both taken by genuinely injured players.
+    await expect(
+      moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("third")!,
+        week: 2,
+        now: NOW,
+      }),
+    ).rejects.toMatchObject({ code: "IR_FULL" });
+  });
+
+  it("frees a slot when its occupant recovers", async () => {
+    const fx = await setup();
+    for (const handle of ["hurt", "alsohurt"]) {
+      await moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get(handle)!,
+        week: 2,
+        now: NOW,
+      });
+    }
+
+    // He is on IR and no longer entitled to be, so he holds the slot against
+    // nobody. The exemption being conditional frees the room as well as
+    // removing the benefit.
+    await fx.client.query("UPDATE players SET injury_designation = NULL WHERE id = $1", [
+      fx.players.get("hurt"),
+    ]);
+
+    await expect(
+      moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("third")!,
+        week: 2,
+        now: NOW,
+      }),
+    ).resolves.toMatchObject({ playerId: fx.players.get("third") });
+  });
+
+  it("refuses somebody who is not on the roster", async () => {
+    const fx = await setup();
+    await fx.client.query("DELETE FROM roster_entries WHERE player_id = $1", [
+      fx.players.get("third"),
+    ]);
+
+    await expect(
+      moveToIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("third")!,
+        week: 2,
+        now: NOW,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_ON_ROSTER" });
+  });
+});
+
+describe("activateFromIr", () => {
+  it("brings a player back", async () => {
+    const fx = await setup();
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get("hurt")!,
+      week: 2,
+      now: NOW,
+    });
+
+    await activateFromIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get("hurt")!,
+    });
+
+    const [row] = await fx.client.query<{ on_ir: boolean }>(
+      "SELECT on_ir FROM roster_entries WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("hurt")],
+    );
+    expect(row?.on_ir).toBe(false);
+  });
+
+  it("activates a recovered player even though the roster is over its counted limit", async () => {
+    const fx = await setup();
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get("hurt")!,
+      week: 2,
+      now: NOW,
+    });
+    await fx.client.query("UPDATE players SET injury_designation = NULL WHERE id = $1", [
+      fx.players.get("hurt"),
+    ]);
+
+    // The asymmetry that keeps continuous enforcement safe. Activation is the
+    // fix for an over-full roster, so refusing it for capacity would trap the
+    // team in the state it is trying to leave.
+    await expect(
+      activateFromIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("hurt")!,
+      }),
+    ).resolves.toMatchObject({ playerId: fx.players.get("hurt") });
+  });
+
+  it("refuses a player who is not on IR", async () => {
+    const fx = await setup();
+    await expect(
+      activateFromIr(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        playerId: fx.players.get("fit")!,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_ON_IR" });
+  });
+});
+
+describe("the check constraint", () => {
+  it("will not let a released player stay on injured reserve", async () => {
+    const fx = await setup();
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get("hurt")!,
+      week: 2,
+      now: NOW,
+    });
+
+    // `0038`'s constraint. Without it a drop leaves `on_ir` true on a
+    // historical row, and any count that forgot `released_at` would exempt
+    // somebody who left months ago.
+    await expect(
+      fx.client.query("UPDATE roster_entries SET released_at = now() WHERE player_id = $1", [
+        fx.players.get("hurt"),
+      ]),
+    ).rejects.toBeTruthy();
+  });
+});
+
+describe("IrError", () => {
+  it("carries a code a route can map to a status", () => {
+    expect(new IrError("nope", "NOT_INJURED").code).toBe("NOT_INJURED");
+  });
+});

--- a/packages/db/src/injured-reserve.ts
+++ b/packages/db/src/injured-reserve.ts
@@ -1,0 +1,166 @@
+import { buildRosterShape, NFL, refuseIrPlacement } from "@rostr/core";
+import type { IrPlacementRefusal } from "@rostr/core";
+import { getLeagueRules } from "./leagues.js";
+import type { SqlClient } from "./client.js";
+import { withTransaction } from "./transaction.js";
+
+/**
+ * Moving a player on and off injured reserve.
+ *
+ * The rules have carried `roster.irSlots` since the schema was written and
+ * nothing read it — see `0038` and `@rostr/core`'s `injured-reserve.ts` for why
+ * that is the `botsAllowed` defect rather than a missing nicety.
+ *
+ * **Neither direction releases anybody.** IR is where a player sits, not whether
+ * he is owned: `roster_entries.released_at` is untouched by both, so a stashed
+ * player is still on the roster, still un-addable by anyone else, and still
+ * subject to every ownership check. What changes is whether he counts against
+ * the limit.
+ */
+export class IrError extends Error {
+  constructor(
+    message: string,
+    readonly code: IrPlacementRefusal | "LEAGUE_NOT_FOUND" | "NOT_ON_IR" | "GAME_STARTED",
+  ) {
+    super(message);
+    this.name = "IrError";
+  }
+}
+
+const REFUSALS: Record<IrPlacementRefusal, string> = {
+  NOT_INJURED:
+    "Injured reserve holds only players carrying an official out designation. " +
+    "This one is listed as available.",
+  IR_FULL: "Every injured reserve slot is taken.",
+  NOT_ON_ROSTER: "That player is not on this roster.",
+};
+
+interface Held {
+  player_id: string;
+  on_ir: boolean;
+  designation: string | null;
+  kickoff_at: string | null;
+}
+
+/**
+ * The roster as the IR rule sees it, locked for the length of the transaction.
+ *
+ * `FOR UPDATE OF r` locks the roster rows and not the joined `players` rows —
+ * the designation is read, never written here, and locking a shared player row
+ * would serialise every team in the league behind one manager's IR move.
+ */
+async function heldRoster(
+  tx: SqlClient,
+  teamId: string,
+  season: number,
+  week: number,
+): Promise<Held[]> {
+  // Joined the way `loadKickoffs` joins — on `sport_id` and a supplied season,
+  // because `players` carries a sport rather than a season. Deriving it here a
+  // second way is how the two would come to disagree about which game a player
+  // is in.
+  return tx.query<Held>(
+    `SELECT r.player_id, r.on_ir, p.injury_designation AS designation,
+            g.kickoff_at
+       FROM roster_entries r
+       JOIN players p ON p.id = r.player_id
+       LEFT JOIN games g
+         ON g.sport_id = p.sport_id
+        AND g.season = $2
+        AND g.week = $3
+        AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
+      WHERE r.team_id = $1 AND r.released_at IS NULL
+      FOR UPDATE OF r`,
+    [teamId, season, week],
+  );
+}
+
+/**
+ * Stash an injured player.
+ *
+ * **Refused once his game has kicked off**, for the same reason `RULES.md` §6
+ * refuses an add or a drop then: moving a player to IR mid-game changes what
+ * counts against the roster while the thing being reacted to is happening. The
+ * lineup lock already stops him being started or benched; this stops the same
+ * reaction taking a different route.
+ */
+export async function moveToIr(
+  db: SqlClient,
+  input: {
+    readonly leagueId: string;
+    readonly teamId: string;
+    readonly playerId: string;
+    readonly week: number;
+    readonly now: Date;
+  },
+): Promise<{ playerId: string }> {
+  const stored = await getLeagueRules(db, input.leagueId);
+  if (!stored) throw new IrError("League has no rules", "LEAGUE_NOT_FOUND");
+
+  const shape = buildRosterShape(stored.rules.roster, NFL);
+
+  return withTransaction(db, async (tx) => {
+    const held = await heldRoster(tx, input.teamId, stored.rules.seasonYear, input.week);
+
+    const refusal = refuseIrPlacement({
+      roster: held.map((row) => ({
+        playerId: row.player_id,
+        onIr: row.on_ir,
+        injuryDesignation: row.designation,
+      })),
+      playerId: input.playerId,
+      irSlots: shape.irSlots,
+    });
+    if (refusal) throw new IrError(REFUSALS[refusal], refusal);
+
+    const player = held.find((row) => row.player_id === input.playerId);
+    if (player?.kickoff_at && new Date(player.kickoff_at) <= input.now) {
+      throw new IrError(
+        "His game has kicked off. Injured reserve is available again next week.",
+        "GAME_STARTED",
+      );
+    }
+
+    await tx.query(
+      "UPDATE roster_entries SET on_ir = true WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL",
+      [input.teamId, input.playerId],
+    );
+
+    return { playerId: input.playerId };
+  });
+}
+
+/**
+ * Bring a player back.
+ *
+ * **Never refused for capacity**, and that is the important asymmetry. A team
+ * whose stashed player recovered is already over the counted limit — the
+ * exemption evaporated the moment his designation cleared — so refusing to
+ * activate him would trap the roster in the illegal state rather than let the
+ * manager resolve it. Activation is the fix, not the offence.
+ *
+ * Nor does it check the kickoff. Coming off IR only ever *adds* to what counts
+ * against the limit, so it cannot be used to dodge anything mid-game, and the
+ * lineup lock still decides whether he can actually be started.
+ */
+export async function activateFromIr(
+  db: SqlClient,
+  input: {
+    readonly leagueId: string;
+    readonly teamId: string;
+    readonly playerId: string;
+  },
+): Promise<{ playerId: string }> {
+  const rows = await db.query<{ player_id: string }>(
+    `UPDATE roster_entries SET on_ir = false
+      WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL AND on_ir
+      RETURNING player_id`,
+    [input.teamId, input.playerId],
+  );
+
+  if (rows.length === 0) {
+    throw new IrError("That player is not on injured reserve.", "NOT_ON_IR");
+  }
+
+  return { playerId: input.playerId };
+}

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -348,6 +348,15 @@ export type RosterPlayer = LineupPlayer & {
    * not be able to invalidate a lineup that was legal when it was set.
    */
   readonly injuryDesignation: string | null;
+  /**
+   * Whether he is stashed on injured reserve.
+   *
+   * **Unlike `injuryDesignation` this is not display-only.** It is the team's
+   * own recorded decision, it decides whether he counts against the roster
+   * limit, and `autoFillLineup` must not start him — a stashed player is on the
+   * roster and out of the rotation.
+   */
+  readonly onIr: boolean;
 };
 export async function loadRosterForWeek(
   db: SqlClient,
@@ -365,6 +374,7 @@ export async function loadRosterForWeek(
     image_url: string | null;
     team_ref: string | null;
     injury_designation: string | null;
+    on_ir: boolean;
   }>(
     `SELECT p.id AS player_id,
             p.full_name,
@@ -375,6 +385,7 @@ export async function loadRosterForWeek(
             p.image_url,
             p.team_ref,
             p.injury_designation,
+            r.on_ir,
             array_agg(DISTINCT pos.key) AS positions,
             g.kickoff_at,
             -- Does this player's team appear anywhere in the season's schedule?
@@ -397,7 +408,7 @@ export async function loadRosterForWeek(
         AND g.week = $3
         AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
       WHERE r.team_id = $1 AND r.released_at IS NULL
-      GROUP BY p.id, p.full_name, p.status, g.kickoff_at, p.team_ref, p.sport_id,
+      GROUP BY p.id, p.full_name, p.status, g.kickoff_at, p.team_ref, p.sport_id, r.on_ir,
                p.image_url, p.injury_designation`,
     [teamId, season, week],
   );
@@ -418,6 +429,7 @@ export async function loadRosterForWeek(
         imageUrl: row.image_url,
         teamRef: row.team_ref,
         injuryDesignation: row.injury_designation,
+        onIr: row.on_ir,
         kickoffAt: row.kickoff_at
           ? Math.floor(new Date(row.kickoff_at).getTime() / 1000)
           : // No game this week. A bye keeps null and stays movable; a player
@@ -809,12 +821,23 @@ export async function autoFillLineup(
       ? await loadProjectedPoints(db, season, week, stored.rules)
       : new Map<string, number>();
 
-  const candidates: AutolineupCandidate[] = [...roster.values()].map((player) =>
-    autolineupCandidate(player, {
-      averageMilliPoints: averages.get(player.playerId) ?? null,
-      projectedMilliPoints: projected.get(player.playerId) ?? null,
-    }),
-  );
+  /*
+    Stashed players are not candidates.
+
+    A player on injured reserve is on the roster and out of the rotation — that
+    is what the slot is for. Leaving him in the pool would let the autofill start
+    the very player his manager put aside as unable to play, and it would do it
+    on a Sunday morning with nobody watching. He is also exempt from the roster
+    limit while he sits there, so starting him would be having it both ways.
+  */
+  const candidates: AutolineupCandidate[] = [...roster.values()]
+    .filter((player) => !player.onIr)
+    .map((player) =>
+      autolineupCandidate(player, {
+        averageMilliPoints: averages.get(player.playerId) ?? null,
+        projectedMilliPoints: projected.get(player.playerId) ?? null,
+      }),
+    );
 
   const slotTypeIds = await loadSlotTypeIds(db, stored.rules);
 

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -39,6 +39,7 @@ import {
   availabilityAt,
   everyoneIsOnWaivers,
   buildRosterShape,
+  countedRosterSize,
   dropDestination,
   initialWaiverPriority,
   NFL,
@@ -584,12 +585,40 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
       ]);
     }
 
-    const [count] = await tx.query<{ n: number }>(
-      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+    /*
+      Roster capacity, with injured reserve subtracted.
+
+      `totalSlots` is starters plus bench and has always excluded IR — the
+      rules said so and nothing acted on it. What changed is that genuinely
+      stashed players are now taken out of the count before the comparison.
+
+      **The designation is read here, live.** A player who recovers while on IR
+      stops being exempt at that moment and counts again, which is the owner's
+      rule that somebody on IR must actually be injured. Nothing is dropped or
+      moved to enforce it: the team simply finds itself at capacity, which is a
+      state they already understand and can fix by activating him.
+    */
+    const held = await tx.query<{
+      player_id: string;
+      on_ir: boolean;
+      designation: string | null;
+    }>(
+      `SELECT r.player_id, r.on_ir, p.injury_designation AS designation
+         FROM roster_entries r
+         JOIN players p ON p.id = r.player_id
+        WHERE r.team_id = $1 AND r.released_at IS NULL`,
       [input.teamId],
     );
     const shape = buildRosterShape(stored.rules.roster, NFL);
-    if (Number(count?.n ?? 0) >= shape.totalSlots) {
+    const counted = countedRosterSize(
+      held.map((row) => ({
+        playerId: row.player_id,
+        onIr: row.on_ir,
+        injuryDesignation: row.designation,
+      })),
+      shape.irSlots,
+    );
+    if (counted >= shape.totalSlots) {
       throw new WaiverError("This roster is full — drop someone first", "ROSTER_FULL");
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,28 @@ export default defineConfig({
      * and on a machine with the variable set it now actually runs.
      */
     include: ["packages/*/src/**/*.test.ts", "apps/web/src/**/*.test.ts"],
+
+    /**
+     * Sixty seconds, matching every other project config in this repo — and this
+     * file carried **no timeout at all**, so it ran on vitest's 5-second default.
+     *
+     * That was never right for what these tests do. Most of them build a fresh
+     * PGlite database — real Postgres compiled to WASM, migrated from zero — per
+     * test, which costs a second or more on an idle machine and several under
+     * load. The suite has been passing on the margin and losing a little of it
+     * with every test added.
+     *
+     * It surfaced as `settlementPlan` timing out at 5001ms with "PGlite is
+     * closed", in a run made slower by ten new tests in a different file. The
+     * same suite passes in isolation at ~1.2s a test. `CLAUDE.md` already
+     * records this shape for the program suite — "fix the window, not the flake"
+     * — and the window here is a default nobody chose.
+     *
+     * A test that genuinely hangs still fails. It just does so on evidence
+     * rather than on how busy the machine happened to be.
+     */
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     coverage: {
       provider: "v8",
       include: ["packages/*/src/**/*.ts"],


### PR DESCRIPTION
`roster.irSlots` is **2** in the default rule set, sits in the frozen hashed document every member signs, and is rendered by `RulesView` above the join control. Nothing else in the repo read it.

That's the `botsAllowed` defect — a guarantee members signed that did nothing — except here the answer is to implement it rather than delete it.

## The rule

Decided by the owner: **"whenever a player is on IR they need to be actually injured."** So eligibility is asked continuously, not just at placement.

The obvious enforcement is to force a recovered player off IR, and it's wrong: it lets a provider's designation drop somebody's roster spot, and it needs a new rule for the team that's then over the limit.

**The exemption is conditional instead.** A recovered player isn't moved, dropped or touched — he stops being *exempt*, so he counts against the limit again and the team is in the ordinary "roster full" state they already understand. Nothing destructive happens on a provider's say-so, and no state exists where a healthy player quietly buys his team an extra roster spot.

The same conditionality frees the slot, so somebody genuinely hurt can take it.

**Activation is never refused for capacity.** A team whose stashed player recovered is *already* over the counted limit — refusing to activate him would trap the roster in the state it's trying to leave. Activation is the fix, not the offence.

## Three places it had to reach

- **The autofill must not start a stashed player.** He's on the roster and out of the rotation; leaving him in the pool would let the autofill start the player his manager set aside as unable to play — on a Sunday morning, while he was exempt from the roster limit *for* being unable to play. The preview filters at the same point, or it names a starter the write won't make.
- **Capacity.** `totalSlots` always excluded IR; now genuinely stashed players are subtracted before the comparison.
- **A released player can't stay on IR** — a check constraint, or a drop leaves `on_ir` true on a historical row and any count that forgets `released_at` exempts someone who left months ago.

## A config default nobody chose

The suite failed on `settlementPlan` timing out at 5001ms with "PGlite is closed", in a run slowed by the ten tests added here. The root `vitest.config.ts` set **no timeout**, so hundreds of tests that each build a fresh WASM Postgres ran on vitest's 5-second default — while every other project config sets 60s or 120s.

Same suite passes in isolation at ~1.2s a test. It's been passing on the margin and losing a little with every test added, which is also the likeliest explanation for an unattributed failure earlier today. Fix the window, not the flake.

## Migration

`0038` applied to the hosted database **before** this merges — additive, defaulted, harmless to the currently-deployed code. (The previous PR did it the other way round and left a window where deployed code queried a column that didn't exist.)

## Checks

`pnpm test` (2088 passed, 2 skipped) — 16 core tests, 10 db tests against real Postgres including the check constraint. Typecheck, lint, prettier, production build. `league-read.test.ts` sweeps the new route and sees its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)