### PR TITLE
fix(db): a veto cast while a trade resolves is refused, not silently discarded

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/trades/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/trades/route.ts
@@ -25,6 +25,10 @@ const STATUS: Record<string, number> = {
   BOT_CANNOT_TRADE: 403,
   BOT_CANNOT_VETO: 403,
   WRONG_STATE: 409,
+  // The vote arrived while the cron was resolving the trade. 409 like
+  // WRONG_STATE beside it, and a separate code because the screen says something
+  // different: "you were a moment late", not "you are looking at something old".
+  TRADE_ALREADY_SETTLED: 409,
   PLAYER_IN_ANOTHER_TRADE: 409,
   ALREADY_VETOED: 409,
   ROSTER_WOULD_OVERFLOW: 409,

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -1472,3 +1472,100 @@ describe("listing", () => {
     expect(proposed.map((trade) => trade.tradeId)).toEqual([open]);
   });
 });
+
+describe("a veto cast while the trade is being resolved — #134", () => {
+  /*
+    `vetoTrade` read the trade's state through `loadTrade` — no lock, nothing
+    binding that read to the insert — and then wrote the vote. So a member voting
+    in the same hour `/api/cron/trades` resolved the trade had their vote written
+    against a trade already decided: `resolveTrade` took its tally before the row
+    landed, so the vote did not count, the row existed, and the screen showed the
+    veto recorded.
+
+    That is worse than refusing them. A member told their vote was late can go and
+    persuade somebody else; a member whose vote is silently dropped believes the
+    league declined to block a trade it may in fact have blocked.
+
+    #133 guards every trade *state* write, and this is not one — a veto is a row
+    in a different table, and the tally is a count taken earlier in the same run,
+    so that guard cannot see it. It was deliberately left out of that PR rather
+    than folded into one whose title would have implied coverage.
+  */
+
+  /**
+   * Settles the trade at the instant the vote is about to be written.
+   *
+   * The state check at the top of vetoTrade passes — the trade really is
+   * ACCEPTED when the voter looks — and the resolution lands before the insert.
+   * That is the race, and it cannot be staged any other way on single-connection
+   * PGlite: the two writers cannot genuinely overlap, but the ordering that
+   * matters can be produced exactly.
+   */
+  function settlingBeforeTheVote(fx: Fixture): PGliteClient {
+    let fired = false;
+    return new Proxy(fx.client, {
+      get(target, prop, receiver) {
+        if (prop !== "query") return Reflect.get(target, prop, receiver);
+        return async (sql: string, params?: unknown[]) => {
+          const run = (
+            target as unknown as {
+              query: (s: string, p?: unknown[]) => Promise<unknown>;
+            }
+          ).query.bind(target);
+          if (!fired && sql.includes("INSERT INTO trade_vetoes")) {
+            fired = true;
+            await settle(fx.client, fx.leagueId, AFTER_WINDOW);
+          }
+          return run(sql, params);
+        };
+      },
+    }) as PGliteClient;
+  }
+
+  it("refuses a vote once the trade has been settled", async () => {
+    const fx = await setupWithSecondLeague();
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+
+    await expect(
+      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2], MONDAY),
+    ).rejects.toSatisfy((e) => e instanceof TradeError && e.code === "TRADE_ALREADY_SETTLED");
+  });
+
+  it("writes no vote row when it refuses", async () => {
+    /*
+      The half that matters. Refusing loudly is only an improvement if the row is
+      genuinely absent — a vote recorded but uncounted is the original defect
+      wearing an error message.
+    */
+    const fx = await setupWithSecondLeague();
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+    await expect(
+      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2], MONDAY),
+    ).rejects.toThrow();
+
+    const rows = await fx.client.query("SELECT team_id FROM trade_vetoes WHERE trade_id = $1", [
+      tradeId,
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("still accepts a vote while the trade is genuinely open", async () => {
+    // The control. Without it the refusal above passes just as well against a
+    // rule that rejected every veto.
+    const fx = await setupWithSecondLeague();
+
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2], MONDAY)).resolves.toBeDefined();
+
+    const rows = await fx.client.query("SELECT team_id FROM trade_vetoes WHERE trade_id = $1", [
+      tradeId,
+    ]);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -56,6 +56,22 @@ export class TradeError extends Error {
       | "BOT_CANNOT_TRADE"
       | "BOT_CANNOT_VETO"
       | "INVOLVED_CANNOT_VETO"
+      /**
+       * The trade was resolved while this vote was in flight. Issue #134.
+       *
+       * Distinct from `WRONG_STATE`, which means the trade was already settled
+       * when the voter looked. This one means it settled underneath them, and
+       * the difference is what the screen has to say: one is "you are looking at
+       * something old", the other is "you were a moment late".
+       *
+       * Worth telling them at all because the alternative was silence. The vote
+       * used to be written against a trade already decided — the row existed,
+       * the tally had been taken before it landed, and the screen showed the
+       * veto recorded. A member who is told their vote was late can go and
+       * persuade somebody; a member whose vote is silently dropped believes the
+       * league declined to block a trade it may in fact have blocked.
+       */
+      | "TRADE_ALREADY_SETTLED"
       | "ALREADY_VETOED"
       | "ROSTER_WOULD_OVERFLOW"
       | "ASSET_GONE",
@@ -674,14 +690,52 @@ export async function vetoTrade(
   );
   if (existing) throw new TradeError("You have already voted", "ALREADY_VETOED");
 
-  await db.query(
+  /*
+    The state check rides **inside the insert**, not above it. Issue #134.
+
+    The check at the top of this function read the trade through `loadTrade`
+    with no lock and nothing binding that read to this write, so a member voting
+    in the same hour `/api/cron/trades` resolved the trade had their vote written
+    against a trade already decided: `resolveTrade` took its tally before the row
+    landed, so the vote did not count, the row existed, and nothing told the
+    member either fact.
+
+    Adding `AND t.state = 'ACCEPTED'` to the SELECT makes the insert itself the
+    check. If the resolution committed first, the SELECT matches nothing, no row
+    is written, and the caller is told — rather than the vote being recorded and
+    quietly ignored.
+
+    **Refusing rather than locking**, which is the choice the issue set out and
+    the reason it is the right one here: `RULES.md` §6 gives the veto window a
+    definite end, so a vote arriving after it closes is genuinely late and saying
+    so is the honest answer. Taking `FOR UPDATE` on the trade in both this
+    function and `resolveTrade` would close the window instead of reporting it,
+    at the cost of a lock on the resolution path that #133 argued against — a
+    bigger change needing its own review, for a race whose correct outcome is
+    "you were late" either way.
+
+    The early check above stays. It is the error message for the ordinary case —
+    somebody opening a settled trade and voting on it — and this one cannot
+    distinguish that from the race.
+  */
+  const written = await db.query<{ trade_id: string }>(
     // The league is stored on the vote, not inferred at read time: the composite
     // foreign keys in 0020 use it to make an out-of-league vote unrepresentable
     // rather than merely uncounted.
     `INSERT INTO trade_vetoes (trade_id, team_id, league_id, created_at)
-       SELECT $1, $2, t.league_id, $3 FROM trades t WHERE t.id = $1`,
+       SELECT $1, $2, t.league_id, $3
+         FROM trades t
+        WHERE t.id = $1 AND t.state = 'ACCEPTED'
+     RETURNING trade_id`,
     [tradeId, actingTeamId, now.toISOString()],
   );
+
+  if (written.length === 0) {
+    throw new TradeError(
+      "That trade was settled while your vote was in flight, so it was not counted",
+      "TRADE_ALREADY_SETTLED",
+    );
+  }
 
   return loadTrade(db, tradeId);
 }


### PR DESCRIPTION
`vetoTrade` read the trade's state through `loadTrade` — no lock, nothing binding that read to the insert — then wrote the vote unconditionally. A member voting in the same hour `/api/cron/trades` resolved the trade had their vote written **against a trade already decided**: the tally was taken before the row landed, so the vote didn't count, the row existed, and the screen showed the veto recorded.

**Worse than refusing them.** A member told their vote was late can go persuade someone else. A member whose vote is silently dropped believes the league declined to block a trade it may in fact have blocked.

#133 guards every trade *state* write — this isn't one. A veto is a row in a different table and the tally is a `count(*)` taken earlier in the same run, so that guard can't see it. Deliberately left out of that PR rather than folded into one whose title would have implied coverage.

## The check rides inside the insert

`AND t.state = 'ACCEPTED'` on the `INSERT ... SELECT` makes the write its own check. If the resolution committed first, the SELECT matches nothing, no row is written, and the caller is told.

**Refusing rather than locking** — the option the issue set out. `RULES.md` §6 gives the veto window a definite end, so a vote arriving after it closes is genuinely late. `FOR UPDATE` in both this function and `resolveTrade` would close the window instead of reporting it, at the cost of a lock on the resolution path #133 argued against — a larger change for a race whose correct outcome is "you were late" either way.

`TRADE_ALREADY_SETTLED` is separate from `WRONG_STATE` because the screen says something different: *"you were a moment late"* vs *"you're looking at something old"*.

## The first test I wrote didn't stage the race

It settled the trade before voting — which the *existing* check catches with `WRONG_STATE`. The real thing needs the state to change **between** the check and the insert, so the test injects the resolution at the instant the vote is about to be written.

Three tests, including one asserting **no row is written** — refusing loudly is only an improvement if the vote is genuinely absent, since a vote recorded but uncounted is the original defect wearing an error message.

## Checks

`pnpm test` — **2165 passed**, 2 skipped. Typecheck, lint, prettier, production build. **Mutation-checked:** dropping the state predicate fails two of the three. No migration.

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)