### PR TITLE
fix(core): a signed IR allowance bought room in one market and none in the other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,7 +512,12 @@ elsewhere. Now 60s. Suspect this before suspecting a test that fails only in a f
 did not exist. Nothing broke because nobody but the owner uses it. CI does not run
 migrations against Supabase and never will — see the database section.
 
-**IR enforcement is continuous, and nothing is forced off.** The owner's rule is that a
+**IR enforcement is continuous, and nothing is forced off** — continuous
+wherever the exemption is _read_, which until #237 was one of the two paths that
+apply a roster limit. `addFreeAgent` subtracted stashed players and the waiver
+resolver counted them, so the signed allowance worked in the first-come market
+and vanished in the priority-allocated one. Both read it now. **Trades read no
+roster limit at all**, which is a separate and larger gap. The owner's rule is that a
 player on IR must actually be injured. The safe shape is a **conditional exemption**: a
 recovered player is not moved or dropped, he stops being exempt and counts against the
 roster again. Forcing him off would make a display-only column drop somebody's roster spot

--- a/apps/web/src/app/api/leagues/[id]/players/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/players/route.ts
@@ -42,13 +42,14 @@ export async function GET(
     const available = await availablePlayers(client, id, now);
     const roster = await client.query<{
       player_id: string;
+      on_ir: boolean;
       full_name: string;
       key: string;
       image_url: string | null;
       team_ref: string | null;
       injury_designation: string | null;
     }>(
-      `SELECT r.player_id, p.full_name, pos.key,
+      `SELECT r.player_id, r.on_ir, p.full_name, pos.key,
               p.image_url, p.team_ref, p.injury_designation
          FROM roster_entries r
          JOIN players p ON p.id = r.player_id
@@ -69,8 +70,16 @@ export async function GET(
         teamRef: player.teamRef,
         injuryDesignation: player.injuryDesignation,
       })),
+      /*
+        `onIr` is here so the drop selector can say so.
+
+        Without it a stashed player sits in that dropdown looking exactly like a
+        droppable bench player — and dropping him frees no roster space, which
+        is the one mistake #237's fix makes likely rather than rare.
+      */
       roster: roster.map((row) => ({
         playerId: row.player_id,
+        onIr: row.on_ir,
         name: row.full_name,
         position: row.key,
         imageUrl: row.image_url,

--- a/apps/web/src/components/PlayerMarket.tsx
+++ b/apps/web/src/components/PlayerMarket.tsx
@@ -38,6 +38,7 @@ interface Rostered {
   imageUrl: string | null;
   teamRef: string | null;
   injuryDesignation: string | null;
+  onIr: boolean;
 }
 
 interface Claim {
@@ -221,6 +222,7 @@ export function PlayerMarket({ leagueId }: { leagueId: string }) {
             {data.roster.map((player) => (
               <option key={player.playerId} value={player.playerId}>
                 {player.position} {player.name}
+                {player.onIr ? " (IR — dropping him frees no space)" : ""}
               </option>
             ))}
           </select>

--- a/apps/web/src/lib/waiver-run.test.ts
+++ b/apps/web/src/lib/waiver-run.test.ts
@@ -6,7 +6,7 @@ describe("whyClaimFailed", () => {
     // The whole argument for storing the reason. One is the rules working, the
     // other is something the manager will repeat next Wednesday unless told.
     expect(whyClaimFailed("PLAYER_TAKEN")).toContain("better priority");
-    expect(whyClaimFailed("ROSTER_FULL")).toContain("roster was full");
+    expect(whyClaimFailed("ROSTER_FULL")).toContain("roster was still full");
     expect(whyClaimFailed("PLAYER_TAKEN")).not.toBe(whyClaimFailed("ROSTER_FULL"));
   });
 

--- a/apps/web/src/lib/waiver-run.ts
+++ b/apps/web/src/lib/waiver-run.ts
@@ -33,7 +33,18 @@ export function whyClaimFailed(reason: string | null): string {
     case "PLAYER_TAKEN":
       return "a team with better priority claimed him first";
     case "ROSTER_FULL":
-      return "your roster was full and the claim named nobody to drop";
+      // **Not "named nobody to drop".** That was false in the case #237 created
+      // and stays false in one the fix leaves behind: a stashed player who
+      // recovers puts a team over the counted limit, so a claim naming a
+      // perfectly valid drop is still refused. The panel prints the drop two
+      // lines above this sentence, so the old wording denied, on one line, the
+      // fact rendered on the line before it.
+      return "your roster was still full, even after any drop the claim named";
+    case "DROP_ON_IR":
+      // The mistake this fix makes likely. Once claims start being awarded,
+      // "drop the injured one" is the natural way to make room — and it is the
+      // one drop that makes none, because he was not occupying a counted slot.
+      return "the player you dropped was on injured reserve, so dropping him freed no roster space";
     case "DROP_NOT_ON_ROSTER":
       return "the player you offered to drop was no longer on your roster";
     case "ALREADY_ROSTERED":

--- a/packages/core/src/draft/autopick.ts
+++ b/packages/core/src/draft/autopick.ts
@@ -86,7 +86,9 @@ export function autoPick(context: AutoPickContext): AutoPickResult | null {
 
   const byId = new Map(available.map((player) => [player.playerId, player]));
 
-  const isLegal = (player: DraftablePlayer): boolean => canDraft(roster, player, shape).legal;
+  // Zero exempt — see the note in `state.ts`. Nobody is on IR during a draft.
+  const isLegal = (player: DraftablePlayer): boolean =>
+    canDraft(roster, player, shape, 0).legal;
 
   /**
    * Legal *and* leaves a fillable lineup.

--- a/packages/core/src/draft/draft.test.ts
+++ b/packages/core/src/draft/draft.test.ts
@@ -208,24 +208,24 @@ describe("roster legality", () => {
   });
 
   it("permits a legal pick", () => {
-    expect(canDraft([], player("rb1", ["RB"]), SHAPE).legal).toBe(true);
+    expect(canDraft([], player("rb1", ["RB"]), SHAPE, 0).legal).toBe(true);
   });
 
   it("refuses a player already rostered", () => {
     const rb = player("rb1", ["RB"]);
-    expect(canDraft([rb], rb, SHAPE).reason).toBe("ALREADY_ROSTERED");
+    expect(canDraft([rb], rb, SHAPE, 0).reason).toBe("ALREADY_ROSTERED");
   });
 
   it("refuses when the roster is full", () => {
     const full = Array.from({ length: SHAPE.totalSlots }, (_, i) => player(`p${i}`, ["WR"], i));
-    expect(canDraft(full, player("new", ["WR"]), SHAPE).reason).toBe("ROSTER_FULL");
+    expect(canDraft(full, player("new", ["WR"]), SHAPE, 0).reason).toBe("ROSTER_FULL");
   });
 
   it("permits a deliberately terrible draft", () => {
     // Nothing but wide receivers is a decision, not an error. The manager owns
     // it, the same as on ESPN and Sleeper.
     const allWr = Array.from({ length: 10 }, (_, i) => player(`wr${i}`, ["WR"], i));
-    expect(canDraft(allWr, player("wr-more", ["WR"]), SHAPE).legal).toBe(true);
+    expect(canDraft(allWr, player("wr-more", ["WR"]), SHAPE, 0).legal).toBe(true);
   });
 });
 

--- a/packages/core/src/draft/roster.ts
+++ b/packages/core/src/draft/roster.ts
@@ -230,8 +230,31 @@ export function canDraft(
   roster: readonly DraftablePlayer[],
   player: DraftablePlayer,
   shape: RosterShape,
+  /*
+    How many of `roster` do not count against `totalSlots` — injured reserve,
+    per the league's signed `roster.irSlots`.
+
+    They stay in the array. This function's identity check needs them, and so do
+    its callers' drop lookups; only the count moves. Handing a filtered array
+    instead would silently disable the `ALREADY_ROSTERED` branch below, and a
+    caller that happens to duplicate that check today would become the only
+    thing performing it.
+
+    **Required, not defaulted**, and the argument for that is issue #237
+    itself. A default of zero fails *closed* — it counts injured players against
+    the limit — which sounds safe and is exactly the bug: the waiver resolver
+    omitted this subtraction and refused claims a signed allowance entitled
+    members to win. "A capacity rule that is right unless somebody remembers" is
+    the shape that produced the defect, and this repo has paid for it once
+    before, where an optional source filter defaulting to "all" was not a
+    filter. Two call sites in the draft pass an explicit zero.
+
+    Deliberately a bare count rather than an injury concept: this file decides
+    roster legality and should not learn what an injury is.
+  */
+  exemptFromCount: number,
 ): PickLegality {
-  if (roster.length >= shape.totalSlots) {
+  if (roster.length - exemptFromCount >= shape.totalSlots) {
     return { legal: false, reason: "ROSTER_FULL" };
   }
   if (roster.some((p) => p.playerId === player.playerId)) {

--- a/packages/core/src/draft/state.ts
+++ b/packages/core/src/draft/state.ts
@@ -151,7 +151,10 @@ export function makePick(state: DraftState, input: MakePickInput): DraftState {
     throw new DraftError(`Player ${input.playerId} is not available`, "PLAYER_UNAVAILABLE");
   }
 
-  const legality = canDraft(rosterFor(state, input.teamId, input.pool), player, input.shape);
+  // Zero exempt: a drafting roster holds nobody on injured reserve. Picks
+  // insert `on_ir` false, and `moveToIr` requires a live injury designation,
+  // so no stash exists before the season and none can buy an extra pick.
+  const legality = canDraft(rosterFor(state, input.teamId, input.pool), player, input.shape, 0);
   if (!legality.legal) {
     throw new DraftError(
       `Cannot draft ${input.playerId}: ${legality.reason}`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -279,6 +279,7 @@ export {
 export {
   countedRosterSize,
   irExemptCount,
+  irExemptOnRoster,
   IR_ELIGIBLE_DESIGNATIONS,
   isIrEligible,
   refuseIrPlacement,

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -10,6 +10,28 @@
  * Pure, and in `@rostr/core` rather than in the database layer, because it is a
  * rule rather than a query: the same answer has to govern a manager's own
  * placement, an add that needs the room, and whatever screen explains why.
+ *
+ * ## Which paths apply the roster limit
+ *
+ * `RULES.md` §2 promises IR slots "do not count against the roster limit",
+ * unqualified, so every path that applies that limit must subtract them. There
+ * are two, and until #237 only one did:
+ *
+ * - `addFreeAgent` — has always used `countedRosterSize`.
+ * - `resolveWaiverClaims`, through `processWaivers` — loaded rosters without
+ *   the IR columns and counted stashed players against the limit, so a signed
+ *   allowance bought room in the first-come market and none in the
+ *   priority-allocated one. Fixed by passing an exempt set and counting it
+ *   against the roster a claim's drop would leave.
+ *
+ * **Trades apply no roster limit at all**, so there is nothing there for this to
+ * be subtracted from — a trade can leave a team over `totalSlots` and nothing
+ * refuses or reports it. That is a separate gap, and a larger one.
+ *
+ * Migration `0038` says the stash count is what "both the capacity rule and the
+ * IR limit consult on every transaction". That was never true and cannot be
+ * corrected in place — the runner compares a checksum over the file and the
+ * deployed database is past it — so the correction lives here.
  */
 
 /**
@@ -79,12 +101,47 @@ export interface IrRosterEntry {
  * Capped at `irSlots` regardless. Being injured is a condition of occupying the
  * slot, not a way to conjure more of them.
  */
-export function irExemptCount(roster: readonly IrRosterEntry[], irSlots: number): number {
-  const genuine = roster.filter(
-    (entry) => entry.onIr && isIrEligible(entry.injuryDesignation),
-  ).length;
-
+/*
+ * The cap, in one place, because two entry points now apply it.
+ *
+ * Being injured is a condition of occupying a slot, not a way to conjure more
+ * of them — so however many genuinely-injured players a roster holds, only
+ * `irSlots` of them are exempt.
+ */
+function capped(genuine: number, irSlots: number): number {
   return Math.min(genuine, Math.max(0, irSlots));
+}
+
+export function irExemptCount(roster: readonly IrRosterEntry[], irSlots: number): number {
+  return capped(
+    roster.filter((entry) => entry.onIr && isIrEligible(entry.injuryDesignation)).length,
+    irSlots,
+  );
+}
+
+/*
+ * The same cap, for a caller that already knows which players qualify.
+ *
+ * **Counts against the array it is given, never against the set.** A player in
+ * the set who is not in this array exempts nothing, and that is the whole
+ * reason this shape was chosen over carrying a per-team count: the waiver
+ * resolver applies it to a *hypothetical* roster — the one a claim's drop would
+ * leave behind — so the answer has to be recomputed there rather than decided
+ * in advance.
+ *
+ * Dropping an exempt player frees an IR slot, not a roster slot. A precomputed
+ * count gets that backwards and awards a claim that should be refused, because
+ * it keeps subtracting for somebody who has just left.
+ *
+ * It also makes the count immune to a roster array that is short of rows for an
+ * unrelated reason: intersecting cannot subtract a player who is not there.
+ */
+export function irExemptOnRoster(
+  roster: readonly { readonly playerId: string }[],
+  exempt: ReadonlySet<string>,
+  irSlots: number,
+): number {
+  return capped(roster.filter((entry) => exempt.has(entry.playerId)).length, irSlots);
 }
 
 /**

--- a/packages/core/src/waivers/claims.ts
+++ b/packages/core/src/waivers/claims.ts
@@ -32,6 +32,7 @@
  */
 
 import type { DraftablePlayer, RosterShape } from "../draft/roster.js";
+import { irExemptOnRoster } from "../season/injured-reserve.js";
 import { canDraft } from "../draft/roster.js";
 
 export interface WaiverClaim {
@@ -52,7 +53,7 @@ export interface WaiverClaim {
 }
 
 export type ClaimFailure =
-  "PLAYER_TAKEN" | "ROSTER_FULL" | "ALREADY_ROSTERED" | "DROP_NOT_ON_ROSTER";
+  "PLAYER_TAKEN" | "ROSTER_FULL" | "ALREADY_ROSTERED" | "DROP_NOT_ON_ROSTER" | "DROP_ON_IR";
 
 export interface ClaimOutcome {
   readonly claimId: string;
@@ -81,6 +82,23 @@ export interface ResolveInput {
   readonly rosters: ReadonlyMap<string, readonly DraftablePlayer[]>;
   readonly pool: ReadonlyMap<string, DraftablePlayer>;
   readonly shape: RosterShape;
+  /*
+    Players stashed on injured reserve who currently qualify for it — the flag
+    **and** a live eligible designation, decided by the caller.
+
+    League-wide and unkeyed by team: a player is on one roster at a time, so the
+    team is already unambiguous, and a set applied to the array being counted
+    cannot disagree with that array about who is on it.
+
+    **Uncapped here.** `irSlots` binds per claim, against the roster the drop
+    would actually leave behind — see the count below.
+
+    **Required, so a caller cannot forget it.** An empty set is the honest answer
+    for a league whose signed rules grant no IR; defaulting to one would be the
+    same shape as an optional filter defaulting to "all", which this repo has
+    already established is not a filter. Forgetting it here reinstates #237.
+  */
+  readonly irExempt: ReadonlySet<string>;
 }
 
 /**
@@ -92,7 +110,7 @@ export interface ResolveInput {
  * exactly.
  */
 export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
-  const { claims, priority, rosters, pool, shape } = input;
+  const { claims, priority, rosters, pool, shape, irExempt } = input;
 
   const rank = new Map(priority.map((teamId, index) => [teamId, index]));
 
@@ -160,7 +178,38 @@ export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
       afterDrop = roster.filter((p) => p.playerId !== claim.dropPlayerId);
     }
 
-    const legality = canDraft(afterDrop, player, shape);
+    /*
+      The exemption is counted against `afterDrop`, not against the roster as it
+      stands. Issue #237.
+
+      Dropping a stashed player frees an **IR** slot, not a roster slot — he was
+      not occupying counted room to begin with. So a count decided before the
+      drop keeps subtracting for somebody who has just left, and awards a claim
+      that should be refused: at fourteen counted plus two stashed, dropping one
+      of the stashed pair would read as thirteen and let a fifteenth counted
+      player in.
+
+      Intersecting with `afterDrop` also means a player in the set who is not in
+      this array exempts nothing, which keeps the arithmetic right when the array
+      is short of rows for reasons of its own.
+    */
+    const exempt = irExemptOnRoster(afterDrop, irExempt, shape.irSlots);
+
+    /*
+      Dropping the stashed player is the natural move once claims start working,
+      and it is the one drop that frees nothing. Saying so is the difference
+      between a mistake made once and a mistake made every Wednesday.
+    */
+    if (
+      claim.dropPlayerId !== null &&
+      irExempt.has(claim.dropPlayerId) &&
+      afterDrop.length - exempt >= shape.totalSlots
+    ) {
+      outcomes.push({ ...base, awarded: false, reason: "DROP_ON_IR" });
+      continue;
+    }
+
+    const legality = canDraft(afterDrop, player, shape, exempt);
     if (!legality.legal) {
       outcomes.push({ ...base, awarded: false, reason: legality.reason ?? "ROSTER_FULL" });
       continue;

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -15,6 +15,9 @@ import {
 import { initialWaiverPriority, resolveWaiverClaims } from "./claims.js";
 import type { WaiverClaim, WaiverResolution } from "./claims.js";
 
+/** No stashed players. Every case here is about priority and capacity, not IR. */
+const NO_IR: ReadonlySet<string> = new Set();
+
 const RULES = NFL_DEFAULT_WAIVERS;
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 
@@ -331,6 +334,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     const winner = result.outcomes.find((o) => o.awarded);
@@ -344,6 +348,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     const loser = result.outcomes.find((o) => o.teamId === "team-b");
@@ -358,6 +363,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.priorityAfter).toEqual(["team-b", "team-c", "team-a"]);
@@ -371,6 +377,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.priorityAfter.indexOf("team-b")).toBe(0);
@@ -383,6 +390,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes.filter((o) => o.awarded)).toHaveLength(2);
@@ -396,6 +404,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.priorityAfter).toEqual(["team-c", "team-a", "team-b"]);
@@ -411,6 +420,7 @@ describe("resolveWaiverClaims", () => {
       rosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes[0]?.awarded).toBe(true);
@@ -425,6 +435,7 @@ describe("resolveWaiverClaims", () => {
       rosters: new Map([["team-a", full]]),
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes[0]).toMatchObject({ awarded: false, reason: "ROSTER_FULL" });
@@ -437,6 +448,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes[0]).toMatchObject({
@@ -460,6 +472,7 @@ describe("resolveWaiverClaims", () => {
       rosters: new Map([["team-a", nearlyFull]]),
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes.filter((o) => o.awarded).map((o) => o.addPlayerId)).toEqual([
@@ -489,6 +502,7 @@ describe("resolveWaiverClaims", () => {
       rosters: new Map([...emptyRosters, ["team-a", nearlyFull]]),
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     const awarded = new Map(
@@ -513,7 +527,7 @@ describe("resolveWaiverClaims", () => {
       claim("c3", "team-a", "other", null, AT(1)),
       claim("c4", "team-b", "third", null, AT(4)),
     ];
-    const args = { priority, rosters: emptyRosters, pool: POOL, shape: SHAPE };
+    const args = { priority, rosters: emptyRosters, pool: POOL, shape: SHAPE, irExempt: NO_IR };
 
     const forwards = resolveWaiverClaims({ ...args, claims });
     const backwards = resolveWaiverClaims({ ...args, claims: [...claims].reverse() });
@@ -539,6 +553,7 @@ describe("resolveWaiverClaims", () => {
       rosters: new Map([["team-a", nearlyFull]]),
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     };
 
     const forwards = resolveWaiverClaims({ ...args, claims });
@@ -558,6 +573,7 @@ describe("resolveWaiverClaims", () => {
       rosters: emptyRosters,
       pool: POOL,
       shape: SHAPE,
+      irExempt: NO_IR,
     });
 
     expect(result.outcomes).toEqual([]);
@@ -570,5 +586,145 @@ describe("initialWaiverPriority", () => {
     // Whoever picked last claims first — the same balancing instinct the snake
     // applies within a round.
     expect(initialWaiverPriority(["a", "b", "c"])).toEqual(["c", "b", "a"]);
+  });
+});
+
+describe("injured reserve and the roster limit — #237", () => {
+  /*
+    `addFreeAgent` subtracted genuinely-stashed players from the capacity
+    comparison and this resolver did not, so a signed `irSlots` allowance bought
+    room in the first-come market and none in the priority-allocated one — the
+    market `RULES.md` §6 exists to make fair.
+
+    The shape below is the one the fix turns on: the exemption is counted
+    against the roster the drop would leave, never decided in advance.
+  */
+
+  /** `n` players, ids `p0…`, all WR so nothing about matching is in play. */
+  const held = (n: number): DraftablePlayer[] =>
+    Array.from({ length: n }, (_, i) => ({
+      playerId: `p${i}`,
+      positions: ["WR"],
+      rank: i + 1,
+    }));
+
+  const shapeOf = (totalSlots: number, irSlots: number): RosterShape => ({
+    starters: [],
+    benchSlots: totalSlots,
+    irSlots,
+    totalSlots,
+  });
+
+  function run(
+    roster: DraftablePlayer[],
+    irExempt: ReadonlySet<string>,
+    shape: RosterShape,
+    dropPlayerId: string | null = null,
+  ) {
+    const target: DraftablePlayer = { playerId: "wanted", positions: ["WR"], rank: 99 };
+    return resolveWaiverClaims({
+      claims: [
+        {
+          claimId: "c1",
+          teamId: "team-a",
+          addPlayerId: "wanted",
+          dropPlayerId,
+          submittedAt: new Date("2026-09-15T12:00:00Z"),
+        },
+      ],
+      priority: ["team-a"],
+      rosters: new Map([["team-a", roster]]),
+      pool: new Map([...roster, target].map((p) => [p.playerId, p])),
+      shape,
+      irExempt,
+    }).outcomes[0];
+  }
+
+  it("awards a claim to a team whose only spare room is an IR exemption", () => {
+    /*
+      The defect, at its smallest. Fourteen rows, one genuinely stashed, so the
+      team counts thirteen of fourteen — `addFreeAgent` allows the pickup and
+      this refused the claim.
+    */
+    const outcome = run(held(14), new Set(["p0"]), shapeOf(14, 2));
+
+    expect(outcome?.awarded).toBe(true);
+  });
+
+  it("still refuses a team that is genuinely full", () => {
+    // No stash, no exemption, no change. The fix must not widen the limit.
+    const outcome = run(held(14), new Set(), shapeOf(14, 2));
+
+    expect(outcome).toMatchObject({ awarded: false, reason: "ROSTER_FULL" });
+  });
+
+  it("counts the exemption against the roster the drop would leave", () => {
+    /*
+      **The case a precomputed count gets backwards.**
+
+      Sixteen rows: fourteen counted plus two stashed, which is the maximal legal
+      roster. The claim drops one of the stashed pair. Deciding the exemption
+      before the drop leaves it at two, so fifteen minus two reads thirteen and
+      the claim is awarded — putting a fifteenth counted player into fourteen
+      slots.
+
+      Dropping a stashed player frees an IR slot, not a roster slot. Recomputing
+      after the drop gives one exemption, fifteen minus one is fourteen, and the
+      claim is correctly refused.
+    */
+    const outcome = run(held(16), new Set(["p0", "p1"]), shapeOf(14, 2), "p0");
+
+    expect(outcome?.awarded).toBe(false);
+  });
+
+  it("says so when the drop was the stashed player", () => {
+    // The mistake the fix makes likely: once claims start working, "drop the
+    // injured one" is the natural move and the one that frees nothing.
+    const outcome = run(held(16), new Set(["p0", "p1"]), shapeOf(14, 2), "p0");
+
+    expect(outcome?.reason).toBe("DROP_ON_IR");
+  });
+
+  it("awards the same claim when the drop is a counted player", () => {
+    // The other half of the pair: dropping somebody who was occupying a counted
+    // slot does free one.
+    const outcome = run(held(16), new Set(["p0", "p1"]), shapeOf(14, 2), "p5");
+
+    expect(outcome?.awarded).toBe(true);
+  });
+
+  it("caps the exemption at the slots the rules grant", () => {
+    /*
+      Three stashed against two slots. Being injured is a condition of occupying
+      a slot, not a way to conjure more of them — so the team counts fifteen of
+      fourteen and is refused, rather than counting thirteen.
+    */
+    // Sixteen rows, three stashed against two slots. Capped: two exempt, so
+    // fourteen counted and the claim is refused. Uncapped: three exempt reads
+    // thirteen and it is awarded. Seventeen rows would refuse either way, which
+    // is why the numbers here are what they are.
+    const outcome = run(held(16), new Set(["p0", "p1", "p2"]), shapeOf(14, 2));
+
+    expect(outcome?.awarded).toBe(false);
+  });
+
+  it("exempts nobody for a player who is not on the roster it is counting", () => {
+    /*
+      The set is league-wide and the count intersects it with the array being
+      counted. A stashed player who is missing from that array — absent from the
+      draft board, say — must not be subtracted, or an unrelated gap conjures a
+      roster slot.
+    */
+    const outcome = run(held(14), new Set(["somebody-else"]), shapeOf(14, 2));
+
+    expect(outcome).toMatchObject({ awarded: false, reason: "ROSTER_FULL" });
+  });
+
+  it("changes nothing for a league whose rules grant no IR", () => {
+    // `irSlots: 0` must be byte-identical to the behaviour before the fix, even
+    // if somebody is flagged.
+    const outcome = run(held(14), new Set(["p0"]), shapeOf(14, 0));
+
+    expect(outcome).toMatchObject({ awarded: false, reason: "ROSTER_FULL" });
   });
 });

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildNflPprRules, NFL } from "@rostr/core";
+import { buildNflPprRules, buildRosterShape, NFL } from "@rostr/core";
 import type { DraftRules, LeagueRules } from "@rostr/core";
 import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
@@ -357,6 +357,111 @@ describe("processing", () => {
   }
 
   const WEDNESDAY = new Date(MONDAY.getTime() + 2 * DAY);
+
+  it("lets a team whose only room is an IR exemption win a claim — #237", async () => {
+    /*
+      **The two markets disagreed, and only the priority-allocated one was
+      wrong.**
+
+      `addFreeAgent` subtracted genuinely-stashed players from the capacity
+      comparison; `processWaivers` loaded rosters with `team_id, player_id` and
+      counted them. So a signed `irSlots` allowance worked on the first-come
+      path and vanished on the blind one — and the refusal arrived on Wednesday,
+      after priority had been spent, with the contested player passed down to a
+      team that was not carrying an injury.
+
+      Driven end to end rather than asserted against the resolver, because the
+      divergence lived in the SQL between them. The assertion is that both
+      answers agree: the free-agent add succeeds **and** the claim is awarded.
+    */
+    const fx = await setup();
+    const claimant = fx.teams[1]!;
+
+    // Fill the team to exactly its limit through the product, then injure one
+    // and stash him the way a manager does.
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    const filled: string[] = [];
+    for (const handle of ["target", "other", "spare"]) {
+      const id = fx.players.get(handle);
+      if (!id) continue;
+      await addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: claimant,
+        addPlayerId: id,
+        now: MONDAY,
+      });
+      filled.push(id);
+    }
+
+    // Pad to capacity with rows the product would have written.
+    const [{ n: heldNow }] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [claimant],
+    );
+    expect(heldNow).toBeGreaterThan(0);
+
+    const injured = filled[0]!;
+    await fx.client.query("UPDATE players SET injury_designation = 'OUT' WHERE id = $1", [
+      injured,
+    ]);
+    await moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      playerId: injured,
+      week: 1,
+      now: MONDAY,
+    });
+
+    /*
+      Now hold the team at exactly `totalSlots` counted rows plus the stash, so
+      the raw count exceeds the limit and only the exemption makes room. Written
+      directly because the fixture's pool is smaller than a real roster; the
+      shape is one `addFreeAgent` produces.
+    */
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [wr] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'WR'",
+      [sport!.id],
+    );
+    const [{ n: counted }] = await fx.client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM roster_entries
+        WHERE team_id = $1 AND released_at IS NULL AND NOT on_ir`,
+      [claimant],
+    );
+    // One short of the limit, so the stashed player is the only thing between
+    // this team and a full roster: raw 14, counted 13. Without the exemption the
+    // claim path sees 14 and refuses; with it, 13 and awards.
+    for (let i = counted; i < shape.totalSlots - 1; i++) {
+      const [row] = await fx.client.query<{ id: string }>(
+        `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+         VALUES ($1, $2, $2, $3, 'CIN') RETURNING id`,
+        [sport!.id, `filler-${i}`, wr!.id],
+      );
+      await fx.client.query(
+        `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+         VALUES ($1, $2, 'FREE_AGENT', $3)`,
+        [claimant, row!.id, MONDAY],
+      );
+    }
+
+    // The free-agent path already allows this. The claim path must agree.
+    const wanted = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, wanted, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: wanted,
+      now: MONDAY,
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    expect(outcome.awarded).toBe(1);
+    expect(outcome.failed).toBe(0);
+  });
 
   it("awards a claim whose drop is a player on injured reserve", async () => {
     /*

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -40,6 +40,7 @@ import {
   everyoneIsOnWaivers,
   buildRosterShape,
   countedRosterSize,
+  isIrEligible,
   dropDestination,
   initialWaiverPriority,
   NFL,
@@ -893,16 +894,50 @@ export async function processWaivers(
 
     const priority = await loadWaiverPriority(tx, leagueId);
 
-    const rosterRows = await tx.query<{ team_id: string; player_id: string }>(
-      `SELECT r.team_id, r.player_id FROM roster_entries r
+    /*
+      The same two IR columns `addFreeAgent` reads, and for the same reason.
+
+      Until #237 this query took `team_id, player_id` only, so the capacity
+      comparison downstream counted stashed players against the roster limit —
+      while `addFreeAgent`, three hundred lines up, subtracted them. A signed
+      `irSlots` allowance bought room in the first-come market and none in the
+      priority-allocated one, which is the market `RULES.md` §6 exists to make
+      fair.
+    */
+    const rosterRows = await tx.query<{
+      team_id: string;
+      player_id: string;
+      on_ir: boolean;
+      designation: string | null;
+    }>(
+      `SELECT r.team_id, r.player_id, r.on_ir, p.injury_designation AS designation
+         FROM roster_entries r
+         JOIN players p ON p.id = r.player_id
         WHERE r.league_id = $1 AND r.released_at IS NULL`,
       [leagueId],
     );
 
     const rosters = new Map<string, DraftablePlayer[]>(priority.map((teamId) => [teamId, []]));
+
+    /*
+      Built **inside the same filter** as `rosters`, and that is load-bearing.
+
+      A rostered player absent from the draft board is already missing from the
+      array the resolver counts. Exempting him as well would subtract him twice
+      and conjure a roster slot out of an unrelated gap, so an exemption is only
+      ever recorded for a player who was actually counted. One loop, one filter,
+      and the two cannot disagree.
+
+      The designation is read live, so a player who has recovered stops being
+      exempt at this run. Nothing is moved or dropped to enforce that; the team
+      simply finds itself at capacity again.
+    */
+    const irExempt = new Set<string>();
     for (const row of rosterRows) {
       const player = pool.get(row.player_id);
-      if (player) rosters.get(row.team_id)?.push(player);
+      if (!player) continue;
+      rosters.get(row.team_id)?.push(player);
+      if (row.on_ir && isIrEligible(row.designation)) irExempt.add(row.player_id);
     }
 
     /**
@@ -1014,6 +1049,7 @@ export async function processWaivers(
       rosters,
       pool,
       shape,
+      irExempt,
     });
 
     let awarded = 0;


### PR DESCRIPTION
A signed `irSlots` allowance worked in the first-come market and vanished in the priority-allocated one. Three agents confirmed it independently, proposed three fixes, and converged — two of them abandoning their own design along the way.

## The defect

`addFreeAgent` subtracted genuinely-stashed players from the capacity comparison. `processWaivers` loaded rosters with `SELECT r.team_id, r.player_id` and counted them.

`roster.irSlots` is in the canonical hashed document, rendered above the join control, and `RULES.md` §2 promises the exemption **unqualified**: *"IR slots hold only players officially designated out or on injured reserve, and do not count against the roster limit."*

**It fires on the first legitimate use of the feature.** Every team leaves the draft at exactly `totalSlots` — `rounds` is set to `starters + bench` — so "stash the injured man, claim his replacement" is the canonical use of an IR slot, and it failed every time. All 8 live leagues carry the default `irSlots: 2`.

It also doesn't require being at capacity: with both slots in use, a team with **two genuinely free counted slots** was refused an unpaired claim.

**And the loss was transferred, not dissipated.** When a claim fails `ROSTER_FULL`, `taken` is never set — so the next team in priority wins the player. A #1-priority team using its signed allowance lost a contested player to a team not carrying an injury, and kept a priority slot it could not cash, because priority moves only on success.

## The fix

**Widen the roster read** to carry `on_ir` and `injury_designation` — the same two columns `addFreeAgent` already reads — and build the exempt set **inside the same filter** as the roster array. That last part is load-bearing: a rostered player absent from the draft board is already missing from the array being counted, so exempting him too would subtract twice and conjure a slot out of an unrelated gap ([#238](https://github.com/6figpsolseeker/rostr/issues/238)'s territory, deliberately not conflated).

**Count the exemption against `afterDrop`, never in advance.** This is the case that decides the whole shape:

| 16 rows = 14 counted + 2 stashed, claim drops a stashed player | |
|---|---|
| Precomputed (exempt = 2) | 15 − 2 = 13 < 14 → **awarded**, putting a 15th counted player in 14 slots |
| Recomputed on `afterDrop` (exempt = 1) | 15 − 1 = 14 ≥ 14 → **refused**, correctly |

Dropping a stashed player frees an **IR** slot, not a roster slot.

**`canDraft` takes the exempt count and keeps the full array.** Handing it a filtered array would silently disable its own `ALREADY_ROSTERED` check — and removing a pure function's guard because a caller happens to duplicate it is how the redundancy becomes the only guard. IR players stay in the array, so a claim naming one as its **drop** still resolves.

**The parameter is required, not defaulted.** A default of `0` fails *closed* — which sounds safe and is exactly this bug: the resolver omitted the subtraction and refused claims members were entitled to win. Both draft call sites pass an explicit `0` with a comment.

## Two states still fail legitimately, and now say why

Shipping the arithmetic alone would turn "the feature silently doesn't work" into "it works except twice, and lies both times."

- `ROSTER_FULL` said *"your roster was full and the claim named nobody to drop"* — rendered on the same line that prints the drop. It now reads *"still full, even after any drop the claim named."* That sentence stays reachable after the fix, via a recovered stash, so it isn't collateral.
- New `DROP_ON_IR`: *"the player you dropped was on injured reserve, so dropping him freed no roster space."* This is the mistake **the fix makes likely** — once claims work, "drop the injured one" is the natural move and the one that frees nothing. Free text column, no migration.
- The drop selector carried **no `onIr` field at all**, so the stashed player looked droppable. Now labelled.

## Tests

Eight core cases plus one end-to-end, all mutation-checked:

```
precompute the exemption      → 2 failed
drop the cap                  → 2 failed
pass 0 instead of exempt      → 2 failed
DROP_ON_IR → ROSTER_FULL      → 1 failed
count the set, not the array  → 3 failed
never exempt (db wiring)      → 1 failed
```

One of my own tests didn't pin what its name claimed — 17 rows with 3 stashed refuses with *or* without the cap. Changed to 16, which discriminates.

`waivers.test.ts`'s existing "awards a claim whose drop is a player on injured reserve" passes **unchanged**, which is the array-retention guarantee.

## Checkable assertions

- **The golden hash does not move.** Zero changes under `packages/core/src/rules/`, `schemaVersion` still 8. This adds no rule field — it honours one that already existed. If the hash moves, the change altered the signed document and is wrong.
- **`addFreeAgent` is untouched.** Same query, same call, same outcomes.
- **The draft is unaffected.** Both call sites pass `0`; nobody is on IR before a season.

## Comments corrected

Migration `0038` claims the stash count is consulted "on every transaction" — false, and it **cannot be edited**: the runner compares a SHA-256 over the file and the deployed database is past it. Corrected in `injured-reserve.ts`'s header, which now names both limit-applying paths and states that trades apply none. CLAUDE.md's "IR enforcement is continuous" is qualified the same way.

## Filed, not fixed

- [#250](https://github.com/6figpsolseeker/rostr/issues/250) — trades apply **no** roster limit at all. Needs a product decision, not a fix.
- [#251](https://github.com/6figpsolseeker/rostr/issues/251) — `"Injured Reserve"` isn't in `IR_ELIGIBLE_DESIGNATIONS`, so 39 production players can't reach this feature. Four copies of the vocabulary, two of them reading a column nothing writes.

Deferred from scope: an `IR_RECOVERED` reason, the pre-flight capacity advice, and the two other false failure messages (`PLAYER_TAKEN`, `DROP_NOT_ON_ROSTER`).

---

2229 tests (was 2220). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
