### PR TITLE
fix(db): a game that failed to ingest no longer claims it synced

### DIFF
--- a/packages/db/migrations/0041_stats_attempted_apart_from_synced.sql
+++ b/packages/db/migrations/0041_stats_attempted_apart_from_synced.sql
@@ -1,0 +1,63 @@
+-- "When did we last try" and "do we have stats" become two columns.
+--
+-- `stats_synced_at` was stamped by `syncBoxScores` on **both** paths — on a
+-- successful ingest, and on a failure alongside the reason in `stats_error`.
+-- The failure stamp was deliberate and load-bearing: it is the only thing
+-- pacing the retry, and `0027`'s own comment records what happened without it.
+-- One game with a permanent discrepancy was re-read seventy-two times a day for
+-- the rest of the season, and sixteen such games would have exceeded the daily
+-- quota outright.
+--
+-- The cost is that the column answered two questions with one value, and the
+-- second answer was wrong. #140 added a hold on finalisation — a week does not
+-- settle while any FINAL game has no box score — and read `stats_synced_at IS
+-- NULL` to mean "no box score". That catches a game nobody ever *tried* to read
+-- and misses one somebody tried and failed on, because the failure stamped the
+-- column. So the week finalised with those players at zero, permanently, which
+-- is precisely what a rate limit on a Sunday produces. Issue #227.
+--
+-- `stats_attempted_at` takes the pacing. `stats_synced_at` goes back to meaning
+-- what its name says, and is set only when stats were actually written.
+--
+-- ## The backfill is deliberately incomplete, and that is the honest option
+--
+-- Every existing row that was synced was also attempted, so the attempt column
+-- is filled from it. What cannot be recovered is the other direction: for a row
+-- carrying both a timestamp and a `stats_error`, nothing here can tell a
+-- *failure* from a *successful ingest that raised warnings* — `stats_error` has
+-- always been written by both, which is exactly why it could not simply be read
+-- as the hold condition instead.
+--
+-- So historical `stats_synced_at` values are left alone rather than
+-- retroactively nulled on a guess. A past failure keeps claiming it synced; the
+-- distinction holds from here. Inventing history to make a new invariant look
+-- older than it is would be worse than a documented gap, and the alternative —
+-- nulling every row with an error — would blank the successful ingests that
+-- merely had a discrepancy, which is most of them.
+--
+-- No production week has finalised yet, so nothing has been decided on the
+-- ambiguous rows.
+ALTER TABLE games
+  ADD COLUMN stats_attempted_at timestamptz;
+
+UPDATE games
+   SET stats_attempted_at = stats_synced_at
+ WHERE stats_synced_at IS NOT NULL;
+
+COMMENT ON COLUMN games.stats_attempted_at IS
+  'When the box-score producer last tried this game, successfully or not. Paces '
+  'the retry: every clause selecting a game for re-read is bounded against this, '
+  'because a game that cannot be read must not be re-fetched every tick. Set on '
+  'both the success and failure paths.';
+
+COMMENT ON COLUMN games.stats_synced_at IS
+  'When stat lines were last written for this game. NULL means no box score has '
+  'been ingested — including for a game that was tried and failed, which is the '
+  'distinction 0041 introduced and which finalizationHold depends on. Use '
+  'stats_attempted_at for pacing, never this.';
+
+-- The index backing the due query follows the column that now paces it.
+-- `0027`'s `games_stats_due_idx` on (season, status, stats_synced_at) stays, for
+-- the correction sweep, which genuinely wants the sync time.
+CREATE INDEX games_stats_attempt_idx
+  ON games (season, status, stats_attempted_at);

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -160,7 +160,9 @@ describe("syncBoxScores", () => {
     await syncBoxScores(fx.client, provider, NFL.key, SEASON);
 
     // Force it back onto the work list, as a recheck inside the window would.
-    await fx.client.query("UPDATE games SET stats_synced_at = now() - interval '2 days'");
+    await fx.client.query(
+      "UPDATE games SET stats_synced_at = now() - interval '2 days', stats_attempted_at = now() - interval '2 days'",
+    );
 
     const again = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
 
@@ -182,7 +184,9 @@ describe("syncBoxScores", () => {
     );
     await syncBoxScores(fx.client, provider, NFL.key, SEASON);
 
-    await fx.client.query("UPDATE games SET stats_synced_at = now() - interval '2 days'");
+    await fx.client.query(
+      "UPDATE games SET stats_synced_at = now() - interval '2 days', stats_attempted_at = now() - interval '2 days'",
+    );
     const corrected = fakeProvider(
       new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 312)], ...bothDefenses })]]),
     );
@@ -216,7 +220,9 @@ describe("syncBoxScores", () => {
       SEASON,
     );
 
-    await fx.client.query("UPDATE games SET stats_synced_at = now() - interval '2 days'");
+    await fx.client.query(
+      "UPDATE games SET stats_synced_at = now() - interval '2 days', stats_attempted_at = now() - interval '2 days'",
+    );
     const result = await syncBoxScores(
       fx.client,
       fakeProvider(
@@ -245,7 +251,9 @@ describe("syncBoxScores", () => {
       SEASON,
     );
 
-    await fx.client.query("UPDATE games SET stats_synced_at = now() - interval '2 days'");
+    await fx.client.query(
+      "UPDATE games SET stats_synced_at = now() - interval '2 days', stats_attempted_at = now() - interval '2 days'",
+    );
     // Both defenses still present, so they are "covered" and therefore eligible
     // for retraction — but points allowed is excluded by key.
     await syncBoxScores(
@@ -414,7 +422,7 @@ describe("syncBoxScores", () => {
     // The retry clause needs the last attempt to be older than
     // FAILED_RETRY_MINUTES, which it is not in a test that just ran.
     await fx.client.query(
-      "UPDATE games SET stats_synced_at = now() - interval '1 hour' WHERE id = $1",
+      "UPDATE games SET stats_synced_at = now() - interval '1 hour', stats_attempted_at = now() - interval '1 hour' WHERE id = $1",
       [fx.gameId],
     );
     await syncBoxScores(fx.client, fakeProvider(new Map([["g1", good]])), NFL.key, SEASON);
@@ -537,7 +545,7 @@ describe("the work list bounds what one run can spend", () => {
     // does not recognise and only two of the five statuses have been observed.
     const fx = await setup("IN_PROGRESS");
     await fx.client.query(
-      "UPDATE games SET kickoff_at = now() - interval '30 hours', stats_synced_at = now()",
+      "UPDATE games SET kickoff_at = now() - interval '30 hours', stats_synced_at = now(), stats_attempted_at = now()",
     );
 
     const result = await syncBoxScores(fx.client, fakeProvider(new Map()), NFL.key, SEASON);
@@ -550,7 +558,7 @@ describe("the work list bounds what one run can spend", () => {
     // that never treats anything as live.
     const fx = await setup("IN_PROGRESS");
     await fx.client.query(
-      "UPDATE games SET kickoff_at = now() - interval '2 hours', stats_synced_at = now()",
+      "UPDATE games SET kickoff_at = now() - interval '2 hours', stats_synced_at = now(), stats_attempted_at = now()",
     );
 
     const box = boxScore("g1", { qb1: [line("pass_yd", 120)], ...bothDefenses });
@@ -574,6 +582,7 @@ describe("the work list bounds what one run can spend", () => {
     await fx.client.query(
       `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays',
                        stats_synced_at = now() - interval '1 hour',
+                       stats_attempted_at = now() - interval '1 hour',
                        final_at = now() - interval '9 days'`,
     );
 
@@ -658,5 +667,91 @@ describe("the work list bounds what one run can spend", () => {
 
     const result = await syncBoxScores(fx.client, fakeProvider(boxes), NFL.key, SEASON);
     expect(result.games).toBe(2);
+  });
+});
+
+describe("a game whose ingest failed — #227", () => {
+  /*
+    `syncBoxScores` stamps `stats_synced_at = now()` on **both** paths: on
+    success, and on failure alongside the reason. The failure stamp is deliberate
+    — it paces the retry, so a game that cannot be read is not re-fetched every
+    ten minutes forever.
+
+    The cost is that the column means two things at once: "when did we last try"
+    and "do we have stats". #140's hold reads it as the second, counting FINAL
+    games with `stats_synced_at IS NULL`, so it catches a game nobody ever tried
+    to read and **misses one somebody tried and failed on** — which is exactly
+    what a 429 mid-Sunday produces.
+
+    These tests drive the real producer against a failing provider rather than
+    hand-writing the row, so they keep describing what the product actually does
+    when the two columns are separated.
+  */
+
+  it("does not claim to have synced a game it could not read", async () => {
+    const fx = await setup();
+    const provider = fakeProvider(
+      new Map([["g1", new Error("Tank01 refused the request (HTTP 429)")]]),
+    );
+
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(1);
+
+    const [row] = await fx.client.query<{
+      stats_synced_at: string | null;
+      stats_attempted_at: string | null;
+      stats_error: string | null;
+    }>("SELECT stats_synced_at, stats_attempted_at, stats_error FROM games WHERE id = $1", [
+      fx.gameId,
+    ]);
+
+    // The attempt is recorded, so the retry stays paced.
+    expect(row?.stats_attempted_at).not.toBeNull();
+    expect(row?.stats_error).toContain("429");
+
+    // But nothing was synced, and the column that says so must not claim it was.
+    // This is the assertion #140's hold depends on.
+    expect(row?.stats_synced_at).toBeNull();
+  });
+
+  it("records both when the read succeeds", async () => {
+    // The other half: a successful ingest sets both, so nothing that paces on
+    // the attempt loses its pacing.
+    const fx = await setup();
+
+    const provider = fakeProvider(
+      new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 300)] })]]),
+    );
+    await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    const [row] = await fx.client.query<{
+      stats_synced_at: string | null;
+      stats_attempted_at: string | null;
+    }>("SELECT stats_synced_at, stats_attempted_at FROM games WHERE id = $1", [fx.gameId]);
+
+    expect(row?.stats_synced_at).not.toBeNull();
+    expect(row?.stats_attempted_at).not.toBeNull();
+  });
+
+  it("does not re-read a failed game on the very next tick", async () => {
+    /*
+      The reason the failure stamp existed in the first place, preserved.
+
+      `stats_error` is set by ordinary warnings as much as by failures, so
+      without pacing one game with a permanent discrepancy was re-read seventy-two
+      times a day — sixteen of those would have exceeded the daily quota outright.
+      Moving the pace onto `stats_attempted_at` must not lose that.
+    */
+    const fx = await setup();
+    const provider = fakeProvider(
+      new Map([["g1", new Error("Tank01 refused the request (HTTP 429)")]]),
+    );
+
+    const first = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+    expect(first.games).toBe(1);
+
+    const second = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+    expect(second.games).toBe(0);
   });
 });

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -182,7 +182,11 @@ export async function syncBoxScores(
         -- clause that can stay true indefinitely is a call every ten minutes
         -- until the season ends.
         AND (
-              g.stats_synced_at IS NULL
+              -- Never *attempted*. Keyed on the attempt rather than the sync
+              -- since #227: a game that failed has no sync time, and selecting
+              -- on that would re-read it every tick — the hammering the retry
+              -- clause below exists to prevent.
+              g.stats_attempted_at IS NULL
            -- Live, and bounded by the clock rather than by the provider
            -- agreeing to move the status on.
            OR (g.status = 'IN_PROGRESS'
@@ -195,7 +199,7 @@ export async function syncBoxScores(
            -- seventy-two times a day for the rest of the season, and sixteen of
            -- them would have exceeded the daily quota outright.
            OR (g.stats_error IS NOT NULL
-               AND g.stats_synced_at < now() - make_interval(mins => $4::int)
+               AND g.stats_attempted_at < now() - make_interval(mins => $4::int)
                AND g.final_at > now() - make_interval(hours => $5::int))
            -- The NFL stat-correction sweep.
            OR (g.final_at > now() - make_interval(hours => $5::int)
@@ -206,6 +210,9 @@ export async function syncBoxScores(
       -- read scores its players zero *right now*, where a re-read only refines a
       -- number that already exists, and plain kickoff order would let a backlog
       -- of old games starve today's.
+      -- Never-read first, and "never read" is now the honest column: a failed
+      -- game still has no stats and still scores its players zero, so it belongs
+      -- at the front with the untried ones rather than behind them.
       ORDER BY (g.stats_synced_at IS NULL) DESC,
                (g.status = 'IN_PROGRESS') DESC,
                g.kickoff_at
@@ -276,8 +283,13 @@ export async function syncBoxScores(
       // and the reason is stored so a game that can never be read does not look
       // healthy forever while the week finalises around it.
       const reason = error instanceof Error ? error.message : String(error);
+      // **The attempt, not the sync.** #227: stamping `stats_synced_at` here made
+      // a game that could not be read indistinguishable from one that was, so
+      // #140's hold — which reads that column as "has a box score" — let the week
+      // finalise with those players at zero. The attempt is what paces the retry
+      // and it is recorded; the sync is not, because none happened.
       await db.query(
-        "UPDATE games SET stats_synced_at = now(), stats_error = $2 WHERE id = $1",
+        "UPDATE games SET stats_attempted_at = now(), stats_error = $2 WHERE id = $1",
         [game.id, reason],
       );
       failures.push({ gameRef: game.external_ref, reason });
@@ -531,10 +543,12 @@ async function ingestOneGame(
     // re-read. The column's own comment says it is set by warnings too. What the
     // *caller* is handed is the list, unjoined — see `GameOutcome.warnings`.
     const problem = problems.length > 0 ? problems.join("; ") : null;
-    await tx.query("UPDATE games SET stats_synced_at = now(), stats_error = $2 WHERE id = $1", [
-      game.id,
-      problem,
-    ]);
+    // Both, on the success path. The attempt column paces the retry and must not
+    // lose its pacing just because the read worked.
+    await tx.query(
+      "UPDATE games SET stats_synced_at = now(), stats_attempted_at = now(), stats_error = $2 WHERE id = $1",
+      [game.id, problem],
+    );
 
     let inserted = 0;
     let revised = 0;

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -829,6 +829,37 @@ describe("a week whose box scores were never read — #140", () => {
     return row?.finalized_at ?? null;
   };
 
+  it("holds a game that was tried and failed, not only one nobody tried", async () => {
+    /*
+      The gap #227 found in this hold, closed by `0041`.
+
+      `syncBoxScores` used to stamp `stats_synced_at` on the **failure** path as
+      well as the success one, because that column was also pacing the retry. So a
+      game that a rate limit had made unreadable looked synced, this hold read it
+      as ingested, and the week finalised with those players at zero —
+      permanently, since a finalised week is never rescored.
+
+      `stats_attempted_at` now carries the pacing and `stats_synced_at` means
+      what its name says. This stages the state the producer writes after a failed
+      read: attempted, an error recorded, nothing synced.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await fx.client.query(
+      `UPDATE games SET status = 'FINAL',
+                       stats_attempted_at = now(),
+                       stats_synced_at = NULL,
+                       stats_error = 'Tank01 refused the request (HTTP 429)'
+        WHERE season = $1 AND week = $2`,
+      [SEASON, WEEK],
+    );
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
+
+    expect(outcome.finalized).toBe(false);
+    expect(outcome.holdReason).toMatch(/no box score/);
+  });
+
   it("holds inside the window rather than settling at zero", async () => {
     const fx = await setup();
     await schedule(fx);


### PR DESCRIPTION
Closes #227 — a gap in the #140 fix I shipped an hour earlier.

## The bug

`syncBoxScores` stamped `stats_synced_at` on **both** paths: success, and failure alongside the reason. The failure stamp is deliberate and load-bearing — it's the only thing pacing the retry, and `0027` records what happened without it (one discrepant game re-read **72×/day** for the rest of the season; sixteen such games would exceed the daily quota).

So one column answered two questions and got the second wrong. #140's hold reads `stats_synced_at IS NULL` as "no box score" — catching a game **nobody tried** and missing one somebody tried and **failed** on. That week finalises with those players at zero, permanently. Exactly what a rate limit on a Sunday produces, and exactly what #97 was filed for.

## `stats_attempted_at` takes the pacing

`stats_synced_at` goes back to meaning what its name says. Every re-read clause bounds against the attempt; the correction sweep still reads the sync time, since a game being re-read for corrections has stats already.

## Why the one-line patch was wrong

Holding on `stats_error IS NOT NULL` is false: that column is written by **warnings on successful ingests** as much as by failures. It would hold most weeks on ordinary warnings until the correction window expired — making §10's fallback the normal path and destroying the distinction #140 exists to draw.

`stat_lines` can't answer it either: no game reference, so "did this game produce rows" isn't a query.

## The backfill is deliberately incomplete

Existing rows get `stats_attempted_at` from `stats_synced_at`. The other direction is unrecoverable — for a row with both a timestamp and an error, nothing can now distinguish a failure from a successful ingest with warnings. Historical values are left alone rather than retroactively nulled on a guess; a past failure keeps claiming it synced, and the distinction holds from here. No production week has finalised, so nothing has been decided on the ambiguous rows.

## Reproduced first, as the issue asked

Three tests drive the real producer against a failing provider — including one asserting the failed game is **not** re-read next tick, which is the pacing the old stamp existed for. A fourth proves #140's hold now fires on a failed ingest.

Four fixtures aged only `stats_synced_at` and had to learn to age both. Same lesson as #73 and #140: a fixture that doesn't produce what the product produces can't see the bug.

## Checks

`pnpm test` — **2162 passed**, 2 skipped. Typecheck, lint, prettier, production build.

**Mutation-checked:** restoring the failure-path sync stamp fails the test named for it and nothing else. `0041` applied to the hosted database **before** this merges.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)