### PR TITLE
fix(db): currentWeek no longer reads a different season's last week

### DIFF
--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -59,17 +59,38 @@ async function run(client: SqlClient, now: Date, request: Request): Promise<Next
     10,
   );
 
-  // The current NFL week, from the schedule rather than a calendar guess: the
-  // week whose games have started and are not yet a week old.
-  const [current] = await client.query<{ week: number }>(
-    `SELECT g.week
-       FROM games g
-       JOIN sports s ON s.id = g.sport_id
-      WHERE s.key = $1 AND g.kickoff_at <= $2
-      ORDER BY g.kickoff_at DESC
-      LIMIT 1`,
-    [NFL.key, now.toISOString()],
+  /*
+    The season this job is actually about. Issue #105.
+
+    The query below is a copy of `currentWeek` — deliberately, because this
+    wants the *lagging* answer and `transactionWeek` is strict — and it carried
+    the same defect: no `g.season`, so with a prior season's games in the table
+    it answered that season's last week from any instant afterwards, forever.
+    Latent only while one season is ingested, and unconditional from January 2027
+    once two coexist.
+
+    Derived from the leagues this run would score rather than from a constant or
+    a calendar: those are the only leagues whose weeks it is about to write, and
+    a season nobody is playing is not one to score.
+  */
+  const [active] = await client.query<{ season: number | null }>(
+    "SELECT max(season) AS season FROM leagues WHERE state IN ('IN_SEASON', 'PLAYOFFS')",
   );
+  const season =
+    active?.season === null || active?.season === undefined ? null : Number(active.season);
+
+  const [current] =
+    season === null
+      ? [undefined]
+      : await client.query<{ week: number }>(
+          `SELECT g.week
+           FROM games g
+           JOIN sports s ON s.id = g.sport_id
+          WHERE s.key = $1 AND g.season = $2 AND g.kickoff_at <= $3
+          ORDER BY g.kickoff_at DESC
+          LIMIT 1`,
+          [NFL.key, season, now.toISOString()],
+        );
 
   const week = Number.isFinite(requestedWeek) ? requestedWeek : Number(current?.week ?? 0);
   if (!week) {

--- a/apps/web/src/app/api/leagues/[id]/matchup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/matchup/route.ts
@@ -66,7 +66,8 @@ export async function GET(
     // Default to the week being played, from the schedule rather than a
     // calendar guess. Week 1 before kickoff, so a league in preseason opens on
     // something rather than on nothing.
-    const week = requestedWeek(request) ?? (await currentWeek(client, NFL.key, now)) ?? 1;
+    const week =
+      requestedWeek(request) ?? (await currentWeek(client, NFL.key, context.season, now)) ?? 1;
 
     const views = await loadWeekMatchups(client, id, week, now);
 

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -8,6 +8,7 @@ import { setLineup } from "./lineups.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import {
+  currentWeek,
   finalizationHours,
   generateSeasonSchedule,
   loadScheduledWeek,
@@ -971,5 +972,86 @@ describe("generateSeasonSchedule below two teams", () => {
     const { written } = await generateSeasonSchedule(fx.client, fx.leagueId, "seed");
 
     expect(written).toBeGreaterThan(0);
+  });
+});
+
+describe("currentWeek is scoped to one season — #105", () => {
+  /*
+    The query selected on sport and kickoff only. With a prior season's games in
+    the table it answered that season's last week from any instant afterwards,
+    permanently — the issue verified 18 for an August 2026 call with a single
+    2025 week-18 row present.
+
+    Latent only because no prior season is ingested today. It becomes live the
+    moment one is, and unconditional from January 2027, when 2026 and 2027 rows
+    coexist every offseason.
+
+    Two readers wanted the lagging answer and were right to: the scoreboard must
+    keep showing Sunday's result until Thursday, and the cron is writing that
+    week's scores. What neither wanted was a row from a different season, which
+    is why this is a filter rather than a move to `transactionWeek`.
+  */
+
+  /** One game, in a season and week of its own. */
+  async function game(
+    fx: Fixture,
+    season: number,
+    week: number,
+    kickoff: Date,
+    ref: string,
+  ): Promise<void> {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    await fx.client.query(
+      "INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status) " +
+        "VALUES ($1, $2, $3, $4, 'CIN', 'BAL', $5, 'FINAL')",
+      [sport.id, ref, season, week, kickoff.toISOString()],
+    );
+  }
+
+  it("ignores a prior season's last week", async () => {
+    // The exact scenario from the issue.
+    const fx = await setup();
+    await game(fx, 2025, 18, new Date("2026-01-04T18:00:00Z"), "prior-18");
+
+    const august = new Date("2026-08-13T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, august)).toBeNull();
+  });
+
+  it("still lags within its own season, which is the point of it", async () => {
+    /*
+      The behaviour that must survive the fix. This answers "which week am I
+      scoring", so from a week's last game until the next week's first kickoff it
+      keeps naming the week just played — that is correct for the scoreboard and
+      for the cron, and it is why neither caller was moved to
+      `transactionWeek`.
+    */
+    const fx = await setup();
+    await game(fx, 2026, 3, new Date("2026-09-27T17:00:00Z"), "w3");
+
+    // Tuesday after week 3, before week 4 kicks off.
+    const tuesday = new Date("2026-09-29T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, tuesday)).toBe(3);
+  });
+
+  it("prefers the most recent kickoff within the season, not the highest week", async () => {
+    // Ordering is by kickoff and not by week number, so a fixture moved later
+    // than a higher-numbered one still answers correctly.
+    const fx = await setup();
+    await game(fx, 2026, 3, new Date("2026-09-27T17:00:00Z"), "w3b");
+    await game(fx, 2026, 4, new Date("2026-10-04T17:00:00Z"), "w4b");
+
+    const between = new Date("2026-09-30T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, between)).toBe(3);
+  });
+
+  it("answers null before the season's first kickoff", async () => {
+    const fx = await setup();
+    await game(fx, 2026, 1, new Date("2026-09-10T00:20:00Z"), "w1b");
+
+    const preseason = new Date("2026-08-01T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, preseason)).toBeNull();
   });
 });

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -80,25 +80,37 @@ export class WeekError extends Error {
  * answers "which week am I scoring" and so keeps naming a week whose games have
  * all been played, right up until the next week kicks off — which is the correct
  * lag for the scoreboard and a three-day hole in any rule that binds on where a
- * roster change lands. It is also not season-scoped: with a prior season's games
- * ingested it answers "week 18" all summer. Both defects have been shipped and
- * fixed once each, in the waiver lock and in the trade deadline.
+ * roster change lands.
+ *
+ * **It is season-scoped now, and this paragraph used to record that it was not.**
+ * Issue #105: with a prior season's games in the table it answered that season's
+ * last week from any instant afterwards — verified as returning 18 for an August
+ * 2026 call with a single 2025 week-18 row present. Latent only because no prior
+ * season is ingested, and unconditional from January 2027 once two seasons
+ * coexist.
+ *
+ * The **lag** is deliberate and stays: this answers "which week am I scoring",
+ * so it keeps naming a week whose games have all been played until the next week
+ * kicks off. A caller enforcing a rule wants `transactionWeek`, which is
+ * strict — that is a different defect, shipped and fixed once each in the waiver
+ * lock and the trade deadline.
  *
  * Returns `null` before the season's first kickoff, when there is no week yet.
  */
 export async function currentWeek(
   db: SqlClient,
   sportKey: string,
+  season: number,
   at: Date,
 ): Promise<number | null> {
   const [row] = await db.query<{ week: number }>(
     `SELECT g.week
        FROM games g
        JOIN sports s ON s.id = g.sport_id
-      WHERE s.key = $1 AND g.kickoff_at <= $2
+      WHERE s.key = $1 AND g.season = $2 AND g.kickoff_at <= $3
       ORDER BY g.kickoff_at DESC
       LIMIT 1`,
-    [sportKey, at.toISOString()],
+    [sportKey, season, at.toISOString()],
   );
 
   return row ? Number(row.week) : null;


### PR DESCRIPTION
The query selected on sport and kickoff only, with **no `g.season`**. With a prior season's games in the table it answered that season's last week from any instant afterwards, permanently — the issue verified **18** for an August 2026 call with a single 2025 week-18 row present.

Latent today because only one season is ingested. Live the moment another is, and **unconditional from January 2027**, when two seasons coexist every offseason.

## A filter, not a move to `transactionWeek`

Both remaining readers want the **lagging** answer and are right to: the scoreboard must keep showing Sunday's result until Thursday, and the cron is writing that week's scores. Switching either to the strict `transactionWeek` would show an empty week from Tuesday and score a week with no games while skipping the one just played.

What neither wanted was a row from a *different season*. The lag stays; the cross-season read goes.

`transactionWeek` was already season-scoped and its docstring already named this defect in `currentWeek` — which is how the issue found it.

## score-week's copy, scoped from the leagues it scores

The cron carries a deliberate duplicate of this SQL for the same lagging semantics, and carried the same defect. Its season now comes from the leagues that would actually be scored (`max(season)` over `IN_SEASON`/`PLAYOFFS`) rather than a constant or the calendar — those are the only leagues whose weeks it's about to write. No active league means no week, which the existing healthy-run path already handles.

## Checks

`pnpm test` — **2151 passed**, 2 skipped. Typecheck, lint, prettier, production build.

Four tests including the issue's exact scenario. **One pins the lag deliberately**, so a future "fix" that made this strict fails loudly rather than quietly changing what the scoreboard shows. **Mutation-checked:** neutering the season predicate fails the cross-season test alone.

No migration.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)