### PR TITLE
fix(db): the veto guard closed the smaller half of its own race

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/trades/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/trades/route.ts
@@ -29,6 +29,7 @@ const STATUS: Record<string, number> = {
   // WRONG_STATE beside it, and a separate code because the screen says something
   // different: "you were a moment late", not "you are looking at something old".
   TRADE_ALREADY_SETTLED: 409,
+  WINDOW_CLOSED: 409,
   PLAYER_IN_ANOTHER_TRADE: 409,
   ALREADY_VETOED: 409,
   ROSTER_WOULD_OVERFLOW: 409,

--- a/apps/web/src/components/TradeBlock.tsx
+++ b/apps/web/src/components/TradeBlock.tsx
@@ -145,6 +145,11 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
       setTheyGive(new Set());
       await mutate();
     } catch (e) {
+      // Refresh on the way out as well as on success. Every refusal here means
+      // the card is showing something that is no longer true — a settled trade
+      // with a live Veto button, or a window that has shut — so leaving it up
+      // invites a second press that gets a different message for the same fact.
+      void mutate();
       setFailure(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(false);

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -1553,6 +1553,144 @@ describe("a veto cast while the trade is being resolved — #134", () => {
     expect(rows).toHaveLength(0);
   });
 
+  it("does not execute a trade that crossed the threshold mid-swap", async () => {
+    /*
+      **The half of #134 the state predicate on the write cannot reach.**
+
+      `resolveTrade` takes its tally before the transaction opens and writes the
+      state as the last statement in it. Everything between — the asset read, two
+      statements per player, the commit — is time in which the trade is still
+      `ACCEPTED` to every other session, so a vote lands, passes the guard, is
+      written, and is discarded because the decision was already made. That is
+      the case the issue's own title names, and the guard is a *read*, so unlike
+      the `UPDATE … WHERE state = X` guards it was modelled on it never contends.
+
+      Here two votes land while the rosters are being swapped. The run must roll
+      back and leave the trade accepted, so the next one settles it as VETOED.
+
+      **What this proves and what it does not.** PGlite is one connection, so the
+      injected votes commit as part of the transaction under test rather than
+      beside it — which is exactly the isolation a second session would not have.
+      So this pins the **re-read**: that the decision is taken again, under the
+      trade's own lock, against whatever is there by then. It cannot pin the lock
+      itself, and no test in this repo can.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    let fired = false;
+    const racing = new Proxy(fx.client, {
+      get(target, prop, receiver) {
+        if (prop !== "query") return Reflect.get(target, prop, receiver);
+        return async (sql: string, params?: unknown[]) => {
+          const run = (
+            target as unknown as { query: (q: string, p?: unknown[]) => Promise<unknown> }
+          ).query.bind(target);
+          if (!fired && sql.includes("UPDATE roster_entries")) {
+            fired = true;
+            for (const voter of [fx.teams[2]!, fx.teams[3]!]) {
+              await run(
+                `INSERT INTO trade_vetoes (trade_id, team_id, league_id, created_at)
+                   SELECT $1, $2, t.league_id, $3 FROM trades t WHERE t.id = $1`,
+                [tradeId, voter, MONDAY.toISOString()],
+              );
+            }
+          }
+          return run(sql, params);
+        };
+      },
+    }) as typeof fx.client;
+
+    await settle(racing, fx.leagueId, AFTER_WINDOW);
+
+    const [after] = await fx.client.query<{ state: string }>(
+      "SELECT state FROM trades WHERE id = $1",
+      [tradeId],
+    );
+    expect(after?.state).not.toBe("EXECUTED");
+  });
+
+  it("refuses a vote once the window has closed, before any cron has run", async () => {
+    /*
+      **The window's end was decided by the cron, not by the window.**
+
+      `vetoTrade` compared `now` to nothing at all: the only gate was the state,
+      and a trade stays ACCEPTED until `/api/cron/trades` next runs. So a vote
+      cast after the published deadline but before the top of the hour was
+      accepted, written, and counted — and the accepting party chooses the
+      minute, so they choose how much grace there is.
+
+      The comment justifying the whole design said "`RULES.md` §6 gives the veto
+      window a definite end, so a vote arriving after it closes is genuinely
+      late". Nothing implemented that end.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const [row] = await fx.client.query<{ veto_deadline: string }>(
+      "SELECT veto_deadline FROM trades WHERE id = $1",
+      [tradeId],
+    );
+    const late = new Date(new Date(row!.veto_deadline).getTime() + 60_000);
+
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2]!, late)).rejects.toSatisfy(
+      (e) => e instanceof TradeError && e.code === "WINDOW_CLOSED",
+    );
+
+    const votes = await fx.client.query(
+      "SELECT team_id FROM trade_vetoes WHERE trade_id = $1",
+      [tradeId],
+    );
+    expect(votes).toHaveLength(0);
+  });
+
+  it("accepts a vote at the last moment of the window", async () => {
+    // The other side of the same boundary. Refusing here would be the fix
+    // overshooting and taking a legitimate vote with it.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const [row] = await fx.client.query<{ veto_deadline: string }>(
+      "SELECT veto_deadline FROM trades WHERE id = $1",
+      [tradeId],
+    );
+
+    await expect(
+      vetoTrade(fx.client, tradeId, fx.teams[2]!, new Date(row!.veto_deadline)),
+    ).resolves.toBeDefined();
+  });
+
+  it("refuses a vote on a trade the cron vetoed, not only one it executed", async () => {
+    /*
+      `EXECUTED` was the only settled state any fixture staged, so narrowing the
+      guard from `= 'ACCEPTED'` to `<> 'EXECUTED'` was green — and `resolveTrade`
+      writes `VETOED` and `EXPIRED` as well, both by the same bare autocommit
+      UPDATE. That mutation restores #134 in full for two of the three outcomes.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await fx.client.query("UPDATE trades SET state = 'VETOED' WHERE id = $1", [tradeId]);
+
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY)).rejects.toSatisfy(
+      (e) => e instanceof TradeError && e.code === "WRONG_STATE",
+    );
+  });
+
+  it("refuses a vote on a trade the cron expired", async () => {
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await fx.client.query("UPDATE trades SET state = 'EXPIRED' WHERE id = $1", [tradeId]);
+
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY)).rejects.toSatisfy(
+      (e) => e instanceof TradeError && e.code === "WRONG_STATE",
+    );
+  });
+
   it("still accepts a vote while the trade is genuinely open", async () => {
     // The control. Without it the refusal above passes just as well against a
     // rule that rejected every veto.

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -36,6 +36,7 @@ import type { LeagueRules } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { withTransaction } from "./transaction.js";
+import { isUniqueViolation } from "./pg-errors.js";
 import { transactionWeek } from "./week.js";
 
 export class TradeError extends Error {
@@ -72,6 +73,23 @@ export class TradeError extends Error {
        * league declined to block a trade it may in fact have blocked.
        */
       | "TRADE_ALREADY_SETTLED"
+      /**
+       * The voter is late. The trade is still accepted and its window has shut.
+       *
+       * Separate from `WRONG_STATE` because the member is not confused about the
+       * state — telling them "only an accepted trade can be blocked" about a
+       * trade that plainly is one sends them looking for a fault that is not
+       * there. `vetoTrade` compared `now` to nothing at all until this existed,
+       * so the window's real end was whenever the hourly cron next ran.
+       */
+      | "WINDOW_CLOSED"
+      /**
+       * Enough vetoes landed while the swap was in flight.
+       *
+       * Rolls the swap back and leaves the trade accepted, so the next run reads
+       * the fuller tally and settles it as VETOED.
+       */
+      | "VETOED_WHILE_EXECUTING"
       | "ALREADY_VETOED"
       | "ROSTER_WOULD_OVERFLOW"
       | "ASSET_GONE",
@@ -666,6 +684,19 @@ export async function vetoTrade(
       "WRONG_STATE",
     );
   }
+
+  /*
+    Read once here so the refusal can say which of the two it was, and enforced
+    again in the write below because this read decides nothing on its own.
+
+    `WINDOW_CLOSED` rather than `WRONG_STATE`: the trade is still accepted and
+    the member is not confused about that, they are late. Telling them "only an
+    accepted trade can be blocked" about a trade that plainly is one sends them
+    looking for a fault that is not there.
+  */
+  if (trade.vetoDeadline !== null && now.getTime() > trade.vetoDeadline.getTime()) {
+    throw new TradeError("The veto window for this trade has closed", "WINDOW_CLOSED");
+  }
   if ([trade.proposerTeamId, trade.receiverTeamId].includes(actingTeamId)) {
     throw new TradeError("A team in the trade cannot vote on it", "INVOLVED_CANNOT_VETO");
   }
@@ -718,18 +749,69 @@ export async function vetoTrade(
     The early check above stays. It is the error message for the ordinary case —
     somebody opening a settled trade and voting on it — and this one cannot
     distinguish that from the race.
+
+    **Two of the three guards below cannot be tested in this repo, and are kept
+    anyway.** PGlite is a single connection, so nothing here can hold a lock
+    against a second session or move a deadline between this read and this
+    write. Deleting either `FOR UPDATE OF t` or the `veto_deadline` clause
+    leaves the suite green. They are the halves that matter in production, and
+    the note is here so a future reader does not read a green suite as licence
+    to simplify them away.
+
+    **`FOR UPDATE OF t`, because a bare SELECT closed only half the window.**
+    An `UPDATE … WHERE state = X` takes a row lock and re-evaluates its
+    predicate against the committed row when it wakes; a `SELECT` inside an
+    `INSERT` does neither. So a vote arriving while `resolveTrade` held its
+    transaction open read the pre-update tuple, matched `ACCEPTED`, and was
+    written — and `resolveTrade` had taken its tally before the swap began, so
+    it was discarded exactly as #134 describes. The lock makes the voter block
+    until that transaction commits and then re-check, which is what the sibling
+    race file's header assumed of this statement and is only true of an UPDATE.
+
+    **And `veto_deadline`, because the window's end was decided by the cron.**
+    The comment below said `RULES.md` §6 "gives the veto window a definite end,
+    so a vote arriving after it closes is genuinely late" — and nothing here
+    compared `now` to anything. A trade whose window shut at 14:30 is not
+    resolved until the hourly run at 15:00, so a vote at 14:45 was accepted,
+    written, and counted. Two members could block a trade after the league had
+    stopped being able to.
   */
-  const written = await db.query<{ trade_id: string }>(
-    // The league is stored on the vote, not inferred at read time: the composite
-    // foreign keys in 0020 use it to make an out-of-league vote unrepresentable
-    // rather than merely uncounted.
-    `INSERT INTO trade_vetoes (trade_id, team_id, league_id, created_at)
+  /*
+    Wrapped, because the read above cannot arbitrate a simultaneous one.
+
+    `ALREADY_VETOED` is decided by a `SELECT` a few statements earlier, so two
+    requests from the same manager — two tabs, a retried fetch — both read no
+    vote and both insert. The loser hits `PRIMARY KEY (trade_id, team_id)` as a
+    raw 23505, and the route translates only `TradeError`, so it became a 500
+    carrying the constraint name.
+
+    That is the shape this module already names in a comment two hundred lines
+    down ("now does, but as a 23505 rather than as an answer") and that six other
+    files in this package translate. It answers the same as the sequential path,
+    which is the point: one manager, one vote, told so either way.
+  */
+  let written: { trade_id: string }[];
+  try {
+    written = await db.query<{ trade_id: string }>(
+      // The league is stored on the vote, not inferred at read time: the composite
+      // foreign keys in 0020 use it to make an out-of-league vote unrepresentable
+      // rather than merely uncounted.
+      `INSERT INTO trade_vetoes (trade_id, team_id, league_id, created_at)
        SELECT $1, $2, t.league_id, $3
          FROM trades t
-        WHERE t.id = $1 AND t.state = 'ACCEPTED'
+        WHERE t.id = $1
+          AND t.state = 'ACCEPTED'
+          AND t.veto_deadline >= $3
+          FOR UPDATE OF t
      RETURNING trade_id`,
-    [tradeId, actingTeamId, now.toISOString()],
-  );
+      [tradeId, actingTeamId, now.toISOString()],
+    );
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new TradeError("This team has already voted on this trade", "ALREADY_VETOED");
+    }
+    throw error;
+  }
 
   if (written.length === 0) {
     throw new TradeError(
@@ -1005,6 +1087,41 @@ async function resolveTrade(
         `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
          VALUES ($1, $2, 'TRADE', $3)`,
         [to, asset.player_id, now.toISOString()],
+      );
+    }
+
+    /*
+      **The tally is re-read here, under the trade's own lock.**
+
+      The count this function decided on was taken before the transaction opened
+      — before the roster swap, which is many round trips and grows with the
+      number of players named. Every vote committed inside that window was
+      written against a trade that was still `ACCEPTED`, passed the guard in
+      `vetoTrade`, and was then discarded, because the decision had already been
+      made. That is #134's own title case, "a veto cast while a trade is
+      executing", and the state predicate on the write does not reach it: the
+      predicate is a *read*, so unlike #133's `UPDATE … WHERE state = X` it takes
+      no row lock and never contends.
+
+      Two halves close it, and neither is sufficient alone. `vetoTrade` takes
+      `FOR UPDATE` on the trade, so a vote arriving from here on blocks until
+      this transaction commits and then re-checks against `EXECUTED`. And this
+      re-read catches every vote that landed before that lock was taken.
+
+      **Locked after the rosters, never before.** `acceptTrade` takes
+      `roster_entries` and then `trades`; taking them the other way round here
+      would be the deadlock this file already orders `ORDER BY player_id` to
+      avoid, in a second pair.
+
+      Throwing rolls the swap back and leaves the trade `ACCEPTED`, which is
+      right: the next hourly run reads the fuller tally and writes `VETOED`.
+    */
+    await tx.query("SELECT id FROM trades WHERE id = $1 FOR UPDATE", [tradeId]);
+    const settled = await loadTrade(tx, tradeId);
+    if (isVetoed(settled.vetoes, electorate, rules.trades)) {
+      throw new TradeError(
+        "This trade was vetoed while it was executing",
+        "VETOED_WHILE_EXECUTING",
       );
     }
 


### PR DESCRIPTION
The five-agent re-audit of #134. All five reached the same conclusion independently: **the fix closes the smaller half of the race, and its title claims the larger one.**

## The window the issue's own title names is still open

`resolveTrade` takes the tally *before* the transaction opens and writes the state as the *last* statement inside it. Everything between — the asset read, two statements per player, the commit — is time in which the trade is still `ACCEPTED` to every other session.

So a vote lands, passes `AND t.state = 'ACCEPTED'`, is written, and is discarded because the decision was already made. That is #134 verbatim: *"a veto cast while a trade is **executing**"*.

**The technique doesn't transfer.** #133's guards are `UPDATE … WHERE state = X` — they take a row lock and re-evaluate their predicate against the committed row when they wake. This one is a `SELECT` feeding an `INSERT`: no row lock, no EvalPlanQual re-check. It doesn't even block — the FK takes `FOR KEY SHARE`, the resolver holds `FOR NO KEY UPDATE`, and those are compatible.

Worse in presentation than before: `vetoTrade` returns `loadTrade` *after* the insert, so the member gets HTTP 200 and **"Vote recorded."** for a vote that decided nothing.

**Two halves close it**, and neither is sufficient alone:

- `FOR UPDATE OF t` on the insert's source — a vote arriving from then on blocks until the transaction commits, then re-checks against `EXECUTED`
- a re-read of the tally inside `resolveTrade`, under the trade's own lock, immediately before the state write — catching every vote that landed before that lock existed

**Locked after the rosters, never before.** `acceptTrade` takes `roster_entries` then `trades`; the other order would be a second deadlock pair alongside the one `ORDER BY player_id` already prevents.

## The veto window had no end

`vetoTrade` compared `now` to **nothing**. The only gate was the state, and a trade stays `ACCEPTED` until the hourly cron runs — so a vote cast after the published deadline was accepted, written, and counted. **The accepting party picks the minute, so they pick how much grace there is** (up to 59 of them).

The comment justifying the whole design said *"`RULES.md` §6 gives the veto window a definite end, so a vote arriving after it closes is genuinely late."* Nothing implemented that end. `WINDOW_CLOSED` now does, checked at the read for the message and again in the write.

## Also

- **A concurrent duplicate veto was a raw 500.** `trades.ts` didn't import `isUniqueViolation` despite six other files in the package translating exactly this race. Now `ALREADY_VETOED`, matching the sequential path.
- **The screen didn't refresh on a refusal**, so a second press got a *different* message for the same fact.

## Tests

Five added. Mutation-checked:

```
early deadline check removed  → refuses a vote once the window has closed
tally re-read removed         → does not execute a trade that crossed the threshold mid-swap
```

Plus the states the critic showed were unstaged: `EXECUTED` was the only settled state any fixture produced, so narrowing the guard to `<> 'EXECUTED'` was green — while `resolveTrade` writes `VETOED` and `EXPIRED` by the same bare UPDATE. Both covered now, both directions of the deadline boundary too.

**Stated rather than glossed:** two guards cannot be tested here at all. PGlite is one connection, so nothing can hold a lock against a second session or move a deadline mid-statement — deleting `FOR UPDATE OF t` or the `veto_deadline` clause leaves the suite green. They are the halves that matter in production, and the code says so where a future reader will hit it.

## Never fired

`trades` and `trade_vetoes` are both **empty** in production; no veto has ever been cast.

---

2208 tests (was 2203). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
