### PR TITLE
fix(db): one unreadable league no longer stops every league's waivers

### DIFF
--- a/apps/web/src/app/api/cron/waivers/route.ts
+++ b/apps/web/src/app/api/cron/waivers/route.ts
@@ -37,7 +37,14 @@ export async function GET(request: Request): Promise<NextResponse> {
 }
 
 async function run(client: SqlClient, now: Date): Promise<NextResponse> {
-  const due = await leaguesDueForWaivers(client, now);
+  /*
+    Selection can fail per league now, and says so. Issue #131.
+
+    It used to be a bare list, computed before the per-league guard below, so one
+    league whose waiver schedule could not be read threw out of here and 500'd
+    the route — no league's waivers ran at all, every hour, deterministically.
+  */
+  const { due, problems } = await leaguesDueForWaivers(client, now);
 
   const runs: {
     leagueId: string;
@@ -80,11 +87,32 @@ async function run(client: SqlClient, now: Date): Promise<NextResponse> {
   // already reported in `runs`, and a row saying "ran, all fine" while three
   // leagues threw would be the healthy face this record exists to remove.
   const failed = runs.filter((entry) => entry.error).length;
-  await recordCronRun(
-    client,
-    "waivers",
-    failed > 0 ? `${failed} of ${due.length} leagues failed` : null,
-  );
 
-  return NextResponse.json({ at: now.toISOString(), due: due.length, runs });
+  /*
+    Both kinds of failure reach the heartbeat, and they are different facts.
+
+    A league that *ran* and threw has a bad claim or a bad roster and will
+    probably be fine next hour. A league that could not even be **asked** whether
+    it was due will never process a claim again until somebody looks — its rules
+    do not parse, or its waiver schedule cannot be computed. Collapsing the two
+    into one count would hide the permanent one behind the transient one.
+  */
+  const notes = [
+    failed > 0 ? `${failed} of ${due.length} leagues failed` : null,
+    problems.length > 0
+      ? `${problems.length} league(s) could not be checked at all: ` +
+        problems.map((p) => `${p.leagueId}: ${p.error}`).join("; ")
+      : null,
+  ].filter((note): note is string => note !== null);
+
+  await recordCronRun(client, "waivers", notes.length > 0 ? notes.join(" — ") : null);
+
+  return NextResponse.json({
+    at: now.toISOString(),
+    due: due.length,
+    runs,
+    // Surfaced in the response as well as the heartbeat: the heartbeat truncates
+    // and this is the one place the whole list is legible.
+    ...(problems.length > 0 ? { unreadable: problems } : {}),
+  });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -72,6 +72,7 @@ export {
   cancelClaim,
   dropPlayer,
   leaguesDueForWaivers,
+  type WaiverDueSelection,
   loadWaiverPriority,
   nextWaiverRun,
   pendingClaims,

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -7,6 +7,7 @@ import { seedSport } from "./sports.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import {
+  leaguesDueForWaivers,
   addFreeAgent,
   availabilityOf,
   availablePlayers,
@@ -1251,5 +1252,124 @@ describe("RULES.md §6 — a player whose game has kicked off cannot be moved", 
         new Date("2026-09-20T17:30:00Z"),
       ),
     ).rejects.toMatchObject({ code: "GAME_STARTED" });
+  });
+});
+
+describe("choosing which leagues are due — #131", () => {
+  /*
+    Selection used to run before the cron's per-league guard, so a throw in here
+    escaped it and 500'd the whole route: **no league's waivers ran at all**,
+    deterministically, every hour, until somebody noticed.
+
+    That is the shape CLAUDE.md documents under "One league's failure never stops
+    the others". It counts waivers among the three cron routes that always did it
+    correctly — and it was looking at the processing loop, which does. This ran
+    above it.
+
+    ## Why the fault is injected rather than staged from data
+
+    The obvious real trigger is an unusable waiver timezone, since nextWeekly
+    hands it to Intl.DateTimeFormat, which throws RangeError on an unknown zone.
+    **That route is closed**: validateLeagueRules checks the value is a real IANA
+    zone and createLeague refuses it, which was worth finding out rather than
+    assuming.
+
+    So there is no cheap way to build a league that throws here today, and that is
+    a good property rather than a reason to skip the test. The guard is not about
+    one cause — it is about the shape: anything that throws while deciding one
+    league's due-ness must not decide for every other league. A wrapper that fails
+    one specific read proves exactly that, and keeps proving it when a future
+    cause arrives that nobody has thought of.
+  */
+
+  /**
+   * A client that fails one league's rules read and passes everything else
+   * through untouched.
+   */
+  function failingFor(client: PGliteClient, leagueId: string): PGliteClient {
+    return new Proxy(client, {
+      get(target, prop, receiver) {
+        if (prop !== "query") return Reflect.get(target, prop, receiver);
+        return async (sql: string, params?: unknown[]) => {
+          if (sql.includes("league_rules") && params?.includes(leagueId)) {
+            throw new Error("simulated: this league's rules could not be read");
+          }
+          return (
+            target as unknown as { query: (s: string, p?: unknown[]) => Promise<unknown> }
+          ).query(sql, params);
+        };
+      },
+    }) as PGliteClient;
+  }
+
+  /** A second league in the same database, with a claim of its own pending. */
+  async function secondLeague(client: PGliteClient): Promise<string> {
+    const commissioner = await createUser(client, "second@example.com", "Second");
+    const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules;
+    const league = await createLeague(client, NFL, {
+      name: "The Other League",
+      commissionerId: commissioner.id,
+      rules,
+    });
+    await client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
+    const [player] = await client.query<{ id: string }>("SELECT id FROM players LIMIT 1");
+    const team = await addTestTeam(client, league.id, "Someone");
+    await client.query(
+      "INSERT INTO waiver_claims (league_id, team_id, add_player_id, state, created_at) " +
+        "VALUES ($1, $2, $3, 'PENDING', $4)",
+      [league.id, team.teamId, player.id, MONDAY],
+    );
+    return league.id;
+  }
+
+  const WEDNESDAY = new Date("2026-09-16T08:00:00Z");
+
+  it("still returns the healthy leagues when one cannot be checked", async () => {
+    const fx = await setup();
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0], fx.players.get("held"), MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[1],
+      addPlayerId: fx.players.get("held"),
+      now: MONDAY,
+    });
+
+    // The selection query only considers leagues actually playing.
+    await fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [
+      fx.leagueId,
+    ]);
+
+    const broken = await secondLeague(fx.client);
+    const client = failingFor(fx.client, broken);
+
+    const selection = await leaguesDueForWaivers(client, WEDNESDAY);
+
+    // The whole point. Before the fix this call threw and the cron 500'd, so no
+    // league's waivers ran — including every healthy one.
+    expect(selection.due).toContain(fx.leagueId);
+  });
+
+  it("reports the league it could not check, rather than skipping it silently", async () => {
+    /*
+      A league whose due-ness cannot be computed will never process another claim
+      until somebody looks at it. Skipping in silence would make it identical to a
+      league with nothing due — which is what this reports for most leagues most
+      hours, so the difference has to be said out loud.
+    */
+    const fx = await setup();
+    const broken = await secondLeague(fx.client);
+    const client = failingFor(fx.client, broken);
+
+    const selection = await leaguesDueForWaivers(client, WEDNESDAY);
+
+    expect(selection.problems.map((entry) => entry.leagueId)).toContain(broken);
+    expect(selection.due).not.toContain(broken);
+  });
+
+  it("reports no problems when every league is readable", async () => {
+    const fx = await setup();
+    const selection = await leaguesDueForWaivers(fx.client, MONDAY);
+    expect(selection.problems).toEqual([]);
   });
 });

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -1169,10 +1169,25 @@ export function nextWaiverRun(rules: LeagueRules, now: Date): Date {
 }
 
 /** Leagues whose waiver run is due and has not happened since. */
+/**
+ * Which leagues are due, and which could not be asked.
+ *
+ * A bare `string[]` was the old shape and it had nowhere to put a failure, so
+ * the only options were to throw — taking every league down with one — or to
+ * skip in silence. Neither is acceptable for a job nobody watches: a league that
+ * can never process another claim has to be distinguishable from one with
+ * nothing due, and most leagues have nothing due most hours.
+ */
+export interface WaiverDueSelection {
+  readonly due: readonly string[];
+  /** Leagues whose due-ness could not be computed. Never empty silently. */
+  readonly problems: readonly { readonly leagueId: string; readonly error: string }[];
+}
+
 export async function leaguesDueForWaivers(
   db: SqlClient,
   now: Date,
-): Promise<readonly string[]> {
+): Promise<WaiverDueSelection> {
   const rows = await db.query<{ id: string }>(
     `SELECT DISTINCT l.id
        FROM leagues l
@@ -1181,25 +1196,62 @@ export async function leaguesDueForWaivers(
   );
 
   const due: string[] = [];
+  const problems: { leagueId: string; error: string }[] = [];
+
   for (const row of rows) {
-    const stored = await getLeagueRules(db, row.id);
-    if (!stored) continue;
+    /*
+      One league's failure must not decide for the others, and **selection is
+      inside that rule as much as processing is** — issue #131.
 
-    // The run this league is currently waiting for. If the next one is more than
-    // a full cycle away, the moment has passed and claims are overdue.
-    const [oldest] = await db.query<{ created_at: string }>(
-      `SELECT min(created_at) AS created_at FROM waiver_claims
-        WHERE league_id = $1 AND state = 'PENDING'`,
-      [row.id],
-    );
-    if (!oldest?.created_at) continue;
+      The cron guards `processWaivers` per league and this function ran before
+      that guard existed, so a throw here escaped it and 500'd the whole route:
+      no league's waivers ran, deterministically, every hour, forever. Exactly
+      the shape `CLAUDE.md` documents under "One league's failure never stops
+      the others", which named the four cron routes and counted waivers among
+      the three that always did it correctly — the loop it was looking at was
+      the one below this.
 
-    if (nextProcessingAt(new Date(oldest.created_at), stored.rules.waivers) <= now) {
-      due.push(row.id);
+      Two things in here can throw for a single league. `getLeagueRules` parses
+      a stored document, and `nextProcessingAt` reads `rules.waivers`, whose
+      weekday is validated nowhere (#132) — so one league with an unusable
+      waiver schedule silently stopped everybody's.
+    */
+    try {
+      const stored = await getLeagueRules(db, row.id);
+      if (!stored) continue;
+
+      // The run this league is currently waiting for. If the next one is more
+      // than a full cycle away, the moment has passed and claims are overdue.
+      const [oldest] = await db.query<{ created_at: string }>(
+        `SELECT min(created_at) AS created_at FROM waiver_claims
+          WHERE league_id = $1 AND state = 'PENDING'`,
+        [row.id],
+      );
+      if (!oldest?.created_at) continue;
+
+      if (nextProcessingAt(new Date(oldest.created_at), stored.rules.waivers) <= now) {
+        due.push(row.id);
+      }
+    } catch (error) {
+      /*
+        Recorded, never swallowed. A league whose schedule cannot be computed
+        will never process a claim again, and a selection that quietly skipped it
+        would look identical to a league with nothing due — which is the state
+        this function reports for most leagues most hours.
+
+        Caught by shape rather than by class, deliberately. An `instanceof`
+        allowlist here would be the same defect this whole change is about:
+        `CLAUDE.md` — "if you find yourself adding an error class to an allowlist
+        inside a per-league loop, the allowlist is the bug."
+      */
+      problems.push({
+        leagueId: row.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
-  return due;
+  return { due, problems };
 }
 
 export { availabilityAt };


### PR DESCRIPTION
`leaguesDueForWaivers` loops per league calling `getLeagueRules` and `nextProcessingAt`, and it ran **before** the cron's per-league guard. A throw for one league escaped that guard and 500'd the whole route — **no league's waivers processed at all**, deterministically, every hour.

`CLAUDE.md` documents this exact shape under *"One league's failure never stops the others"*. It names four cron routes and counts waivers among the three that always did it correctly — and it's right about the loop it was looking at. This ran above that loop.

## Selection reports instead of throwing

`leaguesDueForWaivers` now returns `{ due, problems }`. The bare list had nowhere to put a failure, so the only options were to throw — taking every league down with one — or skip in silence.

Silence isn't acceptable here: a league whose due-ness can't be computed will never process another claim until someone looks, and a skipped league is indistinguishable from one with nothing due, which is what this reports for most leagues most hours.

Caught **by shape, not by class** — an `instanceof` allowlist inside a per-league loop is the defect this change is about, and `CLAUDE.md` says so in those words.

The cron reports the two kinds separately: a league that *ran* and threw has a bad claim and will probably be fine next hour; a league that couldn't be **asked** is stuck until a human intervenes.

## A wrong assumption, corrected rather than shipped

I wrote the test on the premise that an unusable waiver timezone would trigger this — `nextWeekly` hands it to `Intl.DateTimeFormat`, which throws on an unknown zone. **It failed: `validateLeagueRules` checks the value is a real IANA zone and `createLeague` refuses it.** The comment claiming otherwise was removed rather than left in.

So there's no cheap way to build a league that throws here today — a good property, not a reason to skip the test. The guard is about the *shape*, so the test injects a failing read for one league and proves the others still get their waivers. That keeps proving it when a future cause arrives nobody has thought of.

## Checks

`pnpm test` — **2144 passed**, 2 skipped. Typecheck, lint, prettier, production build.

**Mutation-checked:** rethrowing instead of recording fails two of the three new tests. No migration.

Refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)