### PR TITLE
feat: a waiver run says what it decided, and why

### DIFF
--- a/apps/web/src/app/(app)/leagues/[id]/players/page.tsx
+++ b/apps/web/src/app/(app)/leagues/[id]/players/page.tsx
@@ -4,6 +4,8 @@ import { chromeProps } from "@/lib/chrome";
 import { LeagueChrome } from "@/components/LeagueChrome";
 import { getLeagueRules, nextWaiverRun } from "@rostr/db";
 import { PlayerMarket } from "@/components/PlayerMarket";
+import { WaiverRunPanel } from "@/components/WaiverRunPanel";
+import { draftContext } from "@/lib/draft-context";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 
@@ -30,6 +32,12 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
   if (!stored) notFound();
 
   const user = await currentUser();
+
+  // Only to mark the caller's own rows in the run. `draftContext` derives it
+  // from the session and the league's membership, never from a request — the
+  // panel itself is gated at its route, so a null here dims nothing that
+  // matters.
+  const { myTeamId } = await draftContext(id);
   const nextRun = nextWaiverRun(stored.rules, new Date());
 
   return (
@@ -42,6 +50,20 @@ export default async function PlayersPage({ params }: { params: Promise<{ id: st
           its player clears at, which is not always the next one.
         </p>
       </header>
+
+      {/*
+        What the last run decided, above the market rather than below it.
+
+        Somebody opening this page on a Wednesday is here *because* of the run —
+        to find out whether they got the player. Putting the answer under the
+        board would make them scroll past the thing they came for.
+
+        Rendered whether or not they are signed in, and gated by
+        `leagueReadForbidden` at the route: the resolution is a fact about the
+        league, and anyone entitled to see the standings is entitled to see how a
+        player changed hands. `myTeamId` only marks your own rows.
+      */}
+      <WaiverRunPanel leagueId={league.id} myTeamId={myTeamId} />
 
       {user ? (
         <PlayerMarket leagueId={league.id} />

--- a/apps/web/src/app/api/leagues/[id]/waiver-run/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/waiver-run/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { lastWaiverRun } from "@rostr/db";
+import { db } from "@/lib/db";
+import { leagueReadForbidden } from "@/lib/league-read";
+
+/**
+ * What the last waiver run decided.
+ *
+ * **The whole league's claims, not the caller's.** Waivers are decided *between*
+ * teams — "somebody with better priority claimed him first" is an unverifiable
+ * assertion if you can only see your own row, and `RULES.md` makes the
+ * resolution public within the league precisely so it can be checked rather than
+ * trusted. Which is also why this is gated by `leagueReadForbidden` like the
+ * standings and not by membership: a private league reports how it is going only
+ * to people entitled to know, and everyone entitled to see the standings is
+ * entitled to see how a player changed hands.
+ *
+ * `null` before the first run of a season, which is not an error and must not be
+ * a 404 — the league exists and the answer is "nothing yet".
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  const forbidden = await leagueReadForbidden(id);
+  if (forbidden) return forbidden;
+
+  const run = await lastWaiverRun(db(), id);
+
+  return NextResponse.json({ run });
+}

--- a/apps/web/src/components/WaiverRunPanel.tsx
+++ b/apps/web/src/components/WaiverRunPanel.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import useSWR from "swr";
+import { runSummary, whyClaimFailed } from "@/lib/waiver-run";
+
+/**
+ * What the last waiver run decided, and why.
+ *
+ * `processWaivers` runs hourly, resolves every claim by the frozen rules, moves
+ * priority and rewrites rosters — and **told nobody**. A manager filed claims on
+ * Monday and on Wednesday found a player on their roster, or did not, with no
+ * account of which claim won, which lost, or why.
+ *
+ * That is a strange gap for this product in particular. The argument the whole
+ * thing makes is that outcomes are decided by rules anybody can check rather
+ * than by an administrator; a resolution nobody can watch being carried out is
+ * indistinguishable from one somebody made up.
+ *
+ * **Every team's claims, not just yours.** "A team with better priority claimed
+ * him first" is an unverifiable assertion if the only row you can see is your
+ * own — the claim it makes is precisely about somebody else.
+ */
+
+interface Claim {
+  claimId: string;
+  teamId: string;
+  teamName: string;
+  addPlayerName: string;
+  dropPlayerName: string | null;
+  priorityAtClaim: number | null;
+  awarded: boolean;
+  failureReason: string | null;
+}
+
+interface Run {
+  processedAt: string;
+  claims: Claim[];
+}
+
+const fetcher = async (url: string): Promise<Run | null> => {
+  const response = await fetch(url);
+  if (!response.ok) return null;
+  const body = (await response.json()) as { run?: Run | null };
+  return body.run ?? null;
+};
+
+export function WaiverRunPanel({
+  leagueId,
+  myTeamId,
+}: {
+  readonly leagueId: string;
+  /** Used only to mark your own rows. The panel shows the whole run regardless. */
+  readonly myTeamId: string | null;
+}) {
+  const { data: run } = useSWR<Run | null>(`/api/leagues/${leagueId}/waiver-run`, fetcher, {
+    revalidateOnFocus: true,
+  });
+
+  // Nothing has run yet. Rendering "no waiver runs" every week until the first
+  // Wednesday of the season would be furniture — the same argument the
+  // invitations corner makes for disappearing when empty.
+  if (!run || run.claims.length === 0) return null;
+
+  const awarded = run.claims.filter((claim) => claim.awarded).length;
+
+  return (
+    <section className="space-y-3 rounded-lg border border-nocturne-neutral-900 p-5">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-medium tracking-wide text-nocturne-neutral-500 uppercase">
+          Last waiver run
+        </h2>
+        <span className="text-xs text-nocturne-neutral-600">
+          {runSummary({ total: run.claims.length, awarded })} ·{" "}
+          {new Date(run.processedAt).toLocaleString()}
+        </span>
+      </header>
+
+      <ul className="space-y-2">
+        {run.claims.map((claim) => {
+          const mine = claim.teamId === myTeamId;
+
+          return (
+            <li
+              key={claim.claimId}
+              className={`rounded border px-3 py-2 text-sm ${
+                mine
+                  ? "border-nocturne-accent/40 bg-nocturne-accent/5"
+                  : "border-nocturne-neutral-900"
+              }`}
+            >
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                {/*
+                  Priority is shown on every row, won or lost. It is the number
+                  the rules actually decide on, so a run that hides it asks
+                  people to take the ordering on trust — which is the thing this
+                  product exists not to ask.
+                */}
+                {claim.priorityAtClaim !== null && (
+                  <span className="text-[11px] tabular-nums text-nocturne-neutral-600">
+                    #{claim.priorityAtClaim}
+                  </span>
+                )}
+                <span className="text-nocturne-neutral-400">
+                  {mine ? "You" : claim.teamName}
+                </span>
+                <span className="text-nocturne-text">{claim.addPlayerName}</span>
+                {claim.dropPlayerName && (
+                  <span className="text-[11px] text-nocturne-neutral-600">
+                    dropping {claim.dropPlayerName}
+                  </span>
+                )}
+                <span
+                  className={`ml-auto text-[11px] ${
+                    claim.awarded ? "text-nocturne-accent-300" : "text-nocturne-neutral-600"
+                  }`}
+                >
+                  {claim.awarded ? "awarded" : "not awarded"}
+                </span>
+              </div>
+
+              {/*
+                The reason, on losing rows only — a winner has nothing to
+                explain, and `0039`'s constraint means there is never one stored.
+              */}
+              {!claim.awarded && (
+                <p className="mt-1 text-[11px] text-nocturne-neutral-600">
+                  {whyClaimFailed(claim.failureReason)}
+                </p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/lib/waiver-run.test.ts
+++ b/apps/web/src/lib/waiver-run.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { runSummary, whyClaimFailed } from "./waiver-run";
+
+describe("whyClaimFailed", () => {
+  it("distinguishes losing a contest from making a mistake", () => {
+    // The whole argument for storing the reason. One is the rules working, the
+    // other is something the manager will repeat next Wednesday unless told.
+    expect(whyClaimFailed("PLAYER_TAKEN")).toContain("better priority");
+    expect(whyClaimFailed("ROSTER_FULL")).toContain("roster was full");
+    expect(whyClaimFailed("PLAYER_TAKEN")).not.toBe(whyClaimFailed("ROSTER_FULL"));
+  });
+
+  it("explains a stale drop", () => {
+    expect(whyClaimFailed("DROP_NOT_ON_ROSTER")).toContain("no longer on your roster");
+  });
+
+  it("explains a player who was never available", () => {
+    expect(whyClaimFailed("ALREADY_ROSTERED")).toContain("already held him");
+  });
+
+  it("admits an unrecorded reason rather than inventing one", () => {
+    // A claim settled before `0039`. Making up a cause would be the silent
+    // restatement this project exists to prevent.
+    expect(whyClaimFailed(null)).toContain("did not record why");
+  });
+
+  it("never shows a raw code to a manager", () => {
+    // `failure_reason` is free text on purpose, so a new mode needs no
+    // migration — which means this must survive one it has never seen.
+    const sentence = whyClaimFailed("SOME_FUTURE_CODE");
+    expect(sentence).not.toContain("SOME_FUTURE_CODE");
+    expect(sentence).toContain("did not succeed");
+  });
+});
+
+describe("runSummary", () => {
+  it("gives both numbers, so losing is legible", () => {
+    // "1 awarded" alone hides how contested the run was, and how contested it
+    // was is what makes a loss make sense.
+    expect(runSummary({ total: 3, awarded: 1 })).toBe("3 claims · 1 awarded");
+  });
+
+  it("counts one claim in the singular", () => {
+    expect(runSummary({ total: 1, awarded: 1 })).toBe("1 claim · 1 awarded");
+  });
+
+  it("reports a run in which nobody won", () => {
+    expect(runSummary({ total: 2, awarded: 0 })).toBe("2 claims · 0 awarded");
+  });
+});

--- a/apps/web/src/lib/waiver-run.ts
+++ b/apps/web/src/lib/waiver-run.ts
@@ -1,0 +1,63 @@
+/**
+ * How a settled waiver run reads.
+ *
+ * In `lib` for the reason `field.ts`, `chrome.ts` and `autofill.ts` record:
+ * `apps/web` has no jsdom in either vitest project, so a sentence composed
+ * inside a `.tsx` is verified only by being run in production. This one is the
+ * product explaining a contest it decided while nobody was watching, which is
+ * the worst place to be wrong.
+ */
+
+/**
+ * Why a claim lost, in words.
+ *
+ * The four reasons are **not interchangeable**, which is the whole argument for
+ * `0039` recording them:
+ *
+ *   - `PLAYER_TAKEN` is the system working exactly as the rules describe.
+ *     Nobody did anything wrong and there is nothing to do differently.
+ *   - `ROSTER_FULL` is a mistake the manager could have avoided, and will make
+ *     again next Wednesday unless told.
+ *   - `DROP_NOT_ON_ROSTER` is a claim that went stale — the player they offered
+ *     to drop left by some other route before the run.
+ *   - `ALREADY_ROSTERED` means somebody had him before the run even started.
+ *
+ * An unrecognised value falls back to a plain statement rather than throwing or
+ * rendering the raw token. `failure_reason` is deliberately free text so a new
+ * failure mode needs no migration, which means this function must expect one it
+ * has never seen — and a screen showing `SOME_NEW_CODE` to a manager is worse
+ * than one saying only that the claim did not succeed.
+ */
+export function whyClaimFailed(reason: string | null): string {
+  switch (reason) {
+    case "PLAYER_TAKEN":
+      return "a team with better priority claimed him first";
+    case "ROSTER_FULL":
+      return "your roster was full and the claim named nobody to drop";
+    case "DROP_NOT_ON_ROSTER":
+      return "the player you offered to drop was no longer on your roster";
+    case "ALREADY_ROSTERED":
+      return "somebody already held him when the run began";
+    case null:
+      // Every loser since `0039` carries one. A null is a claim settled before
+      // that migration, and inventing a reason for it would be worse than
+      // admitting the record does not have one.
+      return "this claim did not succeed, and the run did not record why";
+    default:
+      return "this claim did not succeed";
+  }
+}
+
+/**
+ * "3 claims · 1 awarded".
+ *
+ * Both numbers, always. "1 awarded" alone hides how contested the run was, and
+ * how contested it was is the thing that makes losing legible.
+ */
+export function runSummary(input: {
+  readonly total: number;
+  readonly awarded: number;
+}): string {
+  const claims = input.total === 1 ? "1 claim" : `${input.total} claims`;
+  return `${claims} · ${input.awarded} awarded`;
+}

--- a/packages/db/migrations/0039_waiver_failure_reason.sql
+++ b/packages/db/migrations/0039_waiver_failure_reason.sql
@@ -1,0 +1,34 @@
+-- Why a waiver claim lost.
+--
+-- `resolveWaiverClaims` has always produced a `ClaimFailure` — PLAYER_TAKEN,
+-- ROSTER_FULL, ALREADY_ROSTERED, DROP_NOT_ON_ROSTER — and `processWaivers`
+-- discarded it, writing only the state. So a manager whose claim failed was told
+-- FAILED and nothing else, and the four reasons are not interchangeable: one
+-- says somebody outranked you, one says your own roster had no room, and one
+-- says the player you offered to drop was already gone.
+--
+-- The distinction is the whole value of the screen. "Somebody with better
+-- priority took him" is the system working as the rules describe; "your roster
+-- was full" is a mistake the manager could have avoided and will make again
+-- unless told.
+--
+-- **Stored rather than re-derived.** The resolver is pure and replayable, so in
+-- principle a run could be recomputed to explain itself — and it must not be.
+-- Replaying needs the rosters and the wire *as they were*, and both have moved
+-- on by the time anybody reads the result: a claim that lost to a rival would
+-- silently start reporting ROSTER_FULL once the winner's roster filled up. A
+-- settled outcome is a fact about a moment, and this repo already records
+-- `priority_at_claim` for exactly the same reason.
+--
+-- Free-text rather than an enum. A new failure mode should not need a migration
+-- to be recordable, and nothing branches on this in SQL — the value is read by
+-- one screen and mapped to a sentence in TypeScript, where an unknown one falls
+-- back to the plain word.
+ALTER TABLE waiver_claims
+  ADD COLUMN failure_reason text;
+
+-- An awarded claim has no reason to carry, and a reason on a winner would be a
+-- row nothing could render. PENDING is unresolved and carries none either.
+ALTER TABLE waiver_claims
+  ADD CONSTRAINT waiver_claims_reason_only_on_failure
+  CHECK (failure_reason IS NULL OR state = 'FAILED');

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -333,3 +333,5 @@ export {
 } from "./membership.js";
 
 export { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";
+
+export { lastWaiverRun, type WaiverRun, type WaiverRunClaim } from "./waiver-run.js";

--- a/packages/db/src/waiver-run.test.ts
+++ b/packages/db/src/waiver-run.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNflPprRules, NFL } from "@rostr/core";
+import type { DraftRules, LeagueRules } from "@rostr/core";
+import { createLeague } from "./leagues.js";
+import { createUser } from "./identity.js";
+import { seedSport } from "./sports.js";
+import { addTestTeam, createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import { dropPlayer, processWaivers, seedWaiverPriority, submitClaim } from "./waivers.js";
+import { lastWaiverRun } from "./waiver-run.js";
+
+const DRAFT: DraftRules = {
+  type: "SNAKE",
+  mode: "SLOW",
+  pickSeconds: 14_400,
+  scheduledAt: 1_756_400_000,
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+/** Monday afternoon ET, comfortably inside the waiver window. */
+const MONDAY = new Date("2026-09-14T18:00:00Z");
+/** Wednesday 07:00 UTC is 03:00 ET — the processing moment. */
+const WEDNESDAY = new Date("2026-09-16T08:00:00Z");
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+interface Fixture {
+  client: PGliteClient;
+  leagueId: string;
+  teams: string[];
+  players: Map<string, string>;
+}
+
+/** Two teams, one holding a player who is about to be dropped onto waivers. */
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const commissioner = await createUser(db, "commish@example.com", "Commish");
+  const league = await createLeague(db, NFL, {
+    name: "Waiver Run League",
+    commissionerId: commissioner.id,
+    rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+  });
+
+  const teams: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);
+  }
+  for (const [index, teamId] of teams.entries()) {
+    await db.query("UPDATE teams SET draft_position = $1 WHERE id = $2", [index + 1, teamId]);
+  }
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const [rb] = await db.query<{ id: string }>(
+    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+    [sport!.id],
+  );
+
+  const players = new Map<string, string>();
+  for (const handle of ["prize", "held"]) {
+    const [row] = await db.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, rb!.id],
+    );
+    players.set(handle, row!.id);
+  }
+
+  // Team 1 has held him a week, so dropping him sends him to waivers rather
+  // than straight to free agency.
+  await db.query(
+    `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+     VALUES ($1, $2, 'DRAFT', $3)`,
+    [teams[0], players.get("prize"), new Date(MONDAY.getTime() - 7 * DAY)],
+  );
+
+  await seedWaiverPriority(db, league.id);
+
+  return { client: db, leagueId: league.id, teams, players };
+}
+
+/** Both teams claim the same player; the run settles it. */
+async function contestedRun(fx: Fixture): Promise<void> {
+  await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("prize")!, MONDAY);
+
+  for (const teamId of fx.teams) {
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId,
+      addPlayerId: fx.players.get("prize")!,
+      now: MONDAY,
+    });
+  }
+
+  await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+}
+
+describe("lastWaiverRun", () => {
+  it("answers null before any run has settled", async () => {
+    const fx = await setup();
+    // The ordinary state before the first Wednesday of a season, not an error.
+    expect(await lastWaiverRun(fx.client, fx.leagueId)).toBeNull();
+  });
+
+  it("returns every team's claims, not only one team's", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    // "Somebody with better priority took him" is unverifiable if you can only
+    // see your own row. `RULES.md` makes the resolution public by design.
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    expect(run?.claims).toHaveLength(2);
+    expect(new Set(run?.claims.map((claim) => claim.teamId))).toEqual(new Set(fx.teams));
+  });
+
+  it("says which claim won", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    const winners = run?.claims.filter((claim) => claim.awarded) ?? [];
+    expect(winners).toHaveLength(1);
+
+    // Priority 1 wins, and priority is seeded **reversed** from the draft order
+    // — the team that drafted last picks first off waivers. Asserted through
+    // the recorded priority rather than a team index, because an index bakes
+    // that reversal into the test as an assumption, which is how this test was
+    // wrong the first time.
+    expect(winners[0]?.priorityAtClaim).toBe(1);
+  });
+
+  it("says why the loser lost", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    // The whole point of `0039`. Before it a loser was told FAILED and nothing
+    // else, and "somebody outranked you" and "your roster was full" are not the
+    // same news.
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    const loser = run?.claims.find((claim) => !claim.awarded);
+    expect(loser?.failureReason).toBe("PLAYER_TAKEN");
+  });
+
+  it("carries the priority each team held when the run began", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    // Recorded by the run, never recomputed — the winner has since moved to the
+    // back, so deriving it now would report the wrong contest.
+    expect(run?.claims.map((claim) => claim.priorityAtClaim)).toEqual([1, 2]);
+  });
+
+  it("names the players rather than making the screen look them up", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    expect(run?.claims[0]?.addPlayerName).toBe("prize");
+    // Rows come back in priority order, and priority reverses the draft — so
+    // the first row is the team that drafted last.
+    expect(run?.claims.map((claim) => claim.teamName).sort()).toEqual(["Team 1", "Team 2"]);
+  });
+
+  it("returns one run, not everything that happened that day", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    // A second run settles nothing new, and must not be merged with the first —
+    // merging two runs would show the same player awarded twice.
+    await processWaivers(fx.client, fx.leagueId, new Date(WEDNESDAY.getTime() + 60_000));
+
+    const run = await lastWaiverRun(fx.client, fx.leagueId);
+    const stamps = new Set(run?.claims.map((claim) => claim.awarded));
+    expect(run?.claims).toHaveLength(2);
+    expect(stamps.size).toBeGreaterThan(0);
+  });
+});
+
+describe("the reason constraint", () => {
+  it("will not record a reason against a winning claim", async () => {
+    const fx = await setup();
+    await contestedRun(fx);
+
+    // `0039`'s check. A reason on a winner is a row nothing could render.
+    await expect(
+      fx.client.query(
+        "UPDATE waiver_claims SET failure_reason = 'PLAYER_TAKEN' WHERE state = 'AWARDED'",
+      ),
+    ).rejects.toBeTruthy();
+  });
+});

--- a/packages/db/src/waiver-run.ts
+++ b/packages/db/src/waiver-run.ts
@@ -1,0 +1,111 @@
+import type { SqlClient } from "./client.js";
+
+/**
+ * What happened in the last waiver run.
+ *
+ * `processWaivers` runs hourly, resolves every claim, moves priority and rewrites
+ * rosters — and told nobody. A manager filed three claims on Monday and on
+ * Wednesday found a player on their roster, or did not, with no account of
+ * which claim won, which lost, or why. The rules make a specific promise about
+ * how contests are decided; a promise nobody can watch being kept is the thing
+ * this whole product exists to replace.
+ *
+ * **Read-only, and it computes nothing.** Every value here was written by the
+ * run itself — the state, the reason, the priority the claim was filed at. A
+ * screen that re-derived any of it would be re-deciding a settled outcome
+ * against rosters that have since moved on.
+ */
+
+export interface WaiverRunClaim {
+  readonly claimId: string;
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly addPlayerId: string;
+  readonly addPlayerName: string;
+  readonly dropPlayerId: string | null;
+  readonly dropPlayerName: string | null;
+  /** Where this team stood when the run began. Recorded, never recomputed. */
+  readonly priorityAtClaim: number | null;
+  readonly awarded: boolean;
+  /** `null` on a winner, and on a loser from before `0039` recorded reasons. */
+  readonly failureReason: string | null;
+  readonly filedAt: string;
+}
+
+export interface WaiverRun {
+  /** When the run settled. */
+  readonly processedAt: string;
+  readonly claims: readonly WaiverRunClaim[];
+}
+
+/**
+ * The most recent settled run in this league.
+ *
+ * **Grouped by `processed_at`, not by date.** A run is one transaction and every
+ * claim it settles carries the same timestamp, so this returns exactly one run
+ * rather than "everything that happened on Wednesday" — which would merge a
+ * re-run, and merging two runs would show a player awarded twice.
+ *
+ * `null` when the league has never had one, which is the ordinary state before
+ * the first Wednesday of a season and is not an error.
+ *
+ * The whole league's claims, not just one team's. Waivers are decided *between*
+ * teams — "somebody with better priority took him" is unverifiable if you can
+ * only see your own row — and `RULES.md` makes the resolution public by design.
+ * Who may look at all is `leagueReadAccess`'s question, asked by the route.
+ */
+export async function lastWaiverRun(
+  db: SqlClient,
+  leagueId: string,
+): Promise<WaiverRun | null> {
+  const [latest] = await db.query<{ processed_at: string }>(
+    `SELECT processed_at FROM waiver_claims
+      WHERE league_id = $1 AND processed_at IS NOT NULL
+      ORDER BY processed_at DESC LIMIT 1`,
+    [leagueId],
+  );
+  if (!latest) return null;
+
+  const rows = await db.query<{
+    id: string;
+    team_id: string;
+    team_name: string;
+    add_player_id: string;
+    add_player_name: string;
+    drop_player_id: string | null;
+    drop_player_name: string | null;
+    priority_at_claim: number | null;
+    state: string;
+    failure_reason: string | null;
+    created_at: string;
+  }>(
+    `SELECT c.id, c.team_id, t.name AS team_name,
+            c.add_player_id, ap.full_name AS add_player_name,
+            c.drop_player_id, dp.full_name AS drop_player_name,
+            c.priority_at_claim, c.state, c.failure_reason, c.created_at
+       FROM waiver_claims c
+       JOIN teams t ON t.id = c.team_id
+       JOIN players ap ON ap.id = c.add_player_id
+       LEFT JOIN players dp ON dp.id = c.drop_player_id
+      WHERE c.league_id = $1 AND c.processed_at = $2
+      ORDER BY c.priority_at_claim NULLS LAST, c.created_at`,
+    [leagueId, latest.processed_at],
+  );
+
+  return {
+    processedAt: latest.processed_at,
+    claims: rows.map((row) => ({
+      claimId: row.id,
+      teamId: row.team_id,
+      teamName: row.team_name,
+      addPlayerId: row.add_player_id,
+      addPlayerName: row.add_player_name,
+      dropPlayerId: row.drop_player_id,
+      dropPlayerName: row.drop_player_name,
+      priorityAtClaim: row.priority_at_claim,
+      awarded: row.state === "AWARDED",
+      failureReason: row.failure_reason,
+      filedAt: row.created_at,
+    })),
+  };
+}

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -1029,9 +1029,17 @@ export async function processWaivers(
     for (const row of claims) {
       if (!alreadyHeld.has(row.add_player_id) && !dropIsFrozen(row)) continue;
 
+      // The reason is known here and nowhere else: these two never reach the
+      // resolver, so its `ClaimFailure` cannot speak for them. Recording the
+      // resolver's vocabulary keeps one set of words for one idea.
       await tx.query(
-        "UPDATE waiver_claims SET state = 'FAILED', processed_at = $2 WHERE id = $1",
-        [row.id, now.toISOString()],
+        `UPDATE waiver_claims SET state = 'FAILED', processed_at = $2, failure_reason = $3
+          WHERE id = $1`,
+        [
+          row.id,
+          now.toISOString(),
+          alreadyHeld.has(row.add_player_id) ? "ALREADY_ROSTERED" : "DROP_NOT_ON_ROSTER",
+        ],
       );
       failed++;
     }
@@ -1044,9 +1052,13 @@ export async function processWaivers(
       const claim = claims.find((row) => row.id === outcome.claimId)!;
 
       if (!outcome.awarded) {
+        // `resolveWaiverClaims` already decided why, and it was being thrown
+        // away. The four reasons are not interchangeable — one says somebody
+        // outranked you, one says your own roster had no room.
         await tx.query(
-          "UPDATE waiver_claims SET state = 'FAILED', processed_at = $2 WHERE id = $1",
-          [outcome.claimId, now.toISOString()],
+          `UPDATE waiver_claims SET state = 'FAILED', processed_at = $2, failure_reason = $3
+            WHERE id = $1`,
+          [outcome.claimId, now.toISOString(), outcome.reason ?? null],
         );
         failed++;
         continue;


### PR DESCRIPTION
`processWaivers` runs hourly, resolves every claim by the frozen rules, moves priority and rewrites rosters — and **told nobody**. A manager filed claims on Monday and on Wednesday found a player on their roster, or didn't, with no account of which claim won, which lost, or why.

Strange gap for this product in particular: the argument it makes is that outcomes follow rules anybody can check rather than an administrator's judgement, and a resolution nobody can watch being carried out is indistinguishable from one somebody made up.

## The reason existed and was thrown away

`resolveWaiverClaims` has always produced a `ClaimFailure` — `PLAYER_TAKEN`, `ROSTER_FULL`, `ALREADY_ROSTERED`, `DROP_NOT_ON_ROSTER` — and `processWaivers` wrote only the state.

They are **not interchangeable**: one says somebody outranked you, which is the rules working; another says your own roster had no room, which is a mistake you'll repeat next Wednesday unless told.

`0039` records it, with a check constraint refusing a reason on a winner. The two pre-resolver failure paths get theirs too — those claims never reach the resolver, so its vocabulary can't speak for them.

**Stored, never re-derived.** The resolver is pure and replayable, so a run could recompute its own explanation — and must not. Replaying needs the rosters and the wire *as they were*: a claim that lost a contest would silently start reporting `ROSTER_FULL` once the winner's roster filled up. `priority_at_claim` is recorded for the same reason.

## Every team's claims, not the caller's

"A team with better priority claimed him first" is unverifiable if the only row you can see is your own — the claim is precisely about somebody else. Gated by `leagueReadForbidden` like the standings rather than by membership: anyone entitled to see how a league is going is entitled to see how a player changed hands.

Priority shows on every row, won or lost. It's the number the rules decide on, and hiding it asks people to take the ordering on trust.

## Two things the tests caught

- **My assumption about who wins was wrong.** Priority is seeded *reversed* from the draft order — the team that drafted last claims first. The test now asserts through the recorded priority rather than a team index, since an index bakes the reversal in as an assumption, which is how it was wrong the first time.
- **An unknown reason must never reach a manager as a raw token.** `failure_reason` is free text so a new mode needs no migration, which means the mapping must survive one it has never seen. A test asserts `SOME_FUTURE_CODE` never appears on screen.

## Migration

`0039` applied to the hosted database **before** this merges.

## Checks

`pnpm test` (2105 passed, 2 skipped) — 8 db tests driving a real contested run, 8 presentation tests. Typecheck, lint, prettier, production build. `league-read.test.ts` sweeps the new route and sees its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)