### PR TITLE
fix(db): #131's guard was right and most of what it said about itself was not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1792,8 +1792,15 @@ than rendering as a blank page for seven days.
 
 ### One league's failure never stops the others
 
-Every cron loops over leagues, and a throw inside that loop must never escape it. Four
-routes do this; three always did it correctly. `score-week`'s playoff block was the
+Every cron does per-league work, and a throw in any of it must never decide for the other
+leagues. Four routes loop; three always did the **loop** correctly.
+
+**And that framing is what hid #131 for months.** This section said "a throw inside that
+loop", named waivers among the three that were fine, and was right about the loop it was
+looking at — while `leaguesDueForWaivers` sat _above_ the loop doing a per-league read per
+league, outside the guard. One league whose rules would not parse threw there and 500'd the
+whole route: no league's waivers ran, every hour, until somebody looked. The rule is about
+**per-league work**, not about a syntactic loop body, and selection is per-league work. `score-week`'s playoff block was the
 exception and the **only** deny-by-default catch in the repo — an `instanceof PlayoffError`
 allowlist that rethrew everything else.
 
@@ -1801,12 +1808,24 @@ allowlist that rethrew everything else.
 run, and left every league after it in a query with **no `ORDER BY`** unscored — the same
 set every ten minutes, deterministically.
 
+Fixed by #223. `leaguesDueForWaivers` returns `{ due, problems }` and guards each league
+itself, so a league nobody can assess is named in `cron_runs` rather than taking the run
+down. Its re-audit found the guard's own comments overclaiming — a permanence the
+catch-by-shape cannot establish, and a heartbeat truncation that does not exist — which
+#239 corrects.
+
 **The fix is the shape, not the class.** Adding `BracketError` to the allowlist would have
 left `StandingsError` — reachable from the same `seedOrder` call — and every future class
 exactly as exposed, because none of these share a base class for an `instanceof` to catch.
 So it records and continues, like `waivers`, `trades`, `draft-tick`, and `score-week`'s own
 scoring catch. **If you find yourself adding an error class to an allowlist inside a
 per-league loop, the allowlist is the bug.**
+
+**Reporting is half of it, and the half that goes missing.** A per-league failure that is
+caught and continued but reaches only the JSON response body is invisible: Vercel keeps no
+cron response bodies, so `pnpm cron:status` reads green. Both `score-week` (#234) and
+`waivers` (#223) shipped a catch before they shipped the `cron_runs` note. If you add a
+guard, add the row.
 
 **Nothing is swallowed.** The failure is reported as `bracketProblem`, because a league
 whose bracket can never be built would otherwise look healthy forever. `BracketError`

--- a/apps/web/src/app/api/cron/waivers/route.ts
+++ b/apps/web/src/app/api/cron/waivers/route.ts
@@ -91,11 +91,17 @@ async function run(client: SqlClient, now: Date): Promise<NextResponse> {
   /*
     Both kinds of failure reach the heartbeat, and they are different facts.
 
-    A league that *ran* and threw has a bad claim or a bad roster and will
-    probably be fine next hour. A league that could not even be **asked** whether
-    it was due will never process a claim again until somebody looks — its rules
-    do not parse, or its waiver schedule cannot be computed. Collapsing the two
-    into one count would hide the permanent one behind the transient one.
+    A league that *ran* and threw got as far as its claims. A league that could
+    not even be **asked** whether it was due did not, and that is worth saying
+    separately: it is the state in which nothing about the league's waivers is
+    known, so it cannot be reasoned about from the rest of the response.
+
+    **Neither bucket is "permanent" and this comment used to say the second was.**
+    Both catches are by shape, so each holds a mixture — an unparseable rule set
+    sits beside a statement timeout in the same list. The split is by *how far the
+    run got*, not by whether the fault will recur, and a reader who takes it for
+    the latter will leave a transient fault alone waiting for a human, or send a
+    human at one that fixed itself an hour ago.
   */
   const notes = [
     failed > 0 ? `${failed} of ${due.length} leagues failed` : null,
@@ -111,8 +117,12 @@ async function run(client: SqlClient, now: Date): Promise<NextResponse> {
     at: now.toISOString(),
     due: due.length,
     runs,
-    // Surfaced in the response as well as the heartbeat: the heartbeat truncates
-    // and this is the one place the whole list is legible.
+    // Structured, where the heartbeat carries the same content flattened into a
+    // sentence. Nothing truncates — `cron_runs.last_outcome` is unbounded `text`
+    // and `cron:status` prints it whole; an earlier comment here claimed a
+    // truncation that does not exist anywhere in the path. What the heartbeat
+    // genuinely does not do is keep history: one row per job, upserted, so the
+    // record of this hour is gone next hour.
     ...(problems.length > 0 ? { unreadable: problems } : {}),
   });
 }

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -9,6 +9,7 @@ import { moveToIr } from "./injured-reserve.js";
 import type { PGliteClient } from "./testing.js";
 import {
   leaguesDueForWaivers,
+  nextWaiverRun,
   addFreeAgent,
   availabilityOf,
   availablePlayers,
@@ -1349,13 +1350,17 @@ describe("choosing which leagues are due — #131", () => {
    * A client that fails one league's rules read and passes everything else
    * through untouched.
    */
-  function failingFor(client: PGliteClient, leagueId: string): PGliteClient {
+  function failingOn(
+    client: PGliteClient,
+    match: string,
+    leagueIds: readonly string[],
+  ): PGliteClient {
     return new Proxy(client, {
       get(target, prop, receiver) {
         if (prop !== "query") return Reflect.get(target, prop, receiver);
         return async (sql: string, params?: unknown[]) => {
-          if (sql.includes("league_rules") && params?.includes(leagueId)) {
-            throw new Error("simulated: this league's rules could not be read");
+          if (sql.includes(match) && leagueIds.some((id) => params?.includes(id))) {
+            throw new Error("simulated: this league could not be read");
           }
           return (
             target as unknown as { query: (s: string, p?: unknown[]) => Promise<unknown> }
@@ -1365,9 +1370,29 @@ describe("choosing which leagues are due — #131", () => {
     }) as PGliteClient;
   }
 
+  /** The original: fails the rules read, which is the guard's first statement. */
+  const failingFor = (client: PGliteClient, leagueId: string): PGliteClient =>
+    failingOn(client, "league_rules", [leagueId]);
+
+  /*
+    Fails the **second** query in the guarded region instead.
+
+    Without this the guard was only ever proven over its first statement, so
+    narrowing the `try` to wrap `getLeagueRules` alone — which looks like a
+    tightening rather than a regression — would have left every later throw
+    escaping again, and all three original tests stayed green. The region has
+    four throw sites and the injection reached one.
+  */
+  const failingLater = (client: PGliteClient, leagueId: string): PGliteClient =>
+    failingOn(client, "min(created_at)", [leagueId]);
+
   /** A second league in the same database, with a claim of its own pending. */
-  async function secondLeague(client: PGliteClient): Promise<string> {
-    const commissioner = await createUser(client, "second@example.com", "Second");
+  async function secondLeague(
+    client: PGliteClient,
+    email = "second@example.com",
+    name = "Second",
+  ): Promise<string> {
+    const commissioner = await createUser(client, email, name);
     const rules = buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules;
     const league = await createLeague(client, NFL, {
       name: "The Other League",
@@ -1388,51 +1413,151 @@ describe("choosing which leagues are due — #131", () => {
 
   const WEDNESDAY = new Date("2026-09-16T08:00:00Z");
 
-  it("still returns the healthy leagues when one cannot be checked", async () => {
-    const fx = await setup();
-    await dropPlayer(fx.client, fx.leagueId, fx.teams[0], fx.players.get("held"), MONDAY);
+  /** The healthy fixture league, playing and with one claim pending. */
+  async function playingWithAClaim(fx: Fixture): Promise<void> {
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, MONDAY);
     await submitClaim(fx.client, {
       leagueId: fx.leagueId,
-      teamId: fx.teams[1],
-      addPlayerId: fx.players.get("held"),
+      teamId: fx.teams[1]!,
+      addPlayerId: fx.players.get("held")!,
       now: MONDAY,
     });
-
     // The selection query only considers leagues actually playing.
     await fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [
       fx.leagueId,
     ]);
+  }
+
+  it("still returns the healthy leagues when one cannot be checked", async () => {
+    const fx = await setup();
+    await playingWithAClaim(fx);
 
     const broken = await secondLeague(fx.client);
-    const client = failingFor(fx.client, broken);
-
-    const selection = await leaguesDueForWaivers(client, WEDNESDAY);
+    const selection = await leaguesDueForWaivers(failingFor(fx.client, broken), WEDNESDAY);
 
     // The whole point. Before the fix this call threw and the cron 500'd, so no
     // league's waivers ran — including every healthy one.
-    expect(selection.due).toContain(fx.leagueId);
+    expect(selection.due).toEqual([fx.leagueId]);
+
+    /*
+      And the healthy league is not blamed for its neighbour.
+
+      `toEqual` rather than `toContain`, on both sides, because attribution is
+      the assertion nobody had written: reporting `rows[0].id` instead of
+      `row.id` survived every original test — one of them had a single-league
+      row set where the two coincide, and the other never looked at `problems`
+      at all. A heartbeat naming an innocent league sends somebody to investigate
+      a healthy one while the stuck league goes on not processing claims.
+    */
+    expect(selection.problems.map((entry) => entry.leagueId)).toEqual([broken]);
   });
 
   it("reports the league it could not check, rather than skipping it silently", async () => {
     /*
-      A league whose due-ness cannot be computed will never process another claim
-      until somebody looks at it. Skipping in silence would make it identical to a
-      league with nothing due — which is what this reports for most leagues most
-      hours, so the difference has to be said out loud.
+      A league whose due-ness cannot be computed is one nothing is known about —
+      skipping in silence would make it identical to a league with nothing due,
+      which is what this reports for most leagues most hours.
     */
     const fx = await setup();
     const broken = await secondLeague(fx.client);
-    const client = failingFor(fx.client, broken);
 
-    const selection = await leaguesDueForWaivers(client, WEDNESDAY);
+    const selection = await leaguesDueForWaivers(failingFor(fx.client, broken), WEDNESDAY);
 
     expect(selection.problems.map((entry) => entry.leagueId)).toContain(broken);
     expect(selection.due).not.toContain(broken);
   });
 
-  it("reports no problems when every league is readable", async () => {
+  it("guards the whole of the per-league work, not just its first statement", async () => {
     const fx = await setup();
-    const selection = await leaguesDueForWaivers(fx.client, MONDAY);
+    await playingWithAClaim(fx);
+    const broken = await secondLeague(fx.client);
+
+    const selection = await leaguesDueForWaivers(failingLater(fx.client, broken), WEDNESDAY);
+
+    expect(selection.due).toEqual([fx.leagueId]);
+    expect(selection.problems.map((entry) => entry.leagueId)).toEqual([broken]);
+  });
+
+  it("keeps going after a failure rather than stopping at the first", async () => {
+    /*
+      Two broken leagues, so the assertion is independent of visit order.
+
+      The selection query has no `ORDER BY`, so a `break` in the catch — the
+      natural-looking edit for someone who reads the loop as "find the due ones"
+      — passed or failed at random depending on which league Postgres returned
+      first. An intermittent red on this repo gets re-run and dismissed, which
+      is worse than a deterministic escape.
+    */
+    const fx = await setup();
+    await playingWithAClaim(fx);
+    const first = await secondLeague(fx.client, "b1@example.com", "Broken One");
+    const second = await secondLeague(fx.client, "b2@example.com", "Broken Two");
+
+    const client = failingOn(fx.client, "league_rules", [first, second]);
+    const selection = await leaguesDueForWaivers(client, WEDNESDAY);
+
+    expect(selection.problems).toHaveLength(2);
+    expect(selection.due).toEqual([fx.leagueId]);
+  });
+
+  it("does not report a problem when every league is readable", async () => {
+    /*
+      **The negative control, and the first version of it ran zero iterations.**
+
+      It called `leaguesDueForWaivers` on the bare fixture, whose league is
+      FORMING with no claims — so the selection query matched nothing, the loop
+      never executed, and `problems` was `[]` because it was initialised `[]`.
+      It passed with the whole `try`/`catch` deleted, and with the function
+      stubbed to return empty. A test with no rows cannot tell you what the loop
+      does with a row.
+
+      This one gives it two readable leagues to walk.
+    */
+    const fx = await setup();
+    await playingWithAClaim(fx);
+    const other = await secondLeague(fx.client);
+
+    const selection = await leaguesDueForWaivers(fx.client, WEDNESDAY);
+
     expect(selection.problems).toEqual([]);
+    expect([...selection.due].sort()).toEqual([fx.leagueId, other].sort());
+  });
+
+  it("does not call a league due before its processing moment", async () => {
+    /*
+      **The rule itself, which had no test at all in the repo.**
+
+      Deleting the schedule comparison and pushing every league unconditionally
+      passed all three original tests — the healthy one was genuinely due at the
+      instant they used, so `toContain` held either way. What that mutation
+      produces is every pending claim resolving on the next hourly tick: the
+      waiver period gone, the blind cycle gone, a claim awarded within an hour of
+      being filed. Both directions are asserted here, the way the sibling
+      `leaguesWithDueTrades` tests already do.
+    */
+    const fx = await setup();
+    await playingWithAClaim(fx);
+
+    // Read the claim back rather than assuming when it was filed. `created_at`
+    // is deliberately the database's and not the caller's, so that a submission
+    // time cannot be chosen by whoever is submitting — which means a fixture
+    // cannot choose it either, and asserting against a hand-picked instant here
+    // would be asserting against a value the product does not write.
+    const [claim] = await fx.client.query<{ created_at: string }>(
+      "SELECT created_at FROM waiver_claims WHERE league_id = $1",
+      [fx.leagueId],
+    );
+    const filed = new Date(claim!.created_at);
+    const runsAt = nextWaiverRun(
+      buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
+      filed,
+    );
+
+    // A minute before its processing moment: filed, waiting, not due.
+    const justBefore = new Date(runsAt.getTime() - 60_000);
+    expect((await leaguesDueForWaivers(fx.client, justBefore)).due).toEqual([]);
+
+    // And due the moment it arrives.
+    expect((await leaguesDueForWaivers(fx.client, runsAt)).due).toEqual([fx.leagueId]);
   });
 });

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -1185,7 +1185,6 @@ export function nextWaiverRun(rules: LeagueRules, now: Date): Date {
   return nextProcessingAt(now, rules.waivers);
 }
 
-/** Leagues whose waiver run is due and has not happened since. */
 /**
  * Which leagues are due, and which could not be asked.
  *
@@ -1197,7 +1196,15 @@ export function nextWaiverRun(rules: LeagueRules, now: Date): Date {
  */
 export interface WaiverDueSelection {
   readonly due: readonly string[];
-  /** Leagues whose due-ness could not be computed. Never empty silently. */
+  /**
+   * Leagues whose due-ness could not be computed.
+   *
+   * Every path that declines to answer for a league lands here — the two
+   * `continue`s below included. They said "never empty silently" while skipping
+   * in exactly the way that sentence forbade; both are unreachable in
+   * production, which is a reason to keep the claim true cheaply rather than a
+   * reason to have made it falsely.
+   */
   readonly problems: readonly { readonly leagueId: string; readonly error: string }[];
 }
 
@@ -1220,22 +1227,37 @@ export async function leaguesDueForWaivers(
       One league's failure must not decide for the others, and **selection is
       inside that rule as much as processing is** — issue #131.
 
-      The cron guards `processWaivers` per league and this function ran before
-      that guard existed, so a throw here escaped it and 500'd the whole route:
-      no league's waivers ran, deterministically, every hour, forever. Exactly
-      the shape `CLAUDE.md` documents under "One league's failure never stops
-      the others", which named the four cron routes and counted waivers among
-      the three that always did it correctly — the loop it was looking at was
-      the one below this.
+      The cron has guarded `processWaivers` per league since it was written, and
+      this call sat **above** that loop — before it in program order, not in
+      time. (An earlier draft of this comment said the guard did not yet exist,
+      which is not what happened and makes the bug sound older than it was.) So
+      a throw here escaped the guard and 500'd the whole route: no league's
+      waivers ran, deterministically, every hour. That is the shape `CLAUDE.md`
+      documents under "One league's failure never stops the others", which counts
+      waivers among the routes that do it correctly — true of the loop it was
+      looking at, and the reason the rule needs stating about *selection* too.
 
-      Two things in here can throw for a single league. `getLeagueRules` parses
-      a stored document, and `nextProcessingAt` reads `rules.waivers`, whose
-      weekday is validated nowhere (#132) — so one league with an unusable
-      waiver schedule silently stopped everybody's.
+      **Not silently.** The route already stamped `cron_runs` and rethrew, so
+      `pnpm cron:status` read FAILING throughout. What it could not say was
+      *which* league, which is what `problems` adds.
+
+      Four things in here can throw for one league: `getLeagueRules` issues a
+      query and then `JSON.parse`s what it finds, the `min(created_at)` query
+      below is a second round trip, and `nextProcessingAt` walks
+      `rules.waivers`. Both of the cheap content-level causes are now closed —
+      the timezone by `validateLeagueRules` and the weekday by #230 — so the
+      guard is latent, and deliberately kept: it is about the shape rather than
+      any one cause.
     */
     try {
       const stored = await getLeagueRules(db, row.id);
-      if (!stored) continue;
+      if (!stored) {
+        // Unrepresentable — `createLeague` writes both rows in one transaction
+        // and `league_rules` carries a DELETE trigger. Reported rather than
+        // skipped so the type's promise above is true of every path.
+        problems.push({ leagueId: row.id, error: "league has no stored rules" });
+        continue;
+      }
 
       // The run this league is currently waiting for. If the next one is more
       // than a full cycle away, the moment has passed and claims are overdue.
@@ -1244,22 +1266,36 @@ export async function leaguesDueForWaivers(
           WHERE league_id = $1 AND state = 'PENDING'`,
         [row.id],
       );
-      if (!oldest?.created_at) continue;
+      if (!oldest?.created_at) {
+        // Also unrepresentable: the selection query joins a PENDING claim, so
+        // one exists by construction. Same reasoning as above.
+        problems.push({ leagueId: row.id, error: "no pending claim to date the run from" });
+        continue;
+      }
 
       if (nextProcessingAt(new Date(oldest.created_at), stored.rules.waivers) <= now) {
         due.push(row.id);
       }
     } catch (error) {
       /*
-        Recorded, never swallowed. A league whose schedule cannot be computed
-        will never process a claim again, and a selection that quietly skipped it
-        would look identical to a league with nothing due — which is the state
-        this function reports for most leagues most hours.
+        Recorded, never swallowed. A selection that quietly skipped a league
+        would look identical to a league with nothing due — the state this
+        function reports for most leagues most hours.
 
-        Caught by shape rather than by class, deliberately. An `instanceof`
-        allowlist here would be the same defect this whole change is about:
-        `CLAUDE.md` — "if you find yourself adding an error class to an allowlist
-        inside a per-league loop, the allowlist is the bug."
+        **This does not mean the league is permanently stuck**, and an earlier
+        version of this comment said it did. Catching by shape is right, and its
+        price is that a transient fault — a statement timeout, a dropped
+        connection, a deadlock on either query above — arrives here looking
+        exactly like an unparseable rule set. Both are reported; only one
+        recovers unaided next hour. Do not let the reporting copy claim a
+        permanence the catch cannot establish.
+
+        Caught by shape rather than by class, deliberately — but note the rule it
+        follows is `CLAUDE.md`'s "if you find yourself adding an error class to an
+        allowlist inside a per-league loop, the allowlist is the bug", which came
+        out of #38 in `score-week`. It is a rule this change obeys, not the
+        defect this change is about; those are different, and conflating them
+        made #131 sound like a repeat of a bug it has nothing to do with.
       */
       problems.push({
         leagueId: row.id,


### PR DESCRIPTION
The comment-and-test half of the five-agent re-audit of #131. The mechanism holds; the prose around it and the coverage under it did not.

## Seven false claims

This repo treats a comment asserting a guarantee the code does not provide as a defect in its own right.

| Claim | Reality |
|---|---|
| "the heartbeat **truncates**" | Nothing truncates. `last_outcome` is unbounded `text`, `cron:status` prints it whole, and the heartbeat already carries the full list. It does not keep *history* — a different fact, now stated. |
| "will **never** process a claim again until somebody looks" | The catch is by shape, so it also absorbs a statement timeout or dropped connection — which recover unaided. **The change's own test manufactures exactly that**, throwing from one `query` call. |
| "weekday is validated nowhere (#132)" | Closed by #230, which cites #131 by name and did not visit this comment. Sends the next reader to build a repro that cannot be built. |
| "this function ran before that guard existed" | The guard existed. Before it in *program order*, not in time. The commit message got this right; the comment did not. |
| "**Two** things in here can throw" | Four: a query, a `JSON.parse`, a second query, the schedule walk. |
| "an `instanceof` allowlist would be **the same defect this change is about**" | It is #38's defect, in `score-week`. A rule this change obeys is not the defect it fixes. |
| "**Never empty silently**" | Two silent `continue`s. Unreachable — so cheap to make true, which they now are. |

## Five mutations that survived the entire suite

| Mutation | Why it survived | What it would cost |
|---|---|---|
| delete the `try`/`catch` entirely | the negative control ran **zero iterations** — its league was FORMING with no claims, so `problems` was `[]` because it was *initialised* `[]` | no control at all on the reporting channel |
| narrow the `try` to wrap only `getLeagueRules` | the injection keyed on the rules read, the guard's **first** statement | **#131 restored** for the other three throw sites |
| push every league unconditionally | the due-ness rule had no test **anywhere in the repo** | every pending claim resolves on the next hourly tick — waiver period gone, blind cycle gone |
| `leagueId: rows[0].id` | one test had a single-league row set; the other never read `problems` | heartbeat names an innocent league; the stuck one stays invisible |
| `break` in the catch | selection has no `ORDER BY`, so it passed or failed at random | #131 restored for every league after the broken one, intermittently — which gets re-run and dismissed |

Six tests now, each mutation-checked against the edit it exists to catch:

```
--- narrow:        5 failed
--- break:         2 failed
--- misattribute:  2 failed
--- alwaysdue:     1 failed
--- alwaysproblem: 4 failed
```

The due-ness test reads `created_at` back from the row rather than assuming it — that column is deliberately the database's and not the caller's, so a fixture cannot choose it either.

## CLAUDE.md

It still named `waivers` among the three routes that "always did it correctly", and still framed the rule as a throw ***inside the loop*** — the framing that let selection sit above the loop unexamined. Now: per-league work, not a syntactic loop body.

Also recorded there: **a guard without a `cron_runs` row is invisible.** Both `score-week` (#234) and `waivers` (#223) shipped the catch before the row.

---

2184 tests (was 2181). Typecheck, lint, prettier clean. No migration, and no behaviour change beyond the two unreachable `continue`s now reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
