### PR TITLE
docs: inline code does not quote an issue reference, as this proved twice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -741,6 +741,19 @@ is 2.
   number is a paragraph away. Check the issue is still open after a merge; it
   takes one command and this has now cost five.
 
+  **Backticks do not protect it, and the PR that documented this proved so by
+  firing it.** #247 was written to record the heading variant above. Its body
+  quoted the offending form as an example, inline, inside backticks — and GitHub
+  parsed the example as a directive and closed the same two issues a second time,
+  on the merge of the commit explaining why they must not be closed. Inline code
+  is not quoting to that parser, and neither, as far as this repo can tell, is
+  anything else.
+
+  So the trap **cannot be written down by demonstrating it**. Describe the shape
+  in words, or use a placeholder number that belongs to nothing. Every real issue
+  number in a PR body wants a paragraph between it and any word resembling close,
+  fix or resolve — including one you are quoting in order to warn about.
+
 - **#157** — provider stats that contradict themselves are ingested silently. Only
   field goals are cross-checked today. Two cheap checks would have caught both
   known cases without a season sweep or a second source.


### PR DESCRIPTION
The PR that documented the heading variant of GitHub's keyword trap **fired the trap** — it closed the same two issues a second time, on merge, because its body quoted the offending form as an example inside backticks.

Inline code is not quoting to that parser.

## What happened

1. Two audit PRs used a section heading meaning "filed rather than repaired", directly above an issue link. Both issues auto-closed on merge.
2. I reopened them and wrote a PR recording the variant. That PR body quoted the literal form as an example.
3. On merge, both issues closed **again** — by the commit explaining why they must not be closed.
4. Reopened once more. They are open now.

## What survives as guidance

The shape cannot be written down by demonstrating it. Two rules, both spatial rather than lexical:

- describe it in words, or use a placeholder number that belongs to nothing
- every real issue number in a PR body wants a paragraph between it and any word resembling the three verbs — **including one being quoted in order to warn about it**

And verify after every merge that the issues a PR merely references are still open. That is one command, and this mechanism has now cost this repo seven closures across five distinct issues.

Docs only. No code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)