### PR TITLE
fix(db)!: no wallet was ever marked verified — and sign in with a wallet

### DIFF
--- a/apps/web/src/app/(app)/signin/page.tsx
+++ b/apps/web/src/app/(app)/signin/page.tsx
@@ -1,4 +1,5 @@
 import { SignInForm } from "@/components/SignInForm";
+import { WalletSignIn } from "@/components/WalletSignIn";
 import { currentUser } from "@/lib/session";
 
 const MESSAGES: Record<string, string> = {
@@ -34,7 +35,8 @@ export default async function SignInPage({
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
         <p className="text-sm text-nocturne-neutral-400">
-          Enter your email and we will send a link. No password to forget or leak.
+          Two ways in, and no password to forget or leak. If you have linked a wallet before,
+          that is the quick one.
         </p>
       </div>
 
@@ -43,6 +45,23 @@ export default async function SignInPage({
           {MESSAGES[error]}
         </p>
       )}
+
+      {/*
+        Wallet first in the reading order, email second, neither buried.
+
+        A returning member takes the top path and never opens their mail; anyone
+        on a new browser, a phone, or a wallet extension that will not load
+        takes the bottom one. Hiding email behind a link would put the recovery
+        route out of sight at exactly the moment it is needed — the same reason
+        the cluster banner warns rather than blocks.
+      */}
+      <WalletSignIn next={next ?? "/"} />
+
+      <div className="flex items-center gap-3" aria-hidden>
+        <span className="h-px flex-1 bg-nocturne-neutral-900" />
+        <span className="text-[11px] text-nocturne-neutral-600">or</span>
+        <span className="h-px flex-1 bg-nocturne-neutral-900" />
+      </div>
 
       <SignInForm next={next ?? "/"} />
 

--- a/apps/web/src/app/api/auth/wallet-signin/route.ts
+++ b/apps/web/src/app/api/auth/wallet-signin/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import {
+  getWallets,
+  issueWalletSignInChallenge,
+  SessionError,
+  signInWithWallet,
+  WALLET_CHALLENGE_PER_IP,
+} from "@rostr/db";
+import { db } from "@/lib/db";
+import { accountGaps } from "@/lib/account";
+import { byIp, enforceRateLimit } from "@/lib/rate-limit";
+import { setSessionCookie } from "@/lib/session";
+
+/**
+ * Sign in with a wallet you have already linked.
+ *
+ * Two steps on one route: `POST` with an address issues a challenge, `POST` with
+ * an address **and** a signature spends it and opens a session. One file because
+ * they are one exchange, and splitting them would put the challenge's rate limit
+ * somewhere the verification could not see.
+ *
+ * **Separate from `/api/auth/wallet`**, which links a wallet to an account you
+ * are already inside. That one requires a session; this one issues one. Sharing
+ * a route would mean a single handler where being signed in is sometimes
+ * required and sometimes forbidden.
+ */
+
+const STATUS: Record<string, number> = {
+  INVALID_WALLET: 400,
+  // Not 404. The address is well-formed and the request is understood — there
+  // is simply no account behind it, and the screen turns this into "sign in by
+  // email once and link it".
+  WALLET_NOT_LINKED: 409,
+  CHALLENGE_NOT_FOUND: 409,
+  CHALLENGE_USED: 409,
+  CHALLENGE_EXPIRED: 410,
+  BAD_SIGNATURE: 403,
+  USER_NOT_FOUND: 401,
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json().catch(() => ({}))) as {
+    address?: unknown;
+    signature?: unknown;
+  };
+
+  if (typeof body.address !== "string") {
+    return NextResponse.json({ error: "address is required" }, { status: 400 });
+  }
+
+  /*
+    Per-address rate limiting is not possible here and per-IP is.
+
+    The other wallet route charges a per-user bucket as well, because it knows
+    who is asking. This one is the thing that establishes that, so there is no
+    account to charge until the exchange succeeds. Per-IP alone is weaker and it
+    is what there is — noted rather than left to be discovered, and the same
+    caveat `clientIp` already carries about spoofing behind a proxy we do not
+    control.
+  */
+  const limited = await enforceRateLimit([byIp(WALLET_CHALLENGE_PER_IP, request)]);
+  if (limited) return limited;
+
+  try {
+    if (typeof body.signature !== "string") {
+      const challenge = await issueWalletSignInChallenge(db(), body.address);
+      return NextResponse.json({
+        message: challenge.message,
+        expiresAt: challenge.expiresAt.toISOString(),
+      });
+    }
+
+    const { user, session } = await signInWithWallet(db(), body.address, body.signature);
+
+    // `gaps` rides along exactly as the emailed-code route sends it, and for the
+    // same reason: fetched afterwards, an account still needing a username would
+    // briefly land somewhere that immediately bounces it.
+    const gaps = accountGaps({
+      username: user.username,
+      verifiedWallets: (await getWallets(db(), user.id)).length,
+    });
+
+    const response = NextResponse.json({ signedIn: true, gaps });
+    setSessionCookie(response, session.token);
+    return response;
+  } catch (error) {
+    if (error instanceof SessionError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: STATUS[error.code] ?? 400 },
+      );
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/components/WalletSignIn.tsx
+++ b/apps/web/src/components/WalletSignIn.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
+import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import bs58 from "bs58";
+
+/**
+ * Sign in with a wallet you have already linked.
+ *
+ * An emailed code is the right way to prove an account is yours the first time
+ * and a poor way to do it the hundredth. A returning member already holds a key
+ * this account has verified; sending them to a mail client for a weaker proof by
+ * a slower route is the friction the owner asked to remove (2026-08-23).
+ *
+ * **It cannot create an account.** Sign-up stays email-first, so a wallet nobody
+ * has linked gets told to sign in by email once — and after that, the wallet
+ * alone is enough forever. The copy under the button says so, because otherwise
+ * a returning member has no way to know they can stop checking their email.
+ *
+ * Offered beside the email form rather than instead of it. A wallet extension
+ * that will not open, a new browser, a phone — email is the path that always
+ * works, and burying it hides the recovery route at the moment it is needed.
+ */
+export function WalletSignIn({ next }: { next: string }) {
+  const { publicKey, signMessage, connected } = useWallet();
+  const { setVisible } = useWalletModal();
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [needsEmail, setNeedsEmail] = useState(false);
+
+  async function signIn(): Promise<void> {
+    // Not connected yet: open the picker and stop. The person presses again
+    // once a wallet is attached, which is one extra click and avoids guessing
+    // which wallet they meant.
+    if (!connected || !publicKey || !signMessage) {
+      setVisible(true);
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setNeedsEmail(false);
+
+    try {
+      const address = publicKey.toBase58();
+
+      const challenge = await fetch("/api/auth/wallet-signin", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address }),
+      });
+      const issued = (await challenge.json().catch(() => ({}))) as {
+        message?: string;
+        error?: string;
+        code?: string;
+      };
+
+      if (!challenge.ok) {
+        // The one refusal with a next step rather than an apology.
+        if (issued.code === "WALLET_NOT_LINKED") {
+          setNeedsEmail(true);
+          return;
+        }
+        throw new Error(issued.error ?? "Could not start wallet sign-in");
+      }
+
+      // Signed exactly as issued. A client that composed its own message could
+      // sign one thing and be credited with another, which is why the server
+      // rebuilds it from the stored nonce and never trusts this text.
+      const signature = await signMessage(new TextEncoder().encode(issued.message ?? ""));
+
+      const verified = await fetch("/api/auth/wallet-signin", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address, signature: bs58.encode(signature) }),
+      });
+      const result = (await verified.json().catch(() => ({}))) as {
+        error?: string;
+        gaps?: { needsUsername?: boolean };
+      };
+      if (!verified.ok) throw new Error(result.error ?? "That signature was not accepted");
+
+      // Same destination rule as the emailed-code form: an account still owing a
+      // username goes to `/welcome` rather than to a page that would bounce it.
+      window.location.href = result.gaps?.needsUsername ? "/welcome" : next;
+    } catch (e) {
+      // A rejected wallet prompt is a decision, not a failure. Saying "signature
+      // rejected" to somebody who pressed Cancel reads as a bug in the app.
+      const message = e instanceof Error ? e.message : String(e);
+      setError(/reject|denied|cancel/i.test(message) ? null : message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => void signIn()}
+        disabled={busy}
+        className="w-full rounded-[4px] border border-nocturne-accent px-4 py-2.5 text-[14px] text-nocturne-accent-200 transition-colors hover:bg-nocturne-accent/10 disabled:opacity-40"
+      >
+        {busy ? "Waiting for your wallet…" : "Continue with wallet"}
+      </button>
+
+      <p className="text-[11.5px] leading-[1.5] text-nocturne-neutral-600">
+        Returning? Connect the wallet you linked and you are in — no email, no code.
+      </p>
+
+      {needsEmail && (
+        <p className="rounded border border-nocturne-accent/40 bg-nocturne-accent/5 px-3 py-2 text-[12px] text-nocturne-accent-100">
+          This wallet is not linked to an account yet. Sign in with your email below once and
+          link it — after that, the wallet on its own is enough.
+        </p>
+      )}
+
+      {error && <p className="text-[12px] text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,9 +75,12 @@ export {
 export {
   buildJoinMessage,
   buildWalletLinkMessage,
+  buildWalletSignInMessage,
   isValidWalletAddress,
   verifyJoinSignature,
   verifyWalletLinkSignature,
+  verifyWalletSignInSignature,
+  type WalletSignInMessageInput,
   type JoinMessageInput,
   type WalletLinkMessageInput,
 } from "./signing.js";

--- a/packages/core/src/signing.ts
+++ b/packages/core/src/signing.ts
@@ -137,3 +137,70 @@ export function verifyWalletLinkSignature(
     return false;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Wallet sign-in
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliberately **not** `LINK_PREFIX`.
+ *
+ * A link signature and a sign-in signature prove the same fact — that somebody
+ * holds this key — and authorise entirely different things. Sharing one message
+ * would let a signature gathered for one purpose be replayed for the other: a
+ * linking prompt, approved by somebody who thought they were adding a wallet to
+ * an account they were already inside, would double as a session for that
+ * account. Two prefixes make the two signatures structurally non-interchangeable
+ * rather than merely intended to be.
+ */
+const SIGNIN_PREFIX = "rostr: sign in";
+
+export interface WalletSignInMessageInput {
+  readonly walletAddress: string;
+  /** Single-use, server-issued, short-lived. */
+  readonly nonce: string;
+}
+
+/**
+ * The text a returning member signs instead of fetching an emailed code.
+ *
+ * **No email in it, unlike the link message.** The signer has not proved who
+ * they are yet — that is what this signature is for — so putting the account's
+ * address in the prompt would disclose it to whoever is holding the wallet
+ * before anything has been established. It also is not needed: the server looks
+ * the account up from the wallet, and the nonce is what ties this signature to
+ * one live challenge.
+ *
+ * The reassurance line is kept word for word from the link message. It is the
+ * sentence that stops a wallet prompt reading like a transaction approval, and
+ * that concern does not change with the purpose.
+ */
+export function buildWalletSignInMessage(input: WalletSignInMessageInput): string {
+  return [
+    SIGNIN_PREFIX,
+    "",
+    `Wallet: ${input.walletAddress}`,
+    `Nonce: ${input.nonce}`,
+    "",
+    "Signing proves you hold this wallet. It moves no funds and",
+    "approves no transaction.",
+  ].join("\n");
+}
+
+/** Verify a signature over the wallet sign-in message. */
+export function verifyWalletSignInSignature(
+  input: WalletSignInMessageInput,
+  signatureBase58: string,
+): boolean {
+  try {
+    const message = new TextEncoder().encode(buildWalletSignInMessage(input));
+    const signature = bs58.decode(signatureBase58);
+    const publicKey = bs58.decode(input.walletAddress);
+
+    if (signature.length !== 64 || publicKey.length !== 32) return false;
+
+    return ed25519.verify(signature, message, publicKey);
+  } catch {
+    return false;
+  }
+}

--- a/packages/db/src/identity.ts
+++ b/packages/db/src/identity.ts
@@ -324,6 +324,17 @@ export async function linkWallet(
   db: SqlClient,
   userId: string,
   address: string,
+  options: {
+    /**
+     * Whether the caller has proved the holder controls this key.
+     *
+     * **Only `linkWalletWithSignature` may pass true**, and it is the only
+     * caller that has checked a signature. Everything reading
+     * `wallets.verified_at` — `findUserByWallet`, and through it invite-by-
+     * address and wallet sign-in — is asking exactly that question.
+     */
+    readonly verified?: boolean;
+  } = {},
 ): Promise<Wallet> {
   if (!isValidWalletAddress(address)) {
     throw new IdentityError("Not a valid Solana public key", "INVALID_WALLET");
@@ -335,6 +346,17 @@ export async function linkWallet(
   );
   if (claimed) {
     if (claimed.user_id === userId) {
+      // Re-linking upgrades an unproven row rather than leaving it. Somebody who
+      // linked before verification existed, or whose first attempt failed after
+      // the insert, gets the same outcome as anyone else — and `COALESCE` keeps
+      // the original moment rather than restamping it on every re-link.
+      if (options.verified === true) {
+        await db.query(
+          "UPDATE wallets SET verified_at = COALESCE(verified_at, now()) WHERE address = $1",
+          [address],
+        );
+      }
+
       const [existing] = await db.query<{ id: string; address: string; is_primary: boolean }>(
         "SELECT id, address, is_primary FROM wallets WHERE address = $1",
         [address],
@@ -357,10 +379,10 @@ export async function linkWallet(
   let row: { id: string; address: string; is_primary: boolean } | undefined;
   try {
     [row] = await db.query<{ id: string; address: string; is_primary: boolean }>(
-      `INSERT INTO wallets (user_id, address, is_primary)
-       VALUES ($1, $2, $3)
+      `INSERT INTO wallets (user_id, address, is_primary, verified_at)
+       VALUES ($1, $2, $3, CASE WHEN $4 THEN now() ELSE NULL END)
        RETURNING id, address, is_primary`,
-      [userId, address, isFirst],
+      [userId, address, isFirst, options.verified === true],
     );
   } catch (error) {
     if (isUniqueViolation(error)) {
@@ -382,9 +404,18 @@ export async function linkWallet(
  * the wrong person.
  *
  * **Only a verified wallet counts.** `wallets.verified_at` is set by
- * `linkWalletWithSignature` and by nothing else, so an unverified row cannot
- * exist through any path the app offers — but reading it explicitly is what
- * stops a future path that writes one from silently making addresses claimable.
+ * `linkWalletWithSignature` and by nothing else.
+ *
+ * **That sentence was false until 2026-08-23, and this function never returned
+ * anybody.** `linkWalletWithSignature` ended by calling `linkWallet`, which
+ * did not write the column — so no wallet in the database had ever been marked
+ * verified, and the check below excluded every row. Inviting somebody by wallet
+ * address, the feature this exists for, answered "no such user" for every
+ * address including correct ones. Nothing failed loudly; it simply never found
+ * anyone.
+ *
+ * Reading it explicitly is still what stops a future path that writes an
+ * unverified row from silently making addresses claimable.
  * Inviting somebody is a small thing; being *reachable* at an address you never
  * proved you hold is the part worth being strict about.
  */

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -337,3 +337,9 @@ export { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";
 export { lastWaiverRun, type WaiverRun, type WaiverRunClaim } from "./waiver-run.js";
 
 export { syncInjuries, type InjurySyncResult } from "./injuries.js";
+
+export {
+  issueWalletSignInChallenge,
+  signInWithWallet,
+  type WalletSignInChallenge,
+} from "./wallet-signin.js";

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -40,7 +40,17 @@ export class SessionError extends Error {
       | "CHALLENGE_NOT_FOUND"
       | "CHALLENGE_EXPIRED"
       | "BAD_SIGNATURE"
-      | "INVALID_WALLET",
+      | "INVALID_WALLET"
+      /**
+       * Wallet sign-in only: nobody has linked this address.
+       *
+       * Distinguishable on purpose. The owner's chosen flow sends that person
+       * to email sign-in once, and a screen cannot say so unless it is told
+       * which refusal this is.
+       */
+      | "WALLET_NOT_LINKED"
+      /** A challenge that was already spent. Separate from expiry, which is a clock. */
+      | "CHALLENGE_USED",
   ) {
     super(message);
     this.name = "SessionError";
@@ -244,5 +254,20 @@ export async function linkWalletWithSignature(
     throw new SessionError("Signature does not match this wallet", "BAD_SIGNATURE");
   }
 
-  return linkWallet(db, userId, address);
+  /*
+    `verified: true`, and this argument is the whole point of the function.
+
+    It read `linkWallet(db, userId, address)` — which never wrote
+    `wallets.verified_at` — so **no wallet in the database has ever been
+    marked verified**, by any path. `findUserByWallet` requires it and could
+    therefore never return anybody, which silently disabled the one feature it
+    was written for: inviting somebody by wallet address. It answered "no such
+    user" for every address, including correct ones.
+
+    `findUserByWallet`'s own docstring asserted that this function set the
+    column "and nothing else" — a comment describing a guarantee the code did
+    not provide, which this repo treats as a defect in its own right. Found on
+    2026-08-23 while building wallet sign-in on top of it.
+  */
+  return linkWallet(db, userId, address, { verified: true });
 }

--- a/packages/db/src/wallet-signin.test.ts
+++ b/packages/db/src/wallet-signin.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWalletLinkMessage, buildWalletSignInMessage } from "@rostr/core";
+import { createUser, linkWallet } from "./identity.js";
+import { issueWalletChallenge, linkWalletWithSignature } from "./sessions.js";
+import { createTestDatabase, testWallet } from "./testing.js";
+import type { PGliteClient } from "./testing.js";
+import { issueWalletSignInChallenge, signInWithWallet } from "./wallet-signin.js";
+import { resolveSession } from "./sessions.js";
+
+let db: PGliteClient | undefined;
+
+afterEach(async () => {
+  await db?.close();
+  db = undefined;
+});
+
+interface Fixture {
+  client: PGliteClient;
+  userId: string;
+  email: string;
+  address: string;
+  sign: (message: string) => string;
+}
+
+/** A verified account holding a linked wallet we can actually sign with. */
+async function setup(): Promise<Fixture> {
+  db = await createTestDatabase();
+
+  // `testWallet` already exists for exactly this, and its curve library is a
+  // dependency of this package — a second signing library would be a second
+  // implementation of the one thing these tests are checking.
+  const wallet = testWallet(7);
+  const address = wallet.address;
+  const sign = wallet.sign;
+
+  const email = "returning@example.test";
+  const user = await createUser(db, email, "Returning");
+
+  // Linked the way a real member links: challenge, signature, verification.
+  // `linkWallet` alone leaves `verified_at` null — deliberately, since an
+  // address somebody merely typed proves nothing — and `findUserByWallet`
+  // requires it, so a fixture taking the shortcut would test a state the
+  // application cannot produce.
+  const link = await issueWalletChallenge(db, user.id, address);
+  await linkWalletWithSignature(db, user.id, address, wallet.sign(link.message));
+
+  return { client: db, userId: user.id, email, address, sign };
+}
+
+describe("issueWalletSignInChallenge", () => {
+  it("issues a challenge for a linked wallet", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+
+    expect(challenge.message).toContain("rostr: sign in");
+    expect(challenge.message).toContain(fx.address);
+  });
+
+  it("never puts the account's email in the message", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+
+    // The signer has not proved who they are yet — that is what the signature
+    // is for. Naming the account in the prompt would disclose it to whoever is
+    // holding the wallet before anything is established.
+    expect(challenge.message).not.toContain(fx.email);
+  });
+
+  it("refuses a wallet nobody has linked, distinguishably", async () => {
+    const fx = await setup();
+    const stranger = testWallet(11).address;
+
+    // The screen has to be able to say "sign in by email once and link it",
+    // which it cannot do unless told which refusal this is.
+    await expect(issueWalletSignInChallenge(fx.client, stranger)).rejects.toMatchObject({
+      code: "WALLET_NOT_LINKED",
+    });
+  });
+
+  it("refuses an unverified wallet", async () => {
+    const fx = await setup();
+    const other = await createUser(fx.client, "other@example.test", "Other");
+    const address = testWallet(12).address;
+    // The shortcut on purpose: linked, never verified.
+    await linkWallet(fx.client, other.id, address);
+
+    // An address somebody typed but never proved must not open a session.
+    await expect(issueWalletSignInChallenge(fx.client, address)).rejects.toMatchObject({
+      code: "WALLET_NOT_LINKED",
+    });
+  });
+
+  it("refuses something that is not a public key", async () => {
+    const fx = await setup();
+    await expect(issueWalletSignInChallenge(fx.client, "not-a-key")).rejects.toMatchObject({
+      code: "INVALID_WALLET",
+    });
+  });
+});
+
+describe("signInWithWallet", () => {
+  it("opens a real session for the right signature", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+
+    const { user, session } = await signInWithWallet(
+      fx.client,
+      fx.address,
+      fx.sign(challenge.message),
+    );
+
+    expect(user.id).toBe(fx.userId);
+    // Not merely returned — usable. A token that does not validate is a sign-in
+    // that only appears to have worked.
+    expect(await resolveSession(fx.client, session.token)).not.toBeNull();
+  });
+
+  it("rejects a signature over a different nonce", async () => {
+    const fx = await setup();
+    await issueWalletSignInChallenge(fx.client, fx.address);
+
+    const forged = buildWalletSignInMessage({ walletAddress: fx.address, nonce: "made-up" });
+    await expect(
+      signInWithWallet(fx.client, fx.address, fx.sign(forged)),
+    ).rejects.toMatchObject({ code: "BAD_SIGNATURE" });
+  });
+
+  it("will not accept a wallet-link signature as a sign-in", async () => {
+    // The reason the two messages carry different prefixes. Without it, a
+    // linking prompt — approved by somebody who thought they were adding a
+    // wallet to an account they were already inside — would double as a session
+    // for that account.
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+    const nonce = challenge.nonce;
+
+    const linkMessage = buildWalletLinkMessage({
+      walletAddress: fx.address,
+      email: fx.email,
+      nonce,
+    });
+
+    await expect(
+      signInWithWallet(fx.client, fx.address, fx.sign(linkMessage)),
+    ).rejects.toMatchObject({ code: "BAD_SIGNATURE" });
+  });
+
+  it("spends the challenge even when the signature is wrong", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+
+    const wrong = buildWalletSignInMessage({ walletAddress: fx.address, nonce: "wrong" });
+    await expect(signInWithWallet(fx.client, fx.address, fx.sign(wrong))).rejects.toThrow();
+
+    // A wrong signature costs a fresh round trip rather than unlimited attempts
+    // against one live nonce — and this one hands out a session.
+    await expect(
+      signInWithWallet(fx.client, fx.address, fx.sign(challenge.message)),
+    ).rejects.toMatchObject({ code: "CHALLENGE_USED" });
+  });
+
+  it("cannot be replayed after a successful sign-in", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+    const signature = fx.sign(challenge.message);
+
+    await signInWithWallet(fx.client, fx.address, signature);
+
+    await expect(signInWithWallet(fx.client, fx.address, signature)).rejects.toMatchObject({
+      code: "CHALLENGE_USED",
+    });
+  });
+
+  it("refuses a signature with no live challenge behind it", async () => {
+    const fx = await setup();
+    const message = buildWalletSignInMessage({ walletAddress: fx.address, nonce: "x" });
+
+    /*
+      `CHALLENGE_USED`, not `CHALLENGE_NOT_FOUND`, and the reason is worth
+      knowing: **linking and signing in share one `wallet_challenges` row**,
+      keyed `UNIQUE (user_id, address)`. The fixture linked this wallet, so the
+      consumed link-challenge is still sitting there.
+
+      That sharing is safe — the two messages carry different prefixes, so a
+      live challenge for one purpose produces a signature the other rejects,
+      which the replay test above pins. What it means is that
+      `CHALLENGE_NOT_FOUND` is nearly unreachable for a wallet that has ever
+      been linked, and a test asserting it would be asserting a state the
+      application does not reach.
+    */
+    await expect(
+      signInWithWallet(fx.client, fx.address, fx.sign(message)),
+    ).rejects.toMatchObject({ code: "CHALLENGE_USED" });
+  });
+
+  it("refuses an expired challenge", async () => {
+    const fx = await setup();
+    const challenge = await issueWalletSignInChallenge(fx.client, fx.address);
+
+    const later = new Date(challenge.expiresAt.getTime() + 1000);
+    await expect(
+      signInWithWallet(fx.client, fx.address, fx.sign(challenge.message), later),
+    ).rejects.toMatchObject({ code: "CHALLENGE_EXPIRED" });
+  });
+
+  it("creates no account for an unknown wallet", async () => {
+    const fx = await setup();
+    const stranger = testWallet(11).address;
+    const message = buildWalletSignInMessage({ walletAddress: stranger, nonce: "x" });
+
+    await expect(signInWithWallet(fx.client, stranger, fx.sign(message))).rejects.toMatchObject(
+      { code: "WALLET_NOT_LINKED" },
+    );
+
+    // Sign-up stays email-first. An account with no email has nothing an
+    // invitation could reach.
+    const [row] = await fx.client.query<{ n: number }>("SELECT count(*)::int AS n FROM users");
+    expect(row?.n).toBe(1);
+  });
+});

--- a/packages/db/src/wallet-signin.ts
+++ b/packages/db/src/wallet-signin.ts
@@ -1,0 +1,147 @@
+import { randomBytes } from "node:crypto";
+import {
+  buildWalletSignInMessage,
+  isValidWalletAddress,
+  verifyWalletSignInSignature,
+} from "@rostr/core";
+import type { SqlClient } from "./client.js";
+import { findUserByWallet } from "./identity.js";
+import type { User } from "./identity.js";
+import { CHALLENGE_TTL_MS, createSession, SessionError } from "./sessions.js";
+import type { Session } from "./sessions.js";
+
+/**
+ * Signing in with a wallet you have already linked.
+ *
+ * An emailed code is the right way to prove an account is yours the first time
+ * and a poor way to do it the hundredth. A returning member already holds a key
+ * this account has verified — asking them to leave the browser, open a mail
+ * client and copy a code is asking for a weaker proof by a slower route.
+ *
+ * **This cannot create an account, and that is the whole boundary.** Sign-up
+ * stays email-first (decided by the owner, 2026-08-23). A wallet nobody has
+ * linked is told to sign in by email once; after that, the wallet alone is
+ * enough forever. Letting it register would produce accounts with no email —
+ * nothing to send an invitation notice to, and the username flow gated behind an
+ * account that has no other way to be reached.
+ */
+
+export interface WalletSignInChallenge {
+  readonly message: string;
+  readonly nonce: string;
+  readonly expiresAt: Date;
+}
+
+/**
+ * Issue a nonce for a wallet that already belongs to somebody.
+ *
+ * **The account is looked up before the challenge is written**, which is what
+ * lets this reuse `wallet_challenges` unchanged: there genuinely is a user, we
+ * simply had not identified them yet. No migration, and one table holding every
+ * live wallet nonce.
+ *
+ * `WALLET_NOT_LINKED` is deliberately distinguishable from every other refusal,
+ * because the owner's chosen flow is to send that person to email sign-in and a
+ * screen cannot say so without being told. **It does disclose that a given
+ * address has an account here** — a real tradeoff, accepted rather than
+ * overlooked. Two things make it a small one: a wallet address is a public
+ * identifier, and any wallet that has ever joined a pot league already announces
+ * the same fact on-chain through its `Membership` PDA. Email sign-in makes the
+ * opposite choice for the opposite reason — an email address is not public, and
+ * `/api/auth/request` answers identically either way.
+ */
+export async function issueWalletSignInChallenge(
+  db: SqlClient,
+  address: string,
+  now: Date = new Date(),
+): Promise<WalletSignInChallenge> {
+  if (!isValidWalletAddress(address)) {
+    throw new SessionError("Not a valid Solana public key", "INVALID_WALLET");
+  }
+
+  // Requires `verified_at IS NOT NULL`, so an address somebody typed but never
+  // proved cannot open a session.
+  const user = await findUserByWallet(db, address);
+  if (!user) {
+    throw new SessionError("This wallet is not linked to an account yet.", "WALLET_NOT_LINKED");
+  }
+
+  const nonce = randomBytes(16).toString("base64url");
+  const expiresAt = new Date(now.getTime() + CHALLENGE_TTL_MS);
+
+  await db.query(
+    `INSERT INTO wallet_challenges (user_id, address, nonce, expires_at)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (user_id, address)
+     DO UPDATE SET nonce = EXCLUDED.nonce,
+                   expires_at = EXCLUDED.expires_at,
+                   created_at = now(),
+                   consumed_at = NULL`,
+    [user.id, address, nonce, expiresAt.toISOString()],
+  );
+
+  return {
+    message: buildWalletSignInMessage({ walletAddress: address, nonce }),
+    nonce,
+    expiresAt,
+  };
+}
+
+/**
+ * Consume the challenge and open a session.
+ *
+ * The message is rebuilt server-side from the stored nonce — never from anything
+ * the client sends — for the same reason `linkWalletWithSignature` does it: a
+ * client that composed its own message could sign one thing and be credited with
+ * another.
+ *
+ * **The challenge is consumed whether or not the signature checks out**, so a
+ * wrong signature costs a fresh round trip rather than unlimited attempts
+ * against one live nonce. Same rule as linking, and it matters more here — this
+ * one hands out a session.
+ */
+export async function signInWithWallet(
+  db: SqlClient,
+  address: string,
+  signatureBase58: string,
+  now: Date = new Date(),
+): Promise<{ user: User; session: Session }> {
+  const user = await findUserByWallet(db, address);
+  if (!user) {
+    throw new SessionError("This wallet is not linked to an account yet.", "WALLET_NOT_LINKED");
+  }
+
+  const [row] = await db.query<{
+    nonce: string;
+    expires_at: string;
+    consumed_at: string | null;
+  }>(
+    `SELECT nonce, expires_at, consumed_at FROM wallet_challenges
+      WHERE user_id = $1 AND address = $2`,
+    [user.id, address],
+  );
+
+  if (!row)
+    throw new SessionError("No sign-in challenge for that wallet", "CHALLENGE_NOT_FOUND");
+  if (row.consumed_at !== null) {
+    throw new SessionError("That challenge has already been used", "CHALLENGE_USED");
+  }
+  if (new Date(row.expires_at).getTime() <= now.getTime()) {
+    throw new SessionError("That challenge has expired", "CHALLENGE_EXPIRED");
+  }
+
+  await db.query(
+    "UPDATE wallet_challenges SET consumed_at = $3 WHERE user_id = $1 AND address = $2",
+    [user.id, address, now.toISOString()],
+  );
+
+  const ok = verifyWalletSignInSignature(
+    { walletAddress: address, nonce: row.nonce },
+    signatureBase58,
+  );
+  if (!ok) throw new SessionError("That signature does not match", "BAD_SIGNATURE");
+
+  const session = await createSession(db, user.id, now);
+
+  return { user, session };
+}


### PR DESCRIPTION
## The bug, found by trying to build on it

`findUserByWallet` requires `wallets.verified_at IS NOT NULL`. **Nothing in the repo ever wrote that column.**

`linkWalletWithSignature` verifies the signature and then calls `linkWallet`, whose INSERT doesn't set it. So every row was unverified, the lookup matched nothing, and **inviting somebody by wallet address answered "no such user" for every address — including correct ones.** Silently: no error, no log, nobody found.

Its own docstring asserted the opposite:

> `wallets.verified_at` is set by `linkWalletWithSignature` and by nothing else, so an unverified row cannot exist through any path the app offers

A comment describing a guarantee the code did not provide.

Fixed at the cause: `linkWallet` takes `{ verified }`, only the signature path passes it, and re-linking upgrades an existing unproven row via `COALESCE` so the original moment survives.

## The feature that found it

Sign in with a wallet you've already linked. An emailed code is right the first time and poor the hundredth — a returning member already holds a key this account has verified.

**It cannot create an account.** Sign-up stays email-first: an unlinked wallet is told to sign in by email once, and after that the wallet alone is enough. Registering from a wallet would produce accounts with no email — nothing an invitation could reach.

## Three decisions worth reading

**A separate signed message.** `SIGNIN_PREFIX`, not `LINK_PREFIX`. The two prove the same fact and authorise different things, so one message would let a linking prompt — approved by someone who thought they were adding a wallet to an account they were *already inside* — double as a session for it. A test signs the link message and asserts sign-in rejects it.

**No email in the sign-in message.** The signer hasn't proved who they are yet; naming the account would disclose it to whoever holds the wallet before anything is established.

**`WALLET_NOT_LINKED` is distinguishable**, so the screen can say what to do next. That *does* disclose an address has an account here — accepted rather than overlooked: wallet addresses are public identifiers, and any wallet that joined a pot league already announces it on-chain. Email sign-in makes the opposite choice because an email address is not public.

## One thing discovered by a failing test

**Linking and signing in share one `wallet_challenges` row** (`UNIQUE (user_id, address)`). Safe — the differing prefixes make a live challenge for one purpose useless for the other — but it means `CHALLENGE_NOT_FOUND` is nearly unreachable once a wallet is linked. The test says so rather than asserting a state the app can't reach.

## UI

Both options offered with equal weight on `/signin`, wallet first in reading order, with a note that a returning user needs nothing else. Email stays visible rather than behind a link — a wallet extension that won't load is exactly when the recovery path must not be hidden.

## Checks

`pnpm test` (2126 passed, 2 skipped) — 13 new tests including the cross-purpose replay. Typecheck, lint, prettier, production build. No migration: the column already existed, unwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)