### PR TITLE
docs: a section heading is prose to GitHub's keyword parser too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -730,6 +730,17 @@ is 2.
   it**. Write "this does not resolve the cause in #165", or keep the number away
   from the verb. Third issue swallowed, first by this mechanism.
 
+  **And a section heading counts. Fourth and fifth swallowed, 2026-08-25.** Two PRs
+  from the audit series carried the heading `## Filed, not fixed` directly above a
+  link to the issue they were explicitly declining to fix; GitHub read `fixed
+#240` and `fixed #243` and closed both on merge. The rule above was already
+  written and already says "in any form" — what it did not say is that headings,
+  labels and list markers are prose to the parser too, and that the safest habit
+  is to keep the word and the number on **different lines with text between
+  them**. "Filed rather than fixed" reads the same and does not fire, because the
+  number is a paragraph away. Check the issue is still open after a merge; it
+  takes one command and this has now cost five.
+
 - **#157** — provider stats that contradict themselves are ingested silently. Only
   field goals are cross-checked today. Two cheap checks would have caught both
   known cases without a season sweep or a second source.


### PR DESCRIPTION
Two issues from the audit series were auto-closed on merge, and I closed them by accident.

[#240](https://github.com/6figpsolseeker/rostr/issues/240) and [#243](https://github.com/6figpsolseeker/rostr/issues/243) were both filed as explicitly **not** fixed by the PRs that reference them. Both PR bodies carried the heading:

```
## Filed, not fixed

[#240](...) — the autofill can start a player whose game is already under way...
```

GitHub's keyword parser read `fixed #240` and `fixed #243` and closed them on merge.

## Why this one stings

The rule is already in `CLAUDE.md`, written after #166 lost #165 to the sentence *"This does not close #165"*:

> never put `close`/`fix`/`resolve` (in any form) immediately before an issue number in a PR body **at all, even to deny it**

I had read that and still broke it, because a **heading** didn't register as "immediately before an issue number." It is, to the parser.

## The habit that actually works

Spatial, not lexical. Keep the verb and the number on **different lines with text between them** — "Filed rather than fixed", then a paragraph, then the link. Reads identically, cannot fire.

And check the issue is still open after the merge. One command, and this mechanism has now swallowed **five**: #79 twice, #165, #240, #243.

Both issues are reopened. Open issue count corrected 35 → **37**.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)