### PR TITLE
docs: the cron table listed six jobs and there are seven

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,12 +144,16 @@ lineup at all** — `setLineup` refuses with `SCHEDULE_MISSING`. `currentWeek` w
 minutes since it shipped. And with `games` hand-populated but no stat lines, every week
 would have finalised **0–0, permanently**, because a finalised week is never rescored.
 
-`docs/LIVE-SCORING.md` describes six automation jobs in the present tense. **Four now
-exist** — season sync, the stats poller, score finalisation and week finalisation.
-**Injury sync and inactives do not exist at all**, and that document argues inactives is
-the one that matters most. Its table now carries an "Exists?" column so the plan and the
-code can be told apart at a glance. Reading a plan as a description is how the claim above
-got written.
+`docs/LIVE-SCORING.md` describes six automation jobs in the present tense. **Five now
+exist** — season sync, the stats poller, score finalisation, week finalisation, and, since
+2026-08-25, **injury sync** (`/api/cron/injuries`, hourly, `packages/db/src/injuries.ts`).
+That passage said injury sync did not exist at all; it does, and it runs.
+
+**Inactives still does not exist**, and that document argues it is the one that matters
+most — a player ruled out ninety minutes before kickoff is the difference between a lineup
+that scores and one that does not. Its table carries an "Exists?" column so the plan and
+the code can be told apart at a glance. Reading a plan as a description is how the claim
+above got written, twice.
 
 **Corrected 2026-08-17, and this passage was the stale one.** It said `syncBoxScores` did
 not exist and that every player therefore scores zero. Both halves are now false, and the
@@ -173,7 +177,7 @@ deployed. Nothing revisited it, so it went on telling every session to discount 
 claim in the file — the confident sentence that stops anyone looking, which is the exact
 failure this document names three times elsewhere.
 
-`pnpm cron:status` on 2026-08-23:
+`pnpm cron:status` on 2026-08-25 — **seven jobs, and this table listed six**:
 
 | Job           | Cadence | State |
 | ------------- | ------- | ----- |
@@ -182,7 +186,13 @@ failure this document names three times elsewhere.
 | `score-week`  | 10m     | OK    |
 | `waivers`     | 60m     | OK    |
 | `trades`      | 60m     | OK    |
+| `injuries`    | 60m     | OK    |
 | `season-sync` | 1440m   | OK    |
+
+`injuries` was added with the injury sync and this table was not revisited — the same
+staleness the table itself was written to correct, one job later. **Do not hand-maintain
+this list.** `cron:status` reads the expected jobs out of `vercel.json`, so the command is
+never wrong; anything transcribed here is a snapshot with a date on it and nothing else.
 
 **And `season-sync` was failing until that morning, which is how this was found.** It had
 recorded `1 of 1 seasons failed` and nothing else — the failure that #419f994 exists to

--- a/docs/LIVE-SCORING.md
+++ b/docs/LIVE-SCORING.md
@@ -93,9 +93,12 @@ Sunday by changing a number.
 > Check with `pnpm cron:status`. The deployment this waits on is an entry in
 > `docs/SETUP-REQUIRED.md`.
 >
-> Four of the six jobs below exist as code. Two do not exist at all. The **Exists?** column
-> says which — added because this table read as a description of production for months, and
-> `CLAUDE.md` names that mistake as how a false claim survived being repeated.
+> Five of the six jobs below exist as code. One does not exist at all. The **Exists?**
+> column says which — added because this table read as a description of production for
+> months, and `CLAUDE.md` names that mistake as how a false claim survived being repeated.
+>
+> Injury sync moved from ❌ to ✅ on 2026-08-25. **Inactives is the one still missing**, and
+> it is the one this document argues matters most.
 
 The NFL schedule is published in May, so **which teams play, and on what date, is known
 months ahead**. The _hour_ is not: late-December kickoffs are held back for flex
@@ -111,7 +114,7 @@ and it did: eight fixtures across weeks 16 and 17 of 2026. See `games.kickoff_tb
 | Job                | Fires                               | Does                                           | Exists? | Where                   |
 | ------------------ | ----------------------------------- | ---------------------------------------------- | ------- | ----------------------- |
 | **Season sync**    | Daily, 09:20 UTC                    | Players, byes, schedule, rankings, projections | ✅      | `/api/cron/season-sync` |
-| **Injury sync**    | Every 6h, and hourly on game days   | Injury designations                            | ❌      | —                       |
+| **Injury sync**    | **Hourly**                          | Injury designations                            | ✅      | `/api/cron/injuries`    |
 | **Inactives**      | **100 minutes before each kickoff** | Official inactive list — see below             | ❌      | —                       |
 | **Game watcher**   | Every 10 min, unconditionally       | Polls until status is `final`                  | 🟡      | `/api/cron/stats`       |
 | **Score finalise** | Same job, on `final`                | Box score → `stat_lines` → recompute → publish | ✅      | `syncBoxScores`         |
@@ -121,8 +124,20 @@ and it did: eight fixtures across weeks 16 and 17 of 2026. See `games.kickoff_tb
 rather than from 2.5 hours after a kickoff — simpler, and more provider calls. The
 2.5-hour window described below is the design, not the code.
 
-**Injuries and inactives have no code at all**, and inactives is the one this document
-argues matters most.
+**Injury sync exists** (`packages/db/src/injuries.ts`, `/api/cron/injuries`, hourly). It
+runs hourly rather than the 6h/game-day split described above, which is simpler and costs
+more calls — the same trade the game watcher makes, and noted here so the row is not read
+as conformance with the plan beside it.
+
+Two properties of it are load-bearing and easy to undo: it **refuses an empty provider
+list**, because "no injuries anywhere in the league" and "the feed returned nothing" are
+indistinguishable in the response and only one of them should clear every designation in
+the database; and it **reports `providerReturned`**, so a quiet run can be told from a
+broken one. A designation is shown and never enforced — `RULES.md` §6 locks a slot at that
+player's own kickoff and says nothing about fitness.
+
+**Inactives still has no code at all**, and it is the one this document argues matters
+most.
 
 ### Inactives matter more than live scoring
 


### PR DESCRIPTION
Two stale claims found while verifying the deploy for #234.

| Claim | Where | Status |
|---|---|---|
| Six cron jobs | `CLAUDE.md` table | **seven** — `injuries` was added and the table not revisited |
| "Injury sync and inactives do not exist at all" | `CLAUDE.md` | **half false** — injury sync exists and runs hourly |
| "Two do not exist at all" / ❌ / "no code at all" | `docs/LIVE-SCORING.md`, three places | same |

`pnpm cron:status` on 2026-08-25:

```
OK  draft-tick    every 1m       last: 0m ago
OK  stats         every 10m      last: 4m ago
OK  score-week    every 10m      last: 8m ago
OK  waivers       every 60m      last: 44m ago
OK  trades        every 60m      last: 43m ago
OK  injuries      every 60m      last: 8m ago
OK  season-sync   every 1440m    last: 1399m ago
```

**Inactives genuinely still does not exist**, and both documents argue it is the one that matters most — a player ruled out 90 minutes before kickoff changes what a manager *does*. So the correction is narrowed to injury sync rather than softened across both.

Three properties of the injury sync are recorded in `LIVE-SCORING.md` while the row is being corrected, because each is one tidy-up away from being undone — and each was **verified against the code**, not recalled:

- refuses an empty provider list ([injuries.ts:95](packages/db/src/injuries.ts#L95)) — "no injuries anywhere" and "the feed returned nothing" are indistinguishable in the response, and only one should clear every designation in the database
- returns `providerReturned` ([:41](packages/db/src/injuries.ts#L41)) so a quiet run can be told from a broken one
- a designation is **shown and never enforced** — no injury column is read anywhere under `packages/core/src/season/` or `lineups.ts`; `RULES.md` §6 locks a slot at that player's own kickoff and says nothing about fitness

Also noted: the job runs hourly, not the 6h/game-day split the table beside it describes, so the row is not read as conformance with a plan it does not follow.

Docs only — no code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)