### PR TITLE
fix(stats): the retry decided by reading its own error message

### DIFF
--- a/apps/web/src/app/api/cron/stats/route.ts
+++ b/apps/web/src/app/api/cron/stats/route.ts
@@ -29,7 +29,9 @@ import { runStatsJob } from "@/lib/jobs/stats";
  * The bounds that make a ten-minute cadence affordable are all in
  * `syncBoxScores` and were sized for it — `LIVE_WINDOW_HOURS` stops a game whose
  * status never advances being re-read for the rest of the season,
- * `MAX_GAMES_PER_RUN` caps the spend of one run, and the query's `ORDER BY`
+ * `MAX_GAMES_PER_RUN` caps how many games one run selects — and since #97 a
+ * game can cost up to three calls, so the spend ceiling is three times the game
+ * ceiling — and the query's `ORDER BY`
  * puts games with no box score first, then live ones, then the newest — so a
  * backlog of older failures cannot starve the current slate. (It ordered
  * oldest-first until the #140 re-audit, at which point #227's promotion of

--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -1058,5 +1058,15 @@ Outstanding questions, none blocking:
 - **`getNFLChangelog` returned empty** for a 3-day window. Its behaviour during
   an active season, and whether it is a usable stat-correction signal, is
   untested.
-- **Rate limits.** Basic is 1,000 calls/month. A live season is ~700 by our
-  estimate, so **Pro ($10/mo) before Week 1** is not optional.
+- **Rate limits.** The plan header says **1,000 per day**, not per month: a live
+  call on 2026-08-22 came back `x-ratelimit-requests-limit: 1000`,
+  `-remaining: 998`, `-reset: ~54000` (about fifteen hours), and a monthly window
+  would not reset in fifteen hours. This line said "1,000 calls/month" and
+  `docs/SETUP-REQUIRED.md` recorded the reading that contradicts it.
+
+**What a 429 looks like on the wire is still unrecorded.** Nobody here has
+observed one — the reading above came from a 200. So the client's handling of it
+is reasoned from RapidAPI's documented headers rather than from a captured
+response, and the burst-versus-quota split it now makes is the part to verify
+first if the retry ever misbehaves. A live season is ~700 by our
+estimate, so **Pro ($10/mo) before Week 1** is not optional.

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -66,9 +66,15 @@ export const LIVE_WINDOW_HOURS = 8;
 /**
  * The most games one run will fetch.
  *
- * A bound on *spend*, not on work: the provider is metered, a run makes one call
- * per game, and nothing else in this query limits how many games it can select
- * at once. A season backfill — `pnpm db:sync 2025`, which is a planned task —
+ * A bound on *spend*, not on work: the provider is metered and nothing else in
+ * this query limits how many games it can select at once.
+ *
+ * **It is not one call per game, and this said it was.** Since #97 the client
+ * retries a transient failure up to three times, so twenty games is a ceiling of
+ * sixty calls when the provider is refusing — which is exactly when the quota is
+ * the thing under pressure. The number here was chosen against the old
+ * arithmetic and has not been re-derived; what has changed is that the sentence
+ * no longer hides the multiplier from whoever re-derives it. A season backfill — `pnpm db:sync 2025`, which is a planned task —
  * puts every game of a played season inside the correction window at once,
  * because `final_at` is stamped when a game is first *observed* final rather
  * than when it was played. Without a ceiling the first run of that fetches
@@ -177,10 +183,13 @@ export async function syncBoxScores(
         -- either, and RULES.md section 10 already scores those players 0 through
         -- the absence of a stat line.
         AND g.status IN ('IN_PROGRESS', 'FINAL')
-        -- **Every clause here needs a ceiling.** This query is the only thing
-        -- pacing a metered provider — the loop below has no delay in it — so a
-        -- clause that can stay true indefinitely is a call every ten minutes
-        -- until the season ends.
+        -- **Every clause here needs a ceiling.** This query is the main thing
+        -- pacing a metered provider, so a clause that can stay true indefinitely
+        -- is a call every ten minutes until the season ends.
+        --
+        -- It used to say "the only thing" and "the loop below has no delay in
+        -- it". Neither survived #97: the client now sleeps between its own
+        -- attempts, and one selection here can cost up to three calls.
         AND (
               -- Never *attempted*. Keyed on the attempt rather than the sync
               -- since #227: a game that failed has no sync time, and selecting

--- a/packages/stats/src/tank01/client.test.ts
+++ b/packages/stats/src/tank01/client.test.ts
@@ -188,6 +188,22 @@ describe("retrying a request — #97", () => {
   }
 
   /** No wall-clock cost, and it records the waits so the shape can be asserted. */
+  /** A 429 carrying the headers RapidAPI sends when the window is spent. */
+  function spentQuota(resetSeconds: string) {
+    return vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 429,
+        headers: new Headers({
+          "x-ratelimit-requests-limit": "1000",
+          "x-ratelimit-requests-remaining": "0",
+          "x-ratelimit-requests-reset": resetSeconds,
+        }),
+        json: () => Promise.resolve({}),
+      } as unknown as Response),
+    );
+  }
+
   function recordingSleep() {
     const waits: number[] = [];
     return {
@@ -308,5 +324,199 @@ describe("retrying a request — #97", () => {
 
     await expect(client.get("getNFLBoxScore")).resolves.toEqual(["ok"]);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for real when nothing injects a clock", async () => {
+    /*
+      **The production backoff, which every other test here replaces.**
+
+      All the retry cases inject `sleepImpl`, so they assert that the client
+      *computes* 200 and 400 and hands them to something — not that anything
+      waits. Defaulting the sleep to `() => Promise.resolve()` passed all
+      nineteen of them, and a retry with no wait is a way to meet a burst limit
+      three times faster, which is the failure the retry exists to avoid.
+
+      Measured loosely: the assertion is that time passed at all, not how much.
+      A tighter bound would be a timing flake on a busy machine, and zero versus
+      six hundred milliseconds is the distinction worth having.
+    */
+    const fetchImpl = flaky(1, 429);
+    const client = new Tank01Client({ apiKey: "k", fetchImpl });
+
+    const started = Date.now();
+    await client.get("getNFLBoxScore", { gameID: "g" });
+
+    expect(Date.now() - started).toBeGreaterThanOrEqual(150);
+  });
+
+  it("does not retry a 429 whose window is hours away", async () => {
+    /*
+      A burst limit and a spent quota both arrive as 429 and need opposite
+      answers — the throw site says so in as many words, and then retried both.
+
+      With `remaining: 0` and a reset measured in hours, two more calls at 200ms
+      and 400ms cannot succeed. They are spent on the allowance that just
+      refused, at the moment it has none left, and the next tick will ask again
+      in ten minutes regardless.
+    */
+    const fetchImpl = spentQuota("54213");
+    const client = new Tank01Client({ apiKey: "k", fetchImpl });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).rejects.toThrow(/429/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries a 429 whose window rolls in seconds", async () => {
+    // The other side of the same header. A burst limit is exactly what the
+    // retry is for, and refusing to retry it would be the fix overshooting.
+    const fetchImpl = spentQuota("3");
+    const client = new Tank01Client({ apiKey: "k", fetchImpl, ...recordingSleep() });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).rejects.toThrow(/429/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries every 5xx, not only the one a test happened to stage", async () => {
+    /*
+      The predicate was a regex over the message — `/HTTP 5[0-9][0-9]/` — and 503
+      was the only status any test staged, so narrowing it to `/HTTP 503/` was
+      green. 500, 502 and 504 are the ordinary gateway failures and would have
+      silently stopped retrying, with a test still named "retries a 5xx".
+    */
+    for (const status of [500, 502, 504]) {
+      const fetchImpl = flaky(1, status);
+      const client = new Tank01Client({ apiKey: "k", fetchImpl, ...recordingSleep() });
+
+      await expect(client.get("getNFLBoxScore", { gameID: "g" })).resolves.toBeDefined();
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it("retries a connection lost while the body is arriving", async () => {
+    /*
+      **The half of "a socket reset mid-Sunday" that was not covered.**
+
+      `fetch` resolves at the headers and streams the rest, so a reset partway
+      through rejects at `response.json()` rather than at the call — and a box
+      score is the largest response this client asks for, tens of kilobytes over
+      many packets, which is precisely where it happens. The parse sat outside
+      every `try`, so it arrived as a bare `TypeError`, failed the
+      `instanceof ProviderError` check, and was thrown on attempt one.
+
+      The existing transport test resets at connection time, which is the shape
+      that was already handled.
+    */
+    let calls = 0;
+    const fetchImpl = vi.fn(() => {
+      calls++;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({}),
+        json: () =>
+          calls === 1
+            ? Promise.reject(new TypeError("terminated"))
+            : Promise.resolve({ statusCode: 200, body: { ok: true } }),
+      } as unknown as Response);
+    });
+
+    const client = new Tank01Client({ apiKey: "k", fetchImpl, ...recordingSleep() });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).resolves.toEqual({
+      ok: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an error Tank01 states in a 200 body", async () => {
+    /*
+      The predicate used to substring-match the message for "failed", and this
+      site interpolates provider text into it — so a Tank01 error string
+      containing that word decided our retry policy. Its comment claimed the
+      message was "composed in one place below", which this line disproves.
+
+      Deterministic errors about the request answer the same however often they
+      are asked.
+    */
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({}),
+        json: () => Promise.resolve({ statusCode: 200, error: "Request failed: bad gameID" }),
+      } as unknown as Response),
+    );
+
+    const client = new Tank01Client({ apiKey: "k", fetchImpl, ...recordingSleep() });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).rejects.toThrow(/bad gameID/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a rate limit declared inside a 200 body", async () => {
+    /*
+      The narrowing `randomness.ts` was rewritten to add, and CLAUDE.md records
+      the cost of not having: some providers answer a rate limit as HTTP 200
+      with the limit in the error body, "where the HTTP-status retry never sees
+      it" — so the retry never fires for the case it was added for.
+
+      `statusCode` has been on this envelope since it was written and was read
+      nowhere. Whether Tank01 uses it this way is unverified; handling it costs
+      nothing and not handling it costs the whole point.
+    */
+    let calls = 0;
+    const fetchImpl = vi.fn(() => {
+      calls++;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({}),
+        json: () =>
+          Promise.resolve(
+            calls === 1
+              ? { statusCode: 429, error: "Too many requests" }
+              : { statusCode: 200, body: { ok: true } },
+          ),
+      } as unknown as Response);
+    });
+
+    const client = new Tank01Client({ apiKey: "k", fetchImpl, ...recordingSleep() });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a nonsense attempt count as the default rather than throwing nothing", async () => {
+    // `options.attempts ?? REQUEST_ATTEMPTS` let 0 and NaN through, the loop ran
+    // zero times, and `throw lastError` threw `undefined` — no HTTP call, and
+    // recorded downstream as the literal string "undefined".
+    const fetchImpl = flaky(1, 429);
+    const client = new Tank01Client({
+      apiKey: "k",
+      fetchImpl,
+      attempts: 0,
+      ...recordingSleep(),
+    });
+
+    // Clamped to one attempt, not zero: it makes a real call and throws a real
+    // error. Before, it made none and threw `undefined`.
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).rejects.toThrow(/429/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("doubles the wait rather than adding to it", async () => {
+    // Two waits cannot tell 200·2^n from 200·n — they are 200 and 400 either
+    // way. A fourth attempt separates them, which is what the injectable
+    // `attempts` was added for and what no test used.
+    const { sleepImpl, waits } = recordingSleep();
+    const client = new Tank01Client({
+      apiKey: "k",
+      fetchImpl: flaky(99, 429),
+      attempts: 4,
+      sleepImpl,
+    });
+
+    await expect(client.get("getNFLBoxScore", { gameID: "g" })).rejects.toThrow(/429/);
+    expect(waits).toEqual([200, 400, 800]);
   });
 });

--- a/packages/stats/src/tank01/client.ts
+++ b/packages/stats/src/tank01/client.ts
@@ -43,30 +43,57 @@ const REQUEST_ATTEMPTS = 3;
 const RETRY_BASE_MS = 200;
 
 /**
- * Whether a failure is worth asking again.
+ * How long one request may hang before it is abandoned.
  *
- * **Narrow on purpose.** A rejected key, a 404 and a malformed envelope answer
- * identically however many times they are asked, so retrying them turns a clear
- * failure into a slow one. Giving up early is also cheap here in a way it is not
- * for the draw: `syncBoxScores` records the error against that game and the next
- * tick picks it up ten minutes later.
- *
- * A transport error counts — a socket reset mid-Sunday is exactly the transient
- * this exists for — but an unrecognised HTTP status does not, for the same
- * fail-closed reason `blockTime` refuses to read an unknown RPC error as a
- * skipped slot.
+ * The same 15s the Sleeper client uses. There was none here at all, which made
+ * the retry unreachable for the failure it most needed to cover: a hung socket
+ * at a throttling gateway never throws, so nothing was ever retried and the
+ * tick simply stalled.
  */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/*
+ * A 429 whose window rolls no sooner than this is treated as spent, not busy.
+ *
+ * Ten minutes is the stats cron's own period: past it, the next tick will ask
+ * again anyway, so sleeping 600ms and spending two more calls buys nothing.
+ */
+const QUOTA_RESET_FLOOR_S = 600;
+
+/*
+ * A request failure, carrying whether asking again could plausibly work.
+ *
+ * **The decision is made where the evidence is, and this used to be a substring
+ * match on the message.** That was wrong twice. Its comment claimed "the message
+ * is composed in one place below, so matching it is a check on this file" — but
+ * a provider error body is interpolated into a `ProviderError` too, so any
+ * Tank01 error string containing the word "failed" was retried three times. And
+ * a 429 arrives with headers saying whether the window rolls in a second or in
+ * fifteen hours, which the throw site read, formatted into prose, and discarded.
+ *
+ * Narrow on purpose, still: a rejected key, a 404 and a malformed envelope
+ * answer identically however many times they are asked, and an unrecognised
+ * status fails closed — the same direction `blockTime` takes about an
+ * unrecognised RPC error. Giving up early is cheap here in a way it is not for
+ * the draw, because `syncBoxScores` records the error against that game and a
+ * later tick re-reads it. **Not the next one** — this said "ten minutes later",
+ * and `FAILED_RETRY_MINUTES` is 20 against a ten-minute cron, so it is the tick
+ * after next. That interval is the whole argument for giving up early, which
+ * makes it worth stating correctly.
+ */
+class Tank01RequestError extends ProviderError {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+    cause?: unknown,
+  ) {
+    super(message, "tank01", cause);
+    this.name = "Tank01RequestError";
+  }
+}
+
 function isRetryable(error: unknown): boolean {
-  if (!(error instanceof ProviderError)) return false;
-
-  // A thrown fetch: DNS, connection reset, timeout. The message is composed in
-  // one place below, so matching it is a check on this file rather than on the
-  // runtime's wording.
-  if (error.message.includes("failed")) return true;
-
-  // Rate limited, or the far side is unwell. Both pass with a wait.
-  if (error.message.includes("HTTP 429")) return true;
-  return /HTTP 5[0-9][0-9]/.test(error.message);
+  return error instanceof Tank01RequestError && error.retryable;
 }
 
 interface Tank01Envelope<T> {
@@ -91,7 +118,14 @@ export class Tank01Client {
     }
     this.apiKey = options.apiKey;
     this.doFetch = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
-    this.attempts = options.attempts ?? REQUEST_ATTEMPTS;
+    // Guarded rather than defaulted, which is what `randomness.ts` does and
+    // says why. `options.attempts ?? REQUEST_ATTEMPTS` lets 0 and NaN through
+    // because neither is nullish, and the loop below then runs zero times and
+    // falls to `throw lastError` with `lastError` still undefined — `throw
+    // undefined`, no HTTP call, recorded downstream as the literal "undefined".
+    this.attempts = Number.isFinite(options.attempts)
+      ? Math.max(1, Math.floor(options.attempts as number))
+      : REQUEST_ATTEMPTS;
     this.sleep = options.sleepImpl ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
   }
 
@@ -104,10 +138,12 @@ export class Tank01Client {
    * meet a rate limit eventually, and one that fails the caller costs more than
    * the wait.
    *
-   * The exposure is newer here than the code is. Every sync before the box-score
-   * producer was operator-run and infrequent; `syncBoxScores` is the first
-   * caller to make **bursts of sequential calls on a schedule**, one per game, at
-   * the top of a ten-minute tick.
+   * The exposure is newer here than the code is, though this used to overstate
+   * how. It called `syncBoxScores` the **first** caller to burst on a schedule;
+   * `season-sync` makes eighteen sequential `listGames` calls plus four more,
+   * and the two crons landed in the same commit. What is particular to the
+   * box-score producer is the cadence — twenty calls at the top of a ten-minute
+   * tick, all day on a Sunday — and that a dropped one decides a matchup.
    *
    * And a dropped game is no longer merely missing. Since #140 a FINAL game with
    * no box score **holds the whole week from finalising** until the correction
@@ -151,67 +187,146 @@ export class Tank01Client {
       url.searchParams.set(key, value);
     }
 
-    let response: Response;
+    /*
+      A deadline, because there was none and the sibling Sleeper client has one.
+
+      Without it a stalled connection is bounded only by the runtime's defaults,
+      and since #97 there are three of them per game — inside a serverless
+      function whose own limit nothing here sets.
+    */
+    const controller = new AbortController();
+    const deadline = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
     try {
-      response = await this.doFetch(url.toString(), {
-        headers: {
-          "X-RapidAPI-Key": this.apiKey,
-          "X-RapidAPI-Host": HOST,
-        },
-      });
-    } catch (error) {
-      throw new ProviderError(`Request to ${path} failed`, "tank01", error);
-    }
+      let response: Response;
+      try {
+        response = await this.doFetch(url.toString(), {
+          signal: controller.signal,
+          headers: {
+            "X-RapidAPI-Key": this.apiKey,
+            "X-RapidAPI-Host": HOST,
+          },
+        });
+      } catch (error) {
+        throw new Tank01RequestError(`Request to ${path} failed`, true, error);
+      }
 
-    if (response.status === 401 || response.status === 403) {
-      throw new ProviderError(
-        `Tank01 rejected the API key (HTTP ${response.status}). ` +
-          `Check TANK01_API_KEY, and that you are subscribed to the NFL API ` +
-          `specifically — each Tank01 sport needs its own subscription.`,
-        "tank01",
-      );
-    }
-    if (response.status === 429) {
-      /**
-       * Report what the response says, never what the plan was assumed to be.
-       *
-       * This used to read "The Basic tier allows 1,000 calls/month" on every
-       * 429, which is wrong twice. RapidAPI returns 429 for a **burst** limit as
-       * well as an exhausted quota, and the two need opposite responses — wait a
-       * second, or wait for the reset. And the tier is not this code's to know:
-       * the message sent somebody to check a monthly quota on an account that
-       * had been upgraded, when the request was simply too quick after the last.
-       *
-       * The headers carry the truth and cost nothing to read. `reset` is
-       * seconds until the window rolls, which is also what distinguishes a
-       * daily allowance from a monthly one without anybody guessing.
-       */
-      const limit = response.headers.get("x-ratelimit-requests-limit");
-      const remaining = response.headers.get("x-ratelimit-requests-remaining");
-      const reset = response.headers.get("x-ratelimit-requests-reset");
+      if (response.status === 401 || response.status === 403) {
+        throw new Tank01RequestError(
+          `Tank01 rejected the API key (HTTP ${response.status}). ` +
+            `Check TANK01_API_KEY, and that you are subscribed to the NFL API ` +
+            `specifically — each Tank01 sport needs its own subscription.`,
+          false,
+        );
+      }
+      if (response.status === 429) {
+        /**
+         * Report what the response says, never what the plan was assumed to be.
+         *
+         * This used to read "The Basic tier allows 1,000 calls/month" on every
+         * 429, which is wrong twice. RapidAPI returns 429 for a **burst** limit as
+         * well as an exhausted quota, and the two need opposite responses — wait a
+         * second, or wait for the reset. And the tier is not this code's to know:
+         * the message sent somebody to check a monthly quota on an account that
+         * had been upgraded, when the request was simply too quick after the last.
+         *
+         * The headers carry the truth and cost nothing to read. `reset` is
+         * seconds until the window rolls, which is also what distinguishes a
+         * daily allowance from a monthly one without anybody guessing.
+         */
+        const limit = response.headers.get("x-ratelimit-requests-limit");
+        const remaining = response.headers.get("x-ratelimit-requests-remaining");
+        const reset = response.headers.get("x-ratelimit-requests-reset");
 
-      const detail =
-        remaining === null && limit === null
-          ? "No rate-limit headers came back, so this may be a per-second burst limit rather than an exhausted quota."
-          : `${remaining ?? "?"} of ${limit ?? "?"} requests left${
-              reset === null ? "" : `, window resets in ${reset}s`
-            }.`;
+        const detail =
+          remaining === null && limit === null
+            ? "No rate-limit headers came back, so this may be a per-second burst limit rather than an exhausted quota."
+            : `${remaining ?? "?"} of ${limit ?? "?"} requests left${
+                reset === null ? "" : `, window resets in ${reset}s`
+              }.`;
 
-      throw new ProviderError(`Tank01 refused the request (HTTP 429). ${detail}`, "tank01");
-    }
-    if (!response.ok) {
-      throw new ProviderError(`Tank01 returned HTTP ${response.status}`, "tank01");
-    }
+        /*
+          Busy or spent, and they are not the same request to make again.
 
-    const envelope = (await response.json()) as Tank01Envelope<T>;
-    if (envelope.error) {
-      throw new ProviderError(`Tank01 error: ${envelope.error}`, "tank01");
-    }
-    if (envelope.body === undefined) {
-      throw new ProviderError(`Tank01 returned no body for ${path}`, "tank01");
-    }
+          The headers above already tell them apart — that is what the comment
+          there is about — and the retry then ignored the answer and asked twice
+          more at 200ms and 400ms. Against a window measured in hours those two
+          calls are guaranteed futile, and they are spent on the quota that
+          refused the first one. Past the floor the next tick will ask anyway.
+        */
+        const resetIn = reset === null ? null : Number.parseInt(reset, 10);
+        const spent =
+          remaining === "0" && resetIn !== null && Number.isFinite(resetIn)
+            ? resetIn >= QUOTA_RESET_FLOOR_S
+            : false;
 
-    return envelope.body;
+        throw new Tank01RequestError(
+          `Tank01 refused the request (HTTP 429). ${detail}`,
+          !spent,
+        );
+      }
+      if (!response.ok) {
+        // 5xx is the far side being unwell and passes with a wait. Every other
+        // status answers the same however often it is asked, and an unrecognised
+        // one fails closed.
+        throw new Tank01RequestError(
+          `Tank01 returned HTTP ${response.status}`,
+          response.status >= 500 && response.status <= 599,
+        );
+      }
+
+      /*
+        Inside the guard, because a reset **during the body** is the transient this
+        whole change is about and it was the one shape not covered.
+
+        `fetch` resolves at the headers and streams the rest, so a connection lost
+        partway through rejects here rather than at the call above — and a box
+        score is the largest response this client asks for, tens of kilobytes over
+        many packets, which is exactly where that happens. It arrived as a bare
+        `TypeError`, failed the `instanceof` check, and was never retried. A
+        truncated body or an HTML error page under a 200 lands here too.
+      */
+      let envelope: Tank01Envelope<T>;
+      try {
+        envelope = (await response.json()) as Tank01Envelope<T>;
+      } catch (error) {
+        throw new Tank01RequestError(`Reading ${path} failed`, true, error);
+      }
+      if (envelope.error) {
+        /*
+          Provider text, so nothing here may be pattern-matched — that was the
+          hole in the old predicate. The **declared status** is what decides.
+
+          `statusCode` has been on this envelope since it was written and was
+          read nowhere, which is a divergence this repo has already paid for
+          once: `randomness.ts` carries 429 in its transient list precisely
+          because "some providers deliver a rate limit as HTTP 200 with the
+          limit in the error body, where the HTTP-status retry never sees it",
+          and CLAUDE.md records that the retry there "never fired for the case
+          it was added for".
+
+          Whether Tank01 does this is **unverified** — no 429 of any shape has
+          ever been captured from it, which `docs/TANK01.md` now says out loud.
+          Handling it costs nothing; not handling it costs the one case the
+          retry exists for. Same trade, same reasoning.
+        */
+        const declared = envelope.statusCode;
+        throw new Tank01RequestError(
+          `Tank01 error: ${envelope.error}`,
+          declared === 429 || (declared !== undefined && declared >= 500 && declared <= 599),
+        );
+      }
+      if (envelope.body === undefined) {
+        throw new Tank01RequestError(`Tank01 returned no body for ${path}`, false);
+      }
+
+      return envelope.body;
+    } finally {
+      // Cleared on every path. An uncleared deadline keeps the runtime's event
+      // loop alive for its full duration after the request has finished, which
+      // is 15 seconds per call in a job that makes twenty of them.
+      clearTimeout(deadline);
+    }
   }
 
   /**


### PR DESCRIPTION
The five-agent re-audit of #97. The retry is sound on the case it was written for. **The decision about what to retry was made by substring-matching a string the client had composed three lines earlier** — and two agents reproduced the consequences against the built client rather than reasoning about them.

## The predicate read its own error message

```ts
if (error.message.includes("failed")) return true;
```

under a comment claiming *"the message is composed in one place below, so matching it is a check on this file rather than on the runtime's wording."*

It is not composed in one place. `` `Tank01 error: ${envelope.error}` `` interpolates **provider-authored text** into the same string, so Tank01 decided our retry policy. Measured against the built client, not argued: a deterministic `Request failed: invalid gameID` was retried three times.

Now a `retryable` flag set where the evidence is, with every throw site stating its own answer.

## Five behaviour fixes

| | Before | Now |
|---|---|---|
| **Spent quota vs burst limit** | both 429, retried identically — 2 futile calls against the allowance that just refused | `remaining: 0` + a window past 10 min is not retried |
| **Reset lost while the body arrived** | rejects at `response.json()`, which sat **outside every `try`** → bare `TypeError` → thrown on attempt 1 | retried; it's the largest response this client asks for |
| **No timeout at all** | a hung socket never throws, so the retry couldn't fire for the failure most likely to stall a tick — ×3 unbounded fetches per game | 15s `AbortController`, matching the Sleeper client |
| **200-declared limit** | `statusCode` declared since the envelope was written, read **nowhere** | 429/5xx in the body is retried |
| **`attempts` unguarded** | `0`/`NaN` → loop runs zero times → `throw undefined`, no HTTP call, recorded downstream as the literal `"undefined"` | guarded, as `randomness.ts` guards it and says why |

The 200-body case is the divergence **this repo has already paid for once**: `randomness.ts` carries 429 in its transient list precisely because some providers deliver a rate limit that way, and CLAUDE.md records that the retry there *"never fired for the case it was added for."*

Whether Tank01 does it is unverified — **no 429 of any shape has ever been captured from it.** `docs/TANK01.md` now says so out loud instead of leaving it to be rediscovered, and corrects "Basic is 1,000 calls/month" against a live reading showing a *daily* window.

## Eight tests, and the first is the one that matters

Every existing retry test injects `sleepImpl` — so they assert the client *computes* 200 and 400 and hands them to something. **Defaulting the production sleep to a no-op passed all nineteen.** A retry with no wait is a way to meet a burst limit three times faster.

All five mutation-checked, one test each:

```
production sleep → no-op    → waits for real when nothing injects a clock
5xx narrowed to 503         → retries every 5xx, not only the one a test staged
quota 429 retried           → does not retry a 429 whose window is hours away
body reset not retryable    → retries a connection lost while the body is arriving
200-declared limit ignored  → retries a rate limit declared inside a 200 body
```

`/HTTP 5[0-9][0-9]/` → `/HTTP 503/` was green because 503 was the only status any fixture staged: 500, 502 and 504 would have silently stopped retrying with a test still named "retries a 5xx". And two waits cannot tell doubling from linear — a fourth attempt separates them, which is what the injectable `attempts` was added for and what no test had used.

## Three false claims in the fix's own prose

| Claim | Measured |
|---|---|
| "the next tick picks it up ten minutes later" | `FAILED_RETRY_MINUTES` is **20** against a 10-minute cron — the tick *after* next. This interval is the entire argument for giving up early |
| "`syncBoxScores` is the **first** caller to burst on a schedule" | `season-sync` makes 22 sequential calls, and both crons landed in the **same commit** |
| "`randomness.ts` has had this since it was written" | a corrective PR days later |

## Two comments sized the spend at one call per game

`MAX_GAMES_PER_RUN`'s docstring — which exists to stop a run exhausting the daily quota — and the work list's *"this query is the only thing pacing a metered provider — the loop below has no delay in it."* The real ceiling is **three times** what both describe. Neither was revisited by #97.

## Filed, not fixed

[#243](https://github.com/6figpsolseeker/rostr/issues/243) — a retried-then-succeeded call leaves no trace anywhere, so a provider degrading toward failure reads as perfectly healthy until the tick where all three attempts fail together. #97 removed the single-failure signal and put nothing in its place.

## Never run in production

Verified: 256 games all `SCHEDULED`, zero `stats_attempted_at`, zero stat lines. The retry loop has never executed once.

---

2203 tests (was 2194). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
