### PR TITLE
fix(db): a week no longer finalises on box scores nobody read

### DIFF
--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -143,11 +143,34 @@ async function score(
   );
 }
 
+/**
+ * A week's games finish **and their box scores are read**.
+ *
+ * Both, because in production both happen: `syncGames` advances the status and
+ * `syncBoxScores` stamps `stats_synced_at`, and a game that is FINAL with no
+ * stats is a failure state rather than a normal one. A fixture that marked only
+ * the status would put every test in that failure state and prove nothing about
+ * the ordinary path — the mistake issue #73's test made, in the other direction.
+ *
+ * Use {@link finishGamesUnread} for the failure this distinction exists to catch.
+ */
 const finishGames = (fx: Fixture) =>
-  fx.client.query("UPDATE games SET status = 'FINAL' WHERE season = $1 AND week = $2", [
-    SEASON,
-    WEEK,
-  ]);
+  fx.client.query(
+    "UPDATE games SET status = 'FINAL', stats_synced_at = now() WHERE season = $1 AND week = $2",
+    [SEASON, WEEK],
+  );
+
+/**
+ * Games the provider called FINAL whose box score was never read. Issue #140.
+ *
+ * The state that used to finalise a week **clean** at 0–0, permanently, and look
+ * exactly like a week in which nobody scored.
+ */
+const finishGamesUnread = (fx: Fixture) =>
+  fx.client.query(
+    "UPDATE games SET status = 'FINAL', stats_synced_at = NULL WHERE season = $1 AND week = $2",
+    [SEASON, WEEK],
+  );
 
 /**
  * Add one more game to a week, at the same kickoff, with a status of its own.
@@ -619,8 +642,10 @@ describe("finalisation", () => {
       [NFL.key],
     );
     await fx.client.query(
-      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status)
-       VALUES ($1, 'g14', $2, 14, 'CIN', 'BAL', $3, 'FINAL')`,
+      // `stats_synced_at` too: a FINAL game whose box score was never read is
+      // the #140 failure state, and this test is about the correction window.
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status, stats_synced_at)
+       VALUES ($1, 'g14', $2, 14, 'CIN', 'BAL', $3, 'FINAL', now())`,
       [sport!.id, SEASON, KICKOFF],
     );
 
@@ -774,6 +799,106 @@ describe("a game that never finishes — docs/RULES.md §10", () => {
 
     expect(outcome.finalized).toBe(false);
     expect(outcome.holdReason).toMatch(/no games are scheduled/);
+  });
+});
+
+describe("a week whose box scores were never read — #140", () => {
+  /*
+    The case that used to finalise **clean**.
+
+    `finalizationHold` decided from the clock and `count(*) FILTER (WHERE status
+    = 'FINAL')` and never once asked whether a box score had been read. So a week
+    where every game was marked FINAL and nothing was ingested settled with
+    `finished === total` — no fallback, nothing in the cron's JSON, nothing on
+    the scoreboard. Every player scored zero, permanently, because a finalised
+    week is never rescored, and twelve teams at 0–0 looks exactly like a week in
+    which nobody scored.
+
+    Reachable because two different jobs on two different cadences write the two
+    facts: `syncGames` advances the status daily, `syncBoxScores` stamps
+    `stats_synced_at` every ten minutes. Nothing orders them, and the stats job
+    can fail for a week while the schedule job keeps marking games FINAL.
+  */
+
+  const finalizedAt = async (fx: Fixture): Promise<string | null> => {
+    const [row] = await fx.client.query<{ finalized_at: string | null }>(
+      "SELECT finalized_at FROM matchups WHERE league_id = $1 AND week = $2 LIMIT 1",
+      [fx.leagueId, WEEK],
+    );
+    return row?.finalized_at ?? null;
+  };
+
+  it("holds inside the window rather than settling at zero", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGamesUnread(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
+
+    expect(outcome.finalized).toBe(false);
+    expect(outcome.holdReason).toMatch(/no box score/);
+    expect(await finalizedAt(fx)).toBeNull();
+  });
+
+  it("names the stats, not the clock, while it is holding", async () => {
+    // Inside the window an operator can still act on this — the stats job can be
+    // re-run and the week finalises on real data. Reporting it as "waiting for
+    // the correction window" would hide the one thing worth doing.
+    const fx = await setup();
+    await schedule(fx);
+    await finishGamesUnread(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
+
+    expect(outcome.holdReason).not.toMatch(/stat corrections/);
+    expect(outcome.holdReason).toMatch(/permanently/);
+  });
+
+  it("still finalises once the window has passed, because the clock is a ceiling", async () => {
+    /*
+      A hold the clock could not override would reintroduce exactly what §10's
+      fallback exists to prevent: one game whose box score never arrives keeping
+      a paying week open forever. Weeks 14 and 17 have to settle.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await finishGamesUnread(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(await finalizedAt(fx)).not.toBeNull();
+  });
+
+  it("says the cause was our ingest, not an abandoned game", async () => {
+    /*
+      The distinction that makes this worth reporting at all. "The clock ran out
+      with games unplayed" is the NFL's doing and §10 covers it; "the clock ran
+      out with stats unread" is our pipeline failing, and those players are about
+      to be paid nothing on data we never fetched. Same permanent outcome, two
+      different responses.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await finishGamesUnread(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/never ingested/);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/stats pipeline/);
+    // Not the postponement wording — the two must stay tellable apart.
+    expect(outcome.finalizedWithUnfinishedGames).not.toMatch(/RULES.md §10/);
+  });
+
+  it("reports nothing extra once the box scores are in", async () => {
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.finalizedWithUnfinishedGames).toBeUndefined();
   });
 });
 

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -534,9 +534,20 @@ async function finalizationHold(
   week: number,
   now: Date,
 ): Promise<FinalizationDecision> {
-  const rows = await db.query<{ total: number; finished: number; last_kickoff: string | null }>(
+  const rows = await db.query<{
+    total: number;
+    finished: number;
+    unread: number;
+    last_kickoff: string | null;
+  }>(
     `SELECT count(*)::int AS total,
             count(*) FILTER (WHERE g.status = 'FINAL')::int AS finished,
+            -- Games the provider called FINAL whose box score was never read.
+            -- Migration 0027 added both columns for exactly this question; nothing
+            -- had asked it. See the stats hold below.
+            count(*) FILTER (
+              WHERE g.status = 'FINAL' AND g.stats_synced_at IS NULL
+            )::int AS unread,
             max(g.kickoff_at) AS last_kickoff
        FROM games g
        JOIN sports s ON s.id = g.sport_id
@@ -557,6 +568,7 @@ async function finalizationHold(
   if (!row?.last_kickoff) return { hold: "no kickoff times are known" };
 
   const finished = Number(row?.finished ?? 0);
+  const unread = Number(row?.unread ?? 0);
   const hours = finalizationHours(rules, week);
   const clearsAt = new Date(new Date(row.last_kickoff).getTime() + hours * 3600 * 1000);
 
@@ -566,6 +578,29 @@ async function finalizationHold(
     // anyway.
     if (finished < total) {
       return { hold: `${total - finished} of ${total} games are still in progress` };
+    }
+
+    /*
+      Every game is FINAL and some box score was never read. Issue #140.
+
+      This is the case that used to finalise **clean** — `finished === total`, so
+      no fallback was set and nothing distinguished it from a healthy week. Every
+      player in those games scores zero, permanently, because a finalised week is
+      never rescored. Twelve teams settling 0–0 looks exactly like a week in
+      which nobody scored.
+
+      Reachable because `games.status` and the box score are written by different
+      jobs on different cadences: `syncGames` marks a game FINAL from the daily
+      season sync, `syncBoxScores` stamps `stats_synced_at` from the ten-minute
+      stats job. Nothing orders them, and the stats job can fail for a week while
+      the schedule job keeps advancing status.
+    */
+    if (unread > 0) {
+      return {
+        hold:
+          `${unread} of ${finished} finished games have no box score yet — ` +
+          `scoring them now would settle the week at zero, permanently`,
+      };
     }
 
     const paying = rules.settlement.payingWeeks.includes(week);
@@ -585,6 +620,29 @@ async function finalizationHold(
         `finalised ${hours}h after the last kickoff with ${total - finished} of ${total} ` +
         `games not marked FINAL — docs/RULES.md §10: affected players score 0 for the ` +
         `week and the matchup stands`,
+    };
+  }
+
+  /*
+    The window is a ceiling on the stats hold too, and that is deliberate.
+
+    A hold the clock could not override would reintroduce exactly what §10's
+    fallback exists to prevent: one game whose box score never arrives keeping a
+    paying week open forever. Weeks 14 and 17 have to settle.
+
+    But it settles **saying so**, as a distinct reason. "The clock ran out with
+    games unplayed" and "the clock ran out with stats unread" call for different
+    responses — the first is the NFL's doing and §10 covers it; the second is our
+    ingest failing, and it means those players are about to be paid nothing on
+    data we never fetched.
+  */
+  if (unread > 0) {
+    return {
+      hold: null,
+      fallback:
+        `finalised ${hours}h after the last kickoff with ${unread} of ${total} ` +
+        `games never ingested — those players score 0 permanently, and the cause ` +
+        `is our stats pipeline rather than an abandoned game`,
     };
   }
 


### PR DESCRIPTION
The most dangerous open issue for 9 September, from the triage.

## The bug

`finalizationHold` decided from the clock and how many games were marked `FINAL`. It never asked whether a box score had been **ingested**.

A week where every game reached FINAL and nothing was read finalised **clean** — `finished === total`, no fallback, nothing in the cron's JSON, nothing on the scoreboard. Every player scores zero **permanently**, because a finalised week is never rescored. Twelve teams at 0–0 looks exactly like a week nobody scored in.

Worse than the case the function was carefully built for: a postponed game at least *reports* itself via `finalizedWithUnfinishedGames`, which `CLAUDE.md` calls the thing worth waking someone for. This produced the same permanent outcome and reported itself as healthy.

## Why it's reachable

Two jobs, two cadences, no ordering: `syncGames` advances `games.status` daily; `syncBoxScores` stamps `stats_synced_at` every ten minutes. The stats job can fail for a week while the schedule job keeps marking games FINAL.

The issue filed this as latent "only because nothing calls `getBoxScore`" — that stopped being true when #96 wired the producer. The stats cron has been running all day.

## Two things the fix had to get right

**The window stays a ceiling.** A hold the clock couldn't override would reintroduce exactly what §10's fallback prevents — one missing box score keeping a paying week open forever. Weeks 14 and 17 must settle.

**It reports as a distinct reason.** "Clock ran out with games unplayed" is the NFL's doing and §10 covers it. "Clock ran out with stats unread" is our pipeline failing. Same outcome, different response — a test asserts the two wordings stay tellable apart.

The columns already existed: `0027` added `stats_synced_at`/`stats_error` for this question and nothing ever asked it.

## The fixture was staging the bug and calling it normal

`finishGames` marked games FINAL without stamping `stats_synced_at`, so every test in the file sat in the exact state this bug is about — which is why the new hold broke three of them immediately. In production a FINAL game normally *has* been ingested; the helper now says so, and `finishGamesUnread` stages the failure deliberately.

Same lesson as #73's test, inverted: a fixture that doesn't produce the state the product produces can't see the bug.

## Checks

`pnpm test` — **2141 passed**, 2 skipped. Typecheck, lint, prettier, production build.

**Mutation-checked:** disabling the hold fails three of the five new tests. No migration.

Refs #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)