### PR TITLE
fix(db): a week settled on our own broken ingest and blamed the NFL for it

### DIFF
--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -250,11 +250,37 @@ async function run(client: SqlClient, now: Date, request: Request): Promise<Next
   const failed = scored.filter(
     (entry) => entry.skipped || entry.failedWeeks?.length || entry.bracketProblem,
   ).length;
-  await recordCronRun(
-    client,
-    "score-week",
-    failed > 0 ? `${failed} of ${scored.length} leagues had a problem` : null,
-  );
+
+  /*
+    A week that settled on the fallback is recorded here too, and it was not.
+
+    `finalizedWithUnfinishedGames` reached the JSON response body and stopped
+    there. Vercel does not keep cron response bodies, so the one durable record
+    of a run — the row `pnpm cron:status` reads — said nothing, and a run in
+    which a paying week permanently scored twelve teams zero on box scores we
+    never fetched was indistinguishable from a quiet Tuesday. Green.
+
+    It is deliberately **not** folded into `failed`. That count means "this
+    league did not get scored", which is a different and recoverable thing; a
+    fallback settlement is the opposite — the league was scored, once, for good.
+    Counting them together would let a retry-shaped response be applied to
+    something no retry can reach.
+  */
+  const onFallback = scored.filter((entry) =>
+    entry.weeks?.some((week) => week.finalizedWithUnfinishedGames),
+  ).length;
+
+  const notes = [
+    ...(failed > 0 ? [`${failed} of ${scored.length} leagues had a problem`] : []),
+    ...(onFallback > 0
+      ? [
+          `${onFallback} of ${scored.length} leagues permanently settled a week on the ` +
+            `clock rather than on complete data — see finalizedWithUnfinishedGames`,
+        ]
+      : []),
+  ];
+
+  await recordCronRun(client, "score-week", notes.length > 0 ? notes.join("; ") : null);
 
   return NextResponse.json({ at: now.toISOString(), week, leagues: scored });
 }

--- a/apps/web/src/app/api/cron/stats/route.ts
+++ b/apps/web/src/app/api/cron/stats/route.ts
@@ -29,10 +29,12 @@ import { runStatsJob } from "@/lib/jobs/stats";
  * The bounds that make a ten-minute cadence affordable are all in
  * `syncBoxScores` and were sized for it — `LIVE_WINDOW_HOURS` stops a game whose
  * status never advances being re-read for the rest of the season,
- * `MAX_GAMES_PER_RUN` caps the spend of one run, and the query's `ORDER BY` puts
- * never-read games first so a backlog cannot starve today's. **Do not raise the
- * frequency here without reading those**; the job makes one provider call per
- * game and has no delay in it.
+ * `MAX_GAMES_PER_RUN` caps the spend of one run, and the query's `ORDER BY`
+ * puts games with no box score first, then live ones, then the newest — so a
+ * backlog of older failures cannot starve the current slate. (It ordered
+ * oldest-first until the #140 re-audit, at which point #227's promotion of
+ * failed games to the front tier had turned that into the starvation this
+ * sentence claimed to prevent.)
  */
 export async function GET(request: Request): Promise<NextResponse> {
   const forbidden = cronForbidden(request);

--- a/packages/db/migrations/0042_stats_column_comments.sql
+++ b/packages/db/migrations/0042_stats_column_comments.sql
@@ -1,0 +1,49 @@
+-- Correct two column comments that asserted guarantees the code did not provide.
+--
+-- `0041` split "we tried to read this game" from "we wrote stat lines for it",
+-- and described the result in two `COMMENT ON COLUMN` strings that were both
+-- wrong in the same direction — each claiming a cleaner separation than the
+-- query actually implemented. This repo treats a comment asserting a guarantee
+-- the code does not provide as a defect in its own right, and a comment stored
+-- in the database is the one place a reader cannot check it against the source
+-- sitting next to it.
+--
+-- 1. "every clause selecting a game for re-read is bounded against this"
+--
+--    False when written. Of the four OR-branches in the box-score work list,
+--    one selected live games with no attempt bound at all, and the NFL
+--    stat-correction sweep was bounded against `stats_synced_at` — the very
+--    column `0041` had just removed from the failure path. So a game that had
+--    synced and then began failing kept a frozen-true predicate and was
+--    re-fetched on every tick, roughly a thousand metered calls for one game,
+--    which is the quota burn the retry bound exists to prevent. The sweep is
+--    now bounded on both columns and the comment says what is true.
+--
+-- 2. "Use stats_attempted_at for pacing, never this."
+--
+--    Contradicted ten lines below in its own file, where the index comment says
+--    the sweep "genuinely wants the sync time". Both are needed and they answer
+--    different questions: the attempt paces, the sync selects.
+--
+-- Also narrowed: NULL is not the only value meaning "no box score for this game
+-- as it finally stood". A game read while IN_PROGRESS carries a sync stamp
+-- older than the final whistle, and `finalizationHold` now treats that as
+-- unread too — otherwise a game whose every post-final read failed settles the
+-- week on third-quarter numbers.
+--
+-- No data changes. Comments only.
+
+COMMENT ON COLUMN games.stats_attempted_at IS
+  'When the box-score producer last tried this game, successfully or not. Set on '
+  'both the success and failure paths. This is what paces re-reads: every clause '
+  'of the work list that can select an already-attempted game is bounded against '
+  'it, so a game that cannot be read is not re-fetched every tick. The one clause '
+  'not bounded against it selects only games that have never been attempted.';
+
+COMMENT ON COLUMN games.stats_synced_at IS
+  'When stat lines were last written for this game. NULL means none ever were — '
+  'including for a game that was tried and failed, which is the distinction 0041 '
+  'introduced. It says a box score was read, not that the final one was: a game '
+  'read while IN_PROGRESS carries a stamp older than final_at, and finalizationHold '
+  'counts that as unread. Selection may read this column; pacing must not rely on '
+  'it alone, because the failure path deliberately leaves it untouched.';

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -43,9 +43,10 @@ const line = (statKey: string, value: number): StatLine => ({ statKey, value });
   SQL and asserted the answer, which is a tautology about a query in this file.
   Deleting both priority keys from the producer left it green.
 */
-function recordingProvider(
-  byRef: Map<string, ProviderBoxScore | Error>,
-): { provider: StatsProvider; asked: string[] } {
+function recordingProvider(byRef: Map<string, ProviderBoxScore | Error>): {
+  provider: StatsProvider;
+  asked: string[];
+} {
   const asked: string[] = [];
   const inner = fakeProvider(byRef);
   return {
@@ -54,9 +55,9 @@ function recordingProvider(
       ...inner,
       getBoxScore: (gameRef: string) => {
         asked.push(gameRef);
-        return (inner as { getBoxScore: (ref: string) => Promise<ProviderBoxScore> }).getBoxScore(
-          gameRef,
-        );
+        return (
+          inner as { getBoxScore: (ref: string) => Promise<ProviderBoxScore> }
+        ).getBoxScore(gameRef);
       },
     } as unknown as StatsProvider,
   };

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -5,7 +5,12 @@ import type { ProviderBoxScore, StatsProvider } from "@rostr/stats";
 import { seedSport } from "./sports.js";
 import { createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
-import { syncBoxScores, unresolvedStatsProblems } from "./box-scores.js";
+import {
+  FAILED_RETRY_MINUTES,
+  FINAL_RECHECK_HOURS,
+  syncBoxScores,
+  unresolvedStatsProblems,
+} from "./box-scores.js";
 
 /**
  * The producer, against the real translator.
@@ -28,6 +33,34 @@ const SEASON = 2026;
 const WEEK = 1;
 
 const line = (statKey: string, value: number): StatLine => ({ statKey, value });
+
+/*
+  The refs a provider was asked for, in the order it was asked.
+
+  The work list's ORDER BY decides which games a run spends its budget on when
+  more are due than MAX_GAMES_PER_RUN allows, and nothing observed it: the test
+  that claimed to check the priority ran its own hand-written copy of the same
+  SQL and asserted the answer, which is a tautology about a query in this file.
+  Deleting both priority keys from the producer left it green.
+*/
+function recordingProvider(
+  byRef: Map<string, ProviderBoxScore | Error>,
+): { provider: StatsProvider; asked: string[] } {
+  const asked: string[] = [];
+  const inner = fakeProvider(byRef);
+  return {
+    asked,
+    provider: {
+      ...inner,
+      getBoxScore: (gameRef: string) => {
+        asked.push(gameRef);
+        return (inner as { getBoxScore: (ref: string) => Promise<ProviderBoxScore> }).getBoxScore(
+          gameRef,
+        );
+      },
+    } as unknown as StatsProvider,
+  };
+}
 
 function fakeProvider(byRef: Map<string, ProviderBoxScore | Error>): StatsProvider {
   return {
@@ -597,6 +630,10 @@ describe("the work list bounds what one run can spend", () => {
     await fx.client.query(
       `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays',
                        stats_synced_at = now() - interval '1 hour',
+                       -- Aged too, or clause one ("never attempted") selects this
+                       -- game and the retry clause this test is the control for
+                       -- never runs.
+                       stats_attempted_at = now() - interval '1 hour',
                        final_at = now() - interval '2 hours'`,
     );
 
@@ -732,6 +769,209 @@ describe("a game whose ingest failed — #227", () => {
 
     expect(row?.stats_synced_at).not.toBeNull();
     expect(row?.stats_attempted_at).not.toBeNull();
+  });
+
+  it("does re-read a failed game once the pacing interval has passed", async () => {
+    /*
+      **The control the pacing test had no partner for, and it was load-bearing.**
+
+      Its sibling below asserts a failed game is NOT re-read immediately. On its
+      own that assertion is satisfied by a game which is never re-read *again*,
+      which is the strictly worse outcome and exactly what one plausible edit
+      produces: point the retry clause back at "stats_synced_at" and a failed
+      game — whose sync stamp is NULL since #227 — matches no clause in the work
+      list, forever. The pacing test then passes harder, and the game silently
+      leaves the queue with its players scoring zero.
+
+      Recovery is the whole point of pacing a retry. A Sunday 429 that clears
+      twenty minutes later has to be picked up.
+    */
+    const fx = await setup();
+    const failing = fakeProvider(
+      new Map([["g1", new Error("Tank01 refused the request (HTTP 429)")]]),
+    );
+
+    expect((await syncBoxScores(fx.client, failing, NFL.key, SEASON)).games).toBe(1);
+    expect((await syncBoxScores(fx.client, failing, NFL.key, SEASON)).games).toBe(0);
+
+    // The provider recovers, and so must the queue.
+    await fx.client.query(
+      `UPDATE games SET stats_attempted_at = now() - make_interval(mins => $2::int)
+        WHERE id = $1`,
+      [fx.gameId, FAILED_RETRY_MINUTES + 5],
+    );
+
+    const provider = fakeProvider(
+      new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 300)] })]]),
+    );
+    const recovered = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(recovered.games).toBe(1);
+    expect(recovered.failures).toHaveLength(0);
+
+    const [row] = await fx.client.query<{ stats_synced_at: string | null }>(
+      "SELECT stats_synced_at FROM games WHERE id = $1",
+      [fx.gameId],
+    );
+    expect(row?.stats_synced_at).not.toBeNull();
+  });
+
+  it("does not erase an earlier successful sync when a later read fails", async () => {
+    /*
+      A game is re-read for the whole 168h correction window, so one transient
+      429 during that window lands on a row that has already ingested cleanly.
+      The failure path must record the attempt and the error and leave the sync
+      stamp exactly where it was.
+
+      Nothing pinned this: every failure staged in this file happens on a row
+      that had never synced, so nulling "stats_synced_at" on the failure path
+      was undetectable. The cost of the missing assertion is not a lost stat
+      line — the stats are already stored — it is that #140's hold reads that
+      column, so the week would report a game that ingested perfectly as
+      "never ingested, the cause is our stats pipeline", and hold or settle on
+      that basis.
+    */
+    const fx = await setup();
+
+    const good = fakeProvider(
+      new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 300)] })]]),
+    );
+    await syncBoxScores(fx.client, good, NFL.key, SEASON);
+
+    const [synced] = await fx.client.query<{ stats_synced_at: string }>(
+      "SELECT stats_synced_at FROM games WHERE id = $1",
+      [fx.gameId],
+    );
+    expect(synced?.stats_synced_at).not.toBeNull();
+
+    // Age both columns past the correction sweep so the game is due again.
+    await fx.client.query(
+      `UPDATE games SET stats_synced_at = now() - make_interval(hours => $2::int),
+                        stats_attempted_at = now() - make_interval(hours => $2::int)
+        WHERE id = $1`,
+      [fx.gameId, FINAL_RECHECK_HOURS + 1],
+    );
+    const [aged] = await fx.client.query<{ stats_synced_at: string }>(
+      "SELECT stats_synced_at FROM games WHERE id = $1",
+      [fx.gameId],
+    );
+
+    const failing = fakeProvider(
+      new Map([["g1", new Error("Tank01 refused the request (HTTP 429)")]]),
+    );
+    const result = await syncBoxScores(fx.client, failing, NFL.key, SEASON);
+    expect(result.failures).toHaveLength(1);
+
+    const [after] = await fx.client.query<{
+      stats_synced_at: string | null;
+      stats_error: string | null;
+    }>("SELECT stats_synced_at, stats_error FROM games WHERE id = $1", [fx.gameId]);
+
+    expect(after?.stats_error).toContain("429");
+    expect(after?.stats_synced_at).toEqual(aged?.stats_synced_at);
+  });
+
+  it("paces the correction sweep on the attempt, not only on the sync", async () => {
+    /*
+      **A hole this fix opened in the fix before it.**
+
+      #227 moved pacing onto "stats_attempted_at" and re-pointed three of the
+      four clauses that select a game for re-read. The fourth — the NFL
+      stat-correction sweep — kept reading the sync time, justified as "a game
+      being re-read for corrections has stats already". True at selection,
+      false at pacing: the failure path no longer touches the sync stamp, so
+      once a synced game starts failing that predicate is frozen true and
+      re-selects it on every tick. Six calls an hour, for up to 168 hours,
+      against a metered provider — roughly a thousand calls for one game, and
+      a rate limit fails a whole slate at once, so the loop feeds the outage
+      that caused it.
+
+      The retry clause could not restrain it: they are OR siblings.
+    */
+    const fx = await setup();
+
+    await syncBoxScores(
+      fx.client,
+      fakeProvider(new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 300)] })]])),
+      NFL.key,
+      SEASON,
+    );
+    await fx.client.query(
+      `UPDATE games SET stats_synced_at = now() - make_interval(hours => $2::int),
+                        stats_attempted_at = now() - make_interval(hours => $2::int)
+        WHERE id = $1`,
+      [fx.gameId, FINAL_RECHECK_HOURS + 1],
+    );
+
+    const failing = fakeProvider(
+      new Map([["g1", new Error("Tank01 refused the request (HTTP 429)")]]),
+    );
+
+    // The sweep legitimately picks it up once.
+    expect((await syncBoxScores(fx.client, failing, NFL.key, SEASON)).games).toBe(1);
+
+    // And must not pick it up again on the next tick, ten minutes later. The
+    // sync stamp is still hours old and always will be; only the attempt moved.
+    expect((await syncBoxScores(fx.client, failing, NFL.key, SEASON)).games).toBe(0);
+  });
+
+  it("reads the newest unread game first, so a backlog cannot starve the slate", async () => {
+    /*
+      **The ordering inverted meaning without a character changing.**
+
+      Before #227 a failed game carried a sync stamp, so it sorted into the last
+      tier — behind never-read games and behind live ones. #227 stopped stamping
+      the sync on failure, which is correct, and thereby promoted every failed
+      game into the *front* tier. The tie-break underneath was kickoff ascending.
+
+      So an outage that fails a whole slate at once leaves 16–32 games which, on
+      the next tick, sort ahead of the current afternoon's and consume the entire
+      LIMIT oldest-first. Live scoring stops for every league, and the newest
+      failures are read last. The comment directly above the clause promised the
+      opposite — "plain kickoff order would let a backlog of old games starve
+      today's" — and had become false at the moment it was written.
+
+      Newest-first within a tier is the fix: the game closest to now is the one
+      whose zero is about to be seen on a scoreboard or frozen by a finalisation.
+
+      This asserts the producer's own ordering by recording what the provider was
+      asked for, rather than re-running the query and agreeing with itself.
+    */
+    const fx = await setup();
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+
+    // A five-day-old failure, still inside its 168h correction window, and today's unread game.
+    await fx.client.query(
+      `UPDATE games SET stats_attempted_at = now() - interval '2 hours',
+                        stats_error = 'Tank01 refused the request (HTTP 429)',
+                        kickoff_at = now() - interval '5 days',
+                        final_at = now() - interval '5 days'
+        WHERE id = $1`,
+      [fx.gameId],
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                          kickoff_at, status, final_at)
+       VALUES ($1, 'today', $2, $3, 'NYG', 'WAS', now() - interval '4 hours', 'FINAL',
+               now() - interval '1 hour')`,
+      [sport!.id, SEASON, WEEK],
+    );
+
+    const { provider, asked } = recordingProvider(
+      new Map([
+        ["g1", boxScore("g1", { qb1: [line("pass_yd", 100)] })],
+        ["today", boxScore("today", { qb1: [line("pass_yd", 200)] })],
+      ]),
+    );
+
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    // Both are due — the point is which one a budget-limited run reaches first.
+    expect(result.games).toBe(2);
+    expect(asked[0]).toBe("today");
   });
 
   it("does not re-read a failed game on the very next tick", async () => {

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -201,21 +201,42 @@ export async function syncBoxScores(
            OR (g.stats_error IS NOT NULL
                AND g.stats_attempted_at < now() - make_interval(mins => $4::int)
                AND g.final_at > now() - make_interval(hours => $5::int))
-           -- The NFL stat-correction sweep.
+           -- The NFL stat-correction sweep. Bounded on **both** columns, and the
+           -- attempt bound is the load-bearing one.
+           --
+           -- It read only the sync time until this change, which was the one
+           -- clause #227 left behind when it moved pacing onto the attempt. A
+           -- game that had synced and then began failing kept its old sync
+           -- stamp, so this predicate stayed true and re-selected it on every
+           -- tick: six calls an hour for the rest of the 168h window, roughly a
+           -- thousand for one game, against the quota the retry clause above
+           -- exists to protect. The retry clause could not restrain it — it is
+           -- an OR sibling, not a gate.
            OR (g.final_at > now() - make_interval(hours => $5::int)
-               AND g.stats_synced_at < now() - make_interval(hours => $6::int))
+               AND g.stats_synced_at < now() - make_interval(hours => $6::int)
+               AND g.stats_attempted_at < now() - make_interval(hours => $6::int))
         )
-      -- Never-read first, then live, then everything else oldest-first. The
-      -- order is doing real work now that there is a LIMIT: a game nobody has
-      -- read scores its players zero *right now*, where a re-read only refines a
-      -- number that already exists, and plain kickoff order would let a backlog
-      -- of old games starve today's.
-      -- Never-read first, and "never read" is now the honest column: a failed
-      -- game still has no stats and still scores its players zero, so it belongs
-      -- at the front with the untried ones rather than behind them.
+      -- Never-read first, then live, then **newest** first.
+      --
+      -- "Never read" is the honest column since #227: a failed game has no sync
+      -- stamp, still has no stats, and still scores its players zero, so it
+      -- belongs at the front with the untried ones rather than behind them.
+      --
+      -- But that promotion is what made the old kickoff_at ASC dangerous, and
+      -- the comment above it — "plain kickoff order would let a backlog of old
+      -- games starve today's" — became false at the moment it was written. A
+      -- provider outage fails a whole slate at once; twenty minutes later those
+      -- games sort into the front tier ahead of the live ones and, oldest-first,
+      -- consume the whole LIMIT before the current afternoon is reached. Live
+      -- scoring stops for every league while the newest failures are read last.
+      --
+      -- Newest-first inverts that. Within a tier the game closest to now is the
+      -- one whose zero is about to be seen on a scoreboard or frozen by a
+      -- finalisation; a week-old failure inside its correction window is real
+      -- but not urgent, and it is still reached once the fresh work is done.
       ORDER BY (g.stats_synced_at IS NULL) DESC,
                (g.status = 'IN_PROGRESS') DESC,
-               g.kickoff_at
+               g.kickoff_at DESC
       LIMIT $8`,
     [
       ids.sportId,

--- a/packages/db/src/matchup.test.ts
+++ b/packages/db/src/matchup.test.ts
@@ -145,11 +145,29 @@ async function score(
   );
 }
 
+/**
+ * A week whose games finished **and whose box scores were read.**
+ *
+ * The sync stamps are not decoration. Since #140 a FINAL game with no box score
+ * holds the week — and past the window settles it while reporting that our
+ * ingest, not the NFL, produced the zeroes. This helper marked only the status
+ * until the #140 re-audit, so every finalisation in this file had silently been
+ * running through that fallback rather than the clean path, and every outcome
+ * carried `finalizedWithUnfinishedGames` with nothing asserting its absence.
+ *
+ * Nothing here was testing what it read as testing. The rule the sibling
+ * `week.test.ts` already states: a fixture must stage a state the product
+ * actually produces.
+ */
 const finishGames = (fx: Fixture) =>
-  fx.client.query("UPDATE games SET status = 'FINAL' WHERE season = $1 AND week = $2", [
-    SEASON,
-    WEEK,
-  ]);
+  fx.client.query(
+    `UPDATE games SET status = 'FINAL',
+                      final_at = now() - interval '1 hour',
+                      stats_synced_at = now(),
+                      stats_attempted_at = now()
+      WHERE season = $1 AND week = $2`,
+    [SEASON, WEEK],
+  );
 
 /** The side of the week's matchups belonging to a given team. */
 function sideOf(views: Awaited<ReturnType<typeof loadWeekMatchups>>, teamId: string) {

--- a/packages/db/src/week.rescore-race.test.ts
+++ b/packages/db/src/week.rescore-race.test.ts
@@ -253,11 +253,29 @@ async function score(
   );
 }
 
+/**
+ * A week whose games finished **and whose box scores were read.**
+ *
+ * The sync stamps are not decoration. Since #140 a FINAL game with no box score
+ * holds the week — and past the window settles it while reporting that our
+ * ingest, not the NFL, produced the zeroes. This helper marked only the status
+ * until the #140 re-audit, so every finalisation in this file had silently been
+ * running through that fallback rather than the clean path, and every outcome
+ * carried `finalizedWithUnfinishedGames` with nothing asserting its absence.
+ *
+ * Nothing here was testing what it read as testing. The rule the sibling
+ * `week.test.ts` already states: a fixture must stage a state the product
+ * actually produces.
+ */
 const finishGames = (fx: Fixture) =>
-  fx.client.query("UPDATE games SET status = 'FINAL' WHERE season = $1 AND week = $2", [
-    SEASON,
-    WEEK,
-  ]);
+  fx.client.query(
+    `UPDATE games SET status = 'FINAL',
+                      final_at = now() - interval '1 hour',
+                      stats_synced_at = now(),
+                      stats_attempted_at = now()
+      WHERE season = $1 AND week = $2`,
+    [SEASON, WEEK],
+  );
 
 const schedule = (fx: Fixture) =>
   persistSchedule(fx.client, fx.leagueId, generateSchedule(fx.teamIds, 14, "seed"));
@@ -380,7 +398,7 @@ describe("a finalised week survives a run that overlapped its finalisation", () 
     // is false. Its UPDATE used to take the `ELSE finalized_at` branch: points
     // replaced, timestamp preserved byte for byte, the row afterwards
     // indistinguishable from one finalised once and never touched. And it
-    // reported `finalized: false, holdReason: "waiting until…"` while doing it.
+    // reported `finalized: false` with a hold reason while doing it.
     const fx = await setup();
     await schedule(fx);
     await finishGames(fx);

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -157,7 +157,15 @@ async function score(
  */
 const finishGames = (fx: Fixture) =>
   fx.client.query(
-    "UPDATE games SET status = 'FINAL', stats_synced_at = now() WHERE season = $1 AND week = $2",
+    `UPDATE games SET status = 'FINAL',
+                      final_at = now() - interval '1 hour',
+                      -- Both columns, and after final_at. The producer writes all
+                      -- three together on a successful read, and the hold now asks
+                      -- whether the sync came *after* the whistle — a sync stamped
+                      -- before it is a mid-game read, not a final line.
+                      stats_synced_at = now(),
+                      stats_attempted_at = now()
+      WHERE season = $1 AND week = $2`,
     [SEASON, WEEK],
   );
 
@@ -169,7 +177,10 @@ const finishGames = (fx: Fixture) =>
  */
 const finishGamesUnread = (fx: Fixture) =>
   fx.client.query(
-    "UPDATE games SET status = 'FINAL', stats_synced_at = NULL WHERE season = $1 AND week = $2",
+    `UPDATE games SET status = 'FINAL',
+                      final_at = now() - interval '1 hour',
+                      stats_synced_at = NULL
+      WHERE season = $1 AND week = $2`,
     [SEASON, WEEK],
   );
 
@@ -184,9 +195,25 @@ async function addGame(fx: Fixture, ref: string, status: string, week = WEEK): P
     "SELECT id FROM sports WHERE key = $1",
     [NFL.key],
   );
+  /*
+    A FINAL game here is a **cleanly ingested** one, for the same reason
+    {@link finishGames} stamps the sync: a row that is FINAL with no box score is
+    the #140 failure state, and a fixture producing it by default would put every
+    §10 postponement test into that state instead.
+
+    It did, and it hid a real defect. The paying-week test below staged one
+    postponed game beside one FINAL game with no stats and asserted the §10
+    wording — which passed only because the postponement branch returned first,
+    swallowing the pipeline failure. Exactly the mistake this file's own
+    {@link finishGames} comment warns about, one function further down.
+  */
   await fx.client.query(
-    `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status)
-     VALUES ($1, $2, $3, $4, 'BUF', 'CIN', $5, $6)`,
+    `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                        kickoff_at, status, final_at, stats_synced_at, stats_attempted_at)
+     VALUES ($1, $2, $3, $4, 'BUF', 'CIN', $5, $6,
+             CASE WHEN $6 = 'FINAL' THEN $5::timestamptz + interval '3 hours' END,
+             CASE WHEN $6 = 'FINAL' THEN $5::timestamptz + interval '4 hours' END,
+             CASE WHEN $6 = 'FINAL' THEN $5::timestamptz + interval '4 hours' END)`,
     [sport!.id, ref, SEASON, week, KICKOFF, status],
   );
 }
@@ -916,10 +943,131 @@ describe("a week whose box scores were never read — #140", () => {
 
     const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
 
-    expect(outcome.finalizedWithUnfinishedGames).toMatch(/never ingested/);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/no box score/);
     expect(outcome.finalizedWithUnfinishedGames).toMatch(/stats pipeline/);
     // Not the postponement wording — the two must stay tellable apart.
     expect(outcome.finalizedWithUnfinishedGames).not.toMatch(/RULES.md §10/);
+  });
+
+  it("reports both reasons when both are true, not the first one found", async () => {
+    /*
+      **The branch order swallowed the pipeline failure, in the incident it was
+      written for.**
+
+      Past the window there were two ifs in a row and the postponement one
+      returned first — so a week carrying a postponed game *and* a FINAL game
+      whose box score never arrived reported only §10's "affected players score 0
+      for the week and the matchup stands". That sentence means "this is the
+      NFL's doing and the frozen rules cover it". Handed to an operator whose
+      ingest had just dropped a game, it is the wrong instruction.
+
+      And it is the *characteristic* shape of a provider outage rather than a
+      corner: when the provider is down syncGames cannot advance a status and
+      syncBoxScores cannot read a box score, so both fire together.
+
+      The test guarding this staged only the pure case, so it could not see it.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await finishGamesUnread(fx);
+    await addGame(fx, "postponed", "POSTPONED");
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/RULES.md §10/);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/stats pipeline/);
+  });
+
+  it("does not blame the NFL when nothing reached FINAL at all", async () => {
+    /*
+      The extreme of the same bug, and the one with no partial excuse.
+
+      unread counts only FINAL games, so when the status column freezes it is
+      structurally zero — there is nothing for the stats branch to notice. Every
+      matchup then settled 0–0 under §10's postponement sentence, blaming an
+      abandoned game for a week in which no game was abandoned.
+
+      Reachable from one place: games.status is written by syncGames alone, from
+      a single daily cron, and mapGameStatus answers SCHEDULED for any wording it
+      does not recognise — so one unfamiliar string turns a whole week's statuses
+      off at once.
+
+      §10 is written about *an* abandoned game. It is the right answer for one
+      fixture of sixteen and the wrong one for sixteen of sixteen, which is the
+      argument the "no games at all" branch above already makes.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    // Kickoff has passed and the provider never moved the status.
+    await fx.client.query(
+      "UPDATE games SET status = 'SCHEDULED' WHERE season = $1 AND week = $2",
+      [SEASON, WEEK],
+    );
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/not one of/);
+    expect(outcome.finalizedWithUnfinishedGames).toMatch(/our ingest/);
+    expect(outcome.finalizedWithUnfinishedGames).not.toMatch(/RULES.md §10/);
+  });
+
+  it("counts a box score read before the final whistle as no box score", async () => {
+    /*
+      stats_synced_at says a box score was read, never that the *final* one was.
+      syncBoxScores reads IN_PROGRESS games too and stamps the column on every
+      success, while the failure path leaves it alone — so a game read at half
+      time whose every post-final read then failed carries a sync stamp older
+      than the whistle, counts as ingested, and settles the week on third-quarter
+      numbers with no fallback reported at all.
+
+      Migration 0041 reasoned only about the never-succeeded direction.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await fx.client.query(
+      `UPDATE games SET status = 'FINAL',
+                       final_at = now() - interval '1 hour',
+                       stats_synced_at = now() - interval '3 hours',
+                       stats_attempted_at = now(),
+                       stats_error = 'Tank01 refused the request (HTTP 429)'
+        WHERE season = $1 AND week = $2`,
+      [SEASON, WEEK],
+    );
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, DURING);
+
+    expect(outcome.finalized).toBe(false);
+    expect(outcome.holdReason).toMatch(/no box score/);
+  });
+
+  it("does not hold a game that ingested cleanly but raised a warning", async () => {
+    /*
+      The one-line version of this hold would have been stats_error IS NOT NULL,
+      and it is false: that column carries ordinary *warnings* from a successful
+      ingest — a field-goal count disagreeing with the plays parsed from it, a
+      defence missing from the box score — as much as failures. Roughly one real
+      game in seven raises one.
+
+      Holding on it would hold most weeks until the correction window expired,
+      making §10's fallback the normal path and destroying the distinction this
+      hold exists to draw. Asserted rather than argued, because the argument
+      lived only in a commit message.
+    */
+    const fx = await setup();
+    await schedule(fx);
+    await finishGames(fx);
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays'
+        WHERE season = $1 AND week = $2`,
+      [SEASON, WEEK],
+    );
+
+    const outcome = await resolveLeagueWeek(fx.client, fx.leagueId, WEEK, AFTER_STANDARD);
+
+    expect(outcome.finalized).toBe(true);
+    expect(outcome.finalizedWithUnfinishedGames).toBeUndefined();
   });
 
   it("reports nothing extra once the box scores are in", async () => {

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -219,8 +219,15 @@ export interface ResolveWeekOutcome {
   /** Why it was not finalised, when it was not. */
   readonly holdReason?: string;
   /**
-   * Set when the week finalised on `RULES.md` §10's postponement fallback —
-   * the scoring window elapsed with games still not marked `FINAL`.
+   * Set when the week finalised on the clock rather than on complete data.
+   *
+   * **Two causes, not one, and the name only describes the first.** It began as
+   * `RULES.md` §10's postponement fallback — the window elapsed with games not
+   * marked `FINAL` — and #140 added a second: the window elapsed with games
+   * marked `FINAL` whose box score we never read. That one is our ingest
+   * failing, not the NFL's, and §10 does not cover it. The string says which,
+   * and says both when both are true; the field name is kept because renaming
+   * it across the route and its consumers buys nothing the string does not.
    *
    * Reported rather than inferred. A week settled on complete data and a week
    * settled because the clock ran out are different facts about the same
@@ -554,11 +561,26 @@ async function finalizationHold(
   }>(
     `SELECT count(*)::int AS total,
             count(*) FILTER (WHERE g.status = 'FINAL')::int AS finished,
-            -- Games the provider called FINAL whose box score was never read.
-            -- Migration 0027 added both columns for exactly this question; nothing
-            -- had asked it. See the stats hold below.
+            -- No box score for this game as it finally stood. Migration 0027
+            -- added both columns for exactly this question and nothing had
+            -- asked it; the stats hold below is what asks.
+            --
+            -- Not simply "stats_synced_at IS NULL", which was the first version
+            -- and is too weak: a game read while IN_PROGRESS stamps the column,
+            -- so a game whose every post-final read then failed counted as
+            -- ingested and settled the week on third-quarter numbers. The sync
+            -- has to be newer than the final whistle to be the final line.
+            --
+            -- A null final_at on a FINAL game means the provider called it
+            -- final without saying when. There is nothing to compare against,
+            -- so the presence of any sync is the best answer available and this
+            -- does not hold on it.
             count(*) FILTER (
-              WHERE g.status = 'FINAL' AND g.stats_synced_at IS NULL
+              WHERE g.status = 'FINAL'
+                AND (
+                  g.stats_synced_at IS NULL
+                  OR (g.final_at IS NOT NULL AND g.stats_synced_at < g.final_at)
+                )
             )::int AS unread,
             max(g.kickoff_at) AS last_kickoff
        FROM games g
@@ -625,13 +647,55 @@ async function finalizationHold(
     };
   }
 
-  if (finished < total) {
+  /*
+    Past the window the week settles, and it reports **every** reason it settled
+    badly rather than the first one found.
+
+    This used to be two `if`s in a row, and the earlier one swallowed the later.
+    `finished < total` returned immediately, so the "stats unread" fallback was
+    unreachable in exactly the mixed state where both were true — one postponed
+    game alongside six whose box scores never arrived reported only the
+    postponement. The comment below asserted the two "call for different
+    responses" while the code made the second one silent.
+
+    Worse at the extreme: when the provider's status column freezes, **nothing**
+    reaches FINAL, `unread` is structurally zero — it counts only FINAL games —
+    and the whole week settled 0–0 under §10's sentence, blaming the NFL for our
+    own stalled ingest. `syncGames` runs once a day from a single cron, and
+    `mapGameStatus` answers SCHEDULED for any wording it does not recognise, so
+    that is a live shape rather than a hypothetical.
+
+    "No game finished at all" is therefore called out separately. §10 is written
+    about *an* abandoned game — it is the right answer for one fixture out of
+    sixteen and the wrong one for sixteen out of sixteen, which is the same
+    argument the `total === 0` branch above already makes.
+  */
+  const reasons: string[] = [];
+
+  if (finished === 0 && total > 0) {
+    reasons.push(
+      `not one of ${total} games is marked FINAL — the schedule sync has not ` +
+        `advanced any status, so this is our ingest rather than an abandoned game`,
+    );
+  } else if (finished < total) {
+    reasons.push(
+      `${total - finished} of ${total} games are not marked FINAL — ` +
+        `docs/RULES.md §10: affected players score 0 for the week and the matchup stands`,
+    );
+  }
+
+  if (unread > 0) {
+    reasons.push(
+      `${unread} of ${total} games have no box score from after the final whistle — ` +
+        `those players score 0 permanently, and the cause is our stats pipeline ` +
+        `rather than an abandoned game`,
+    );
+  }
+
+  if (reasons.length > 0) {
     return {
       hold: null,
-      fallback:
-        `finalised ${hours}h after the last kickoff with ${total - finished} of ${total} ` +
-        `games not marked FINAL — docs/RULES.md §10: affected players score 0 for the ` +
-        `week and the matchup stands`,
+      fallback: `finalised ${hours}h after the last kickoff: ${reasons.join("; ")}`,
     };
   }
 
@@ -648,16 +712,6 @@ async function finalizationHold(
     ingest failing, and it means those players are about to be paid nothing on
     data we never fetched.
   */
-  if (unread > 0) {
-    return {
-      hold: null,
-      fallback:
-        `finalised ${hours}h after the last kickoff with ${unread} of ${total} ` +
-        `games never ingested — those players score 0 permanently, and the cause ` +
-        `is our stats pipeline rather than an abandoned game`,
-    };
-  }
-
   return { hold: null };
 }
 


### PR DESCRIPTION
The 5-agent read-only re-audit of #140 and #227. Six defects, all reproduced by reading the code before being fixed, each with a test that fails when the fix is reverted.

## What was wrong

**1. Branch order decided the reason, and the wrong branch won.** Past the correction window, `finished < total` returned before the "stats were never read" branch — so the pipeline failure was unreachable whenever a game was also unplayed. The comment between them asserted the two "call for different responses" while the code made the second silent.

That is the *characteristic* shape of a provider outage, not a corner: when the provider is down `syncGames` cannot advance a status **and** `syncBoxScores` cannot read a box score.

**2. At the extreme, a week where nothing reached FINAL settled 0–0 blaming §10.** `unread` counts only FINAL games, so a frozen status column makes it structurally zero. `games.status` is written by one daily cron, and `mapGameStatus` answers SCHEDULED for any wording it does not recognise — one unfamiliar string turns a whole week's statuses off at once.

**3. `stats_synced_at` says a box score was read, not that the *final* one was.** A game read at half time whose every post-final read then failed carried a stamp older than the whistle, counted as ingested, and settled the week on third-quarter numbers with no fallback at all. `0041` reasoned only about the never-succeeded direction.

**4. A hole #227 opened in itself.** It moved pacing onto `stats_attempted_at` and re-pointed three of four re-read clauses. The stat-correction sweep kept reading the sync time — true at selection, false at pacing. Once a synced game starts failing, that predicate is frozen true: ~1,000 metered calls for one game, and a rate limit fails a whole slate at once, so the loop feeds the outage that caused it.

**5. #227 inverted the work list's priority without changing a character of it.** Not stamping the sync on failure promoted every failed game into the *front* tier, ahead of live games, tie-broken oldest-first. An outage's backlog then consumes the whole `LIMIT` before the current afternoon is reached — the exact starvation the comment above it promised to prevent.

**6. Nothing durable recorded a fallback settlement.** The reason reached the cron's JSON body and stopped there. `cron:status` read green after a run in which a paying week permanently scored twelve teams zero.

## Why none of it was visible

Four fixtures were staging states the product cannot produce:

| fixture | staged | consequence |
|---|---|---|
| `addGame` | FINAL with no box score | the §10 paying-week test was itself staging the #140 failure |
| `finishGames` in `matchup.test` | FINAL, no sync | every finalisation ran through the fallback, unasserted |
| `finishGames` in `week.rescore-race.test` | same | same, plus a comment describing a hold reason it no longer produced |
| the retry clause's declared control | `stats_attempted_at` NULL | selected as never-attempted; the clause it controls never ran |

Same signal as #73, #140 and #227 before it.

## Mutation checks

Each reverted independently; exactly the test written for it fails.

| mutation | caught by |
|---|---|
| drop the sweep's attempt bound | `paces the correction sweep on the attempt` |
| null `stats_synced_at` on failure | `does not erase an earlier successful sync` |
| point the retry back at the sync | `does re-read a failed game once the pacing interval has passed` |
| restore the branch order | `reports both reasons` + `does not blame the NFL` |
| drop the whistle comparison | `counts a box score read before the final whistle as no box score` |
| flip the ordering to ascending | `reads the newest unread game first` |

The third is worth naming: pointing the retry back at `stats_synced_at` makes a failed game — which has no sync stamp since #227 — match **no** clause, so it is never re-read again. The old pacing test passed *harder* under it.

## Not fixed here

- **#232** — a partial ingest reports itself clean; unmatched refs never reach `stats_error`
- **#233** — `/ops/stats` cannot tell "no stats at all" from "ingested with a warning"

Both pre-existing.

## Migration

`0042` corrects two `COMMENT ON COLUMN` strings from `0041` that claimed a cleaner separation than the query implemented. **Already applied to the hosted database** — migrate-then-merge, per #211.

---

2178 tests passing (was 2170). Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)