### PR TITLE
fix(db): #100's guard skipped the slot its own headline case was about

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1451,6 +1451,31 @@ the lock from a roster map that had already lost the player, so they agreed and 
 wrong. `loadKickoffs` is now the one definition of when a player locks, and the lineup
 route asks it the same question `setLineup` does.
 
+**The lock is decided from a snapshot read outside the transaction, and that is deliberate
+— issue #100.** Nothing slow may run under a row lock, so the rules load, the roster load,
+the kickoff load and `validateLineup` all happen first. What closes the gap between that
+read and the write is a **per-slot compare on the way out**: a slot whose stored value has
+moved since the snapshot is refused with `LINEUP_MOVED` (409, retryable), and a slot the
+request did not change is **skipped**, not rewritten.
+
+Skipping is the half that had to be corrected after the fact, and it defeated the fix in
+its own headline case. Unchanged slots were originally written with no `WHERE`, which is an
+assertion about state rather than an abstention: the editor posts every slot on every save,
+so `null === null` took that branch and blanked whatever the autofill had just put in a slot
+the manager's page showed as empty — past the lock, and past `validateLineup`, which had
+judged an empty slot that no longer existed.
+
+**The retry carries the manager's edit, not their snapshot.** `applyLineupEdit` in
+`apps/web/src/lib/lineup-edit.ts` is the one definition of what a change means, used both to
+build the first attempt and to re-apply it to a re-read lineup. The first version diffed two
+slot lists and kept the stale one wherever they differed — reverting the other writer across
+the whole lineup while its comment claimed to preserve it.
+
+**What no test in this repo can show:** PGlite is a single connection, so the interleaving
+helper's "other writer" shares the session under test and its `COMMIT` commits the
+transaction it is interfering with. The race tests pin the compare; they say nothing about
+the row lock, and `setLineup`'s atomicity is not demonstrable here. The helper says so.
+
 **`autoFillLineup` evicts a player who left the roster before his kickoff.** He is a hole,
 not a choice the manager made — and leaving him let his slot lock at kickoff around a
 player nobody rosters, who then scored for the team that cut him. Note the `lockedAssignments`

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -36,9 +36,16 @@ const STATUS: Record<string, number> = {
   // re-reads and submits again. 409 rather than 422: the request was well formed.
   LINEUP_MOVED: 409,
   SLOT_TYPE_UNKNOWN: 500,
-  // #98: this fell through to 400 with no diagnosis. A league whose games are
-  // not ingested cannot enforce a kickoff lock, so it refuses rather than
-  // accepting a lineup it could not police.
+  // A league whose games are not ingested cannot enforce a kickoff lock, so it
+  // refuses rather than accepting a lineup it could not police.
+  //
+  // **409 is a partial answer to #98 and this comment used to overstate it
+  // twice.** It said the code "fell through to 400 with no diagnosis"; the catch
+  // already returned the error message, and #98 says so itself ("the diagnosis
+  // is right"). What #98 actually asks for is **503** — the manager did nothing
+  // wrong and there is nothing they can do, which is a server-state problem
+  // wearing a 4xx. Moving it out of the 400 bucket is an improvement and not the
+  // fix; #98 stays open for the status itself.
   SCHEDULE_MISSING: 409,
 };
 

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { applyLineupEdit } from "@/lib/lineup-edit";
+import type { LineupEdit } from "@/lib/lineup-edit";
 import { opponentLabel } from "@/lib/opponent";
 import { isIrEligible as irEligible } from "@rostr/core";
 import { previewHeading, whyNot } from "@/lib/autofill";
@@ -167,7 +169,7 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
    *
    * `isRetry` exists so the retry cannot recurse: see the LINEUP_MOVED branch.
    */
-  async function save(next: Slot[], isRetry = false): Promise<void> {
+  async function save(next: Slot[], edit: LineupEdit, isRetry = false): Promise<void> {
     setSaving(true);
     setProblems([]);
     setSaveError(null);
@@ -195,10 +197,18 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
       /*
         `LINEUP_MOVED` is retryable and everything else here is not. Issue #100.
 
-        The server now validates the kickoff lock against state it holds a lock
-        on, so a save built from a stale snapshot can be refused — and the
-        ordinary cause is nobody's fault: the score-week cron's autofill wrote a
-        slot in the ten minutes since this screen last polled.
+        The server compares each slot against its own read and refuses one that
+        moved underneath the request, so a save can come back refused through
+        nobody's fault: the score-week cron's autofill committed a slot in the
+        milliseconds between that read and the write.
+
+        Two corrections to what this said, because both would mislead somebody
+        reasoning about the window. The lock is **not** validated against state
+        the server holds a lock on — the read is still outside the transaction
+        and the compare-and-swap is what detects movement. And the window is not
+        "the ten minutes since this screen last polled": this page polls every
+        thirty seconds, and the comparison is against the server's own fresh
+        read, so the client's staleness does not enter it at all.
 
         Surfacing that as an error would be worse than the bug it closes. The
         manager did nothing wrong, the fix is mechanical, and `setSaveError`
@@ -213,15 +223,22 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
       if (!response.ok && body.code === "LINEUP_MOVED" && !isRetry) {
         const fresh = await mutate();
         if (fresh) {
-          // Re-submit against what the server actually holds now, keeping this
-          // manager's own change and taking everything else from the refresh.
-          const merged = fresh.slots.map((slot) => {
-            const mine = next.find(
-              (entry) => entry.slotType === slot.slotType && entry.slotIndex === slot.slotIndex,
-            );
-            return mine && mine.playerId !== slot.playerId ? mine : slot;
-          });
-          await save(merged, true);
+          /*
+            Re-apply the manager's **decision** to what the server now holds.
+
+            Not a merge of two slot lists. This used to diff `next` against
+            `fresh` and keep `next` wherever they disagreed — which is the slot
+            the manager changed *and* every slot another writer had moved since
+            the page last polled, so the retry reverted the other writer across
+            the whole lineup while its comment claimed to be preserving it. On an
+            unlocked slot that silently undid the autofill; on a locked one it
+            came back 422 naming a slot the manager never touched.
+
+            `applyLineupEdit` is the same function `assign` used to build the
+            first attempt, so there is one definition of what a change means
+            rather than an apply and a re-apply that can drift.
+          */
+          await save(applyLineupEdit(fresh.slots, edit), edit, true);
           return;
         }
       }
@@ -264,16 +281,8 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
   }
 
   function assign(slot: Slot, playerId: string | null): void {
-    const next = data!.slots.map((entry) =>
-      entry.slotType === slot.slotType && entry.slotIndex === slot.slotIndex
-        ? { ...entry, playerId }
-        : // Moving a player into a slot takes him out of wherever he was.
-          entry.playerId === playerId && playerId !== null
-          ? { ...entry, playerId: null }
-          : entry,
-    );
-
-    void save(next);
+    const edit = { slotType: slot.slotType, slotIndex: slot.slotIndex, playerId };
+    void save(applyLineupEdit(data!.slots, edit), edit);
   }
 
   /*

--- a/apps/web/src/lib/lineup-edit.test.ts
+++ b/apps/web/src/lib/lineup-edit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { applyLineupEdit } from "./lineup-edit.js";
+import type { LineupSlot } from "./lineup-edit.js";
+
+const slots = (...entries: [string, number, string | null][]): LineupSlot[] =>
+  entries.map(([slotType, slotIndex, playerId]) => ({ slotType, slotIndex, playerId }));
+
+describe("applyLineupEdit", () => {
+  it("puts the player in the named slot", () => {
+    const after = applyLineupEdit(slots(["QB", 0, null], ["RB", 0, null]), {
+      slotType: "QB",
+      slotIndex: 0,
+      playerId: "p1",
+    });
+
+    expect(after).toEqual(slots(["QB", 0, "p1"], ["RB", 0, null]));
+  });
+
+  it("vacates the slot the player came from", () => {
+    // Otherwise the submission holds him twice and the server refuses the whole
+    // lineup for a slot the manager did not think they were editing.
+    const after = applyLineupEdit(slots(["FLEX", 0, "p1"], ["RB", 0, null]), {
+      slotType: "RB",
+      slotIndex: 0,
+      playerId: "p1",
+    });
+
+    expect(after).toEqual(slots(["FLEX", 0, null], ["RB", 0, "p1"]));
+  });
+
+  it("clears one slot without blanking every other empty one", () => {
+    /*
+      The `playerId !== null` guard. Without it, clearing a slot matches every
+      slot already holding null — they all "hold the same player" — and one
+      dropdown set to empty wipes the lineup.
+    */
+    const after = applyLineupEdit(slots(["QB", 0, "p1"], ["RB", 0, null], ["WR", 0, "p2"]), {
+      slotType: "QB",
+      slotIndex: 0,
+      playerId: null,
+    });
+
+    expect(after).toEqual(slots(["QB", 0, null], ["RB", 0, null], ["WR", 0, "p2"]));
+  });
+
+  it("distinguishes slots of the same type by index", () => {
+    const after = applyLineupEdit(slots(["RB", 0, "p1"], ["RB", 1, "p2"]), {
+      slotType: "RB",
+      slotIndex: 1,
+      playerId: "p3",
+    });
+
+    expect(after).toEqual(slots(["RB", 0, "p1"], ["RB", 1, "p3"]));
+  });
+
+  it("leaves every slot the edit does not name exactly as it found them", () => {
+    /*
+      **The property the retry depends on, and the one the old merge broke.**
+
+      After a `LINEUP_MOVED` the editor re-reads the lineup and re-applies the
+      manager's decision to it. If applying that decision also carried anything
+      from the manager's stale snapshot, the retry would revert whatever the
+      other writer had just done — which is what the previous merge did, across
+      every slot the two lists disagreed about.
+
+      Here the fresh list holds a player in RB the manager's page never showed.
+      Editing QB must not touch him.
+    */
+    const fresh = slots(["QB", 0, null], ["RB", 0, "autofilled"], ["WR", 0, "p2"]);
+
+    const after = applyLineupEdit(fresh, { slotType: "QB", slotIndex: 0, playerId: "p1" });
+
+    expect(after).toEqual(slots(["QB", 0, "p1"], ["RB", 0, "autofilled"], ["WR", 0, "p2"]));
+  });
+
+  it("still vacates on the retry when the player is the one who moved", () => {
+    // The one case where touching another slot is correct: the manager is moving
+    // a player the refresh shows somewhere else.
+    const fresh = slots(["FLEX", 0, "p1"], ["RB", 0, "autofilled"]);
+
+    const after = applyLineupEdit(fresh, { slotType: "RB", slotIndex: 0, playerId: "p1" });
+
+    expect(after).toEqual(slots(["FLEX", 0, null], ["RB", 0, "p1"]));
+  });
+
+  it("does not mutate the list it was given", () => {
+    const before = slots(["QB", 0, null]);
+    applyLineupEdit(before, { slotType: "QB", slotIndex: 0, playerId: "p1" });
+    expect(before).toEqual(slots(["QB", 0, null]));
+  });
+});

--- a/apps/web/src/lib/lineup-edit.ts
+++ b/apps/web/src/lib/lineup-edit.ts
@@ -1,0 +1,65 @@
+/**
+ * What a manager's single lineup change means, applied to a slot list.
+ *
+ * `LineupEditor` posts the **whole** slot list on every dropdown change, so the
+ * request body carries a manager's one decision surrounded by eight slots they
+ * did not touch. That is fine on the way out — the server compares each slot
+ * against its own fresh read — but it makes the change itself unrecoverable
+ * afterwards: nothing in the payload distinguishes "I chose this" from "this is
+ * what my page happened to show".
+ *
+ * It matters on exactly one path. A `LINEUP_MOVED` refusal is retried once
+ * against a re-read lineup, and the retry has to re-apply the manager's decision
+ * to what the server now holds. The first version of that merge compared the
+ * stale list against the fresh one and kept the stale value wherever they
+ * differed — which is every slot another writer had moved, not the one the
+ * manager touched. Its comment claimed the opposite ("keeping this manager's own
+ * change and taking everything else from the refresh"), and what it did was
+ * revert the other writer across the whole lineup.
+ *
+ * So the edit is carried as an edit, and the same function applies it both
+ * times. One definition, rather than an apply and a re-apply that can disagree.
+ *
+ * This lives in `lib/` rather than in the component because `apps/web` has no
+ * jsdom in either vitest project: a rule written in `.tsx` is verified only by
+ * being run in production, and this one is reached only by a race.
+ */
+
+export interface LineupSlot {
+  readonly slotType: string;
+  readonly slotIndex: number;
+  readonly playerId: string | null;
+}
+
+export interface LineupEdit {
+  readonly slotType: string;
+  readonly slotIndex: number;
+  readonly playerId: string | null;
+}
+
+const sameSlot = (a: { slotType: string; slotIndex: number }, b: LineupEdit): boolean =>
+  a.slotType === b.slotType && a.slotIndex === b.slotIndex;
+
+/**
+ * Apply one change to a slot list, vacating the player's previous slot.
+ *
+ * Moving a player into a slot takes him out of wherever he was — otherwise the
+ * submission holds him twice and `validateLineup` refuses the whole lineup for a
+ * second slot the manager did not think they were editing.
+ *
+ * Clearing a slot (`playerId: null`) vacates nothing else: there is no player to
+ * find elsewhere, and the `playerId === null` guard is what stops every empty
+ * slot in the list being treated as "the same player" and blanked together.
+ */
+export function applyLineupEdit<T extends LineupSlot>(
+  slots: readonly T[],
+  edit: LineupEdit,
+): T[] {
+  return slots.map((slot) => {
+    if (sameSlot(slot, edit)) return { ...slot, playerId: edit.playerId };
+    if (edit.playerId !== null && slot.playerId === edit.playerId) {
+      return { ...slot, playerId: null };
+    }
+    return slot;
+  });
+}

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -716,6 +716,54 @@ describe("ensureLineups", () => {
     expect(lineup.every((slot) => slot.playerId === null)).toBe(true);
   });
 
+  it("fills a slot whose row already exists holding null", async () => {
+    /*
+      **The case `IS NOT DISTINCT FROM` exists for in `setLineup`, and the one
+      `=` would break silently.**
+
+      `setLineupUnchecked` has carried this test since it was written. #224
+      copied the compare-and-swap into `setLineup` and did not copy the test, so
+      the same one-character mutation — `IS NOT DISTINCT FROM $6` to `= $6` —
+      was green across the whole suite.
+
+      What it costs: `NULL = NULL` is `NULL`, so the CAS matches nothing, zero
+      rows come back, and the manager is told `LINEUP_MOVED`. Forever. The
+      editor's one retry re-reads the same null and is refused again. Every
+      autofill-off manager would be locked out of setting a lineup at all, and
+      every team gets rows like this the moment `ensureLineups` runs.
+
+      The ordering here is the whole point: `ensureLineups` **first**, so the row
+      is present holding null, then the manager fills it. The sibling test below
+      does it the other way round and cannot see this.
+    */
+    const fx = await setup();
+    await fx.client.query("UPDATE teams SET autofill_enabled = false WHERE id = $1", [
+      fx.teamId,
+    ]);
+
+    // Materialised, empty — exactly what an opted-out team carries.
+    await ensureLineups(fx.client, fx.leagueId, WEEK, BEFORE_ANYTHING);
+    const [row] = await fx.client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM lineups
+        WHERE team_id = $1 AND week = $2 AND player_id IS NULL`,
+      [fx.teamId, WEEK],
+    );
+    expect(row?.n).toBe(9);
+
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+      now: BEFORE_ANYTHING,
+    });
+
+    const after = await loadLineup(fx.client, fx.teamId, WEEK, fx.rules);
+    expect(after.find((slot) => slot.slotType === "QB")?.playerId).toBe(
+      fx.players.get("sun-qb"),
+    );
+  });
+
   it("does not touch a slot the opted-out manager set themselves", async () => {
     // The switch means "do not choose for me", not "do not let me choose".
     const fx = await setup();
@@ -1354,6 +1402,27 @@ describe("a lineup that moves under the manager — #100", () => {
    * Keyed on the `FOR UPDATE` statement rather than on `BEGIN`, because that is
    * the first thing inside the transaction and leaves the snapshot already taken.
    */
+  /*
+    Runs `interfere` immediately before the transaction's `FOR UPDATE` executes.
+
+    **What this proves and what it does not.** PGlite is a single connection, so
+    the "other writer" runs on the *same* session as the transaction it is
+    interfering with. Two consequences, both stated because neither is obvious
+    and one of them makes an assertion here weaker than it reads:
+
+    - The interference lands after the snapshot at `loadLineup` and before the
+      lock is taken, which is the window the **compare-and-swap** closes. So
+      these tests pin the CAS. They say nothing about the row lock — no test in
+      this repo can, and deleting `FOR UPDATE` fails them only because the hook
+      keys on that SQL text.
+    - The interferer's own `withTransaction` issues a real `COMMIT` on the shared
+      connection, which commits the outer transaction too. So a test here cannot
+      demonstrate that `setLineup` is atomic; a `ROLLBACK` afterwards would not
+      undo what the loop had already written.
+
+    Both are limits of the harness rather than of the code, and both were found
+    by the #100 re-audit rather than being known when this was written.
+  */
   function interferingAt(client: PGliteClient, interfere: () => Promise<void>): PGliteClient {
     let fired = false;
     return new Proxy(client, {
@@ -1432,6 +1501,54 @@ describe("a lineup that moves under the manager — #100", () => {
     const after = await loadLineup(fx.client, fx.teamId, WEEK, fx.rules);
     const held = after.find((slot) => slot.slotType === "QB");
     expect(held?.playerId).toBe(fx.players.get("thu-qb"));
+  });
+
+  it("does not revert another writer's change to a slot it did not touch", async () => {
+    /*
+      **The hole the unchanged-slot exemption left, and it defeated the fix in
+      its own headline scenario.**
+
+      The test below asserts that submitting a slot at the value you read is not
+      refused — correct, and it is uncontended, so it could not see what the
+      write actually did. Unchanged slots were written with no `WHERE`, which
+      reverts a concurrent write rather than ignoring it.
+
+      Here the manager changes RB while the autofill fills the QB slot their
+      snapshot showed as empty. The QB assignment is unchanged from that
+      snapshot, so it must neither refuse nor overwrite.
+    */
+    const fx = await setup();
+
+    const client = interferingAt(fx.client, async () => {
+      await setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        now: BEFORE_ANYTHING,
+      });
+    });
+
+    // The whole-snapshot save the editor sends: QB as it was read (empty), RB
+    // changed. Only the RB assertion is the manager's.
+    await expect(
+      setLineup(client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [
+          { slotType: "QB", slotIndex: 0, playerId: null },
+          { slotType: "RB", slotIndex: 0, playerId: fx.players.get("rb-a") },
+        ],
+        now: BEFORE_ANYTHING,
+      }),
+    ).resolves.toBeDefined();
+
+    const after = await loadLineup(fx.client, fx.teamId, WEEK, fx.rules);
+    expect(after.find((slot) => slot.slotType === "QB")?.playerId).toBe(
+      fx.players.get("thu-qb"),
+    );
+    expect(after.find((slot) => slot.slotType === "RB")?.playerId).toBe(fx.players.get("rb-a"));
   });
 
   it("still accepts a save that changes nothing about the moved slot", async () => {

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -13,6 +13,15 @@
  * refuses any change to them — so starting a player after seeing him score is
  * rejected regardless of what the client believed.
  *
+ * **That read is taken before the transaction opens, and it is worth being exact
+ * about what follows from it.** The lock decision is made against a snapshot,
+ * not against rows the request holds a lock on; what closes the gap is the
+ * per-slot compare on the way out, which refuses a slot that moved in between
+ * (`LINEUP_MOVED`) and skips one the request asserted nothing about. So a
+ * crafted request gets the same answer as the screen for every rule the lock
+ * expresses — and can additionally be told to try again, which the screen never
+ * is. Issue #100, and its re-audit.
+ *
  * ## A team always has a lineup by kickoff
  *
  * `resolveWeek` throws if a scheduled team has no lineup, deliberately: scoring
@@ -110,10 +119,12 @@ export class LineupError extends Error {
       /**
        * The stored lineup moved between validation and the write. **Retryable.**
        *
-       * Issue #100. `setLineup` validated against a snapshot taken before its
-       * transaction opened, so a manager whose PUT was in flight while the
-       * score-week cron's autofill committed had their lock check evaluated
-       * against a slot that was empty when they looked and is not any more.
+       * Issue #100. `setLineup` validates against a snapshot taken before its
+       * transaction opens — still, deliberately, so that nothing slow is done
+       * under a row lock — so a manager whose PUT is in flight while the
+       * score-week cron's autofill commits can have their lock check evaluated
+       * against a slot that was empty when they looked and is not any more. This
+       * is how that is caught, rather than how it was.
        *
        * Distinct from `INVALID_LINEUP` because the two need opposite responses:
        * an illegal lineup must be shown to the person so they can change it, and
@@ -701,19 +712,43 @@ export async function setLineup(
       const key = `${assignment.slotType}#${assignment.slotIndex}`;
       const expected = byKey.get(key) ?? null;
 
-      // Unchanged slots are written without a guard. They assert nothing about
-      // the state, so a concurrent write to one is not a conflict — and guarding
-      // them is what would break the editor's whole-lineup save.
-      if (expected === assignment.playerId) {
-        await tx.query(
-          `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id, locked_at)
-           VALUES ($1, $2, $3, $4, $5, NULL)
-           ON CONFLICT (team_id, week, slot_type_id, slot_index)
-           DO UPDATE SET player_id = EXCLUDED.player_id`,
-          [input.teamId, input.week, slotTypeId, assignment.slotIndex, assignment.playerId],
-        );
-        continue;
-      }
+      /*
+        An unchanged slot is **skipped**, not written.
+
+        The principle was already right here and the code did the opposite of it.
+        The comment read "they assert nothing about the state, so a concurrent
+        write to one is not a conflict" — and then wrote the value anyway, with
+        no `WHERE`, which is precisely how you assert something about the state:
+        it reverted whatever another writer had put there in the meantime.
+
+        The common instance is `null === null`, because the editor posts every
+        slot on every change. So the sequence the whole fix was written for —
+        read the lineup, the autofill commits a player into an empty slot, write
+        — clobbered that slot back to empty. And it did so **past the lock**: the
+        `FOR UPDATE` above had by then locked a row holding a player whose game
+        had kicked off, and `validateLineup` had already passed, because the
+        snapshot it judged said the slot was empty and an empty slot never locks.
+        That is the "a locked slot may not be emptied" bypass this module names
+        two hundred lines up, arriving through the write loop instead of the
+        validator.
+
+        Skipping rather than guarding, and the reason is not the one the
+        original comment gave. It said a whole-lineup compare "would refuse every
+        save issued within thirty seconds of an autofill pass", which is false:
+        the CAS baseline is not the client's snapshot but `current`, the server's
+        own read taken milliseconds earlier in the same request. A compare on
+        every slot would refuse only when something moved inside that window.
+
+        The real reason is smaller and holds: refusing the manager's whole save
+        because a slot they never touched moved is charging them for another
+        writer's timing. They asserted nothing about it, so we write nothing to
+        it, and whatever the other writer decided stands.
+
+        Nothing depends on the row existing. `loadLineup` synthesises an entry
+        for every starting slot whether or not a row is there, and `resolveWeek`
+        is preceded by `ensureLineups`, which materialises them.
+      */
+      if (expected === assignment.playerId) continue;
 
       const written = await tx.query<{ slot_index: number }>(
         `INSERT INTO lineups (team_id, week, slot_type_id, slot_index, player_id, locked_at)
@@ -1072,9 +1107,11 @@ export async function autoFillLineup(
  * tidy. The ordinary case is an empty slot, so the compared value is `NULL`, and
  * `NULL = NULL` is `NULL` rather than true — `=` would refuse to fill any row
  * that had ever been materialised, which is every slot the autofill itself could
- * not fill on an earlier pass. The `::uuid` cast goes with it: beside a `uuid`
- * column a bare parameter is `unknown` on the null path and Postgres cannot
- * resolve the operator.
+ * not fill on an earlier pass. The `::uuid` cast is kept for explicitness, not because it is required. This was
+ * described here as load-bearing — "beside a uuid column a bare parameter is
+ * unknown on the null path and Postgres cannot resolve the operator" — and
+ * `setLineup`'s copy of this compare omits it and resolves against both PGlite
+ * and Postgres. One of the two had to be wrong; measured, it was this sentence.
  *
  * **Not `WHERE lineups.player_id IS NULL`.** "Only ever fill an empty slot" is
  * the tempting simplification and it is wrong twice: it forbids evicting a


### PR DESCRIPTION
The five-agent re-audit of #100. The compare-and-swap is real — but it **exempted unchanged slots, and the commit's own narrated attack goes straight through the exemption.**

## The hole

`LineupEditor` posts every slot on every save, so a slot the manager did not touch arrives carrying the value their page last showed — `null` for an empty one. Now run the sequence #224's commit message describes:

1. the PUT reads RB1 as empty
2. the score-week autofill commits a mid-game player into RB1
3. the manager's write lands

`expected` is `null`, the submitted value is `null`, so the guard was skipped and the slot written with **no `WHERE`** — blanking the player the autofill had just placed.

Past the row lock, which by then held a row the code had decided not to look at. Past `validateLineup`, which judged an empty slot that no longer existed, and whose emptiness is exactly why `isSlotLocked` returned false. That is the *"a locked slot may not be emptied"* bypass this module names 200 lines up, arriving through the write loop instead of the validator — and it reopens the lock for the **next** request, since the slot now reads empty.

The exemption's comment had the principle right and the code did the opposite of it:

> They assert nothing about the state, so a concurrent write to one is not a conflict

…and then wrote the value anyway. Unchanged slots are now **skipped**.

Its stated justification was also false: *"a whole-lineup compare would refuse every save issued within thirty seconds of an autofill pass."* The baseline is not the client's snapshot — it is the server's own read, taken milliseconds earlier in the same request.

## The retry reverted the other writer

It diffed the stale slot list against the fresh one and kept the stale value wherever they differed — the slot the manager changed **and** every slot somebody else had moved. Its comment claimed to be *"keeping this manager's own change and taking everything else from the refresh."*

| the other writer's slot | result |
|---|---|
| unlocked | silently undid the autofill |
| locked | 422 naming a slot the manager never touched — the un-actionable message the retry exists to prevent |

`applyLineupEdit` (`apps/web/src/lib/lineup-edit.ts`) now carries the decision as a decision and applies it to whatever the server holds. **Same function builds the first attempt**, so there is one definition of what a change means. In `lib/` with 7 tests — `apps/web` has no jsdom, and a rule reached only by a race is otherwise verified only in production.

## A one-character mutation was green and would have bricked lineup editing

`IS NOT DISTINCT FROM $6` → `= $6`. `NULL = NULL` is `NULL`, the compare matches nothing, and every autofill-off manager gets `LINEUP_MOVED` **forever** — the rows `ensureLineups` materialises hold null.

`setLineupUnchecked` has carried a test for exactly this since it was written. #224 copied the compare and not the test. Copied now, with the ordering that makes it discriminating: `ensureLineups` first, *then* the manager fills the row.

Both new tests mutation-checked:

```
IS NOT DISTINCT FROM -> =        → 1 failed: "fills a slot whose row already exists holding null"
restore the unguarded write      → 1 failed: "does not revert another writer's change to a slot it did not touch"
```

## Four corrected claims

| Claim | Measured |
|---|---|
| "validates the kickoff lock against state it holds a lock on" | the read is still outside the transaction; the CAS is what detects movement |
| "the ten minutes since this screen last polled" | `refreshInterval: 30_000` |
| `SCHEDULE_MISSING` "fell through to 400 with no diagnosis" | the catch already returned the message, and #98 says so itself. **#98 asks for 503**, so it stays open |
| the `::uuid` cast is required | the copy omitting it resolves against both PGlite and Postgres — the docstring was the wrong half |

## What no test here can show

`interferingAt` now says so. PGlite is a single connection, so the staged "other writer" shares the session under test and its `COMMIT` commits that transaction. The race tests pin the **compare**; nothing pins the row lock, and `setLineup`'s atomicity is not demonstrable in this harness.

## Filed, not fixed

[#240](https://github.com/6figpsolseeker/rostr/issues/240) — the autofill can start a player whose game is already under way, locking the manager out of a slot they still held for hours. No race required, and it is what puts a locked player into an empty-looking slot in the first place.

---

2193 tests (was 2184). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
