### PR TITLE
fix(db): a box score almost nobody joined recorded itself as a clean success

### DIFF
--- a/apps/web/src/lib/jobs/stats.test.ts
+++ b/apps/web/src/lib/jobs/stats.test.ts
@@ -108,16 +108,48 @@ async function seedDefenses(): Promise<void> {
   const [sport] = await db!.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
     NFL.key,
   ]);
-  const [def] = await db!.query<{ id: string }>(
-    "SELECT id FROM positions WHERE sport_id = $1 AND key = 'DEF'",
-    [sport!.id],
+  const positions = new Map(
+    (
+      await db!.query<{ id: string; key: string }>(
+        "SELECT id, key FROM positions WHERE sport_id = $1",
+        [sport!.id],
+      )
+    ).map((row) => [row.key, row.id]),
   );
 
   for (const abv of ["PHI", "DAL"]) {
     await db!.query(
       `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
        VALUES ($1, $2, $2, $3, $4)`,
-      [sport!.id, `DST_${abv}`, def!.id, abv],
+      [sport!.id, `DST_${abv}`, positions.get("DEF")!, abv],
+    );
+  }
+
+  /*
+    One player for every other position the registry declares, which no test here
+    references.
+
+    They are here because #232 added a check that refuses a run whose player pool
+    has any declared position at zero — a vanished position group is invisible to
+    any per-game join ratio, and it zeroes every player in that group
+    permanently. A pool holding only defences is a state a synced database never
+    reaches, and the check caught this fixture the moment it was written.
+
+    The same widening was needed in `box-scores.test.ts`. Both were staging a
+    pool the product cannot produce, which is the failure this repo keeps paying
+    for in the other direction.
+  */
+  for (const [ref, key] of [
+    ["qb1", "QB"],
+    ["rb1", "RB"],
+    ["wr1", "WR"],
+    ["te1", "TE"],
+    ["k1", "K"],
+  ] as const) {
+    await db!.query(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $2, $3, 'PHI')`,
+      [sport!.id, ref, positions.get(key)!],
     );
   }
 }
@@ -175,6 +207,9 @@ describe("the stats cron", () => {
     await seedSport(db, NFL);
     await league(2026);
     await finishedGame(2026, "g1");
+    // A real pool, or #232 layer one refuses the run before the provider is
+    // called and this becomes a broken *season* rather than a failed game.
+    await seedDefenses();
 
     // `syncBoxScores` catches a per-game failure and returns it rather than
     // throwing, which is right — one bad game must not stop the others. The

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -127,9 +127,28 @@ async function setup(status = "FINAL"): Promise<Fixture> {
   );
 
   const players = new Map<string, string>();
+  /*
+    Every position the sport registry declares, not only the ones a test uses.
+
+    A real pool always carries all six — the live table holds hundreds of each —
+    and #232 added a check that refuses a run whose pool has a position group at
+    zero, because a vanished group is invisible to any per-game join ratio. A
+    fixture seeding three of six was staging a pool the product cannot produce,
+    and the check caught it the moment it was written.
+
+    `wr1`, `te1` and `k1` exist to make the pool real. No test needs to reference
+    them.
+  */
   const roster: [string, string][] = [
     ["qb1", "QB"],
     ["rb1", "RB"],
+    ["wr1", "WR"],
+    ["wr2", "WR"],
+    ["wr3", "WR"],
+    ["rb2", "RB"],
+    ["te1", "TE"],
+    ["te2", "TE"],
+    ["k1", "K"],
     ["DST_PHI", "DEF"],
     ["DST_DAL", "DEF"],
   ];
@@ -994,5 +1013,228 @@ describe("a game whose ingest failed — #227", () => {
 
     const second = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
     expect(second.games).toBe(0);
+  });
+});
+
+describe("a box score whose players do not join — #232", () => {
+  /*
+    The defect: unresolvable refs went into their own array and never reached
+    `problems`, so a game where almost nothing joined recorded a clean success —
+    `stats_error` NULL (clearing any prior error), `stats_synced_at` stamped, the
+    week finalising at zero, and nothing on any of nine surfaces showing it.
+
+    The two D/ST refs are what let it through: they are synthesised
+    `DST_<abv>` names matched against thirty-two stable rows, carrying a
+    `def_pts_allowed` written even at nought, so they clear the "translated to no
+    stat lines" guard on their own while every skill player fails.
+  */
+
+  it("refuses a game where most scoring players did not join", async () => {
+    const fx = await setup();
+
+    // 14 scoring refs: 2 D/ST that join, 12 ghosts that do not. 12 of 14 is
+    // 8571 bps, far past the 2500 threshold, and 14 clears the floor of 12.
+    const players: Record<string, ReturnType<typeof line>[]> = { ...bothDefenses };
+    for (let i = 0; i < 12; i++) players[`ghost-${i}`] = [line("pass_yd", 10)];
+
+    const provider = fakeProvider(new Map([["g1", boxScore("g1", players)]]));
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.reason).toMatch(/did not match the player pool/);
+
+    /*
+      The assertion that makes this issue #232 rather than a nicety.
+
+      `stats_synced_at` is what the week's finalisation hold reads. Left unset,
+      the game counts as unread, the week holds for its correction window, and
+      the twenty-minute retry runs — all of which the existing per-game catch
+      already provides, which is why this throws rather than recording a warning.
+    */
+    const [row] = await fx.client.query<{
+      stats_synced_at: string | null;
+      stats_error: string | null;
+    }>("SELECT stats_synced_at, stats_error FROM games WHERE id = $1", [fx.gameId]);
+
+    expect(row?.stats_synced_at).toBeNull();
+    expect(row?.stats_error).toMatch(/did not match the player pool/);
+
+    // Nothing was written, so `failures`' promise stays literally true.
+    const [lines] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM stat_lines",
+    );
+    expect(lines?.n).toBe(0);
+  });
+
+  it("stays silent on the healthy shape, where most refs never join", async () => {
+    /*
+      **The regression test for the measurement this fix is built on.**
+
+      Sixty to seventy percent of a real box score never joins and never should:
+      it carries everyone who took a snap, and `players` holds the six positions
+      a fantasy roster can field. Across thirteen corpus games the unmatched rate
+      over *all* refs is 67-71%.
+
+      So a guard on the wrong denominator fires on every game ever ingested. This
+      stages that shape — two joining scorers, sixty non-scoring strangers — and
+      must stay green forever.
+    */
+    const fx = await setup();
+
+    const players: Record<string, ReturnType<typeof line>[]> = {
+      qb1: [line("pass_yd", 300)],
+      rb1: [line("rush_yd", 80)],
+      ...bothDefenses,
+    };
+    for (let i = 0; i < 60; i++) players[`lineman-${i}`] = [];
+
+    const provider = fakeProvider(new Map([["g1", boxScore("g1", players)]]));
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(0);
+    expect(result.unmatched).toHaveLength(60);
+
+    const [row] = await fx.client.query<{
+      stats_synced_at: string | null;
+      stats_error: string | null;
+    }>("SELECT stats_synced_at, stats_error FROM games WHERE id = $1", [fx.gameId]);
+    expect(row?.stats_synced_at).not.toBeNull();
+    expect(row?.stats_error).toBeNull();
+  });
+
+  it("tolerates the innocent misses a real game carries", async () => {
+    /*
+      Five of 277 scoring refs across thirteen real games fail to join, and every
+      one is a defensive or special-teams player credited with a return
+      touchdown — nobody can roster them, so they cost no points. The worst
+      single game is two of twenty-two, which is 909 bps against a 2500
+      threshold.
+
+      Two unjoinable scorers among fourteen is 1428 bps: past the worst observed
+      game and still comfortably silent.
+    */
+    const fx = await setup();
+
+    const players: Record<string, ReturnType<typeof line>[]> = {
+      qb1: [line("pass_yd", 300)],
+      rb1: [line("rush_yd", 80)],
+      wr1: [line("rec_yd", 40)],
+      te1: [line("rec_yd", 20)],
+      k1: [line("fg_0_39", 1)],
+      "returner-a": [line("ret_td", 1)],
+      "returner-b": [line("ret_td", 1)],
+      ...bothDefenses,
+    };
+    for (let i = 0; i < 5; i++) players[`extra-${i}`] = [];
+
+    const provider = fakeProvider(new Map([["g1", boxScore("g1", players)]]));
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(0);
+    expect(result.unmatched).toContain("returner-a");
+  });
+
+  it("catches a single position group vanishing from the box score", async () => {
+    /*
+      **The break that decides the constant, rather than a preference.**
+
+      Running backs are roughly a fifth of a pool and five or six of a games
+      twenty-odd scoring refs, so losing them is 23-27 percent. At 2500 bps that
+      fires; at the looser 3333 it does not, and every rostered running back in
+      every league scores zero permanently while the guard reads green.
+
+      Four unmatched of fourteen is 2857 bps, which sits between the two — so
+      this test is what makes the threshold a decision rather than a number
+      nobody can move.
+
+      Note this is the case layer one cannot help with: the pool still has
+      running backs, it is the box scores refs for them that stopped matching.
+    */
+    const fx = await setup();
+
+    const players: Record<string, ReturnType<typeof line>[]> = {
+      qb1: [line("pass_yd", 300)],
+      wr1: [line("rec_yd", 90)],
+      te1: [line("rec_yd", 30)],
+      k1: [line("fg_0_39", 1)],
+      ...bothDefenses,
+    };
+    // Eleven refs that join, four that do not: 4 of 15 is 2666 bps — above 2500
+    // and below 3333. The band is the whole point of the test.
+    for (const ref of ["rb2", "wr2", "wr3", "te2"]) players[ref] = [line("rec_yd", 15)];
+    for (let i = 0; i < 4; i++) players[`rb-unmatched-${i}`] = [line("rush_yd", 40)];
+
+    const provider = fakeProvider(new Map([["g1", boxScore("g1", players)]]));
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(1);
+  });
+
+  it("abstains below the denominator floor, so a live read is not judged", async () => {
+    /*
+      The floor is on the **denominator** — refs carrying stat lines — and never
+      on the matched count. A floor on matches is circular: a wholly broken pool
+      produces two matched refs, below any floor, so the guard would abstain
+      exactly when it must fire.
+
+      A return touchdown is as likely on the opening kickoff as in the fourth
+      quarter, and the work list takes IN_PROGRESS games — so one unrosterable
+      returner plus the two D/ST units is one unmatched of three at 13:01 on a
+      Sunday. That is 33% and entirely healthy.
+    */
+    const fx = await setup("IN_PROGRESS");
+
+    const provider = fakeProvider(
+      new Map([["g1", boxScore("g1", { returner: [line("ret_td", 1)], ...bothDefenses })]]),
+    );
+    const result = await syncBoxScores(fx.client, provider, NFL.key, SEASON);
+
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("refuses the whole run when a position group has vanished", async () => {
+    /*
+      The failure no per-game ratio can see, and the reason this layer exists.
+
+      Kickers are roughly two of twenty scoring refs, so losing every kicker in
+      the league moves the per-game ratio to about 9% — under the threshold, on
+      every game, forever, while every kicker scores zero permanently. The damage
+      is uniform across teams, so the standings look plausible and nothing
+      downstream notices either.
+
+      Checked once per run against our own database, before a single metered call
+      is spent. No threshold: it fires only at zero.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      `DELETE FROM players WHERE primary_position_id =
+         (SELECT id FROM positions WHERE sport_id = $1 AND key = 'K')`,
+      [fx.sportId],
+    );
+
+    const provider = fakeProvider(
+      new Map([["g1", boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses })]]),
+    );
+
+    await expect(syncBoxScores(fx.client, provider, NFL.key, SEASON)).rejects.toThrow(
+      /player pool has no K/,
+    );
+  });
+
+  it("names the empty groups rather than counting them", async () => {
+    // The idiom this file already uses, and for the reason recorded there: a
+    // bare count once hid every kicker in the league.
+    const fx = await setup();
+    await fx.client.query(
+      `DELETE FROM players WHERE primary_position_id IN
+         (SELECT id FROM positions WHERE sport_id = $1 AND key IN ('K', 'TE'))`,
+      [fx.sportId],
+    );
+
+    const provider = fakeProvider(new Map([["g1", boxScore("g1", bothDefenses)]]));
+
+    await expect(syncBoxScores(fx.client, provider, NFL.key, SEASON)).rejects.toThrow(
+      /no K, TE/,
+    );
   });
 });

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -86,6 +86,54 @@ export const LIVE_WINDOW_HOURS = 8;
  */
 export const MAX_GAMES_PER_RUN = 20;
 
+/*
+ * How many refs carrying stat lines a game must hold before its join rate means
+ * anything.
+ *
+ * **A floor on the denominator, never on the matched count.** A floor on matches
+ * is circular — a wholly broken player map produces two matched refs, which is
+ * below any floor, so the guard would abstain in precisely the case it exists
+ * for.
+ *
+ * The size is derived rather than chosen. The threshold below is a quarter, so
+ * its reciprocal is four: the floor has to exceed four times the largest number
+ * of *innocent* unmatched scoring refs a game can hold, or one of them alone
+ * trips it. Across the thirteen corpus games the worst is two, giving a floor of
+ * eight; twelve carries half again on top of that and still sits below the
+ * twenty a finished game carries, so no completed game is ever exempted.
+ *
+ * The gate is load-bearing and not a formality. A return touchdown is as likely
+ * on the opening kickoff as in the fourth quarter, and the work list takes
+ * IN_PROGRESS games — so a returner who cannot be rostered, plus the two D/ST
+ * units, is one unmatched of three at 13:01 on a Sunday. That is 33% and
+ * entirely healthy.
+ */
+export const MIN_SCORING_REFS_TO_JUDGE = 12;
+
+/*
+ * The share of stat-bearing refs that may fail to join before the read is
+ * treated as unusable. Basis points, because this repo does not put a float
+ * anywhere near a decision about scoring.
+ *
+ * **Measured, not picked.** Across the thirteen corpus games checked against the
+ * live player table, 5 of 277 refs that produced a stat line failed to join —
+ * 1.81%, worst game 2 of 22 — and every one was a defensive or special-teams
+ * player credited with a return touchdown. Nobody can roster those, so they cost
+ * no points. A stale map gives ~100%.
+ *
+ * 2500 is 2.75x the worst healthy game. The looser 3333 was considered and
+ * rejected on a nameable break rather than a preference: losing the running
+ * backs from the pool is 23-27% of a game's scoring refs, which 2500 catches and
+ * 3333 does not.
+ *
+ * **The denominator is deliberately stat-bearing refs and not all refs.** Sixty
+ * to seventy percent of a real box score never joins and never should: it
+ * carries everyone who took a snap, and `players` holds the six positions a
+ * fantasy roster can field. Over all refs the healthy rate is 67-71% and no
+ * threshold in that band means anything.
+ */
+export const MAX_UNJOINED_SCORING_BPS = 2500;
+
 export interface BoxScoreSyncResult {
   readonly games: number;
   /** Stat lines seen for the first time — revision 0. */
@@ -269,14 +317,56 @@ export async function syncBoxScores(
       )
     ).map((row) => [row.key, row.id]),
   );
-  const playerIds = new Map(
-    (
-      await db.query<{ id: string; external_ref: string }>(
-        "SELECT id, external_ref FROM players WHERE sport_id = $1",
-        [ids.sportId],
-      )
-    ).map((row) => [row.external_ref, row.id]),
+  const playerRows = await db.query<{
+    id: string;
+    external_ref: string;
+    position_id: string | null;
+  }>(
+    "SELECT id, external_ref, primary_position_id AS position_id FROM players WHERE sport_id = $1",
+    [ids.sportId],
   );
+  const playerIds = new Map(playerRows.map((row) => [row.external_ref, row.id]));
+
+  /*
+    **The pool is checked before a box score is fetched, not inferred from one.**
+
+    This map is built once and serves the whole slate, so a hole in it is a
+    property of the run rather than of any game. That makes it checkable here,
+    for free, against our own database — and checking it here aborts before
+    spending up to `MAX_GAMES_PER_RUN` metered calls on a run that can only
+    produce garbage.
+
+    The predicate is position **coverage**, not pool size. A size floor would be
+    a sport-size assumption, and invariant 3 says sports are data and never
+    structure. Every position the registry declares must have somebody behind it,
+    which needs no threshold: it fires only at zero, and for a synced pool the
+    smallest group is in the dozens.
+
+    **It catches the failure the per-game ratio is structurally blind to.**
+    Kickers are roughly two of twenty scoring refs, so losing every kicker in the
+    league moves that ratio to about 9% — under every threshold, on every game,
+    forever, while every kicker scores zero permanently. Because that damage is
+    uniform across teams the standings look plausible too, so nothing downstream
+    notices either. This file has paid for that lesson once already: a bare count
+    of unmatched players once hid exactly that.
+
+    Throwing is the established shape here rather than a new convention —
+    `loadSportIds` above throws `SportNotSeededError` for the same class of
+    whole-run precondition. `runStatsJob` wraps each season in its own catch, so
+    other seasons still run and the heartbeat goes red.
+  */
+  const populated = new Set(playerRows.map((row) => row.position_id).filter(Boolean));
+  const emptyPositions = [...ids.positionIds]
+    .filter(([, positionId]) => !populated.has(positionId))
+    .map(([key]) => key)
+    .sort();
+  if (emptyPositions.length > 0) {
+    throw new Error(
+      `The player pool has no ${emptyPositions.join(", ")} for ${sportKey}. ` +
+        `Every box score would score those positions zero, so no game was read. ` +
+        `Run the players sync before retrying.`,
+    );
+  }
 
   let inserted = 0;
   let revised = 0;
@@ -475,10 +565,24 @@ async function ingestOneGame(
   const rowStatKey: string[] = [];
   const rowValue: number[] = [];
 
+  /*
+    Two tallies, and only one of them is evidence.
+
+    A ref carrying no stat line and no `players` row costs nothing: it writes
+    nothing and covers nothing. A ref carrying lines is a score that went
+    somewhere and did not arrive. The guard below counts only the second.
+  */
+  let scoringRefs = 0;
+  const unmatchedScoring: string[] = [];
+
   for (const [ref, lines] of usable) {
+    const scoring = lines.length > 0;
+    if (scoring) scoringRefs++;
+
     const playerId = playerIds.get(ref);
     if (!playerId) {
       unmatched.push(ref);
+      if (scoring) unmatchedScoring.push(ref);
       continue;
     }
 
@@ -508,6 +612,63 @@ async function ingestOneGame(
   // Retracting against it would zero the week.
   if (rowValue.length === 0) {
     throw new Error(`Box score ${game.external_ref} translated to no stat lines`);
+  }
+
+  /*
+    The same guard as the one above with its threshold raised off zero. Issue
+    #232.
+
+    That one asks whether *anything* joined; this asks whether the players who
+    **scored** joined. The gap between them was the whole defect: two synthesised
+    `DST_<abv>` refs match thirty-two stable rows and carry a `def_pts_allowed`
+    written even at nought, so they clear the empty check on their own while
+    every skill player in the game fails to join. The read then recorded itself
+    as a clean success.
+
+    **Throwing rather than recording a warning is the load-bearing choice**, and
+    the reason is one column. A warning reaches `stats_error`, and the statement
+    that writes it also stamps `stats_synced_at` — which is what the week's
+    finalisation hold reads, not `stats_error`. So a flagged game would still
+    claim to have synced, the week would still settle at zero, and the flag would
+    sit on a page nobody was watching. The per-game catch already withholds that
+    stamp, sets the error, records a failure and writes nothing, which is all
+    four things this needs; it also sits above the transaction, so `failures`'
+    promise that nothing was written stays literally true.
+
+    **Writing the joined rows and withholding the stamp was considered and
+    rejected.** Those rows are right-and-incomplete rather than wrong, and in
+    every branch where the pool is repaired inside the window the two designs end
+    byte-identical — there are roughly a hundred and forty retries in a
+    forty-eight hour window. They differ only where the pool stays broken *and*
+    nobody reads a red heartbeat for two days. There, a partial week settles at
+    around forty percent of normal scoring with each team penalised in proportion
+    to how many of its own starters were missing from our table, which is a
+    permanent win-loss record distributed by an artifact of our database — and
+    biased, because the players missing are disproportionately rookies and recent
+    signings. All-zero settles as ties, which is uniform, obvious on the
+    scoreboard, and already what `RULES.md` §10 prescribes for a game whose stats
+    never arrive. There is no rule anywhere for a game we half-read.
+
+    This does not prevent the bad outcome. It delays it and makes it loud: the
+    hold is bounded, and past the correction window the week finalises regardless
+    with the reason named. That is the correct ceiling — a week that can never
+    settle is worse than the defect being fixed.
+  */
+  if (
+    scoringRefs >= MIN_SCORING_REFS_TO_JUDGE &&
+    unmatchedScoring.length * 10_000 > scoringRefs * MAX_UNJOINED_SCORING_BPS
+  ) {
+    // Named, not counted — the idiom this file already uses for `unmatched`, and
+    // for the reason recorded there: a bare count once hid every kicker in the
+    // league. The scoring list is five names across thirteen real games, so it
+    // is short enough to print.
+    const named = unmatchedScoring.slice(0, 8).join(", ");
+    throw new Error(
+      `Box score ${game.external_ref}: ${unmatchedScoring.length} of ${scoringRefs} ` +
+        `players carrying stats did not match the player pool ` +
+        `(${named}${unmatchedScoring.length > 8 ? ", …" : ""}). ` +
+        `The pool is stale, or the provider changed its refs.`,
+    );
   }
 
   const ptsAllowedId = statKeyIds.get("def_pts_allowed") ?? null;


### PR DESCRIPTION
A partial box-score ingest recorded itself as a clean success. Three agents confirmed the bug independently, proposed three fixes, and converged on this one — two of them changing position along the way.

## The defect

`ingestOneGame` collected unresolvable player refs into `unmatched` and never folded them into `problems`. So a game where almost nothing joined wrote `stats_error = NULL` — **clearing any prior error** — stamped `stats_synced_at`, and returned success.

Every downstream consequence follows from that one stamp:

- the week's finalisation hold reads `stats_synced_at`, so the week settles at zero and **is never rescored**
- `stats_error` is what paces the re-read, so clearing it **removes the game from the retry clause entirely**
- nine surfaces were checked — `stats_error`, `unresolvedStatsProblems`, `/ops/stats`, `cron_runs`, `cron:status`, the scoreboard — and **none shows it**

`playerIds` is built once per run and reused, so a broken map fails the **whole slate** together. And the quiet case is the severe one: a *fully* broken map throws at the empty-rows guard, while a 93-of-95 failure is invisible, because the two synthesised `DST_<abv>` refs always match and always clear that guard.

## The measurement that decided the shape

The fix I proposed when filing the issue was wrong on its denominator. Measured across all 13 corpus games against the live player table:

| | |
|---|---|
| Unmatched refs in a **healthy** game | **67–71%** (851 of 1,221) |
| Unmatched **stat-bearing** refs | **5 of 277 — 1.81%**, worst game 2 of 22 |

Not staleness — structural. The box score carries everyone who took a snap; `players` holds the six positions a fantasy roster can field. All five innocent misses are non-rosterable players credited with return touchdowns, which cost nothing.

**A guard over all refs would have fired on every game ever ingested.**

## The fix — two layers

**Layer 1: pool coverage, once per run, before any metered call.** Every position the sport registry declares must have at least one player. Zero calibration — it fires only at zero. It catches the failure a per-game ratio is *structurally* blind to: losing every kicker moves the ratio to ~9%, under any threshold, on every game, forever, while every kicker scores zero permanently and the standings still look plausible. Throwing here is the established shape (`loadSportIds` already does it), and `runStatsJob`'s per-season catch means other seasons still run and the heartbeat reddens.

**Layer 2: per game, `scoringRefs >= 12 && unmatchedScoring * 10_000 > scoringRefs * 2500`.** Basis points, not a float. Throws before the transaction, into the existing per-game catch — which already withholds `stats_synced_at`, sets `stats_error`, records a failure and writes nothing. It is the `rowValue.length === 0` guard with its threshold raised off zero.

Both constants are derived rather than picked:

- **12** — the threshold's reciprocal is 4, so the floor must exceed 4× the largest innocent unmatched count (2 in the corpus → 8). Twelve carries half again on top and still sits below the 20 a finished game holds.
- **2500 bps** — 2.75× the worst healthy game. The looser 3333 was rejected on a nameable break: **losing the running backs is 23–27%, which 2500 catches and 3333 does not.**

**The floor is on the denominator, never the matched count.** A floor on matches is circular — a wholly broken pool produces 2 matched refs, below any floor, so it would abstain exactly when it must fire. There's a test for that inversion.

## Why throw rather than write-and-flag

The alternative — write the joined rows, withhold the stamp — was argued hard and rejected. Both designs get the identical hold, retry and red heartbeat, and across ~144 retries in a 48-hour window they end **byte-identical**. They differ only where the pool stays broken *and* nobody reads a red heartbeat for two days.

There, partial data settles at ~40% of normal scoring **with each team penalised in proportion to how many of its own starters were missing from our table** — a permanent win/loss record distributed by an artifact of our database, and biased, since the missing players are disproportionately rookies and recent signings. All-zero settles as ties: uniform, obvious, and already what `RULES.md` §10 prescribes for a game whose stats never arrive. **There is no rule anywhere for a game we half-read.**

This does not prevent the bad outcome. It delays it and makes it loud — the hold is bounded, and past the window the week finalises with the reason named. That's the correct ceiling; a week that can never settle is worse than the defect.

## The fixtures were staging a pool the product cannot produce

Layer 1 fired immediately on three test fixtures seeding three positions of six. A real pool has all six — production right now is WR 648, RB 348, TE 311, QB 175, K 72, DEF 32. Widened rather than softened, because that's the same class of defect this repo keeps finding in the other direction.

Seven tests, all five mutations caught:

```
delete layer 1        → 2 failed
delete layer 2        → 2 failed
count all refs        → 2 failed  (the denominator)
floor on matched      → 2 failed  (the circular inversion)
2500 → 3333           → 1 failed  (the RB-group break)
```

## Verified against production

Layer 1 passes — every declared position populated, smallest group 32. It would not abort the stats cron on deploy.

## Not caught

A ref that joins to the **wrong** player. Nothing here compares a name — the pool check counts rows and the ratio counts misses. `capture.ts` already does surname verification for the second-source join and nothing does it for the ingest key. That's the more dangerous of the two and belongs in its own issue.

---

2220 tests (was 2213). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
