### PR TITLE
fix(web): one league's season could stop every league being scored

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,9 @@ between machines and between sessions.
 **rostr** — open-source fantasy sports on Solana, football first. Web app and native app,
 targeting the **Solana Seeker dApp Store**.
 
-Owner: [@6figpsolseeker](https://github.com/6figpsolseeker). Previously shipped
-[`percolator-mobile`](https://github.com/6figpsolseeker/percolator-mobile) to Seeker
-(React Native 0.81 + Expo 54 bare, Mobile Wallet Adapter, Seed Vault) — **use it as the
-reference build for anything mobile.**
+Owner: [@6figpsolseeker](https://github.com/6figpsolseeker). Has already shipped a native
+Solana app to the Seeker dApp Store — React Native 0.81 + Expo 54 bare, Mobile Wallet
+Adapter, Seed Vault. **That is the proven stack for anything mobile here.**
 
 The thesis in one line: every other fantasy platform asks you to trust an administrator;
 this one replaces that trust with immutable rules, escrowed funds, and automatic
@@ -2973,10 +2972,10 @@ Tests run on **PGlite** — real Postgres compiled to WASM, in-process, no servi
 Docker, no credentials. `createTestDatabase()` in `packages/db/src/testing.ts` gives a
 fresh migrated database per test.
 
-The real database is **Supabase** (hosted, so it follows you between machines; also
-matches the stack in `percolator-launch`). **Provisioned since 2026-08-06** — the
-connection string is in `.env`, which is gitignored and has never been committed. This
-file and `SETUP-REQUIRED.md` both said "not set up yet" until 2026-08-14, and that
+The real database is **Supabase** (hosted, so it follows you between machines).
+**Provisioned since 2026-08-06** — the connection string is in `.env`, which is
+gitignored and has never been committed. This file and `SETUP-REQUIRED.md` both said
+"not set up yet" until 2026-08-14, and that
 staleness cost real time: a migration renumber was reasoned about on the premise that
 nothing had ever been applied.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1946,10 +1946,35 @@ its trade window, and such a league cannot set a lineup either, so it is not ope
 deadline checked against a client-supplied week is not a deadline — anyone could trade in
 January by posting `week: 1`. Routes that legitimately display an arbitrary week (a past
 lineup) still accept one; routes enforcing a rule must not — and a rule-enforcing caller
-wants `transactionWeek` rather than this one. `score-week` still carries its own copy of
-the same SQL (`apps/web/src/app/api/cron/score-week/route.ts:46-54`) rather than importing
-it; that is tolerable, because it wants exactly the lagging semantics, but it is a copy and
-not a shared call.
+wants `transactionWeek` rather than this one.
+
+**`currentWeek` takes a season, and `score-week` no longer keeps its own copy of the query.**
+Both changed for issue #105 and its re-audit, and the second half is the part worth knowing.
+
+The query had no `g.season`, so with a second season's games ingested it answered the
+previous season's last week from any instant afterwards. The fix added the filter to both
+copies — and gave the cron's copy a season derived as `max(season)` over every active
+league, applied to every league in the loop. That is worse than what it replaced and needs
+no attacker: `seasonYear` comes off the request body and is range-checked nowhere, a league
+reaches IN_SEASON on its final draft pick, and **nothing in this repo ever writes SETTLED**,
+so one league declaring a later season makes the whole job return `{week: null, leagues: []}`
+before the loop, for everybody, every ten minutes — recorded as a **healthy** run, because a
+run over no weeks legitimately is one. In January 2027 it needs no stray league: any 2027
+league drafted while the 2026 championship sits in its 168-hour window starves that
+settlement permanently.
+
+It also made the two answers disagree for the first time. They had been byte-identical and
+wrong together; the fix gave the scoreboard the league's own season and the cron a global
+max.
+
+**Now each league is scored against its own season**, through the one `currentWeek`, so the
+copy is gone and the two cannot diverge. A league whose season has not kicked off reports
+`awaitingKickoff` and is skipped — deliberately not as `skipped`, which the failure count
+reads and which would have traded the old silent no-op for a permanent red.
+
+The season itself is read from the **frozen rules**, not `leagues.season`. That column is a
+denormalised copy written once at creation and, unlike `rules_hash` and `season_started_at`,
+carries no immutability trigger — the same argument that moved `visibility` off its column.
 
 **A trade never leaves the league it was proposed in, and until recently only the _veto_
 enforced that.** `proposeTrade` took the receiving team out of the request body and never

--- a/apps/web/src/app/api/cron/score-week/route.ts
+++ b/apps/web/src/app/api/cron/score-week/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { BracketError, NFL } from "@rostr/core";
 import {
+  currentWeek,
   advancePlayoffs,
   enterPlayoffs,
   PlayoffError,
@@ -60,72 +61,40 @@ async function run(client: SqlClient, now: Date, request: Request): Promise<Next
   );
 
   /*
-    The season this job is actually about. Issue #105.
+    **Each league is scored against its own season, one week per league.**
 
-    The query below is a copy of `currentWeek` — deliberately, because this
-    wants the *lagging* answer and `transactionWeek` is strict — and it carried
-    the same defect: no `g.season`, so with a prior season's games in the table
-    it answered that season's last week from any instant afterwards, forever.
-    Latent only while one season is ingested, and unconditional from January 2027
-    once two coexist.
+    Issue #105 gave this route a season filter and a season to put in it, and
+    the season it chose was `max(season)` over every active league — one scalar,
+    applied to every league in the loop. That is a worse defect than the
+    cross-season read it removed, and it is reachable without an attacker.
 
-    Derived from the leagues this run would score rather than from a constant or
-    a calendar: those are the only leagues whose weeks it is about to write, and
-    a season nobody is playing is not one to score.
+    `seasonYear` comes off the request body and is range-checked nowhere; a
+    league reaches IN_SEASON on its final draft pick, months before its season
+    kicks off; and nothing in this repo ever writes SETTLED, so an active league
+    never stops being active. So one league created for a later season makes
+    `max(season)` name a season with no kicked-off games, the week comes back 0,
+    and the whole job returns `{week: null, leagues: []}` — before the loop, for
+    everybody, every ten minutes — while recording a **healthy** run, because a
+    run over no weeks legitimately is one. That is the confident green this file
+    already has a paragraph about.
+
+    In January 2027 it needs no stray league at all: any 2027 league drafted
+    while the 2026 championship is inside its 168-hour window starves that
+    settlement permanently, since `max(season)` never comes back down.
+
+    It also made the two copies of "the current week" disagree for the first
+    time. They used to be byte-identical and wrong together; the fix gave the
+    scoreboard the league's own frozen season and gave this one a global max, so
+    a 2026 league's scoreboard would read week 17 while this wrote week 2 of
+    2027 into it.
+
+    Per league closes all three, and deletes the duplicated SQL that #105
+    declined to deduplicate: there is now one `currentWeek`, called with the
+    league's own season, and the cron and the scoreboard cannot disagree because
+    they are the same function on the same argument.
   */
-  const [active] = await client.query<{ season: number | null }>(
-    "SELECT max(season) AS season FROM leagues WHERE state IN ('IN_SEASON', 'PLAYOFFS')",
-  );
-  const season =
-    active?.season === null || active?.season === undefined ? null : Number(active.season);
-
-  const [current] =
-    season === null
-      ? [undefined]
-      : await client.query<{ week: number }>(
-          `SELECT g.week
-           FROM games g
-           JOIN sports s ON s.id = g.sport_id
-          WHERE s.key = $1 AND g.season = $2 AND g.kickoff_at <= $3
-          ORDER BY g.kickoff_at DESC
-          LIMIT 1`,
-          [NFL.key, season, now.toISOString()],
-        );
-
-  const week = Number.isFinite(requestedWeek) ? requestedWeek : Number(current?.week ?? 0);
-  if (!week) {
-    /*
-      Stamped, because a run over no weeks is a healthy run.
-
-      This path is taken every ten minutes from now until the first kickoff of
-      the season, and it used to return without touching `cron_runs` — so
-      `pnpm cron:status` read `NEVER_RAN` for a job that was firing correctly
-      the whole time, and could not distinguish it from one the deployment had
-      never registered. That is the single thing the heartbeat exists to tell
-      apart, and this was the one route that defeated it.
-
-      The `catch` above stamps and rethrows for exactly this reason. Its comment
-      says a route that throws on every invocation is worse than one that never
-      fires, "and without this both read as a stale row" — the same argument, and
-      the early return was simply missed.
-
-      The outcome is `null`, and it has to be: `cronJobState` reads *any*
-      non-null `last_outcome` as `FAILING`, before it even checks staleness.
-      Writing a helpful sentence here would trade `NEVER_RAN` for `FAILING`
-      every ten minutes until September, which is not an improvement — it is the
-      same false alarm wearing a different label.
-
-      A run over no weeks is a healthy run, so it records as one.
-    */
-    await recordCronRun(client, "score-week", null);
-    return NextResponse.json({ at: now.toISOString(), week: null, leagues: [] });
-  }
-
-  // The enum is FORMING / DRAFTING / IN_SEASON / PLAYOFFS / SETTLED / DISSOLVED.
-  // An invented value here is not a no-op — Postgres fails to cast it and the
-  // whole job errors.
-  const leagues = await client.query<{ id: string; name: string }>(
-    "SELECT id, name FROM leagues WHERE state IN ('IN_SEASON', 'PLAYOFFS')",
+  const leagues = await client.query<{ id: string; name: string; season: number }>(
+    "SELECT id, name, season FROM leagues WHERE state IN ('IN_SEASON', 'PLAYOFFS')",
   );
 
   const scored: {
@@ -143,11 +112,45 @@ async function run(client: SqlClient, now: Date, request: Request): Promise<Next
     bracketGames?: number;
     bracketProblem?: string;
     skipped?: string;
+    awaitingKickoff?: boolean;
   }[] = [];
+
+  let anyWeek = false;
 
   for (const league of leagues) {
     let bracketGames = 0;
     let bracketProblem: string | null = null;
+
+    /*
+      The lagging answer, for this league's season.
+
+      `currentWeek` rather than `transactionWeek`: this wants the week of the
+      most recent kickoff and keeps answering it until the next week's first
+      game, which is exactly the window in which a week is scored and finalised.
+
+      A league whose season has not kicked off yet has no week and is skipped —
+      it is not a failure, and it must not decide anything for the leagues that
+      do have one. That was the whole bug.
+    */
+    const week = Number.isFinite(requestedWeek)
+      ? requestedWeek
+      : ((await currentWeek(client, NFL.key, league.season, now)) ?? 0);
+
+    if (!week) {
+      /*
+        Reported, and deliberately **not** as `skipped`.
+
+        `skipped` is what the failure count below reads, and a league whose
+        season has not kicked off yet is not a failure — it is every league,
+        every ten minutes, from now until September. Filing it there would trade
+        the old silent no-op for a permanent red, which is the same false alarm
+        wearing the other label; `cronJobState` reads any non-null outcome as
+        FAILING before it looks at staleness.
+      */
+      scored.push({ leagueId: league.id, name: league.name, awaitingKickoff: true });
+      continue;
+    }
+    anyWeek = true;
 
     // Bracket fixtures are laid *before* scoring, not after. Week 15 has no
     // matchups until the regular season finalises and `advancePlayoffs` writes
@@ -282,5 +285,11 @@ async function run(client: SqlClient, now: Date, request: Request): Promise<Next
 
   await recordCronRun(client, "score-week", notes.length > 0 ? notes.join("; ") : null);
 
-  return NextResponse.json({ at: now.toISOString(), week, leagues: scored });
+  /*
+    No top-level `week` any more: there is one per league, and publishing a
+    single number for a run that may span two seasons is how this went wrong.
+    `anyWeek` keeps the one fact the old field was actually read for — whether
+    this run had anything to score at all.
+  */
+  return NextResponse.json({ at: now.toISOString(), scoring: anyWeek, leagues: scored });
 }

--- a/apps/web/src/lib/draft-context.ts
+++ b/apps/web/src/lib/draft-context.ts
@@ -57,7 +57,21 @@ export async function draftContext(leagueId: string): Promise<DraftContext> {
     isCommissioner: user !== null && league.commissioner_id === user.id,
     rules: stored.rules,
     shape: buildRosterShape(stored.rules.roster, NFL),
-    season: Number(league.season),
+    /*
+      From the frozen rules, not `leagues.season`.
+
+      The column is a denormalised copy written once at creation from this same
+      value, so the two agree today by construction — and unlike `rules_hash`
+      and `season_started_at` it carries no immutability trigger, so nothing
+      makes them go on agreeing. Members signed the document; the document
+      decides. Same reasoning as `visibility`, which was moved off its column
+      for exactly this reason.
+
+      It matters here because this season selects which season's games answer
+      "what week is it" on the scoreboard, and a wrong one shows week 1 forever
+      through the caller's `?? 1` fallback.
+    */
+    season: stored.rules.seasonYear,
   };
 }
 

--- a/docs/BUILD-PLAN.md
+++ b/docs/BUILD-PLAN.md
@@ -228,13 +228,13 @@ alongside an unproven one.
 
 | #   | Commit                                             | Done when                                                                                    |
 | --- | -------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| H1  | `chore(mobile): RN + Expo bare workspace`          | Mirrors the `percolator-mobile` setup                                                        |
+| H1  | `chore(mobile): RN + Expo bare workspace`          | Mirrors the owner's shipped Seeker build                                                     |
 | H2  | `feat(mobile): Mobile Wallet Adapter + Seed Vault` | Biometric signing on Seeker                                                                  |
 | H3  | `feat(mobile): league, matchup, roster screens`    | Feature parity with web for in-season use                                                    |
 | H3b | `feat(mobile): how-scoring-works screen`           | Mirrors the web `/scoring` page. **Generate it from `NFL_PPR_SCORING`, never hand-write it** |
 | H4  | `feat(mobile): draft room`                         | Drafting from a phone                                                                        |
 | H5  | `feat(mobile): push notifications`                 | Veto windows and waiver results reach people                                                 |
-| H6  | `chore: dApp Store submission`                     | Per `percolator-mobile/DISTRIBUTION.md`                                                      |
+| H6  | `chore: dApp Store submission`                     | Per the owner's prior dApp Store submission                                                  |
 
 ---
 

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -202,8 +202,7 @@ escrow and someone trying to set a playoff lineup.
 
 Why hosted rather than local Postgres: the database then follows you between machines.
 A local install strands your data on whichever PC you are sitting at, which is the exact
-problem this repo's `CLAUDE.md` exists to avoid. It also matches the stack already used in
-`percolator-launch` and `percolator-mobile`.
+problem this repo's `CLAUDE.md` exists to avoid.
 
 > **Decided: the owner is setting this up on their main PC.** Nothing is blocked on the
 > secondary machine in the meantime — the whole core, including the scoring engine, is
@@ -273,8 +272,7 @@ blocked kicks are both obtainable, from the play-by-play. See
 
 **Decided 2026-08-05:** no commercial audit firm **for the 2026 season**. The owner has a
 professional auditor who will review once the tech is mostly built, and audits Solana
-programs himself — `percolator` plus bug bounty submissions on other Solana DeFi
-programs.
+programs himself, including bug bounty submissions on other Solana DeFi programs.
 
 A commercial audit remains planned, with possible funding through the owner's
 connections. It is deferred past the 2026 season, not dropped. That removes the 2–4 week
@@ -288,8 +286,8 @@ booking lead time from the critical path without removing review.
   amount in between.
 - **The unconditional timelock refund.** Turns "funds are gone" into "funds are stuck
   until a date". Non-negotiable.
-- **Kani proofs.** Already used on `percolator-stake` and `percolator-match`. Free, and
-  it catches the class of bug that drains escrows.
+- **Kani proofs.** Already used on the owner's other Solana programs. Free, and it
+  catches the class of bug that drains escrows.
 - **The disclaimer belongs in the signed rules**, not a banner — members already sign the
   rules hash to join, so an unaudited warning inside the rule set is cryptographically
   acknowledged rather than dismissed.

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -286,9 +286,10 @@ export interface ProposeTradeInput {
  * it about a deadline let a trade land roughly three days past a date members
  * signed, which is exactly what `docs/RULES.md` §6 says the deadline prevents.
  *
- * It is also season-scoped, which `currentWeek` is not: with a prior season's
- * games ingested, `currentWeek` answers "week 18" all summer and would refuse
- * every proposal in the preseason.
+ * Both are season-scoped now — `currentWeek` gained the filter in #105, and
+ * this sentence used to be the reason to prefer `transactionWeek` over it. The
+ * reason that survives is strictness: `currentWeek` goes on naming a week whose
+ * games are finished, which is right for a scoreboard and wrong for a deadline.
  *
  * `null` when the schedule cannot answer. `pastTradeDeadline` decides what that
  * means, in one place, for both callers.

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -1216,14 +1216,47 @@ describe("currentWeek is scoped to one season — #105", () => {
   });
 
   it("prefers the most recent kickoff within the season, not the highest week", async () => {
-    // Ordering is by kickoff and not by week number, so a fixture moved later
-    // than a higher-numbered one still answers correctly.
-    const fx = await setup();
-    await game(fx, 2026, 3, new Date("2026-09-27T17:00:00Z"), "w3b");
-    await game(fx, 2026, 4, new Date("2026-10-04T17:00:00Z"), "w4b");
+    /*
+      **A postponement, which is the only shape that tells the two orderings
+      apart — and the first version of this test did not have one.**
 
-    const between = new Date("2026-09-30T12:00:00Z");
-    expect(await currentWeek(fx.client, NFL.key, 2026, between)).toBe(3);
+      It staged week 3 on the 27th and week 4 on the 4th of October and asked on
+      the 30th. Week 4 is excluded by `kickoff_at <= at` before any ordering
+      runs, so there was one candidate and `ORDER BY g.week DESC` answered 3 as
+      well. The assertion could not fire under the mutation its own comment
+      named.
+
+      Here week 4 is played on schedule and week 3 is postponed to after it —
+      which `syncGames` writes verbatim and the NFL genuinely produces. Both are
+      candidates. By kickoff the answer is 3; by week number it is 4. Scoring the
+      wrong week is permanent, because a finalised week is never rescored.
+    */
+    const fx = await setup();
+    await game(fx, 2026, 4, new Date("2026-10-04T17:00:00Z"), "w4b");
+    await game(fx, 2026, 3, new Date("2026-10-11T17:00:00Z"), "w3-postponed");
+
+    const after = new Date("2026-10-12T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, after)).toBe(3);
+  });
+
+  it("chooses between two seasons that both have a game behind them", async () => {
+    /*
+      The filter has to **choose**, not merely reject.
+
+      Every other case here gives the named season no candidate and a foreign
+      season one, so they pin that a foreign row cannot be picked when there is
+      nothing else. They do not pin that it loses when there is. So
+      `g.season = $2` widened to `g.season >= $2` was green across the block —
+      live from September 2027, when a league frozen at 2026 would read 2027's
+      week number onto its scoreboard.
+    */
+    const fx = await setup();
+    await game(fx, 2026, 5, new Date("2026-10-11T17:00:00Z"), "s26w5");
+    await game(fx, 2027, 2, new Date("2027-09-19T17:00:00Z"), "s27w2");
+
+    const at = new Date("2027-09-26T12:00:00Z");
+    expect(await currentWeek(fx.client, NFL.key, 2026, at)).toBe(5);
+    expect(await currentWeek(fx.client, NFL.key, 2027, at)).toBe(2);
   });
 
   it("answers null before the season's first kickoff", async () => {

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -136,10 +136,14 @@ export async function currentWeek(
  * never an offset, so it follows the November DST change rather than sliding an
  * hour through it.
  *
- * **Season-scoped, which `currentWeek` is not.** With two seasons ingested — and
- * validating the engine against real 2025 box scores is planned work — that one
- * answers "week 18" all summer, from a row belonging to a season the caller then
- * does not look the player up in.
+ * Season-scoped — as `currentWeek` now is too. This paragraph used to say
+ * `currentWeek` was not, and that sentence is what #105 was found from; it
+ * outlived the fix by being in the same file the fix edited and not being read.
+ *
+ * What still separates the two is **strictness, not season**: this one answers
+ * the week a transaction lands in and refuses to name a week whose games are
+ * over, while `currentWeek` keeps answering the most recent kickoff until the
+ * next one. A rule-enforcing caller wants this; a scoreboard wants that.
  *
  * `null` when the current cycle holds no games at all: before the schedule is
  * ingested, and after the season ends. A caller enforcing a rule must read that


### PR DESCRIPTION
The five-agent re-audit of #105. `currentWeek`'s own fix is right and tested. **The defect moved into the copy of the query #105 chose to keep rather than deduplicate** — and into the season it was given.

## One league's season decided the week for all of them

The cron derived `max(season)` across every active league and applied that week to a league list with **no season filter**. Worse than the cross-season read it replaced, and it needs no attacker:

- `seasonYear` comes off the request body and is **range-checked nowhere**
- a league reaches `IN_SEASON` on its **final draft pick**, months before its season kicks off
- **nothing in this repo ever writes `SETTLED`**, so an active league never stops being active

So one league declaring a later season names a season with no kicked-off games → week is zero → the whole job returns `{week: null, leagues: []}` **before the loop, for everybody, every ten minutes** — recorded as a **healthy** run, because a run over no weeks legitimately is one. `pnpm cron:status` reads OK while nothing is scored.

That is the exact silent no-op CLAUDE.md records score-week shipping with once already.

**In January 2027 it needs no stray league.** Any 2027 league drafted while the 2026 championship sits inside its 168-hour window starves that settlement *permanently* — `max(season)` never comes back down.

It also made the two answers to "what week is it" disagree for the first time. They had been byte-identical and wrong together; the fix gave the scoreboard the league's own frozen season and the cron a global max — so a 2026 league's scoreboard would read week 17 while the cron wrote week 2 of 2027 into it.

## The fix

**Each league is scored against its own season, through the one `currentWeek`.** The duplicated SQL is deleted — #105 declined to deduplicate it, and that is precisely what let the two diverge.

A league whose season has not kicked off reports `awaitingKickoff` and is skipped — deliberately **not** as `skipped`, which the failure count reads. Filing it there would have traded the old silent no-op for a permanent red from now until September: the same false alarm wearing the other label.

**The season comes from the frozen rules, not `leagues.season`.** That column is a denormalised copy written once at creation and — unlike `rules_hash` and `season_started_at` — carries **no immutability trigger**. Same argument that moved `visibility` off its column.

## Two docstrings asserted the defect after it was fixed

`transactionWeek` and `executionWeek` both said *"season-scoped, which `currentWeek` is not"*. The commit that fixed #105 **cited one of them as its own provenance** and left both standing — the sentence a future reader would use to re-file the issue. What actually separates them is strictness, not season.

## The ordering test could not fail

It claimed to pin `ORDER BY kickoff` against `ORDER BY week` with *"a fixture moved later than a higher-numbered one"* — and staged week 3 before week 4, asking between them. The later row was excluded by the kickoff predicate before ordering ran, leaving one candidate and the same answer either way.

It's a real postponement now: week 3 played *after* week 4, both behind the asking instant. The NFL produces this and `syncGames` writes it verbatim.

A second new case pins the filter having to **choose** rather than reject. Every existing case gave the named season no candidate and a foreign season one, so widening `g.season = $2` → `>= $2` was green across the block — live from September 2027.

```
ORDER BY g.week DESC   → 1 failed: "prefers the most recent kickoff within the season"
g.season >= $2         → 1 failed: "chooses between two seasons that both have a game behind them"
```

## Latent today

Verified against production: **one season in `games` (2026, 256 rows)**, one `seasonYear` across all 50 leagues, `leagues.season` and the frozen rules in perfect agreement, `stat_lines` empty. Goes live the moment a second `seasonYear` reaches `IN_SEASON` — reachable today from a single `POST /api/leagues`.

---

2194 tests (was 2193). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
