### PR TITLE
fix(db): a removed team no longer bricks a league at LEAGUE_FULL

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/join/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/join/route.ts
@@ -37,6 +37,9 @@ const STATUS: Record<string, number> = {
   RULES_MISSING: 500,
   LEAGUE_CLOSED: 409,
   LEAGUE_FULL: 409,
+  // A genuine race for the last seat, unlike LEAGUE_FULL beside it. 409 rather
+  // than 500 because nothing is wrong, and the client may simply try again.
+  SEAT_CONFLICT: 409,
   ALREADY_JOINED: 409,
   INVALID_WALLET: 400,
   WALLET_NOT_LINKED: 403,

--- a/packages/db/src/membership.test.ts
+++ b/packages/db/src/membership.test.ts
@@ -568,15 +568,24 @@ describe("joinLeague", () => {
     ).rejects.toSatisfy((e: unknown) => e instanceof JoinError && e.code === "LEAGUE_FULL");
   });
 
-  it("says LEAGUE_FULL when the slot index refuses, not just when the count does", async () => {
-    // The count and the insert are not atomic against each other, so two people
-    // clicking Join on the last seat both read the same `taken` and both derive
-    // the same slot. `UNIQUE (league_id, slot)` refuses the loser — correctly,
-    // and previously as an unhandled 500, because the route maps only `JoinError`.
-    //
-    // The race cannot be staged on single-connection PGlite. One team present
-    // makes `taken` 1, so the join derives slot 2 — occupying exactly that slot
-    // puts the insert in the state the loser of a real race reaches.
+  it("joins into a gap rather than refusing, when a slot has been vacated", async () => {
+    /*
+      **This test previously asserted the opposite, and that is issue #73.**
+
+      It was called "says LEAGUE_FULL when the slot index refuses", and it staged
+      a league whose only team sat at slot 2 — a gap at slot 1 — then asserted
+      the join was refused. Its comment explained the state as the loser of a
+      concurrent-join race, because a real race cannot be staged on
+      single-connection PGlite.
+
+      But a hole below `max(slot)` is not what losing a race looks like. It is
+      what `removeBot` and `removeMember` leave behind, and under the old
+      `count(*) + 1` arithmetic it bricked the league permanently. Somebody had
+      the defect on screen, read it as the race, and wrote it down as correct.
+
+      The fixture is kept and the assertion inverted, because the state it builds
+      is exactly the one that used to fail.
+    */
     const fx = await setup();
     const m = await member(fx, 1, "a@example.com");
 
@@ -585,6 +594,8 @@ describe("joinLeague", () => {
       [fx.leagueId, "Squatter"],
     );
 
+    // `count(*)` is 1 and `max(slot)` is 2. The old arithmetic derived 2 and
+    // collided; the slot asserted here is what says which formula ran.
     await expect(
       joinLeague(fx.client, {
         leagueId: fx.leagueId,
@@ -592,6 +603,43 @@ describe("joinLeague", () => {
         walletAddress: m.address,
         signature: signJoin(fx, m.address, m.secret),
         teamName: "A",
+      }),
+    ).resolves.toMatchObject({ slot: 3 });
+  });
+
+  it("still refuses a full league whose slots are not contiguous", async () => {
+    /*
+      The capacity check must survive the fix, and this is the case that proves
+      it rather than the contiguous one above.
+
+      Under the old arithmetic the seat cap was enforced twice: once by
+      `count(*) >= maxTeams`, and once by accident, because two joiners deriving
+      the same `count + 1` collided on the unique index. `max + 1` removes the
+      second, so the first has to hold on its own — including on a field with a
+      hole in it, where `max(slot)` has run ahead of the count.
+
+      Twelve teams occupying slots 1..13 with slot 5 vacated: the count says
+      full, the highest slot says there is room. The count is the one that
+      decides.
+    */
+    const fx = await setup();
+    for (let i = 0; i < 13; i++) await addTestTeam(fx.client, fx.leagueId, `Team ${i}`);
+    await fx.client.query("DELETE FROM teams WHERE league_id = $1 AND slot = 5", [fx.leagueId]);
+
+    const [row] = await fx.client.query<{ n: number; hi: number }>(
+      "SELECT count(*)::int AS n, max(slot)::int AS hi FROM teams WHERE league_id = $1",
+      [fx.leagueId],
+    );
+    expect(row).toMatchObject({ n: 12, hi: 13 });
+
+    const m = await member(fx, 1, "a@example.com");
+    await expect(
+      joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Late",
       }),
     ).rejects.toSatisfy((e: unknown) => e instanceof JoinError && e.code === "LEAGUE_FULL");
   });
@@ -654,6 +702,92 @@ describe("bots", () => {
       rules,
     };
   }
+
+  describe("a league survives a removal", () => {
+    /*
+      Issue #73, end to end through the real product paths — no hand-crafted rows.
+
+      `joinLeague` derived its slot from `count(*) + 1` while `addBot` used
+      `max(slot) + 1`, and both removal paths hard-delete without renumbering.
+      After any non-top deletion the next joiner derived an occupied slot,
+      `UNIQUE (league_id, slot)` refused it, and it surfaced as `LEAGUE_FULL` —
+      permanently, because joining is the only thing that would raise the count.
+    */
+
+    it("lets somebody join after a bot is removed", async () => {
+      /*
+        **The mandatory sequence**, not an exotic one. `drawDraftOrder` refuses
+        an odd number of *rows*, so a league that squared an odd field with a bot
+        and then found one more manager cannot draft until the bot goes — which
+        is precisely what `removeBot` is for.
+      */
+      const fx = await freeLeague(3);
+      await addBot(fx.client, fx.leagueId, "Robo");
+      await addTestTeam(fx.client, fx.leagueId, "Human 4");
+
+      await removeBot(fx.client, fx.leagueId);
+
+      const m = await member(fx, 1, "late@example.com");
+      const team = await joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Late",
+      });
+
+      // The number, not merely that it resolved: `count(*) + 1` would be 5,
+      // which the bot's departure left occupied. Pinning 6 is what says the
+      // derivation changed rather than the symptom being papered over.
+      expect(team.slot).toBe(6);
+    });
+
+    it("lets somebody join after a member is removed", async () => {
+      // The second trigger, which the issue does not mention and which needs no
+      // bot — so it fires in leagues that allow none.
+      const fx = await freeLeague(3);
+      await fx.client.query("DELETE FROM teams WHERE league_id = $1 AND slot = 2", [
+        fx.leagueId,
+      ]);
+
+      const m = await member(fx, 1, "late@example.com");
+      const team = await joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Late",
+      });
+
+      expect(team.slot).toBe(4);
+    });
+
+    it("keeps join order readable across a gap", async () => {
+      // The only thing anything reads `slot` for is `ORDER BY` — the draft
+      // shuffle's input, standings order, a waiver tiebreak. A gap must not
+      // disturb that, which is what makes gaps acceptable rather than damage to
+      // be repaired by renumbering.
+      const fx = await freeLeague(3);
+      await fx.client.query("DELETE FROM teams WHERE league_id = $1 AND slot = 2", [
+        fx.leagueId,
+      ]);
+
+      const m = await member(fx, 1, "late@example.com");
+      await joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Late",
+      });
+
+      const rows = await fx.client.query<{ name: string; slot: number }>(
+        "SELECT name, slot FROM teams WHERE league_id = $1 ORDER BY slot",
+        [fx.leagueId],
+      );
+      expect(rows.map((r) => r.name)).toEqual(["Human 1", "Human 3", "Late"]);
+    });
+  });
 
   it("adds a bot with no owner", async () => {
     const fx = await freeLeague();

--- a/packages/db/src/membership.ts
+++ b/packages/db/src/membership.ts
@@ -44,6 +44,17 @@ export class JoinError extends Error {
       | "LEAGUE_NOT_FOUND"
       | "LEAGUE_CLOSED"
       | "LEAGUE_FULL"
+      /**
+       * Two seats claimed at the same instant. **Retryable, unlike
+       * `LEAGUE_FULL`**, which is why it is a separate code rather than a
+       * friendlier message.
+       *
+       * Before #73 a slot collision was reported as `LEAGUE_FULL`, so a league
+       * holding four of twelve seats told everybody it was full — and told them
+       * to look at a count that said otherwise. Whatever lands here in future is
+       * a genuine race, and a race is worth trying again.
+       */
+      | "SEAT_CONFLICT"
       | "ALREADY_JOINED"
       | "INVALID_WALLET"
       | "WALLET_NOT_LINKED"
@@ -240,6 +251,34 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
   const maxTeams = stored.rules.league.maxTeams;
 
   return withTransaction(db, async (tx) => {
+    /*
+      One join per league at a time, and an **advisory** lock rather than a row
+      lock. Issue #73.
+
+      Something has to serialise this, because the count below and the insert
+      after it are two statements: without it both joiners read the same `taken`
+      and both pass a capacity check only one of them may pass. That used to be
+      arbitrated by accident — see the slot comment below — and it no longer is.
+
+      `SELECT ... FROM leagues ... FOR UPDATE` was the obvious choice and is
+      wrong. It would order this path leagues → teams, while `drawDraftOrder`
+      runs drafts → teams and `startDraft` runs drafts → leagues, putting a
+      `teams`-then-`leagues` edge in reach of the draft path and a
+      `leagues`-then-`teams` edge here. Nothing takes this advisory key
+      anywhere else in the schema, so no cycle through it can exist at all.
+
+      Transaction-scoped, so it is released by COMMIT or ROLLBACK and can never
+      be stranded on a backend the connection pooler hands back —
+      `migrations/README.md` records that failure for session-scoped locks.
+
+      **PGlite is a single connection, so no test here can exercise the
+      contention this exists for.** What the tests below do prove is the
+      arithmetic, which is what actually bricked leagues.
+    */
+    await tx.query("SELECT pg_advisory_xact_lock(hashtext('teams.slot'), hashtext($1))", [
+      league.id,
+    ]);
+
     const [count] = await tx.query<{ taken: number }>(
       "SELECT count(*)::int AS taken FROM teams WHERE league_id = $1",
       [league.id],
@@ -247,27 +286,60 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
     const taken = Number(count?.taken ?? 0);
     if (taken >= maxTeams) throw new JoinError("League is full", "LEAGUE_FULL");
 
-    // Two people clicking Join on the last seat both read the same `taken` and
-    // both compute the same slot, so `UNIQUE (league_id, slot)` arbitrates and
-    // the loser is refused. That is why the count above cannot admit an extra
-    // member even without a lock — the collision is on the value derived from
-    // the stale read, not on the read itself.
-    //
-    // Translated rather than left to escape: losing that race means the league
-    // filled up, which is `LEAGUE_FULL` and a 409, not a 500. The wrap is around
-    // this one statement so no other uniqueness in the transaction can be
-    // relabelled as a full league.
+    /*
+      The slot is `max + 1`, never `count + 1`. **This is issue #73**, and the
+      comment that stood here asserted the opposite as a safety property.
+
+      Nothing renumbers on removal — `removeBot` and `removeMember` both
+      hard-delete — so after any non-top deletion `count + 1` names a slot that
+      is still occupied. `UNIQUE (league_id, slot)` then refuses the insert, and
+      the catch below relabelled that as `LEAGUE_FULL`: a four-of-twelve league
+      reporting itself full, **permanently**, because the count cannot rise when
+      joining is the thing that would raise it.
+
+      The sequence is not exotic. `drawDraftOrder` refuses an **odd number of
+      rows**, so a league that squared itself with a bot and then found one more
+      manager *has* to remove that bot before it can draft. That is the flow
+      `removeBot` exists for.
+
+      `max(slot) + 1` is what `addBot` and `addTestTeam` already did — this was
+      the odd one out of three. Gaps are fine and always were: every consumer
+      reads `slot` only as an `ORDER BY` (the draft shuffle's input, standings
+      order, a waiver tiebreak), and no caller reads the value.
+
+      **Do not "fix" this by renumbering instead.** `slot` orders the shuffle
+      input and `0028`'s field lock watches INSERT and DELETE but **not UPDATE**,
+      so a renumbering path would re-roll the draft order straight past the lock
+      that exists to freeze it.
+    */
     let team: { id: string; slot: number } | undefined;
     try {
       [team] = await tx.query<{ id: string; slot: number }>(
         `INSERT INTO teams (league_id, owner_id, is_bot, name, slot)
-         VALUES ($1, $2, false, $3, $4)
+         VALUES ($1, $2, false, $3,
+                 COALESCE((SELECT max(slot) FROM teams WHERE league_id = $1), 0) + 1)
          RETURNING id, slot`,
-        [league.id, input.userId, input.teamName, taken + 1],
+        [league.id, input.userId, input.teamName],
       );
     } catch (error) {
+      /*
+        Kept as a backstop, and no longer as the routine path.
+
+        Under the lock above a collision with another *join* is impossible, and
+        `max + 1` cannot collide with a committed row by construction. What is
+        still reachable is a join racing `addBot`, which derives its slot the
+        same way and takes no lock — transient, and a retry succeeds.
+
+        It is reported as `SEAT_CONFLICT` rather than `LEAGUE_FULL` because the
+        two are different facts and only one of them is retryable. Telling
+        somebody a four-of-twelve league is full is what sent commissioners to
+        stare at a seat count that contradicted the error.
+      */
       if (isUniqueViolation(error)) {
-        throw new JoinError("League is full", "LEAGUE_FULL");
+        throw new JoinError(
+          "Somebody else took a seat at that moment. Try again.",
+          "SEAT_CONFLICT",
+        );
       }
       throw error;
     }


### PR DESCRIPTION
Closes the first finding from the issue triage. Confirmed by three agents with different methods — one reproducing it against a real database, one tracing statically, one tasked with **refuting** it (which conceded).

## The bug

`joinLeague` derived a slot as `count(*) + 1`; `addBot` and `addTestTeam` used `max(slot) + 1`. Both removal paths hard-delete and nothing renumbers, so after **any** non-top deletion `count + 1` names an occupied slot → `UNIQUE (league_id, slot)` refuses → relabelled `LEAGUE_FULL` → **permanent**, because joining is the only thing that would raise the count.

Reproduced: a league holding **4 of 12 seats** reporting itself full.

## Severity: the sequence is mandatory

`drawDraftOrder` refuses an odd number of **rows**, so a league that squared an odd field with a bot and then found one more manager *cannot draft* until the bot is removed. That's the flow `removeBot` exists for — and the flow that bricked the league.

`removeMember` is a **second trigger** with no bot involved, so it fires in leagues that allow none. The issue named only the first.

Pot leagues were never exposed (all three mutators refuse when there's money) — which, since v1 is free-leagues-only, protects nothing that will actually run.

## Why the obvious one-liner would have been wrong

`max(slot) + 1` alone **introduces** a bug the old code accidentally prevented. Under `count + 1`, concurrent joiners derived the *same* slot and collided — the unique index was enforcing capacity as a side effect. With `max + 1` they no longer collide, both pass a stale `count < maxTeams`, and a 12-team league reaches 13.

So capacity needs a real lock — and an **advisory** one, not `FOR UPDATE` on the league row. That would order this path `leagues → teams` while `drawDraftOrder` runs `drafts → teams` and `startDraft` runs `drafts → leagues`, creating a genuine cycle risk. Nothing else takes this advisory key, so no cycle can exist.

## Gaps are correct; renumbering would be dangerous

Every reader of `slot` uses it only as `ORDER BY`. **Do not repair gaps by renumbering** — `slot` orders the draft shuffle's input and `0028`'s field lock watches INSERT and DELETE but *not* UPDATE, so renumbering would re-roll the draft order straight past the lock that freezes it.

## A test asserted the bug as correct

`membership.test.ts` staged a league whose only team sat at slot 2 and asserted the join was refused, explaining it as the concurrent-join race. A hole below `max(slot)` is not a lost race — it's what removal leaves behind. Fixture kept, assertion inverted.

**The suite was structurally blind:** `addTestTeam` uses the safe formula, so every fixture-built league was immune and `joinLeague`'s real arithmetic was only ever tested on contiguous fields.

## Checks

`pnpm test` — **2136 passed**, 2 skipped. Typecheck, lint, prettier, production build.

**Mutation-checked:** reverting the arithmetic fails all four new tests. No migration.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)