### PR TITLE
fix(db): a manager could not drop a player they had put on injured reserve

### DIFF
--- a/packages/db/src/injured-reserve.test.ts
+++ b/packages/db/src/injured-reserve.test.ts
@@ -7,6 +7,7 @@ import { seedSport } from "./sports.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import { activateFromIr, IrError, moveToIr } from "./injured-reserve.js";
+import { dropPlayer } from "./waivers.js";
 
 const DRAFT: DraftRules = {
   type: "SNAKE",
@@ -239,6 +240,80 @@ describe("activateFromIr", () => {
         playerId: fx.players.get("fit")!,
       }),
     ).rejects.toMatchObject({ code: "NOT_ON_IR" });
+  });
+});
+
+describe("releasing a player who is on injured reserve", () => {
+  /*
+    **A manager could not drop a player they had put on IR.**
+
+    `0038` asserts `CHECK (NOT on_ir OR released_at IS NULL)` — IR is a state of
+    a *rostered* player, so a released row must not still claim one of the
+    league's IR slots. Right, and nothing in the product upheld it: four places
+    set `released_at` and not one of them cleared `on_ir`. Every drop, every
+    free-agent swap-out, every awarded waiver claim's drop, and every executed
+    trade of an IR'd player raised a constraint violation instead.
+
+    The test below is the reason it survived. It asserts the constraint fires on
+    a hand-written UPDATE and treats that as the feature — which it is — while
+    never once asking what the product's own release paths do. The constraint
+    was checked against a statement no code in this repo executes, and the four
+    that do were never staged.
+
+    The waiver run's site is the worst of them: it throws inside
+    `processWaivers`' transaction, so the whole league's cycle rolls back, the
+    claims stay PENDING, and `leaguesDueForWaivers` re-selects that league every
+    hour, forever. The trade site rolls back a trade the league already approved,
+    which `ASSET_GONE` exists to make impossible.
+  */
+  it("lets a manager drop a player who is on IR", async () => {
+    const fx = await setup();
+    const playerId = fx.players.get("hurt")!;
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId,
+      week: 2,
+      now: NOW,
+    });
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teamId, playerId, NOW),
+    ).resolves.toBeTruthy();
+
+    const [row] = await fx.client.query<{ on_ir: boolean; released_at: string | null }>(
+      "SELECT on_ir, released_at FROM roster_entries WHERE player_id = $1",
+      [playerId],
+    );
+
+    // Released, and no longer holding an IR slot. Both halves matter: the row
+    // stays for the audit trail, and a count that forgot `released_at` must not
+    // exempt somebody who left months ago — which is what the constraint is for.
+    expect(row?.released_at).not.toBeNull();
+    expect(row?.on_ir).toBe(false);
+  });
+
+  it("frees the IR slot for somebody else once the drop lands", async () => {
+    // The consequence of leaving `on_ir` set on a released row, had the
+    // constraint not refused it outright. Two IR slots, one used and dropped:
+    // the allowance has to come back.
+    const fx = await setup();
+    const dropped = fx.players.get("hurt")!;
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: dropped,
+      week: 2,
+      now: NOW,
+    });
+    await dropPlayer(fx.client, fx.leagueId, fx.teamId, dropped, NOW);
+
+    const [held] = await fx.client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM roster_entries
+        WHERE team_id = $1 AND on_ir AND released_at IS NULL`,
+      [fx.teamId],
+    );
+    expect(held?.n).toBe(0);
   });
 });
 

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -959,8 +959,22 @@ async function resolveTrade(
       // append-only with `released_at` precisely so any past week's roster can be
       // reconstructed — a trade that edited history would make a settled week
       // unverifiable.
+      /*
+        `on_ir = false` because the row is being released, and `0038` asserts
+        an IR slot belongs to a rostered player.
+
+        Without it a trade naming an IR'd player threw a check violation inside
+        this transaction and rolled back a trade the league had already approved
+        — the outcome `ASSET_GONE` exists to make impossible, arriving by a
+        route none of its reasoning covers.
+
+        The player does not arrive at the receiving team on IR. That is correct:
+        IR eligibility is the *receiving* league's roster rules applied to a
+        current designation, and `moveToIr` is how it is claimed. Carrying the
+        flag across would spend one of the new team's slots without them asking.
+      */
       const released = await tx.query<{ id: string }>(
-        `UPDATE roster_entries SET released_at = $3
+        `UPDATE roster_entries SET released_at = $3, on_ir = false
           WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL
         RETURNING id`,
         [asset.from_team_id, asset.player_id, now.toISOString()],

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -5,6 +5,7 @@ import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
 import { seedSport } from "./sports.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
+import { moveToIr } from "./injured-reserve.js";
 import type { PGliteClient } from "./testing.js";
 import {
   leaguesDueForWaivers,
@@ -355,6 +356,68 @@ describe("processing", () => {
   }
 
   const WEDNESDAY = new Date(MONDAY.getTime() + 2 * DAY);
+
+  it("awards a claim whose drop is a player on injured reserve", async () => {
+    /*
+      **This rolled back the whole league's waiver cycle, every hour, forever.**
+
+      `0038` asserts `CHECK (NOT on_ir OR released_at IS NULL)` — an IR slot
+      belongs to a rostered player — and the awarded claim's drop set
+      `released_at` without clearing `on_ir`. The run is a single transaction, so
+      the violation did not fail one claim: it discarded every award in the
+      league, left all the claims PENDING, and `leaguesDueForWaivers` re-selected
+      the league on the next tick to fail identically.
+
+      None of the four release paths had a test staging an IR'd player. The IR
+      suite asserted the constraint against a hand-written UPDATE that no code in
+      this repo executes, and called the refusal correct.
+    */
+    const fx = await setup();
+    const claimant = fx.teams[1]!;
+
+    // Acquired through the product, then genuinely out, then parked on IR the
+    // way a manager does it — no hand-written roster row.
+    const injured = fx.players.get("target")!;
+    await addFreeAgent(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: injured,
+      now: MONDAY,
+    });
+    await fx.client.query("UPDATE players SET injury_designation = 'OUT' WHERE id = $1", [
+      injured,
+    ]);
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      playerId: injured,
+      week: 1,
+      now: MONDAY,
+    });
+
+    // Somebody to claim, and a claim that pays for him with the IR'd player.
+    const wanted = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, wanted, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: wanted,
+      dropPlayerId: injured,
+      now: MONDAY,
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    expect(outcome.awarded).toBe(1);
+    expect(outcome.failed).toBe(0);
+
+    const [row] = await fx.client.query<{ on_ir: boolean; released_at: string | null }>(
+      "SELECT on_ir, released_at FROM roster_entries WHERE player_id = $1 AND team_id = $2",
+      [injured, claimant],
+    );
+    expect(row?.released_at).not.toBeNull();
+    expect(row?.on_ir).toBe(false);
+  });
 
   it("awards a contested player to the best priority", async () => {
     // Priority is the reverse of the draft order, so team 4 outranks team 2.

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -459,7 +459,11 @@ export async function dropPlayer(
     await refuseIfFrozen(tx, leagueId, playerId);
     await refuseIfKickedOff(tx, stored.rules, playerId, now, "dropped");
 
-    await tx.query("UPDATE roster_entries SET released_at = $2 WHERE id = $1", [
+    // Leaving IR is part of leaving the roster. `0038` asserts
+    // `CHECK (NOT on_ir OR released_at IS NULL)` — an IR slot belongs to a
+    // rostered player — and this UPDATE violated it outright, so a manager
+    // simply could not release anyone they had placed there.
+    await tx.query("UPDATE roster_entries SET released_at = $2, on_ir = false WHERE id = $1", [
       entry.id,
       now.toISOString(),
     ]);
@@ -579,10 +583,12 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
 
       await refuseIfFrozen(tx, input.leagueId, input.dropPlayerId);
 
-      await tx.query("UPDATE roster_entries SET released_at = $2 WHERE id = $1", [
-        entry.id,
-        input.now.toISOString(),
-      ]);
+      // Same as `dropPlayer`: releasing clears the IR slot, or `0038`'s check
+      // refuses the swap.
+      await tx.query(
+        "UPDATE roster_entries SET released_at = $2, on_ir = false WHERE id = $1",
+        [entry.id, input.now.toISOString()],
+      );
     }
 
     /*
@@ -1065,8 +1071,19 @@ export async function processWaivers(
       }
 
       if (claim.drop_player_id) {
+        /*
+          `on_ir = false` for the same reason as every other release, and this
+          is the site where omitting it cost the most.
+
+          The whole run is one transaction, so `0038`'s check did not refuse one
+          claim — it rolled back the entire league's cycle. The claims stayed
+          PENDING, `leaguesDueForWaivers` re-selected the league on the next
+          hourly tick, and it failed identically. A league with one manager
+          dropping an IR'd player as part of a claim would never have processed
+          a waiver again.
+        */
         await tx.query(
-          `UPDATE roster_entries SET released_at = $3
+          `UPDATE roster_entries SET released_at = $3, on_ir = false
             WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL`,
           [claim.team_id, claim.drop_player_id, now.toISOString()],
         );


### PR DESCRIPTION
Found by the five-agent re-audit of **#131**. It is not a defect in that fix — it is a defect in **#212** that the audit reached because both live in the waiver path.

## The bug

`0038` asserts `CHECK (NOT on_ir OR released_at IS NULL)`. That is the right constraint: an IR slot belongs to a *rostered* player, and without it a count that forgot `released_at` would exempt somebody who left months ago.

**Four places set `released_at`. None cleared `on_ir`.**

| Site | Reached by | Consequence |
|---|---|---|
| `dropPlayer` | the drop button | request fails |
| `addFreeAgent` drop side | the swap | request fails |
| `processWaivers` awarded drop | the hourly cron | **the whole league's cycle rolls back, every hour, forever** |
| `resolveTrade` | the trades cron | **rolls back a trade the league already approved** |

The third is the one that matters. The run is a single transaction, so the violation did not fail one claim — it discarded every award in the league, left all the claims `PENDING`, and `leaguesDueForWaivers` re-selected that league on the next tick to fail identically. One manager paying for a claim with an IR'd player would have stopped their league's waivers permanently.

The fourth rolls back a trade the league had already approved — the outcome `ASSET_GONE` exists to make impossible, arriving by a route none of its reasoning covers.

## Why it survived

The IR suite's only constraint test writes this by hand and asserts it is **refused**:

```ts
await expect(
  fx.client.query("UPDATE roster_entries SET released_at = now() WHERE player_id = $1", [...]),
).rejects.toBeTruthy();
```

That statement is a paraphrase of what all four production sites execute. The test calls the refusal the feature. So the constraint was verified against a statement no code in this repo runs, while the four that do run it were never staged.

Same family as #73, #140 and #227 — but a new shape. Not a fixture staging a state the product cannot produce; a fixture staging the product's **own** statement and reading the failure as a pass.

## Not carried across

A traded player does **not** arrive at the receiving team on IR. IR eligibility is the receiving roster's rules applied to a current designation, claimed through `moveToIr`. Carrying the flag over would spend one of the new team's signed slots without them asking.

## Tests

Three, mutation-checked — removing `on_ir = false` from every site fails exactly these three and nothing else:

- `lets a manager drop a player who is on IR`
- `frees the IR slot for somebody else once the drop lands`
- `awards a claim whose drop is a player on injured reserve` — drives `addFreeAgent` → `moveToIr` → `dropPlayer` → `submitClaim` → `processWaivers`, no hand-written roster rows

**Stated rather than glossed:** `resolveTrade`'s site is fixed by symmetry and has **no test of its own**. Given that an untested release site is exactly what this PR is about, that is filed as a follow-up rather than left implied.

## Not live yet

`roster_entries WHERE on_ir AND released_at IS NULL` is **0 rows** in production, so nothing has hit this. IR is fully wired in the UI and the season starts 9 Sep.

---

2181 tests passing (was 2178). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)