### PR TITLE
feat(web): each player shows who he plays this week

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -215,6 +215,13 @@ export async function GET(
          * and keeps him out of the autofill.
          */
         onIr: player.onIr,
+        /**
+         * Who he plays this week, from the fixture already stored. Sent as the
+         * two raw facts rather than a composed "vs NO" — the screen decides how
+         * to say it, and `lib/opponent.ts` is where that decision is tested.
+         */
+        opponentRef: player.opponentRef,
+        isHome: player.isHome,
         kickoffAt: player.kickoffAt,
         /**
          * How settled this player's week is. A bye, a fixture whose kickoff

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { opponentLabel } from "@/lib/opponent";
 import { isIrEligible as irEligible } from "@rostr/core";
 import { previewHeading, whyNot } from "@/lib/autofill";
 import useSWR from "swr";
@@ -44,6 +45,9 @@ interface RosterPlayer {
   availability: "SCHEDULED" | "TIME_TBD" | "BYE" | "UNSCHEDULED";
   /** Stashed on injured reserve: on the roster, out of the rotation. */
   onIr: boolean;
+  /** This week's opponent, or null on a bye and on an un-ingested fixture. */
+  opponentRef: string | null;
+  isHome: boolean | null;
   milliPoints: number;
   /** This week's projection under this league's scoring. Null if unpublished. */
   projectedMilliPoints: number | null;
@@ -424,6 +428,30 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                         {positionGroup(player.positions)}
                       </span>
                       {player.teamRef ?? "FA"}
+                      {/*
+                        Who he plays, next to who he plays for. A manager
+                        deciding a lineup is comparing matchups, and sending
+                        them to another tab to find out who somebody faces is
+                        the friction this removes.
+                      */}
+                      {(() => {
+                        const opponent = opponentLabel({
+                          opponentRef: player.opponentRef,
+                          isHome: player.isHome,
+                          availability: player.availability,
+                        });
+                        return opponent === null ? null : (
+                          <span
+                            className={
+                              opponent === "BYE"
+                                ? "text-nocturne-neutral-700"
+                                : "text-nocturne-neutral-500"
+                            }
+                          >
+                            {opponent}
+                          </span>
+                        );
+                      })()}
                     </span>
                   </span>
                 </button>
@@ -538,6 +566,21 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                   <span className="block text-[10px] text-nocturne-neutral-600">
                     {positionGroup(player.positions)}
                     {player.teamRef ? ` · ${player.teamRef}` : ""}
+                    {/*
+                      The bench is where a substitution gets decided, so the
+                      matchup matters here at least as much as it does on a
+                      starter. Injured reserve deliberately does not carry it:
+                      a stashed player is out of the rotation, and naming his
+                      fixture would invite a comparison that cannot be acted on.
+                    */}
+                    {(() => {
+                      const opponent = opponentLabel({
+                        opponentRef: player.opponentRef,
+                        isHome: player.isHome,
+                        availability: player.availability,
+                      });
+                      return opponent === null ? null : ` · ${opponent}`;
+                    })()}
                   </span>
                 </span>
               </button>

--- a/apps/web/src/lib/opponent.test.ts
+++ b/apps/web/src/lib/opponent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { opponentLabel } from "./opponent";
+
+describe("opponentLabel", () => {
+  it("says vs at home", () => {
+    expect(opponentLabel({ opponentRef: "NO", isHome: true, availability: "SCHEDULED" })).toBe(
+      "vs NO",
+    );
+  });
+
+  it("says @ away", () => {
+    // Two facts in three characters, and the convention every fantasy site
+    // already uses — a manager reading "@ KC" knows both who and where.
+    expect(
+      opponentLabel({ opponentRef: "MIA", isHome: false, availability: "SCHEDULED" }),
+    ).toBe("@ MIA");
+  });
+
+  it("says BYE on a bye week", () => {
+    expect(opponentLabel({ opponentRef: null, isHome: null, availability: "BYE" })).toBe("BYE");
+  });
+
+  it("says nothing when the fixture is simply not stored", () => {
+    // The mutation this exists to catch. A bye and an un-ingested fixture both
+    // arrive with no opponent and are opposite instructions: one says start
+    // somebody else, the other says he will play. Rendering "BYE" here would
+    // bench a player who is going to take the field.
+    expect(
+      opponentLabel({ opponentRef: null, isHome: null, availability: "UNSCHEDULED" }),
+    ).toBeNull();
+  });
+
+  it("still names the opponent when only the kickoff hour is unknown", () => {
+    // TIME_TBD is a real fixture whose hour the NFL has not fixed. The opponent
+    // is known and worth showing — withholding it would treat "we don't know
+    // when" as "we don't know who".
+    expect(opponentLabel({ opponentRef: "SEA", isHome: true, availability: "TIME_TBD" })).toBe(
+      "vs SEA",
+    );
+  });
+
+  it("prefers BYE over a stale opponent", () => {
+    // Belt and braces: availability decides first, so a leftover fixture row
+    // cannot make a bye week look playable.
+    expect(opponentLabel({ opponentRef: "NO", isHome: true, availability: "BYE" })).toBe("BYE");
+  });
+});

--- a/apps/web/src/lib/opponent.ts
+++ b/apps/web/src/lib/opponent.ts
@@ -1,0 +1,40 @@
+/**
+ * "vs NO", "@ MIA", "BYE".
+ *
+ * In `lib` for the reason `field.ts`, `chrome.ts`, `autofill.ts` and
+ * `waiver-run.ts` all record: `apps/web` has no jsdom in either vitest project,
+ * so a string composed inside a `.tsx` is verified only by being run in
+ * production.
+ *
+ * **`vs` and `@` rather than a home/away badge**, because it is the convention
+ * every fantasy site already uses and it carries two facts in three characters.
+ * A manager reading `@ KC` knows both who and where without a legend.
+ */
+
+export type Availability = "SCHEDULED" | "TIME_TBD" | "BYE" | "UNSCHEDULED";
+
+export function opponentLabel(input: {
+  readonly opponentRef: string | null;
+  readonly isHome: boolean | null;
+  readonly availability: Availability;
+}): string | null {
+  /*
+    Availability decides first, and that ordering is the whole point.
+
+    A bye and a fixture nobody has ingested both arrive here with no opponent,
+    and they are opposite instructions: one says start somebody else, the other
+    says he will play and we do not know the hour. `gameAvailability` already
+    separates them from data this module does not have — bye weeks and the TBD
+    flag — so re-deriving anything from the missing opponent would be a second,
+    worse answer to a question already answered.
+  */
+  if (input.availability === "BYE") return "BYE";
+
+  // A fixture we have not stored, or a player whose club we do not know. Not a
+  // bye, and saying nothing is better than implying one — a manager who benches
+  // somebody because the screen went quiet has been misled by an absence.
+  // `availability` is what tells them which of the two this is.
+  if (input.opponentRef === null || input.isHome === null) return null;
+
+  return `${input.isHome ? "vs" : "@"} ${input.opponentRef}`;
+}

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -357,6 +357,21 @@ export type RosterPlayer = LineupPlayer & {
    * roster and out of the rotation.
    */
   readonly onIr: boolean;
+  /**
+   * Who he plays this week — "NO", "MIA" — and whether at home.
+   *
+   * **Derived from the fixture we already store, not fetched.** `games` carries
+   * both team refs and `players.team_ref` says which one he is, so the opponent
+   * is the other one. No provider call, no new column, and it cannot disagree
+   * with the kickoff shown beside it because both come from the same row.
+   *
+   * Null on a bye, and on a week whose fixture has not been ingested — the two
+   * are told apart by `availability`, which is the field that already makes that
+   * distinction. Nothing here should be used to infer a bye.
+   */
+  readonly opponentRef: string | null;
+  /** True when his club is the home side. Null whenever `opponentRef` is. */
+  readonly isHome: boolean | null;
 };
 export async function loadRosterForWeek(
   db: SqlClient,
@@ -375,6 +390,8 @@ export async function loadRosterForWeek(
     team_ref: string | null;
     injury_designation: string | null;
     on_ir: boolean;
+    home_team_ref: string | null;
+    away_team_ref: string | null;
   }>(
     `SELECT p.id AS player_id,
             p.full_name,
@@ -388,6 +405,8 @@ export async function loadRosterForWeek(
             r.on_ir,
             array_agg(DISTINCT pos.key) AS positions,
             g.kickoff_at,
+            g.home_team_ref,
+            g.away_team_ref,
             -- Does this player's team appear anywhere in the season's schedule?
             -- Distinguishes a bye (scheduled, just not this week) from a
             -- team_ref that matches nothing at all.
@@ -409,6 +428,7 @@ export async function loadRosterForWeek(
         AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
       WHERE r.team_id = $1 AND r.released_at IS NULL
       GROUP BY p.id, p.full_name, p.status, g.kickoff_at, p.team_ref, p.sport_id, r.on_ir,
+               g.home_team_ref, g.away_team_ref,
                p.image_url, p.injury_designation`,
     [teamId, season, week],
   );
@@ -430,6 +450,15 @@ export async function loadRosterForWeek(
         teamRef: row.team_ref,
         injuryDesignation: row.injury_designation,
         onIr: row.on_ir,
+        // The other side of his own fixture. Both refs are present or neither
+        // is, so one null check covers the pair.
+        opponentRef:
+          row.home_team_ref === null || row.away_team_ref === null
+            ? null
+            : row.home_team_ref === row.team_ref
+              ? row.away_team_ref
+              : row.home_team_ref,
+        isHome: row.home_team_ref === null ? null : row.home_team_ref === row.team_ref,
         kickoffAt: row.kickoff_at
           ? Math.floor(new Date(row.kickoff_at).getTime() / 1000)
           : // No game this week. A bye keeps null and stays movable; a player


### PR DESCRIPTION
A manager setting a lineup is comparing matchups, and the screen said who a player plays *for* and nothing about who he plays *against*. Choosing between two flex options meant leaving for another tab.

**Derived, not fetched.** `games` already stores both team refs and `players.team_ref` says which side he's on. No provider call, no new column, no migration — and it can't disagree with the kickoff beside it, because both come from the same joined row.

Checked against the real synced 2026 schedule rather than reasoned about:

```
Sam LaPorta (DET)        vs NO
Travis Etienne Jr. (NO)  @ DET
```

One fixture, both sides, home and away the right way round.

## `vs` and `@`, not a badge

The convention every fantasy site uses, and it carries two facts in three characters — `@ KC` tells you who and where with no legend.

## Availability decides before the opponent does

A bye and an un-ingested fixture both arrive with no opponent, and they're **opposite instructions**: one says start someone else, the other says he'll play and we don't know the hour. `gameAvailability` already separates them, so `opponentLabel` asks it first and never infers a bye from an absence — rendering `BYE` there would bench a player who's about to take the field. There's a test named for it.

`TIME_TBD` still shows the opponent: not knowing *when* isn't not knowing *who*.

## Where it appears — and doesn't

Starters and bench, the bench most of all since that's where a substitution gets decided. **Not on injured reserve** — a stashed player is out of the rotation, and naming his fixture invites a comparison nobody can act on.

## Checks

`pnpm test` (2132 passed, 2 skipped) — 6 new tests. Typecheck, lint, prettier, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)