### PR TITLE
fix(db): the lineup lock is evaluated against state that cannot move

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -31,7 +31,15 @@ const STATUS: Record<string, number> = {
   LEAGUE_NOT_FOUND: 404,
   TEAM_NOT_IN_LEAGUE: 403,
   INVALID_LINEUP: 422,
+  // Retryable, unlike every other code here. Nothing about the lineup is wrong —
+  // somebody else wrote the slot between validation and the write, so the client
+  // re-reads and submits again. 409 rather than 422: the request was well formed.
+  LINEUP_MOVED: 409,
   SLOT_TYPE_UNKNOWN: 500,
+  // #98: this fell through to 400 with no diagnosis. A league whose games are
+  // not ingested cannot enforce a kickoff lock, so it refuses rather than
+  // accepting a lineup it could not police.
+  SCHEDULE_MISSING: 409,
 };
 
 function weekOf(request: Request): number {

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -162,7 +162,12 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
   if (error) return <p className="text-sm text-red-400">{error.message}</p>;
   if (!data) return <p className="text-sm text-nocturne-neutral-600">Loading your lineup…</p>;
 
-  async function save(next: Slot[]): Promise<void> {
+  /**
+   * Save, with one retry reserved for a stale snapshot.
+   *
+   * `isRetry` exists so the retry cannot recurse: see the LINEUP_MOVED branch.
+   */
+  async function save(next: Slot[], isRetry = false): Promise<void> {
     setSaving(true);
     setProblems([]);
     setSaveError(null);
@@ -183,8 +188,44 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
 
       const body = (await response.json()) as {
         error?: string;
+        code?: string;
         problems?: { message: string }[];
       };
+
+      /*
+        `LINEUP_MOVED` is retryable and everything else here is not. Issue #100.
+
+        The server now validates the kickoff lock against state it holds a lock
+        on, so a save built from a stale snapshot can be refused — and the
+        ordinary cause is nobody's fault: the score-week cron's autofill wrote a
+        slot in the ten minutes since this screen last polled.
+
+        Surfacing that as an error would be worse than the bug it closes. The
+        manager did nothing wrong, the fix is mechanical, and `setSaveError`
+        renders text nobody could act on. So it re-reads and submits the same
+        intent once.
+
+        **Once, not in a loop.** A second refusal means the slot is genuinely
+        contested rather than merely stale, and a retry loop against a lock is
+        how a UI hammers a server it cannot win against. The second failure is
+        shown.
+      */
+      if (!response.ok && body.code === "LINEUP_MOVED" && !isRetry) {
+        const fresh = await mutate();
+        if (fresh) {
+          // Re-submit against what the server actually holds now, keeping this
+          // manager's own change and taking everything else from the refresh.
+          const merged = fresh.slots.map((slot) => {
+            const mine = next.find(
+              (entry) => entry.slotType === slot.slotType && entry.slotIndex === slot.slotIndex,
+            );
+            return mine && mine.playerId !== slot.playerId ? mine : slot;
+          });
+          await save(merged, true);
+          return;
+        }
+      }
+
       if (!response.ok) {
         setProblems((body.problems ?? []).map((problem) => problem.message));
         throw new Error(body.error ?? "Could not save that lineup");

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -12,6 +12,7 @@ import {
   autoFillLineup,
   ensureLineups,
   loadAverages,
+  LineupError,
   loadKickoffs,
   loadLineup,
   loadProjectedPoints,
@@ -1315,5 +1316,153 @@ describe("the lock survives a drop", () => {
 
     const qb = filled.find((slot) => slot.slotType === "QB" && slot.slotIndex === 0);
     expect(qb?.playerId).toBe(fx.players.get("thu-qb"));
+  });
+});
+
+describe("a lineup that moves under the manager — #100", () => {
+  /*
+    `setLineup` validated against a lineup it read **before** its transaction
+    opened, and `current` is the sole input to both lock guards: `SLOT_LOCKED`
+    compares against it, and `PLAYER_LOCKED` uses it to decide whether a slot is
+    even changing. An empty slot never locks.
+
+    So: the manager's PUT reads RB1 as empty; the score-week cron's autofill
+    commits a mid-game player into RB1; the manager's write lands and neither
+    guard fires, because both were evaluated against a slot that was empty when
+    it was read. A locked slot holding a player whose game had started was
+    replaced — which `season/lineup.ts` names as the exact thing the lock
+    exists to prevent.
+
+    **No second human is needed.** The manager races the cron, which runs every
+    ten minutes.
+
+    Migration `0016` predicted this in writing and closed only the duplicate
+    half with a unique index; the lock half stayed open until now.
+
+    ## Why the interference is injected
+
+    PGlite is a single connection, so the two writers cannot genuinely overlap.
+    What can be staged exactly is the ordering that matters: the snapshot is
+    taken, *then* somebody else's write commits, *then* our write runs. The proxy
+    below performs the interfering write at the instant `setLineup` opens its
+    transaction — which is the same interleaving, deterministically.
+  */
+
+  /**
+   * A client that lets one write land the moment `setLineup` takes its row lock.
+   *
+   * Keyed on the `FOR UPDATE` statement rather than on `BEGIN`, because that is
+   * the first thing inside the transaction and leaves the snapshot already taken.
+   */
+  function interferingAt(client: PGliteClient, interfere: () => Promise<void>): PGliteClient {
+    let fired = false;
+    return new Proxy(client, {
+      get(target, prop, receiver) {
+        if (prop !== "query") return Reflect.get(target, prop, receiver);
+        return async (sql: string, params?: unknown[]) => {
+          const run = (
+            target as unknown as {
+              query: (s: string, p?: unknown[]) => Promise<unknown>;
+            }
+          ).query.bind(target);
+          if (!fired && sql.includes("FOR UPDATE") && sql.includes("lineups")) {
+            fired = true;
+            await interfere();
+          }
+          return run(sql, params);
+        };
+      },
+    }) as PGliteClient;
+  }
+
+  it("refuses a write whose slot changed after validation", async () => {
+    const fx = await setup();
+
+    // The manager's snapshot: QB is empty.
+
+    const client = interferingAt(fx.client, async () => {
+      // Somebody else — the autofill — puts a player in that slot after the
+      // snapshot was taken and before the write lands.
+      await setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        now: BEFORE_ANYTHING,
+      });
+    });
+
+    await expect(
+      setLineup(client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).rejects.toSatisfy((e) => e instanceof LineupError && e.code === "LINEUP_MOVED");
+  });
+
+  it("leaves the other writer's value in place when it refuses", async () => {
+    // The refusal must not be a partial write. What is in the slot afterwards is
+    // what the winner put there, not a half-applied version of the loser's
+    // request.
+    const fx = await setup();
+
+    const client = interferingAt(fx.client, async () => {
+      await setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        now: BEFORE_ANYTHING,
+      });
+    });
+
+    await expect(
+      setLineup(client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).rejects.toThrow();
+
+    const after = await loadLineup(fx.client, fx.teamId, WEEK, fx.rules);
+    const held = after.find((slot) => slot.slotType === "QB");
+    expect(held?.playerId).toBe(fx.players.get("thu-qb"));
+  });
+
+  it("still accepts a save that changes nothing about the moved slot", async () => {
+    /*
+      The scoping that keeps the editor working. `LineupEditor` posts the whole
+      slot list on every dropdown change, from a snapshot up to 30 s old, so a
+      whole-lineup compare would refuse every save issued within thirty seconds
+      of an autofill pass — reintroducing from the other side the exact failure
+      #99 removed.
+
+      Here the manager submits the QB slot holding the value it already holds.
+      That asserts nothing, so it must not refuse.
+    */
+    const fx = await setup();
+
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+      now: BEFORE_ANYTHING,
+    });
+
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).resolves.toBeDefined();
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -106,7 +106,21 @@ export class LineupError extends Error {
       | "TEAM_NOT_IN_LEAGUE"
       | "INVALID_LINEUP"
       | "SLOT_TYPE_UNKNOWN"
-      | "SCHEDULE_MISSING",
+      | "SCHEDULE_MISSING"
+      /**
+       * The stored lineup moved between validation and the write. **Retryable.**
+       *
+       * Issue #100. `setLineup` validated against a snapshot taken before its
+       * transaction opened, so a manager whose PUT was in flight while the
+       * score-week cron's autofill committed had their lock check evaluated
+       * against a slot that was empty when they looked and is not any more.
+       *
+       * Distinct from `INVALID_LINEUP` because the two need opposite responses:
+       * an illegal lineup must be shown to the person so they can change it, and
+       * this one means nothing is wrong except the timing. The client re-reads
+       * and submits again.
+       */
+      | "LINEUP_MOVED",
     readonly problems: readonly LineupProblem[] = [],
   ) {
     super(message);
@@ -631,7 +645,50 @@ export async function setLineup(
 
   const slotTypeIds = await loadSlotTypeIds(db, stored.rules);
 
+  /*
+    Everything above validated against `current`, which was read before this
+    transaction opened. Issue #100: that snapshot can go stale under the manager,
+    and the thing it goes stale about is the **lock**.
+
+    `current` is the sole input to both lock guards — `SLOT_LOCKED` compares
+    against it, `PLAYER_LOCKED` uses it to decide whether a slot is even
+    changing — and an empty slot never locks. So the sequence is: the manager's
+    PUT reads RB1 as empty; the score-week cron's autofill commits a mid-game
+    player into RB1; the manager's write lands and neither guard fires, because
+    both were evaluated against a slot that was empty when it was read.
+
+    That is a **lock bypass**, not a lost update. It is the thing
+    `season/lineup.ts` names as the whole point of the lock: "someone starts a
+    player after seeing him score." No second human is needed — the manager
+    races the cron.
+
+    Two things close it, and both are needed:
+
+    - The row lock stops an existing row moving under us. It cannot help for a
+      slot that has **no row yet**, which is exactly the autofill's case: it
+      INSERTs where the manager saw nothing.
+    - So the write also carries a compare-and-swap against the value validated
+      against. `0016` predicted this in writing and closed only the duplicate
+      half with a unique index.
+
+    **Scoped to slots this request actually changes.** `LineupEditor` posts the
+    entire slot list on every dropdown change, from a snapshot up to 30 s old, so
+    a whole-lineup compare would fail every save issued within thirty seconds of
+    an autofill pass — reintroducing from the other side the exact failure #99
+    removed. An unchanged slot is not a claim about anything and must never
+    refuse.
+  */
   return withTransaction(db, async (tx) => {
+    // Locks the rows that exist. See above for why that is half the answer.
+    await tx.query(`SELECT 1 FROM lineups WHERE team_id = $1 AND week = $2 FOR UPDATE`, [
+      input.teamId,
+      input.week,
+    ]);
+
+    const byKey = new Map(
+      current.map((slot) => [`${slot.slotType}#${slot.slotIndex}`, slot.playerId]),
+    );
+
     for (const assignment of input.assignments) {
       const slotTypeId = slotTypeIds.get(assignment.slotType);
       if (!slotTypeId) {
@@ -641,13 +698,57 @@ export async function setLineup(
         );
       }
 
-      await tx.query(
+      const key = `${assignment.slotType}#${assignment.slotIndex}`;
+      const expected = byKey.get(key) ?? null;
+
+      // Unchanged slots are written without a guard. They assert nothing about
+      // the state, so a concurrent write to one is not a conflict — and guarding
+      // them is what would break the editor's whole-lineup save.
+      if (expected === assignment.playerId) {
+        await tx.query(
+          `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id, locked_at)
+           VALUES ($1, $2, $3, $4, $5, NULL)
+           ON CONFLICT (team_id, week, slot_type_id, slot_index)
+           DO UPDATE SET player_id = EXCLUDED.player_id`,
+          [input.teamId, input.week, slotTypeId, assignment.slotIndex, assignment.playerId],
+        );
+        continue;
+      }
+
+      const written = await tx.query<{ slot_index: number }>(
         `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id, locked_at)
          VALUES ($1, $2, $3, $4, $5, NULL)
          ON CONFLICT (team_id, week, slot_type_id, slot_index)
-         DO UPDATE SET player_id = EXCLUDED.player_id`,
-        [input.teamId, input.week, slotTypeId, assignment.slotIndex, assignment.playerId],
+         DO UPDATE SET player_id = EXCLUDED.player_id
+          WHERE lineups.player_id IS NOT DISTINCT FROM $6
+        RETURNING slot_index`,
+        [
+          input.teamId,
+          input.week,
+          slotTypeId,
+          assignment.slotIndex,
+          assignment.playerId,
+          expected,
+        ],
       );
+
+      if (written.length === 0) {
+        /*
+          The slot holds something other than what we validated against, so the
+          lock decision above was made about a state that no longer exists.
+
+          Refused rather than reconciled here: what belongs in that slot now
+          depends on whether the new occupant's game has started, which is the
+          question `validateLineup` answers, and answering it a second time
+          inside the write loop would be a second implementation of the lock.
+          The caller re-reads and submits against the truth.
+        */
+        throw new LineupError(
+          `${assignment.slotType} slot ${assignment.slotIndex + 1} changed while you were ` +
+            `editing — reload and try again`,
+          "LINEUP_MOVED",
+        );
+      }
     }
 
     return loadLineup(tx, input.teamId, input.week, stored.rules);


### PR DESCRIPTION
`setLineup` read the stored lineup **before** opening its transaction and handed that snapshot to `validateLineup`. `current` is the sole input to both lock guards — `SLOT_LOCKED` compares against it, `PLAYER_LOCKED` uses it to decide whether a slot is even changing — and an empty slot never locks.

So: a manager's PUT reads RB1 as empty → the score-week cron's autofill commits a mid-game player into RB1 → the manager's write lands and **neither guard fires**, because both were evaluated against a slot that was empty when it was read.

A **lock bypass**, not a lost update. `season/lineup.ts` names it as the entire purpose of the lock — *"someone starts a player after seeing him score"* — and **no second human is needed.** The manager races a cron that runs every ten minutes.

Migration `0016` predicted this in writing: it noted the read happens before the transaction with no row lock, closed the *duplicate* half with a deferrable unique index, and left the lock half open.

## Two mechanisms, because one isn't enough

`FOR UPDATE` stops an existing row moving under us. It can't help for a slot with **no row yet** — exactly the autofill's case, which INSERTs where the manager saw nothing. So the write also carries a compare-and-swap against the validated value.

## Scoped to slots the request actually changes

`LineupEditor` posts the whole slot list on every dropdown change from a snapshot up to 30s old. A whole-lineup compare would refuse every save within thirty seconds of an autofill pass — reintroducing from the other side the exact failure #99 removed. Unchanged slots assert nothing and are written unguarded.

## `LINEUP_MOVED` is retryable, and the editor treats it so

A refusal rendered as an error would be worse than the bug it closes — the manager did nothing wrong. The editor re-reads, merges its own change over the fresh state, and submits **once**. Not a loop: a second refusal means genuinely contested, and a retry loop against a lock is how a UI hammers a server it can't win against.

Route maps it 409, not 422 — the request was well formed. Also picks up `SCHEDULE_MISSING`, which was falling through to a bare 400 with no diagnosis (#98).

## Checks

`pnpm test` — **2147 passed**, 2 skipped. Typecheck, lint, prettier, production build.

Interference is injected at the instant the transaction opens: PGlite is single-connection and can't genuinely overlap two writers, but it *can* stage the ordering that matters, deterministically. **Mutation-checked:** disabling the detection fails the two tests written for it and nothing else.

No migration.

Refs #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)