### PR TITLE
feat: injury designations refresh hourly, instead of once a day

### DIFF
--- a/apps/web/src/app/api/cron/injuries/route.ts
+++ b/apps/web/src/app/api/cron/injuries/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { NFL } from "@rostr/core";
+import { recordCronRun, syncInjuries } from "@rostr/db";
+import { Tank01Provider } from "@rostr/stats";
+import { db } from "@/lib/db";
+import { cronForbidden } from "@/lib/cron";
+
+/**
+ * Injury designations, hourly.
+ *
+ * `docs/LIVE-SCORING.md` lists this job in a table of six and marks it **❌ does
+ * not exist**, then argues at length that it is the timely feed that matters
+ * most: it changes what a manager *does* — whether to bench a questionable
+ * starter — where a live score only changes what they watch.
+ *
+ * Designations reached the database only through `season-sync`, which runs once
+ * a day at 09:20 UTC. So a player ruled out on a Sunday morning would surface
+ * the following morning: after his game, after the lock, after the week scored.
+ *
+ * ## Hourly, and not faster
+ *
+ * Tank01 refreshes rosters **hourly** and this reads the roster endpoint, so a
+ * ten-minute cadence would spend ten calls to learn what one call already knew.
+ * The provider's refresh rate is the binding constraint, not ours — the same
+ * point `LIVE-SCORING.md` makes about gameday inactives, where hourly is
+ * genuinely not good enough and a different endpoint is needed.
+ *
+ * **This job is not that one.** It does not solve inactives. The T-90 inactive
+ * list is a separate feed with two properties nobody has been able to verify —
+ * what a populated entry contains, and when it fills — and both are answerable
+ * only on a real gameday. Do not let this job's existence read as that problem
+ * being closed.
+ *
+ * One provider call per run, whole-league.
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const forbidden = cronForbidden(request);
+  if (forbidden) return forbidden;
+
+  const client = db();
+
+  const apiKey = process.env["TANK01_API_KEY"];
+  if (!apiKey) {
+    // Refused rather than reported as an empty success, exactly as the stats
+    // job refuses. "Ran, changed nothing" is the healthy face a missing
+    // credential must not be allowed to wear, and the heartbeat is the only
+    // thing anybody looks at.
+    await recordCronRun(client, "injuries", "TANK01_API_KEY is not set");
+    return NextResponse.json(
+      {
+        error:
+          "TANK01_API_KEY is not set, so injury designations cannot refresh. " +
+          "See docs/SETUP-REQUIRED.md.",
+      },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await syncInjuries(client, new Tank01Provider({ apiKey }), NFL.key);
+
+    /*
+      Only an **empty provider list** is reported, never a quiet run.
+
+      Any non-null `last_outcome` makes `cron:status` read FAILING, so an
+      hourly job that reported "nothing changed" would show red for most of the
+      offseason and all of a quiet Tuesday. That is the crying-wolf failure this
+      repo already warns about for the cluster banner: a warning people learn to
+      dismiss is worse than no warning, because it takes the real one with it.
+
+      An empty list is a different fact and genuinely alarming.
+      `syncInjuries` refuses to apply one — clearing every designation at once
+      would empty every injured reserve in every league — so nothing is damaged,
+      and the heartbeat is the only place that refusal is visible.
+    */
+    await recordCronRun(
+      client,
+      "injuries",
+      result.providerReturned === 0
+        ? "the provider returned no injuries at all — refused rather than clearing every designation"
+        : null,
+    );
+
+    return NextResponse.json({ ...result });
+  } catch (error) {
+    await recordCronRun(
+      client,
+      "injuries",
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -21,6 +21,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/injuries",
+      "schedule": "35 * * * *"
+    },
+    {
       "path": "/api/cron/season-sync",
       "schedule": "20 9 * * *"
     }

--- a/packages/db/src/cron-health.test.ts
+++ b/packages/db/src/cron-health.test.ts
@@ -88,7 +88,7 @@ describe("expectedJobs", () => {
     expect(expectedJobs({})).toEqual([]);
   });
 
-  it("pins the six real jobs against the real vercel.json", () => {
+  it("pins the seven real jobs against the real vercel.json", () => {
     // The tripwire. If the file moves, or a job is added or renamed without
     // this being revisited, the check silently reports zero jobs scheduled —
     // which is exactly the "everything is fine" reading that hid the problem.
@@ -101,6 +101,10 @@ describe("expectedJobs", () => {
       { name: "score-week", everyMinutes: 10 },
       { name: "waivers", everyMinutes: 60 },
       { name: "trades", everyMinutes: 60 },
+      // Hourly because Tank01 refreshes rosters hourly and this reads the
+      // roster endpoint — a faster cadence would spend calls to learn what one
+      // already knew. Offset to :35 so it does not land with waivers and trades.
+      { name: "injuries", everyMinutes: 60 },
       { name: "season-sync", everyMinutes: 1440 },
     ]);
   });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -335,3 +335,5 @@ export {
 export { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";
 
 export { lastWaiverRun, type WaiverRun, type WaiverRunClaim } from "./waiver-run.js";
+
+export { syncInjuries, type InjurySyncResult } from "./injuries.js";

--- a/packages/db/src/injuries.test.ts
+++ b/packages/db/src/injuries.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { NFL } from "@rostr/core";
+import type { ProviderInjury, StatsProvider } from "@rostr/stats";
+import { seedSport } from "./sports.js";
+import { createTestDatabase } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import { syncInjuries } from "./injuries.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+/** Only `listInjuries` is ever called; the rest exist to satisfy the interface. */
+function providerReturning(injuries: ProviderInjury[]): StatsProvider {
+  return {
+    name: "test",
+    listPlayers: () => Promise.resolve([]),
+    listGames: () => Promise.resolve([]),
+    getBoxScore: () => Promise.reject(new Error("not used")),
+    listInjuries: () => Promise.resolve(injuries),
+    healthCheck: () => Promise.resolve({ ok: true }),
+  } as unknown as StatsProvider;
+}
+
+interface Fixture {
+  client: PGliteClient;
+  ids: Map<string, string>;
+}
+
+/** Three players: one out, one questionable, one fit. */
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+  await seedSport(db, NFL);
+
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    NFL.key,
+  ]);
+  const [rb] = await db.query<{ id: string }>(
+    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+    [sport!.id],
+  );
+
+  const ids = new Map<string, string>();
+  for (const ref of ["hurt", "iffy", "fit"]) {
+    const [row] = await db.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, ref, ref, rb!.id],
+    );
+    ids.set(ref, row!.id);
+  }
+
+  await db.query("UPDATE players SET injury_designation = 'Out' WHERE external_ref = 'hurt'");
+  await db.query(
+    "UPDATE players SET injury_designation = 'Questionable' WHERE external_ref = 'iffy'",
+  );
+
+  return { client: db, ids };
+}
+
+async function designationOf(fx: Fixture, ref: string): Promise<string | null> {
+  const [row] = await fx.client.query<{ injury_designation: string | null }>(
+    "SELECT injury_designation FROM players WHERE external_ref = $1",
+    [ref],
+  );
+  return row?.injury_designation ?? null;
+}
+
+describe("syncInjuries", () => {
+  it("applies a new designation", async () => {
+    const fx = await setup();
+    await syncInjuries(
+      fx.client,
+      providerReturning([
+        { externalRef: "hurt", designation: "Out", description: "hamstring" },
+        { externalRef: "iffy", designation: "Questionable", description: null },
+        { externalRef: "fit", designation: "Doubtful", description: "ankle" },
+      ]),
+      NFL.key,
+    );
+
+    expect(await designationOf(fx, "fit")).toBe("Doubtful");
+  });
+
+  it("clears a player who no longer appears in the list", async () => {
+    const fx = await setup();
+
+    // The half that is easy to miss. `listInjuries` filters to players who
+    // *have* a designation, so somebody who recovers stops appearing rather
+    // than being returned with a null — and a sync that only applied the rows
+    // it received could never clear anything.
+    const result = await syncInjuries(
+      fx.client,
+      providerReturning([{ externalRef: "hurt", designation: "Out", description: null }]),
+      NFL.key,
+    );
+
+    expect(await designationOf(fx, "iffy")).toBeNull();
+    expect(result.cleared).toBe(1);
+  });
+
+  it("keeps a stale designation from holding a healthy player on IR", async () => {
+    const fx = await setup();
+
+    // Not cosmetic. `isIrEligible` reads this column, so a designation that
+    // never clears keeps a recovered player exempt from the roster limit for
+    // the rest of the season — the owner's IR rule reopened from the ingest
+    // side.
+    await syncInjuries(
+      fx.client,
+      providerReturning([
+        { externalRef: "iffy", designation: "Questionable", description: null },
+      ]),
+      NFL.key,
+    );
+
+    expect(await designationOf(fx, "hurt")).toBeNull();
+  });
+
+  it("refuses an empty list rather than clearing everybody", async () => {
+    const fx = await setup();
+
+    // A provider returning nothing is far likelier to be a bad response than a
+    // week in which nobody in the NFL is injured. Applying it would empty every
+    // injured reserve in every league at once, and nothing would report it.
+    const result = await syncInjuries(fx.client, providerReturning([]), NFL.key);
+
+    expect(result).toEqual({ designated: 0, cleared: 0, providerReturned: 0 });
+    expect(await designationOf(fx, "hurt")).toBe("Out");
+    expect(await designationOf(fx, "iffy")).toBe("Questionable");
+  });
+
+  it("counts only what actually changed", async () => {
+    const fx = await setup();
+
+    // Both rows already say this. A run that reported them as updates would
+    // make an hourly job look like it was rewriting the league every hour.
+    const result = await syncInjuries(
+      fx.client,
+      providerReturning([
+        { externalRef: "hurt", designation: "Out", description: null },
+        { externalRef: "iffy", designation: "Questionable", description: null },
+      ]),
+      NFL.key,
+    );
+
+    expect(result.designated).toBe(0);
+    expect(result.cleared).toBe(0);
+  });
+
+  it("distinguishes a quiet run from an empty provider response", async () => {
+    const fx = await setup();
+
+    // Both matter to the cron: any non-null outcome makes `cron:status` read
+    // FAILING, so a quiet hour must look different from a broken feed or the
+    // job shows red through the whole offseason and takes the real alarm with
+    // it.
+    const quiet = await syncInjuries(
+      fx.client,
+      providerReturning([
+        { externalRef: "hurt", designation: "Out", description: null },
+        { externalRef: "iffy", designation: "Questionable", description: null },
+      ]),
+      NFL.key,
+    );
+    const broken = await syncInjuries(fx.client, providerReturning([]), NFL.key);
+
+    expect(quiet.providerReturned).toBe(2);
+    expect(broken.providerReturned).toBe(0);
+    expect(quiet.designated).toBe(broken.designated);
+  });
+
+  it("updates a designation that changed", async () => {
+    const fx = await setup();
+    const result = await syncInjuries(
+      fx.client,
+      providerReturning([
+        { externalRef: "hurt", designation: "Questionable", description: null },
+        { externalRef: "iffy", designation: "Questionable", description: null },
+      ]),
+      NFL.key,
+    );
+
+    expect(await designationOf(fx, "hurt")).toBe("Questionable");
+    expect(result.designated).toBe(1);
+  });
+
+  it("ignores a player the provider knows and we do not", async () => {
+    const fx = await setup();
+
+    // A player list that ran after ours. Nothing to update, and inventing a row
+    // would put a player in the database with no position and no club.
+    await expect(
+      syncInjuries(
+        fx.client,
+        providerReturning([
+          { externalRef: "hurt", designation: "Out", description: null },
+          { externalRef: "stranger", designation: "Out", description: null },
+        ]),
+        NFL.key,
+      ),
+    ).resolves.toBeDefined();
+
+    const [row] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM players WHERE external_ref = 'stranger'",
+    );
+    expect(row?.n).toBe(0);
+  });
+});

--- a/packages/db/src/injuries.ts
+++ b/packages/db/src/injuries.ts
@@ -1,0 +1,140 @@
+import type { StatsProvider } from "@rostr/stats";
+import type { SqlClient } from "./client.js";
+
+/**
+ * Keep injury designations current between player syncs.
+ *
+ * `season-sync` runs **once a day**, at 09:20 UTC. It carries designations along
+ * with everything else, so a player ruled out on a Sunday morning would not
+ * reach a manager until the following morning — after his game, after the lock,
+ * after the week was scored. `docs/LIVE-SCORING.md` argues this is the timely
+ * feed that matters most, on the grounds that it changes what somebody *does*
+ * where a live score only changes what they watch.
+ *
+ * This is the same provider endpoint the daily sync reads, so it is **not a
+ * fresher source** — Tank01 refreshes rosters hourly and this cannot beat that.
+ * What it changes is our own cadence, from a day to whatever the schedule says.
+ * That is the whole of the improvement and the docstring should not imply more.
+ *
+ * ## It writes exactly three columns
+ *
+ * Designation, description, return date. Not the name, the club, the headshot or
+ * anything else the player sync owns. A frequent job that touched everything
+ * would be a second writer for every profile column, racing the daily one and
+ * costing a full upsert per player per run.
+ */
+
+export interface InjurySyncResult {
+  /** Players whose designation was set or changed. */
+  readonly designated: number;
+  /** Players whose designation was cleared because they no longer carry one. */
+  readonly cleared: number;
+  /**
+   * How many rows the provider returned, before anything was applied.
+   *
+   * Reported separately from `designated` because **zero returned and zero
+   * changed are different facts**. A quiet hour in which nobody's status moved
+   * is the ordinary state of this job and must read as healthy; a provider
+   * returning nothing at all is a broken response wearing the same face, and it
+   * is the one worth waking somebody for.
+   */
+  readonly providerReturned: number;
+}
+
+/**
+ * Apply the provider's current injury list.
+ *
+ * **The list is a complete snapshot, and clearing is the half that is easy to
+ * miss.** `listInjuries()` filters to players who *have* a designation, so a
+ * player who recovers simply stops appearing — he is not returned with a null.
+ * A sync that only applied the rows it received could therefore never clear
+ * anything, and every player ever designated would read "Out" for the rest of
+ * the season.
+ *
+ * That is not a cosmetic bug any more. `isIrEligible` reads this column, so a
+ * stale designation would keep a healthy player on injured reserve and exempt
+ * from the roster limit **indefinitely** — the exact hole the owner's rule
+ * ("whenever a player is on IR they need to be actually injured") exists to
+ * close, reopened from the ingest side.
+ *
+ * So absence here means "not injured", and it is safe to read it that way for
+ * one specific reason: this is a single-source snapshot of one sport's whole
+ * player list, not a partial update. **If a second provider is ever added, this
+ * must not simply run twice** — two snapshots would each clear what the other
+ * asserted. That is the same "absent is not an assertion" problem
+ * `syncPlayers` already solves with its `hasProfile` gate, and the answer here
+ * would have to be a source column rather than a second call.
+ *
+ * The clear is scoped to the sport, so a future sport's designations cannot be
+ * wiped by football's snapshot.
+ */
+export async function syncInjuries(
+  db: SqlClient,
+  provider: StatsProvider,
+  sportKey: string,
+): Promise<InjurySyncResult> {
+  const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+    sportKey,
+  ]);
+  if (!sport) throw new Error(`Unknown sport: ${sportKey}`);
+
+  const injuries = await provider.listInjuries();
+
+  /*
+    An empty list is refused rather than applied.
+
+    A provider returning nothing is far more likely to be a bad response, an
+    auth failure that answered 200, or a schema change than it is to be a week
+    in which no player in the NFL is injured. Applying it would clear every
+    designation in the database at once — and, through `isIrEligible`, silently
+    empty every injured reserve in every league.
+
+    A stale designation costs one manager one wrong badge. A mass clear costs
+    every league its roster accounting, and nothing would report it.
+  */
+  if (injuries.length === 0) {
+    return { designated: 0, cleared: 0, providerReturned: 0 };
+  }
+
+  const designated = await db.query<{ external_ref: string }>(
+    `UPDATE players AS p
+        SET injury_designation = v.designation,
+            injury_description = v.description,
+            updated_at = now()
+       FROM (
+         SELECT unnest($2::text[]) AS external_ref,
+                unnest($3::text[]) AS designation,
+                unnest($4::text[]) AS description
+       ) AS v
+      WHERE p.sport_id = $1
+        AND p.external_ref = v.external_ref
+        AND (p.injury_designation IS DISTINCT FROM v.designation
+             OR p.injury_description IS DISTINCT FROM v.description)
+      RETURNING p.external_ref`,
+    [
+      sport.id,
+      injuries.map((injury) => injury.externalRef),
+      injuries.map((injury) => injury.designation),
+      injuries.map((injury) => injury.description),
+    ],
+  );
+
+  const cleared = await db.query<{ external_ref: string }>(
+    `UPDATE players
+        SET injury_designation = NULL,
+            injury_description = NULL,
+            injury_return_date = NULL,
+            updated_at = now()
+      WHERE sport_id = $1
+        AND injury_designation IS NOT NULL
+        AND NOT (external_ref = ANY($2::text[]))
+      RETURNING external_ref`,
+    [sport.id, injuries.map((injury) => injury.externalRef)],
+  );
+
+  return {
+    designated: designated.length,
+    cleared: cleared.length,
+    providerReturned: injuries.length,
+  };
+}


### PR DESCRIPTION
`docs/LIVE-SCORING.md` lists six automation jobs and marks this one **❌ does not exist**, then argues at length that it's the timely feed that matters most: it changes what a manager *does* — whether to bench a questionable starter — where a live score only changes what they watch.

`listInjuries()` has been on the Tank01 adapter throughout with **no production caller** — only test stubs. Designations reached the database solely through `season-sync`, daily at 09:20 UTC, so a player ruled out Sunday morning surfaced the *next* morning: after his game, after the lock, after the week scored.

## Clearing is the half that's easy to miss

`listInjuries()` filters to players who *have* a designation, so someone who recovers stops appearing rather than being returned with a null. A sync that only applied the rows it received could never clear anything — every player ever designated would read "Out" for the rest of the season.

**That stopped being cosmetic when IR shipped last PR.** `isIrEligible` reads this column, so a designation that never clears keeps a healthy player on injured reserve and exempt from the roster limit indefinitely — the owner's rule reopened from the ingest side. There's a test named for exactly that.

Absence means "not injured" here, and the docstring records the one condition that makes it safe: a single-source snapshot of the whole player list. **A second provider must not simply run this twice** — two snapshots would each clear what the other asserted.

## An empty list is refused, and a quiet run is not the same thing

A provider returning nothing is far likelier to be a bad response or an auth failure that answered 200 than a week with nobody hurt in the NFL. Applying it would empty every injured reserve in every league.

**And a quiet hour must not look like that.** Any non-null `last_outcome` makes `cron:status` read FAILING, so a job reporting "nothing changed" would show red through the entire offseason and take the real alarm with it. `providerReturned` separates them; only an empty response is recorded.

## Hourly, and not faster

Tank01 refreshes rosters hourly and this reads the roster endpoint — ten minutes would spend ten calls to learn what one already knew. Offset to :35 so it doesn't land with waivers and trades.

**This is not the inactives job**, and the route says so. The T-90 inactive list is a separate feed with two properties nobody has verified — what a populated entry contains, and when it fills — both answerable only on a real gameday. This job's existence must not read as that being closed.

## The tripwire fired

`expectedJobs` pinned six jobs and now pins seven. That's the guard working: a job added to `vercel.json` without visiting the pin would be reported by nothing.

## Checks

`pnpm test` (2113 passed, 2 skipped) — 8 new db tests. Typecheck, lint, prettier, production build. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)