### PR TITLE
fix(core): three comments that described rules the system does not have

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -519,8 +519,18 @@ for leagues without a pot, or the rule would only hold where there is money.
 
 Without it the attack is trivial and does not even look like one: accept a trade, drop the
 player you promised, and the swap executes into a roster spot that no longer holds him.
-`lockedByTrade` is consulted by dropping and by proposing, so a committed player cannot
-leave by any path.
+`lockedByTrade` is consulted by dropping, by proposing and by accepting.
+
+**It used to say "so a committed player cannot leave by any path", and that inference is
+what produced #77.** Three call sites are not every path: `processWaivers` and
+`resolveTrade` both release players and neither can refuse, because a throw inside
+`processWaivers` rolls back the whole league's run and leaves the claim PENDING forever,
+and `resolveTrade` cannot undo a trade the league already approved because a game started.
+
+Guarding the door and guarding the outcome are different jobs, and this needs both. What
+actually closes it is `ASSET_GONE` — execution refuses rather than inserting when the
+release matches no row, which is the only check that does not depend on knowing _how_ the
+player left.
 
 ### The bracket is recomputed, never accumulated
 

--- a/packages/core/src/draft/autopick.ts
+++ b/packages/core/src/draft/autopick.ts
@@ -33,7 +33,12 @@
  *
  * "Unsafe" means it would leave the starting lineup unfillable. A manager may do
  * that to themselves deliberately; auto-pick never does it on their behalf,
- * because they were not there to choose and the penalty is a forfeited stake.
+ * because they were not there to choose.
+ *
+ * **The penalty is not a forfeited stake, and this used to say it was.** That
+ * rule was removed in schema 4 (2026-08-08, see `DECISIONS.md`); the real cost is
+ * a slot the autofill can never fill, scoring zero every week for the rest of the
+ * season.
  */
 
 import type { DraftablePlayer, RosterShape } from "./roster.js";
@@ -88,7 +93,9 @@ export function autoPick(context: AutoPickContext): AutoPickResult | null {
    *
    * A manager who picks manually may strand their own starters — that is their
    * call. Auto-pick must not do it on their behalf, because the manager was not
-   * there to make the choice and the penalty is a forfeited stake.
+   * there to make the choice, and an unfillable slot scores zero every week for
+   * the rest of the season. (Not a forfeited stake — see the note at the top of
+   * this file.)
    */
   const isSafe = (player: DraftablePlayer): boolean =>
     isLegal(player) && !wouldStrandStarters(roster, player, shape, picksRemainingAfter);

--- a/packages/core/src/draft/roster.ts
+++ b/packages/core/src/draft/roster.ts
@@ -246,9 +246,24 @@ export function canDraft(
  * Advisory, not a block. A manual pick may proceed anyway; auto-pick avoids it.
  *
  * The stakes are worth stating plainly wherever this surfaces in a UI: a roster
- * that cannot fill its starting slots produces an invalid lineup every week,
- * and three consecutive invalid lineups mean the team is abandoned and its stake
- * is forfeited. On ESPN that is an embarrassment; here it is someone's buy-in.
+ * that cannot fill its starting slots cannot field a legal lineup, so the
+ * autofill has nobody to put in the empty slot and it scores zero every week
+ * for the rest of the season. On ESPN that is an embarrassment; here it is a
+ * team that cannot compete in a league other people are playing.
+ *
+ * **This used to say the team would be abandoned and its stake forfeited. That
+ * rule was removed in schema 4 on 2026-08-08 and is not coming back** — see
+ * `DECISIONS.md` and `CLAUDE.md`'s "Abandonment is gone. Do not bring it back".
+ * It could never fire: it counted consecutive weeks with an *invalid* lineup,
+ * and the autofill runs before a week is scored, so a lineup is never invalid at
+ * that moment. It was removed rather than repaired, because a manager who stops
+ * setting lineups is not defrauding anyone and a stake forfeited for inattention
+ * is a rule people would only ever meet by losing money to it.
+ *
+ * A comment describing a punishment the system deliberately no longer has is the
+ * defect class this repo treats as real in its own right, and this one had the
+ * added cost of making the consequence sound worse than it is — which is exactly
+ * the kind of sentence a UI would have copied.
  *
  * @param picksRemainingAfter picks this team has left *after* this one
  */

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -963,3 +963,66 @@ describe("hashLeagueRules", () => {
     );
   });
 });
+
+describe("the waiver weekday is checked against the union — #132", () => {
+  /*
+    The hour beside it was validated and the day was not. `nextWeekly` resolves a
+    weekday to an index, so an unrecognised one produces a schedule that cannot
+    be computed — and every value here is frozen at creation and hashed, so a
+    league created with a typo can never be corrected.
+
+    It is also what made #131 dangerous: `leaguesDueForWaivers` computes this for
+    every league with a pending claim, so one league with an unusable weekday
+    could take the whole run down.
+
+    The timezone next to it *was* checked for being a real IANA zone. This closes
+    the gap the pair left.
+  */
+
+  it("refuses a weekday that is not one of the seven", () => {
+    const rules = FIXTURE;
+    const broken = {
+      ...rules,
+      waivers: {
+        ...rules.waivers,
+        processing: { ...rules.waivers.processing, day: "WENSDAY" },
+      },
+    } as LeagueRules;
+
+    const problems = validateLeagueRules(broken, NFL);
+    expect(problems.some((p) => p.includes("WENSDAY"))).toBe(true);
+  });
+
+  it("names the acceptable values, so the fix is obvious", () => {
+    // A rule frozen at creation is worth an error somebody can act on the first
+    // time rather than after a second refused attempt.
+    const rules = FIXTURE;
+    const broken = {
+      ...rules,
+      waivers: { ...rules.waivers, weeklyLock: { ...rules.waivers.weeklyLock, day: "funday" } },
+    } as LeagueRules;
+
+    const problems = validateLeagueRules(broken, NFL);
+    expect(problems.some((p) => p.includes("WEDNESDAY"))).toBe(true);
+  });
+
+  it("is case-sensitive, because the stored value is", () => {
+    // The document is hashed verbatim, so "monday" and "MONDAY" are different
+    // bytes and only one of them is what every reader compares against.
+    const rules = FIXTURE;
+    const broken = {
+      ...rules,
+      waivers: {
+        ...rules.waivers,
+        processing: { ...rules.waivers.processing, day: "wednesday" },
+      },
+    } as LeagueRules;
+
+    expect(validateLeagueRules(broken, NFL).length).toBeGreaterThan(0);
+  });
+
+  it("accepts the default rule set unchanged", () => {
+    const rules = FIXTURE;
+    expect(validateLeagueRules(rules, NFL)).toEqual([]);
+  });
+});

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -366,12 +366,49 @@ function validateWaivers(rules: LeagueRules, out: string[]): void {
     if (!Number.isInteger(moment.hour) || moment.hour < 0 || moment.hour > 23) {
       out.push(`${label}.hour must be an integer 0-23, got ${moment.hour}`);
     }
+
+    /*
+      The day, checked against the union it is typed as. Issue #132.
+
+      The hour beside it was validated and the day was not, which is the gap
+      that matters: `nextWeekly` resolves a weekday to an index, and an
+      unrecognised one produces a schedule that cannot be computed. Every value
+      here is frozen at creation and hashed, so a league created with a typo can
+      never be corrected — and `leaguesDueForWaivers` calls this for every league
+      with a pending claim, which is why one bad value used to be able to stop
+      every league's waivers (#131).
+
+      `WEEKDAYS` is written out rather than derived from the type: a union is
+      erased at runtime, so there is nothing to iterate. It is the same
+      arrangement `TIEBREAKER_DISCRIMINANTS` uses, and carries the same
+      obligation — a weekday added to the type must be added here too.
+    */
+    if (!WEEKDAYS.has(moment.day)) {
+      out.push(`${label}.day must be one of ${[...WEEKDAYS].join(", ")}, got "${moment.day}"`);
+    }
   }
 
   if (w.weeklyLock.day === w.processing.day && w.weeklyLock.hour === w.processing.hour) {
     out.push("the weekly lock and processing run cannot be the same moment");
   }
 }
+
+/**
+ * The seven days, as values.
+ *
+ * A `Weekday` union exists at the type level and is gone at runtime, so nothing
+ * generated from it can check a value that arrived as JSON — which is exactly how
+ * a rule field typed as an enum reaches this function unchecked.
+ */
+const WEEKDAYS: ReadonlySet<string> = new Set([
+  "SUNDAY",
+  "MONDAY",
+  "TUESDAY",
+  "WEDNESDAY",
+  "THURSDAY",
+  "FRIDAY",
+  "SATURDAY",
+]);
 
 function validateTrades(rules: LeagueRules, out: string[]): void {
   const t = rules.trades;


### PR DESCRIPTION
Three small ones from the triage, each a sentence asserting behaviour the code doesn't provide.

## #129 — a punishment removed in schema 4, still documented

`roster.ts` told anyone building a UI that *"three consecutive invalid lineups mean the team is abandoned and its stake is forfeited. On ESPN that is an embarrassment; here it is someone's buy-in."* `autopick.ts` said it twice more, as the reason auto-pick won't strand a starter.

Abandonment was **removed 2026-08-08**, and `CLAUDE.md` has a section headed *"Abandonment is gone. Do not bring it back"*. It could never fire — it counted weeks with an *invalid* lineup, and the autofill runs before a week is scored.

The real consequence is now stated instead: an unfillable slot scores zero every week for the rest of the season. Bad, but not a forfeited stake — and a sentence a UI would have copied shouldn't say it is.

## #132 — the weekday was never checked against its own union

`validateWaivers` validated the **hour** beside it and not the day. `nextWeekly` resolves a weekday to an index, so an unrecognised one produces a schedule that can't be computed — and every value here is frozen at creation and hashed, so a typo can never be corrected.

It's also what made #131 dangerous: `leaguesDueForWaivers` computes this for every league with a pending claim, so one bad weekday could take the whole run down.

The timezone next to it **was** already checked for being a real IANA zone — found while fixing #131, when a test built on the opposite assumption failed. This closes the gap the pair left.

`WEEKDAYS` is written out rather than derived: a union is erased at runtime. Same arrangement as `TIEBREAKER_DISCRIMINANTS`, same obligation — and the comment says so.

## #119 — the inference that produced #77

`DECISIONS.md` said `lockedByTrade` *"is consulted by dropping and by proposing, so a committed player cannot leave by any path."* Three call sites aren't every path: `processWaivers` and `resolveTrade` both release players and **neither can refuse**. It now says what actually closes it — `ASSET_GONE`, the only check that doesn't depend on knowing *how* the player left.

## Checks

`pnpm test` — **2169 passed**, 2 skipped. Typecheck, lint, prettier.

Four tests for the weekday, including one pinning **case sensitivity**: the document is hashed verbatim, so `monday` and `MONDAY` are different bytes. Golden hash unmoved — validation reads the document, it doesn't encode it.

Refs #129, #132, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)