### PR TITLE
fix(core): the commit that fixed three false comments left three false comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1895,9 +1895,15 @@ voters, so `vetoesRequired` returns 0 — and a threshold of zero would otherwis
 trade is vetoed before anyone votes. `isVetoed` short-circuits it.
 
 **Accepting freezes the players; it does not move them.** Between acceptance and execution
-they are in escrow: `lockedByTrade` is consulted by `dropPlayer` (which throws
-`IN_A_TRADE`), by `proposeTrade`, and by `acceptTrade` — the proposal's checks are stale by
-the time anyone accepts.
+they are in escrow. The freeze is consulted at **five** sites: `refuseIfFrozen` in
+`dropPlayer` (which throws `IN_A_TRADE`) and in `addFreeAgent`'s drop leg, `lockedByTrade`
+in `proposeTrade` and in `acceptTrade` — the proposal's checks are stale by the time anyone
+accepts — and a pre-resolution filter in `processWaivers`, which fails the claim rather than
+throwing, because a throw there rolls back every league's run.
+
+**This sentence named three of the five and #119 was closed without touching it.** That
+issue's title names this file; the fix reached `docs/DECISIONS.md` only, and got the count
+wrong there too. Recount before repeating it.
 
 **In `acceptTrade`, take every row lock first and read the freeze set second.** The obvious
 order is wrong and looks right: two concurrent accepts of the same player both read an

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -94,7 +94,7 @@ silently change — which is precisely the thing immutability is meant to preven
 
 ```
 teams             id, league_id, owner_id (nullable), is_bot, name,
-                  draft_position, waiver_priority, strikes, abandoned_at
+                  draft_position, waiver_priority, ~~strikes, abandoned_at~~ (dropped by migration `0015` — abandonment was removed in schema 4)
 roster_entries    id, team_id, league_id, player_id, acquired_via, acquired_at,
                   released_at
 lineups           id, team_id, week, slot_type_id, player_id, locked_at

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -519,13 +519,25 @@ for leagues without a pot, or the rule would only hold where there is money.
 
 Without it the attack is trivial and does not even look like one: accept a trade, drop the
 player you promised, and the swap executes into a roster spot that no longer holds him.
-`lockedByTrade` is consulted by dropping, by proposing and by accepting.
+The freeze is consulted at **five** sites: `refuseIfFrozen` in `dropPlayer` and in
+`addFreeAgent`'s drop leg, `lockedByTrade` in `proposeTrade` and in `acceptTrade`, and a
+pre-resolution filter in `processWaivers`.
 
-**It used to say "so a committed player cannot leave by any path", and that inference is
-what produced #77.** Three call sites are not every path: `processWaivers` and
-`resolveTrade` both release players and neither can refuse, because a throw inside
-`processWaivers` rolls back the whole league's run and leaves the claim PENDING forever,
-and `resolveTrade` cannot undo a trade the league already approved because a game started.
+**This paragraph has now been wrong twice, in opposite directions, and the second time was
+the correction.** It first said "so a committed player cannot leave by any path", and that
+inference is what produced #77. The fix for #119 replaced it with "three call sites", which
+undercounted by two — and then said `processWaivers` "cannot refuse", which is false: it
+has carried a `dropIsFrozen` filter since #118, fails the claim rather than throwing, and
+its own docstring says exactly that. So a reader was told the guard was absent from the one
+release path that has a purpose-built one.
+
+What is true is narrower. `processWaivers` cannot refuse **by throwing** — the whole run is
+one transaction, so a throw would roll back every league's claims and leave them PENDING
+forever — which is why it filters instead. And `resolveTrade` is exempt for a different reason
+again, which the correction also got wrong. Not "because a game started" — that is the
+kickoff lock's rationale, copied across from a different rule — but because **it _is_ the
+trade executing.** Guarding it against the freeze it sets would expire every trade in the
+league.
 
 Guarding the door and guarding the outcome are different jobs, and this needs both. What
 actually closes it is `ASSET_GONE` — execution refuses rather than inserting when the

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -12,10 +12,10 @@ The only permitted post-creation changes are:
 
 Anything not listed as league state below is a rule, and rules do not move.
 
-|                                     |                                                                                                                                                                                                                                               |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Rules** (frozen)                  | scoring, roster, league size, buy-in token + amount, payout split, draft type + timer + date, waiver system, trade deadline, veto threshold + window, playoff count, playoff weeks, tiebreaker order, abandonment policy, commissioner powers |
-| **State** (moves during the season) | rosters, standings, waiver order, matchup results, trade history, strike counts                                                                                                                                                               |
+|                                     |                                                                                                                                                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rules** (frozen)                  | scoring, roster, league size, buy-in token + amount, payout split, draft type + timer + date, waiver system, trade deadline, veto threshold + window, playoff count, playoff weeks, tiebreaker order, commissioner powers |
+| **State** (moves during the season) | rosters, standings, waiver order, matchup results, trade history                                                                                                                                                          |
 
 ---
 

--- a/packages/core/src/draft/draft.test.ts
+++ b/packages/core/src/draft/draft.test.ts
@@ -379,7 +379,13 @@ describe("autoPick", () => {
   it("skips a queued player who would strand the lineup", () => {
     // The queue was written before the board looked like this. Auto-pick must
     // not strand a lineup on the manager's behalf — they were not there to
-    // choose it, and the penalty is a forfeited stake.
+    // choose it, and an unfillable slot scores nothing until they trade or sign
+    // their way out of it.
+    //
+    // The reason here used to be "the penalty is a forfeited stake", which was
+    // the abandonment rule removed in schema 4. #129 corrected the two
+    // docstrings and missed this one — the test that pins the behaviour, and so
+    // the copy a maintainer reads before changing it.
     const roster = [
       player("qb1", ["QB"]),
       player("rb1", ["RB"]),

--- a/packages/core/src/draft/roster.ts
+++ b/packages/core/src/draft/roster.ts
@@ -246,10 +246,20 @@ export function canDraft(
  * Advisory, not a block. A manual pick may proceed anyway; auto-pick avoids it.
  *
  * The stakes are worth stating plainly wherever this surfaces in a UI: a roster
- * that cannot fill its starting slots cannot field a legal lineup, so the
- * autofill has nobody to put in the empty slot and it scores zero every week
- * for the rest of the season. On ESPN that is an embarrassment; here it is a
+ * that cannot fill its starting slots leaves one empty, so the autofill has
+ * nobody to put in it and it scores nothing every week until somebody signs or
+ * trades their way out of it. On ESPN that is an embarrassment; here it is a
  * team that cannot compete in a league other people are playing.
+ *
+ * **Not "cannot field a legal lineup", and not "for the rest of the season."**
+ * This said both, and both are stronger than the code. `validateLineup` refuses
+ * an empty starter only under `requireFull`, which no production caller sets —
+ * and the paragraph below says as much, that the autofill runs before a week is
+ * scored so a lineup is never invalid at that moment. A hole drafted on Sunday
+ * is fillable from free agency on Monday. This comment was rewritten once
+ * already, to remove a forfeited-stake rule that no longer exists; the
+ * replacement overshot in the other direction and contradicted its own next
+ * paragraph.
  *
  * **This used to say the team would be abandoned and its stake forfeited. That
  * rule was removed in schema 4 on 2026-08-08 and is not coming back** — see

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -1002,8 +1002,29 @@ describe("the waiver weekday is checked against the union — #132", () => {
       waivers: { ...rules.waivers, weeklyLock: { ...rules.waivers.weeklyLock, day: "funday" } },
     } as LeagueRules;
 
-    const problems = validateLeagueRules(broken, NFL);
-    expect(problems.some((p) => p.includes("WEDNESDAY"))).toBe(true);
+    /*
+      Matched against the problem for **this** field, not against the whole
+      array. Searching every problem for "WEDNESDAY" passed for the wrong
+      reason under a mutation that dropped Wednesday from the accepted set: the
+      substring matched the message *rejecting* Wednesday. A test named "names
+      the acceptable values" was satisfied by a value being named unacceptable.
+    */
+    const problem = validateLeagueRules(broken, NFL).find((p) =>
+      p.startsWith("weeklyLock.day"),
+    );
+
+    expect(problem).toContain("funday");
+    for (const day of [
+      "SUNDAY",
+      "MONDAY",
+      "TUESDAY",
+      "WEDNESDAY",
+      "THURSDAY",
+      "FRIDAY",
+      "SATURDAY",
+    ]) {
+      expect(problem).toContain(day);
+    }
   });
 
   it("is case-sensitive, because the stored value is", () => {
@@ -1019,6 +1040,114 @@ describe("the waiver weekday is checked against the union — #132", () => {
     } as LeagueRules;
 
     expect(validateLeagueRules(broken, NFL).length).toBeGreaterThan(0);
+  });
+
+  it("accepts every one of the seven, so the list cannot lose a day", () => {
+    /*
+      Both directions. Three tests refuse a bad value and none accepted a good
+      one, so dropping a day from `WEEKDAYS` was green — and the consequence is
+      the opposite of the bug being fixed: a validator that refuses a correct,
+      ordinary rule set. Sunday and Saturday are the ones nobody would notice.
+    */
+    const days = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"];
+
+    for (const day of days) {
+      const rules = {
+        ...FIXTURE,
+        waivers: {
+          ...FIXTURE.waivers,
+          weeklyLock: { day, hour: 0 },
+          processing: { day, hour: 3 },
+        },
+      } as LeagueRules;
+
+      expect(validateLeagueRules(rules, NFL)).toEqual([]);
+    }
+  });
+
+  it("refuses a processing run earlier in the day than its own lock", () => {
+    /*
+      **The silent one, two lines from the loud one.**
+
+      The pair was checked for identity only. `everyoneIsOnWaivers` asks whether
+      now is before the processing run that follows the most recent lock, and
+      `nextProcessingAt` is strictly after — so a processing hour earlier in the
+      same weekday pushes that answer a whole cycle forward, and every unrostered
+      player sits on waivers for 167 hours of every week.
+
+      Free agency open for one hour, all season, in a document that is frozen and
+      hashed and cannot be amended. Nothing throws; every function returns a
+      plausible answer. The weekday check got written because its failure is
+      loud, and this one is the reason that is not the right filter.
+    */
+    const broken = {
+      ...FIXTURE,
+      waivers: {
+        ...FIXTURE.waivers,
+        weeklyLock: { day: "WEDNESDAY", hour: 4 },
+        processing: { day: "WEDNESDAY", hour: 3 },
+      },
+    } as LeagueRules;
+
+    expect(
+      validateLeagueRules(broken, NFL).some((p) => p.includes("after the weekly lock")),
+    ).toBe(true);
+  });
+
+  it("allows the two moments on different days in any order", () => {
+    // Tuesday's lock and Wednesday's run is the default, and the ordering rule
+    // must not reach across days — a lock late on Tuesday with a run early on
+    // Wednesday is the ordinary arrangement.
+    const rules = {
+      ...FIXTURE,
+      waivers: {
+        ...FIXTURE.waivers,
+        weeklyLock: { day: "TUESDAY", hour: 23 },
+        processing: { day: "WEDNESDAY", hour: 3 },
+      },
+    } as LeagueRules;
+
+    expect(validateLeagueRules(rules, NFL)).toEqual([]);
+  });
+
+  it("refuses a waiver period that is fractional or absurd", () => {
+    /*
+      It was bounded below only. A fractional value passed here and threw from
+      `canonicalize` instead, which breaks this module's contract that a creator
+      sees everything wrong at once; and with no ceiling, 3650 meant no player
+      ever cleared waivers for the life of the league.
+    */
+    for (const days of [1.5, 3650]) {
+      const broken = {
+        ...FIXTURE,
+        waivers: { ...FIXTURE.waivers, waiverPeriodDays: days },
+      } as LeagueRules;
+
+      expect(validateLeagueRules(broken, NFL).some((p) => p.includes("waiverPeriodDays"))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("refuses a tiebreaker that is not one of the five", () => {
+    /*
+      The same gap as the weekday, one field over, failing far more quietly.
+
+      `scoresFor` has no default arm, so an unrecognised link returns undefined
+      and `orderGroup` reads that as "not applicable here" — the typo is dropped
+      from a chain that is signed, hashed and unamendable. Nothing throws. It
+      just seeds the playoffs differently, and seed 1 carries the best-record
+      prize. Issue #132 asked for this sweep in the same pass.
+    */
+    const broken = {
+      ...FIXTURE,
+      schedule: {
+        ...FIXTURE.schedule,
+        tiebreakers: ["WIN_PCT", "POINTS_FRO", "LOWEST_TEAM_ID"],
+      },
+    } as LeagueRules;
+
+    expect(validateLeagueRules(broken, NFL).some((p) => p.includes("POINTS_FRO"))).toBe(true);
   });
 
   it("accepts the default rule set unchanged", () => {

--- a/packages/core/src/rules/validate.ts
+++ b/packages/core/src/rules/validate.ts
@@ -19,7 +19,7 @@ import {
   MILLI_POINTS_PER_POINT,
   MIN_BUY_IN_BASE_UNITS,
 } from "./types.js";
-import type { LeagueRules, ScoringRule } from "./types.js";
+import type { LeagueRules, ScoringRule, Tiebreaker, Weekday } from "./types.js";
 
 const FAST_PICK_SECONDS = [90, 120, 300, 600];
 const SLOW_PICK_SECONDS = [3600, 14_400, 28_800, 86_400];
@@ -333,6 +333,24 @@ function validateSchedule(rules: LeagueRules, out: string[]): void {
     if (prev !== undefined && week <= prev) out.push("playoffWeeks must ascend");
   }
 
+  /*
+    Every link checked for membership, not only the last one for identity.
+
+    This is the same gap as the weekday (#132) and it fails far more quietly.
+    `scoresFor` has no default arm, so an unrecognised tiebreaker returns
+    `undefined`, and `orderGroup` reads that as "not applicable here" and skips
+    it — a typo is silently dropped from a chain that is signed, hashed and
+    unamendable. The chain still terminates, so nothing throws; it just seeds the
+    playoffs differently, and seed 1 carries the best-record prize.
+
+    Issue #132 asked for this sweep in the same pass and it was not done.
+  */
+  for (const tiebreaker of s.tiebreakers) {
+    if (!TIEBREAKERS.has(tiebreaker)) {
+      out.push(`unknown tiebreaker "${tiebreaker}"`);
+    }
+  }
+
   if (s.tiebreakers.length === 0) {
     out.push("at least one tiebreaker is required");
   } else if (s.tiebreakers.at(-1) !== "LOWEST_TEAM_ID") {
@@ -345,7 +363,24 @@ function validateSchedule(rules: LeagueRules, out: string[]): void {
 function validateWaivers(rules: LeagueRules, out: string[]): void {
   const w = rules.waivers;
 
-  if (w.waiverPeriodDays <= 0) out.push("waiverPeriodDays must be positive");
+  /*
+    Bounded on both sides and required to be whole.
+
+    It was `<= 0` only. A fractional value passed here and then threw from
+    `canonicalize`, which breaks this module's own contract — validation returns
+    problems so a creator sees everything wrong at once, and does not throw. And
+    with no ceiling, `waiverPeriodDays: 3650` meant no player ever cleared
+    waivers for the life of the league, while a large enough value overflowed
+    `waiverClearsAt` into a bare `RangeError` with no per-league catch above it.
+
+    Fourteen days is generous against a rule ESPN sets at one; the point is that
+    a number beyond it is a typo rather than a preference.
+  */
+  if (!Number.isInteger(w.waiverPeriodDays) || w.waiverPeriodDays <= 0) {
+    out.push(`waiverPeriodDays must be a whole number of days, got ${w.waiverPeriodDays}`);
+  } else if (w.waiverPeriodDays > 14) {
+    out.push(`waiverPeriodDays must be 14 or fewer, got ${w.waiverPeriodDays}`);
+  }
   if (w.shortTenureHours < 0) out.push("shortTenureHours cannot be negative");
 
   // A timezone, never an offset — the season crosses the daylight-saving change.
@@ -371,8 +406,12 @@ function validateWaivers(rules: LeagueRules, out: string[]): void {
       The day, checked against the union it is typed as. Issue #132.
 
       The hour beside it was validated and the day was not, which is the gap
-      that matters: `nextWeekly` resolves a weekday to an index, and an
-      unrecognised one produces a schedule that cannot be computed. Every value
+      that matters: `nextWeekly` walks nine days comparing each one's weekday
+      against this value and throws when none matches, so an unrecognised one
+      produces a schedule that cannot be computed at all. (It does not resolve
+      the value to an index — an earlier version of this comment said so, and the
+      index lookup there is applied to the weekday `Intl` observed, never to
+      this one.) Every value
       here is frozen at creation and hashed, so a league created with a typo can
       never be corrected — and `leaguesDueForWaivers` calls this for every league
       with a pending claim, which is why one bad value used to be able to stop
@@ -388,8 +427,31 @@ function validateWaivers(rules: LeagueRules, out: string[]): void {
     }
   }
 
-  if (w.weeklyLock.day === w.processing.day && w.weeklyLock.hour === w.processing.hour) {
-    out.push("the weekly lock and processing run cannot be the same moment");
+  /*
+    The two moments must be distinct **and in order**, and only the first half
+    was checked.
+
+    `everyoneIsOnWaivers` asks whether now is before the processing run that
+    follows the most recent lock, and `nextProcessingAt` is strictly after — so
+    a processing hour *earlier* in the same weekday pushes that answer a whole
+    cycle forward. Lock Wednesday 04:00, process Wednesday 03:00, and every
+    unrostered player sits on waivers for 167 hours of every week: free agency
+    open for one hour, all season, in a document that is frozen and hashed and
+    cannot be amended.
+
+    Nothing throws on that. The weekday check above fails loudly, which is why it
+    was the one that got written; this one returns a plausible answer to every
+    question and simply makes the league unplayable in a way nobody can name.
+  */
+  if (w.weeklyLock.day === w.processing.day) {
+    if (w.weeklyLock.hour === w.processing.hour) {
+      out.push("the weekly lock and processing run cannot be the same moment");
+    } else if (w.processing.hour < w.weeklyLock.hour) {
+      out.push(
+        "the processing run must come after the weekly lock, not before it — " +
+          "otherwise free agency closes for all but an hour of each week",
+      );
+    }
   }
 }
 
@@ -399,8 +461,31 @@ function validateWaivers(rules: LeagueRules, out: string[]): void {
  * A `Weekday` union exists at the type level and is gone at runtime, so nothing
  * generated from it can check a value that arrived as JSON — which is exactly how
  * a rule field typed as an enum reaches this function unchecked.
+ *
+ * **Typed `ReadonlySet<Weekday>`, not `ReadonlySet<string>`.** As `string` this
+ * was the weaker of two hand-written copies of the same seven days — the one in
+ * `waivers/schedule.ts` is `readonly Weekday[]`, so a misspelling there fails the
+ * build, while a misspelling here compiled. The result would have been a
+ * validator that rejects the correct spelling and accepts the typo, for a
+ * document that is then hashed and frozen. The precedent this cites,
+ * `TIEBREAKER_DISCRIMINANTS`, is pinned by a test; the shape was copied and the
+ * guard was not.
  */
-const WEEKDAYS: ReadonlySet<string> = new Set([
+/**
+ * The tiebreaker names, as values, for the same reason WEEKDAYS exists.
+ *
+ * Typed against the union so a typo here is a build error rather than a
+ * validator that rejects the real chain and accepts a broken one.
+ */
+const TIEBREAKERS: ReadonlySet<Tiebreaker> = new Set<Tiebreaker>([
+  "WIN_PCT",
+  "POINTS_FOR",
+  "HEAD_TO_HEAD",
+  "POINTS_AGAINST",
+  "LOWEST_TEAM_ID",
+]);
+
+const WEEKDAYS: ReadonlySet<Weekday> = new Set<Weekday>([
   "SUNDAY",
   "MONDAY",
   "TUESDAY",


### PR DESCRIPTION
The five-agent re-audit of #230 — the commit that fixed three false comments. **Its own corrections were false**, which is the sharpest possible result for that PR.

## The correction was wrong in both directions

#119 asked for the trade-freeze enforcement points to be described correctly. The replacement says:

> `lockedByTrade` is consulted by dropping, by proposing and by accepting. … `processWaivers` and `resolveTrade` both release players and **neither can refuse**

| Claim | Reality |
|---|---|
| three sites | **five** — `addFreeAgent`'s drop leg and `processWaivers` are both missing |
| `processWaivers` cannot refuse | **it does** — `dropIsFrozen` filters the claim and fails it, since #118, ten days *before* #230 |
| `resolveTrade` is exempt "because a game started" | that's the **kickoff lock's** rationale, copied across. It's exempt because *it is the trade executing* — guarding it would expire every trade in the league |

And **CLAUDE.md was never touched** — the file named first in the issue title, still carrying the same three-of-five count. #119 was closed 6 seconds after merge with half its scope open.

Two agents found this independently; one traced the paragraph to the file it was transplanted from.

## The sweep #132 asked for was skipped, and the field it named fails more quietly

#132 closed with *"`validate.ts` may have the same gap for other string-union rule fields — worth a sweep in the same pass."* Only the weekday was done.

**`schedule.tiebreakers` is the same class and worse.** `scoresFor` has no default arm, so an unrecognised link returns `undefined` and `orderGroup` reads that as "not applicable here" — a typo is **silently dropped** from a chain that is signed, hashed and unamendable. Nothing throws. It reseeds the playoffs, and seed 1 carries the best-record prize.

## Two live validation holes one field over

- **`weeklyLock` and `processing` were checked for identity, not order.** Lock Wednesday 04:00, process Wednesday 03:00 → `nextProcessingAt` is strictly-after, so every unrostered player sits on waivers **167 hours of every week**, all season, frozen and unamendable. Nothing throws; every function returns a plausible answer.
- **`waiverPeriodDays` was bounded below only.** `3650` meant no player ever cleared waivers; a fractional value passed validation and threw from `canonicalize` instead — breaking this module's own contract that a creator sees everything wrong at once.

## The guard was the weaker of two copies

`WEEKDAYS` was `ReadonlySet<string>` while its twin in `waivers/schedule.ts` is `readonly Weekday[]`. A misspelling in the twin fails the build; **a misspelling in the guard compiled** — producing a validator that rejects the correct spelling and accepts the typo, on a document that is then hashed. It cited `TIEBREAKER_DISCRIMINANTS` as precedent and copied the shape without the test that makes it safe.

## The mutations that were green

Run empirically by the test critic against a built copy:

| Mutation | Was | Now |
|---|---|---|
| `WEEKDAYS = {TUESDAY, WEDNESDAY}` — five real days refused | green | **fails** |
| drop `SUNDAY` | green | **fails** |
| add `FUNDAY` / lowercase alias | green | **fails at build** |

Only two of seven days were ever pinned as *acceptable*, and only because they're the defaults. Worse, one existing test **passed because of the rejection it was meant to disprove** — `includes("WEDNESDAY")` matched the message rejecting Wednesday as invalid. It now matches against that field's own problem.

Four new rules, each mutation-checked one-for-one.

## #129 had already regressed

The removed abandonment rule survived in four more places, including **`draft.test.ts` — the test that pins the behaviour**, so a maintainer following the corrected docstring to its test finds the removed rule restated as the reason. Also `DATA-MODEL.md` (two columns dropped by migration `0015`) and `RULES.md`'s own summary table, which contradicted `RULES.md:618` three hundred lines down.

And the #129 correction itself overshot: *"cannot field a legal lineup"* is false — `validateLineup` refuses an empty starter only under `requireFull`, which no production caller sets — and the same comment says so five lines later.

## Verified against production

50 leagues, every one `TUESDAY`/`WEDNESDAY`, across schemaVersions 4 through 8. **Zero would fail any of the new checks.** The golden hash is unmoved: validation reads the document, it does not encode it.

---

2213 tests (was 2208). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
