### PR TITLE
fix(stats): the Tank01 client retries, instead of dropping a game on one 429

### DIFF
--- a/packages/stats/src/tank01/client.test.ts
+++ b/packages/stats/src/tank01/client.test.ts
@@ -145,3 +145,168 @@ describe("healthCheck", () => {
 
 // Stat mapping is covered in stat-map.test.ts, against field names verified
 // from a live box score.
+
+describe("retrying a request — #97", () => {
+  /*
+    The client threw on the first 429 and on any non-OK response. No retry, no
+    backoff, no pacing — while randomness.ts has given the Solana beacon three
+    attempts with a doubling backoff since it was written, for the same exposure.
+
+    It did not matter while every sync was operator-run and infrequent.
+    syncBoxScores is the first caller to make bursts of sequential calls on a
+    schedule, one per game, at the top of a ten-minute tick.
+
+    And since #140 a dropped game is no longer merely missing: a FINAL game with
+    no box score holds the whole week from finalising until the correction window
+    runs out, so one unretried 429 on a Sunday costs either a week that will not
+    settle or one that settles with those players at zero permanently.
+  */
+
+  /** Fails the first `failures` calls with `status`, then succeeds. */
+  function flaky(failures: number, status: number) {
+    let calls = 0;
+    const impl = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls <= failures) {
+        return Promise.resolve({
+          ok: false,
+          status,
+          text: () => Promise.resolve(""),
+          json: () => Promise.resolve({}),
+          headers: new Headers({}),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(""),
+        json: () => Promise.resolve({ statusCode: 200, body: ["ok"] }),
+        headers: new Headers({}),
+      } as Response);
+    });
+    return impl;
+  }
+
+  /** No wall-clock cost, and it records the waits so the shape can be asserted. */
+  function recordingSleep() {
+    const waits: number[] = [];
+    return {
+      waits,
+      sleepImpl: (ms: number) => {
+        waits.push(ms);
+        return Promise.resolve();
+      },
+    };
+  }
+
+  it("succeeds after a transient 429", async () => {
+    const fetchImpl = flaky(1, 429);
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).resolves.toEqual(["ok"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("backs off by doubling, rather than hammering", async () => {
+    // Matches randomness.ts: 200ms then 400ms. Asserted rather than assumed,
+    // because a retry with no wait is a way to meet a burst limit faster.
+    const fetchImpl = flaky(2, 429);
+    const { waits, sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await client.get("getNFLBoxScore");
+    expect(waits).toEqual([200, 400]);
+  });
+
+  it("gives up after the third attempt and reports the real reason", async () => {
+    const fetchImpl = flaky(99, 429);
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).rejects.toThrow(/HTTP 429/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries a 5xx", async () => {
+    const fetchImpl = flaky(1, 503);
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).resolves.toEqual(["ok"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a rejected key", async () => {
+    /*
+      The narrowness that keeps a clear failure from becoming a slow one. A 401
+      answers identically however many times it is asked, and three attempts
+      with backoff would delay the one error an operator can actually act on.
+    */
+    const fetchImpl = flaky(99, 401);
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).rejects.toThrow(/rejected the API key/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 404", async () => {
+    const fetchImpl = flaky(99, 404);
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).rejects.toThrow(/HTTP 404/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a thrown transport error", async () => {
+    // A socket reset mid-Sunday is exactly the transient this exists for, and it
+    // never reaches a status code at all.
+    let calls = 0;
+    const fetchImpl = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(new Error("ECONNRESET"));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(""),
+        json: () => Promise.resolve({ statusCode: 200, body: ["ok"] }),
+        headers: new Headers({}),
+      } as Response);
+    });
+    const { sleepImpl } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore")).resolves.toEqual(["ok"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/stats/src/tank01/client.ts
+++ b/packages/stats/src/tank01/client.ts
@@ -17,6 +17,56 @@ export interface Tank01Options {
   readonly apiKey: string;
   /** Injectable for tests. Defaults to global `fetch`. */
   readonly fetchImpl?: typeof globalThis.fetch;
+  /**
+   * Attempts per request, including the first. Defaults to
+   * {@link REQUEST_ATTEMPTS}.
+   *
+   * Injectable so a test can pin how many round trips it expects rather than
+   * inferring them from a constant it does not control — the same reasoning
+   * `randomness.ts` gives for the beacon's.
+   */
+  readonly attempts?: number;
+  /** Injectable so retry backoff costs a test no wall-clock time. */
+  readonly sleepImpl?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Three, matching `RPC_ATTEMPTS` in `packages/db/src/randomness.ts`.
+ *
+ * Not tuned independently: the two clients have the same shape of exposure —
+ * sequential unpaced calls at a metered endpoint — and a second number would be
+ * a second thing to reason about with no evidence behind it.
+ */
+const REQUEST_ATTEMPTS = 3;
+
+/** First backoff step; doubles per attempt. 200ms, 400ms. */
+const RETRY_BASE_MS = 200;
+
+/**
+ * Whether a failure is worth asking again.
+ *
+ * **Narrow on purpose.** A rejected key, a 404 and a malformed envelope answer
+ * identically however many times they are asked, so retrying them turns a clear
+ * failure into a slow one. Giving up early is also cheap here in a way it is not
+ * for the draw: `syncBoxScores` records the error against that game and the next
+ * tick picks it up ten minutes later.
+ *
+ * A transport error counts — a socket reset mid-Sunday is exactly the transient
+ * this exists for — but an unrecognised HTTP status does not, for the same
+ * fail-closed reason `blockTime` refuses to read an unknown RPC error as a
+ * skipped slot.
+ */
+function isRetryable(error: unknown): boolean {
+  if (!(error instanceof ProviderError)) return false;
+
+  // A thrown fetch: DNS, connection reset, timeout. The message is composed in
+  // one place below, so matching it is a check on this file rather than on the
+  // runtime's wording.
+  if (error.message.includes("failed")) return true;
+
+  // Rate limited, or the far side is unwell. Both pass with a wait.
+  if (error.message.includes("HTTP 429")) return true;
+  return /HTTP 5[0-9][0-9]/.test(error.message);
 }
 
 interface Tank01Envelope<T> {
@@ -29,6 +79,8 @@ export class Tank01Client {
   readonly name = "tank01";
   private readonly apiKey: string;
   private readonly doFetch: typeof globalThis.fetch;
+  private readonly attempts: number;
+  private readonly sleep: (ms: number) => Promise<void>;
 
   constructor(options: Tank01Options) {
     if (!options.apiKey) {
@@ -39,10 +91,61 @@ export class Tank01Client {
     }
     this.apiKey = options.apiKey;
     this.doFetch = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.attempts = options.attempts ?? REQUEST_ATTEMPTS;
+    this.sleep = options.sleepImpl ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
   }
 
-  /** Raw GET against a Tank01 endpoint, unwrapping its `{ body }` envelope. */
+  /**
+   * Raw GET against a Tank01 endpoint, unwrapping its `{ body }` envelope.
+   *
+   * **Retried, since #97.** Three attempts with a doubling backoff — the same
+   * shape `randomness.ts` gives the Solana beacon, and for the same reason
+   * `CLAUDE.md` records there: sequential unpaced calls at a metered endpoint
+   * meet a rate limit eventually, and one that fails the caller costs more than
+   * the wait.
+   *
+   * The exposure is newer here than the code is. Every sync before the box-score
+   * producer was operator-run and infrequent; `syncBoxScores` is the first
+   * caller to make **bursts of sequential calls on a schedule**, one per game, at
+   * the top of a ten-minute tick.
+   *
+   * And a dropped game is no longer merely missing. Since #140 a FINAL game with
+   * no box score **holds the whole week from finalising** until the correction
+   * window runs out — so a single unretried 429 on a Sunday now costs either a
+   * week that will not settle or, past the window, one that settles with those
+   * players at zero permanently.
+   */
   async get<T>(path: string, params: Record<string, string> = {}): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.attempts; attempt++) {
+      try {
+        return await this.attempt<T>(path, params);
+      } catch (error) {
+        lastError = error;
+
+        /*
+          Retried only when trying again could plausibly work.
+
+          A bad key, a malformed envelope or a 404 will answer identically
+          however many times it is asked, and retrying them turns a clear failure
+          into a slow one. `isRetryable` is deliberately narrow for the same
+          reason `blockTime` is narrow about what counts as a skipped slot: the
+          fail-closed direction here is to give up and report, because the caller
+          records the error per game and the next tick tries again anyway.
+        */
+        if (attempt === this.attempts || !isRetryable(error)) throw error;
+
+        await this.sleep(RETRY_BASE_MS * 2 ** (attempt - 1));
+      }
+    }
+
+    // Unreachable: the loop either returns or throws. Present so the function is
+    // total rather than relying on the reader to prove that.
+    throw lastError;
+  }
+
+  private async attempt<T>(path: string, params: Record<string, string> = {}): Promise<T> {
     const url = new URL(`https://${HOST}/${path}`);
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);


### PR DESCRIPTION
The client threw on the first 429 and on any non-OK response — no retry, no backoff, no pacing — while `randomness.ts` has given the Solana beacon three attempts with a doubling backoff since it was written, for the same exposure.

It didn't matter while every sync was operator-run and infrequent. **`syncBoxScores` is the first caller to make bursts of sequential calls on a schedule**, one per game, at the top of a ten-minute tick.

**And a dropped game stopped being merely missing an hour ago.** Since #140, a FINAL game with no box score holds the whole week from finalising until the correction window runs out. One unretried 429 on a Sunday now costs either a week that won't settle, or — past the window — one that settles with those players at zero permanently.

Three attempts, 200ms doubling. Not tuned independently from the beacon's: same shape of exposure, and a second number is a second thing to reason about with no evidence behind it.

## The predicate is deliberately narrow

A rejected key, a 404 and a malformed envelope answer identically however many times they're asked — retrying them turns a clear failure into a slow one and delays the one error an operator can act on. Retryable: thrown transport errors, 429, 5xx.

Giving up early is cheaper here than for the draw, which is why the balance differs — `syncBoxScores` records the failure against that game and the next tick retries in ten minutes, where a failed draw sends a commissioner back to a button.

## Found while doing this, and deliberately NOT fixed here

`stats_synced_at` is stamped on **failure as well as success**, since it doubles as the retry pacer. So the #140 hold — which counts FINAL games with `stats_synced_at IS NULL` — does **not** catch a game whose ingest failed: it looks synced.

The column serves two purposes ("when did we last try" and "do we have stats") and separating them is a schema decision, not something to guess at inside a retry change. Filed rather than bolted on. This PR materially reduces how often it can arise, which is the honest description of what it does about it.

## Checks

`pnpm test` — **2158 passed**, 2 skipped. Typecheck, lint, prettier, production build.

Seven tests: success-after-429, the doubling shape **asserted rather than assumed**, exhaustion after three, a 5xx, a thrown transport error, and both non-retryable cases pinned at exactly one call.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)