### PR TITLE
fix(db): the seat lock only worked if every writer took it — addBot did not

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -333,7 +333,7 @@ rights; unacceptable when the contract has to settle. The chain ends on lowest t
 
 **Rejected: join order.** The obvious reading of "team ID" is a 1..N number, and
 `teams.slot` is exactly that. Ranking on it is worse than the arbitrariness it removes.
-`slot` is `count(*) + 1` at join, so the lowest belongs to whoever joined first — in
+`slot` is `max(slot) + 1` at join — it was `count(*) + 1` until #73, which is a mechanism change and not a conclusion one: both are monotone in join order, so the lowest slot still belongs to whoever joined first and the rejection of join-order as a tiebreaker still stands —, so the lowest belongs to whoever joined first — in
 practice the commissioner, who holds the league URL before anyone else has seen it. That
 makes the last word on every unresolved tie, and the 1000 bps regular-season prize hanging
 off seed 1, a standing property of having created the league. It is the same special power

--- a/packages/core/src/season/standings.ts
+++ b/packages/core/src/season/standings.ts
@@ -265,7 +265,7 @@ function orderGroup(
     // checksum moved.
     //
     // Sorting on the join slot was considered and rejected. `slot` is
-    // `count(*) + 1` at join, so the lowest belongs to whoever joined first —
+    // `max(slot) + 1` at join (it was `count(*) + 1` until #73), so the lowest belongs to whoever joined first —
     // in practice the commissioner, who holds the league URL before anyone
     // else. That would give one participant the last word on every unresolved
     // tie, and the 1000 bps regular-season prize that hangs off seed 1, by

--- a/packages/db/src/membership.test.ts
+++ b/packages/db/src/membership.test.ts
@@ -607,6 +607,45 @@ describe("joinLeague", () => {
     ).resolves.toMatchObject({ slot: 3 });
   });
 
+  it("lets the replacement for a removed member in, when max(slot) says full and the count does not", async () => {
+    /*
+      **The discriminating case, and the one the test below cannot see.**
+
+      That test stages count 12 and max 13 against a cap of 12 — both say full,
+      so it passes whether the capacity gate reads `count(*)` or `max(slot)`.
+      Harmonising the two, which is the natural-looking cleanup since they sit
+      thirty lines apart, would therefore stay green while reintroducing #73 at
+      the capacity gate — and in its worst form: a league with a visibly free
+      seat refusing every join forever, because joining is the only thing that
+      raises the number.
+
+      Here they disagree. Twelve teams, the one at slot 5 removed: count is 11,
+      `max(slot)` is 12, the cap is 12. The seat is genuinely free and the join
+      must succeed. Removing the *top* slot would not do — that drops max as
+      well, and the two agree again.
+    */
+    const fx = await setup();
+    for (let i = 0; i < 12; i++) await addTestTeam(fx.client, fx.leagueId, `Team ${i}`);
+    await fx.client.query("DELETE FROM teams WHERE league_id = $1 AND slot = 5", [fx.leagueId]);
+
+    const [before] = await fx.client.query<{ n: number; hi: number }>(
+      "SELECT count(*)::int AS n, max(slot)::int AS hi FROM teams WHERE league_id = $1",
+      [fx.leagueId],
+    );
+    expect(before).toMatchObject({ n: 11, hi: 12 });
+
+    const m = await member(fx, 1, "replacement@example.com");
+    await expect(
+      joinLeague(fx.client, {
+        leagueId: fx.leagueId,
+        userId: m.userId,
+        walletAddress: m.address,
+        signature: signJoin(fx, m.address, m.secret),
+        teamName: "Replacement",
+      }),
+    ).resolves.toMatchObject({ slot: 13 });
+  });
+
   it("still refuses a full league whose slots are not contiguous", async () => {
     /*
       The capacity check must survive the fix, and this is the case that proves

--- a/packages/db/src/membership.ts
+++ b/packages/db/src/membership.ts
@@ -325,10 +325,19 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
       /*
         Kept as a backstop, and no longer as the routine path.
 
-        Under the lock above a collision with another *join* is impossible, and
-        `max + 1` cannot collide with a committed row by construction. What is
-        still reachable is a join racing `addBot`, which derives its slot the
-        same way and takes no lock — transient, and a retry succeeds.
+        Under the lock a collision with another writer of this table is
+        impossible, because every one of them now takes the same key —
+        `joinLeague` here and `addBot` below.
+
+        **This used to say `max + 1` "cannot collide with a committed row by
+        construction", and that was false**, in a way its own next sentence
+        contradicted. Under READ COMMITTED the `max(slot)` subquery reads the
+        statement's snapshot, so a row committed by an unlocked writer between
+        that snapshot and the index check is a committed row that collides. It
+        was true only of rows committed *before* the statement began. `addBot`
+        was that unlocked writer, and it could also push the league past
+        `maxTeams` entirely, which is why it now takes the lock rather than the
+        comment being reworded.
 
         It is reported as `SEAT_CONFLICT` rather than `LEAGUE_FULL` because the
         two are different facts and only one of them is retryable. Telling
@@ -344,12 +353,37 @@ export async function joinLeague(db: SqlClient, input: JoinLeagueInput): Promise
       throw error;
     }
 
-    const [membership] = await tx.query<{ id: string }>(
-      `INSERT INTO league_memberships (league_id, user_id, team_id, wallet_id, rules_hash, signature)
-       VALUES ($1, $2, $3, $4, $5, $6)
-       RETURNING id`,
-      [league.id, input.userId, team!.id, wallet.id, stored.hash, input.signature],
-    );
+    /*
+      Wrapped, because the lock above made this the **only** way a same-user
+      double-submit can fail.
+
+      The `ALREADY_JOINED` check runs outside the transaction, so two overlapping
+      requests from one person both read no membership. Before the lock they also
+      both derived `count + 1`, so the loser hit the caught unique violation on
+      `teams` — the wrong message, but a 409. Now the lock serialises them: the
+      loser sees a fresh count, takes a non-colliding `max + 1` slot, and fails
+      here instead, on `UNIQUE (league_id, user_id)`, unwrapped, as a 500.
+      Deterministically, where it used to be one ordering of two.
+
+      The lock did not create the path. It made it the only one, so it needs the
+      translation the other insert already had.
+    */
+    let membership: { id: string } | undefined;
+    try {
+      [membership] = await tx.query<{ id: string }>(
+        `INSERT INTO league_memberships (league_id, user_id, team_id, wallet_id, rules_hash, signature)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id`,
+        [league.id, input.userId, team!.id, wallet.id, stored.hash, input.signature],
+      );
+    } catch (error) {
+      // Same fact as the pre-transaction check above, reached by the racing
+      // path. It should answer alike rather than as an unhandled 500.
+      if (isUniqueViolation(error)) {
+        throw new JoinError("Already a member of this league", "ALREADY_JOINED");
+      }
+      throw error;
+    }
 
     return {
       teamId: team!.id,
@@ -388,6 +422,36 @@ export async function addBot(
   const { maxBots, maxTeams } = stored.rules.league;
 
   return withTransaction(db, async (tx) => {
+    /*
+      The same lock `joinLeague` takes, and it belongs here for the same reason.
+
+      **A lock only closes a hole if every writer respects it**, and when the
+      join took this key it was the only one that did. `addBot` has the identical
+      check-then-insert — it reads `count(*)` in one statement and inserts in
+      another, and under READ COMMITTED those are separate snapshots.
+
+      So a commissioner adding a bot while the last manager joins could overfill
+      the league. `addBot` reads 11 of 12 and passes; the join commits at slot
+      12; `addBot`'s INSERT then re-reads `max(slot)` as 12 and writes **13** — a
+      different slot, so `UNIQUE (league_id, slot)` never arbitrates and a
+      thirteenth team lands silently in a twelve-team league.
+
+      **That is a regression from the join fix, not an old hole.** Under
+      `count(*) + 1` the join derived the same slot as the bot and the unique
+      index refused one of them. `max(slot) + 1` removes that accidental
+      arbitration, which is exactly why the capacity check needed a real lock —
+      on every writer, not one of them.
+
+      `maxTeams` is an anchored term compared against the chain, so exceeding it
+      diverges the Postgres field from what members signed.
+
+      Two concurrent `addBot` calls had the same shape against `maxBots`; this
+      closes that too.
+    */
+    await tx.query("SELECT pg_advisory_xact_lock(hashtext('teams.slot'), hashtext($1))", [
+      leagueId,
+    ]);
+
     await requireOpenField(tx, leagueId);
 
     const [counts] = await tx.query<{ taken: number; bots: number; humans: number }>(
@@ -428,12 +492,34 @@ export async function addBot(
 
     if (taken >= maxTeams) throw new JoinError("League is full", "LEAGUE_FULL");
 
-    const [team] = await tx.query<{ id: string; slot: number }>(
-      `INSERT INTO teams (league_id, is_bot, name, slot)
-       VALUES ($1, true, $2, COALESCE((SELECT max(slot) FROM teams WHERE league_id = $1), 0) + 1)
-       RETURNING id, slot`,
-      [leagueId, name],
-    );
+    /*
+      Translated rather than left to escape, which is what `joinLeague`'s
+      equivalent does.
+
+      The join's `SEAT_CONFLICT` docstring named "a join racing `addBot`" as the
+      one collision still reachable, and gave the join side a retryable code. This
+      side got nothing: the INSERT was unwrapped and the route rethrows anything
+      that is not a `JoinError`, so a commissioner met an unlabelled 500 for the
+      very event the other side calls retryable. Same fact, two answers.
+
+      With both writers on the lock the collision should now be unreachable. The
+      catch stays for the reason the join's does — a backstop that says something
+      useful if it ever is.
+    */
+    let team: { id: string; slot: number } | undefined;
+    try {
+      [team] = await tx.query<{ id: string; slot: number }>(
+        `INSERT INTO teams (league_id, is_bot, name, slot)
+         VALUES ($1, true, $2, COALESCE((SELECT max(slot) FROM teams WHERE league_id = $1), 0) + 1)
+         RETURNING id, slot`,
+        [leagueId, name],
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new JoinError("Somebody took a seat at that moment. Try again.", "SEAT_CONFLICT");
+      }
+      throw error;
+    }
 
     return { teamId: team!.id, slot: Number(team!.slot) };
   });


### PR DESCRIPTION
Found by a five-agent audit of **#221 — my own fix from earlier today.** Two agents reached it independently; one demonstrated it with a probe test.

## The regression

#221 gave `joinLeague` an advisory lock because `max(slot) + 1` removed the *accidental* capacity enforcement — under `count(*) + 1`, two joiners derived the same slot and the unique index refused one.

`addBot` is the other production writer of `teams`, has the identical check-then-insert, and took **no lock**:

```
addBot reads 11 of 12, passes its cap check
a join commits at slot 12
addBot's INSERT re-reads max(slot) = 12 and writes 13
```

**Thirteen teams in a twelve-team league, no error.** Differing slots mean the unique index never arbitrates — exactly the arbitration `max + 1` removed. A lock only closes a hole if *every* writer respects it, and #221's covered one of two.

`maxTeams` is an anchored term compared against the chain, so exceeding it diverges Postgres from what members signed. Two concurrent `addBot` calls had the same shape against `maxBots`.

## Two smaller regressions from the same commit

**Same-user double-submit: 409 → deterministic 500.** The `ALREADY_JOINED` check runs outside the transaction. Pre-lock, both submits derived `count + 1` and the loser hit the *caught* violation on `teams`. The lock serialises them, so the loser now takes a non-colliding slot and fails one statement later on `UNIQUE (league_id, user_id)` — unwrapped. The lock didn't create the path; it made it the only one.

**`SEAT_CONFLICT`'s mirror was an unlabelled 500.** #221 named "a join racing `addBot`" as the one reachable collision and gave only the join side a retryable code.

## A comment that contradicted its own next sentence

> `max + 1` cannot collide with a committed row by construction

False under READ COMMITTED — the subquery reads the statement's snapshot, so a row committed by an unlocked writer afterwards *is* a committed row that collides. The very next sentence named that writer.

## The test that couldn't see it

#221's capacity test stages count 12 **and** max 13 against a cap of 12 — both say full, so it passes whether the gate reads `count(*)` or `max(slot)`. Harmonising those (they sit 30 lines apart) would reintroduce #73 at the capacity gate in its worst form: a league with a visibly free seat refusing every join forever.

The new test makes them **disagree** — twelve teams, slot 5 removed, count 11, max 12, cap 12 — and asserts the replacement gets in. Mutating the gate to `max(slot)` now fails exactly that test; before, it was green across all 2,170.

## Checks

`pnpm test` — **2170 passed**, 2 skipped. Typecheck, lint, prettier, production build. No migration.

Also corrects the two surviving copies of *"`slot` is `count(*) + 1` at join"*. The conclusion there survives — both formulas are monotone in join order — so only the mechanism was wrong.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)