### PR TITLE
fix(core): a cut player vanished from his own fantasy roster

### DIFF
--- a/apps/web/src/lib/waiver-run.ts
+++ b/apps/web/src/lib/waiver-run.ts
@@ -30,6 +30,11 @@
  */
 export function whyClaimFailed(reason: string | null): string {
   switch (reason) {
+    case "PLAYER_UNAVAILABLE":
+      // States the observable fact and implies no permanence. Whether such a
+      // player should be claimable is undecided, so this must not read as a
+      // rule — no "cannot be claimed", no advice to stop trying.
+      return "he is no longer on an NFL roster, so the run could not award him";
     case "PLAYER_TAKEN":
       return "a team with better priority claimed him first";
     case "ROSTER_FULL":

--- a/packages/core/src/draft/roster.ts
+++ b/packages/core/src/draft/roster.ts
@@ -21,6 +21,29 @@
 import type { SportDef } from "../sports/types.js";
 import type { RosterRules } from "../rules/types.js";
 
+/*
+ * A player a team currently holds. Identity, and deliberately nothing else.
+ *
+ * Roster legality asks two questions — does this team hold him, and how many
+ * does it hold — and neither needs to know what he plays.
+ *
+ * **It is a separate type from `DraftablePlayer` because sharing that one made
+ * the draft board the only convenient way to build a roster**, and the board is
+ * filtered on `players.active`, which the daily sync clears for anyone the
+ * provider reports as an NFL free agent. So a rostered player his club had cut
+ * fell out of the array and off his own roster: a valid drop was refused, and a
+ * claim with no drop was counted against a roster one short of its true size
+ * and awarded past the limit. Issue #238.
+ *
+ * Ownership is a `roster_entries` question; the board answers availability. A
+ * type narrow enough to be satisfied from the roster table is what keeps them
+ * apart — and a type with no `positions` field cannot be wrong about positions,
+ * which is the failure a synthesised empty array would have introduced instead.
+ */
+export interface RosterMember {
+  readonly playerId: string;
+}
+
 export interface DraftablePlayer {
   readonly playerId: string;
   /** Every position this player may fill. */
@@ -227,7 +250,17 @@ export interface PickLegality {
  * {@link wouldStrandStarters}.
  */
 export function canDraft(
-  roster: readonly DraftablePlayer[],
+  /*
+    `RosterMember`, because this function reads identity and count only —
+    `roster.length` and one `playerId` comparison.
+
+    If a check here ever needs `positions`, that is a change of contract: widen
+    it deliberately and say so, rather than letting a caller hand over a
+    `DraftablePlayer[]` and assume the field behind it is real. The draft's
+    callers do pass one; the waiver resolver cannot, and that difference is the
+    point.
+  */
+  roster: readonly RosterMember[],
   player: DraftablePlayer,
   shape: RosterShape,
   /*

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,7 @@ export {
   unfilledStarterSlots,
   wouldStrandStarters,
   type DraftablePlayer,
+  type RosterMember,
   type IllegalPickReason,
   type PickLegality,
   type RosterShape,

--- a/packages/core/src/waivers/claims.ts
+++ b/packages/core/src/waivers/claims.ts
@@ -31,7 +31,7 @@
  *      not move at all.
  */
 
-import type { DraftablePlayer, RosterShape } from "../draft/roster.js";
+import type { DraftablePlayer, RosterMember, RosterShape } from "../draft/roster.js";
 import { irExemptOnRoster } from "../season/injured-reserve.js";
 import { canDraft } from "../draft/roster.js";
 
@@ -53,7 +53,12 @@ export interface WaiverClaim {
 }
 
 export type ClaimFailure =
-  "PLAYER_TAKEN" | "ROSTER_FULL" | "ALREADY_ROSTERED" | "DROP_NOT_ON_ROSTER" | "DROP_ON_IR";
+  | "PLAYER_TAKEN"
+  | "ROSTER_FULL"
+  | "ALREADY_ROSTERED"
+  | "DROP_NOT_ON_ROSTER"
+  | "DROP_ON_IR"
+  | "PLAYER_UNAVAILABLE";
 
 export interface ClaimOutcome {
   readonly claimId: string;
@@ -79,7 +84,11 @@ export interface ResolveInput {
   /** Team IDs in waiver priority order, best first. */
   readonly priority: readonly string[];
   /** Current rosters by team ID. */
-  readonly rosters: ReadonlyMap<string, readonly DraftablePlayer[]>;
+  /*
+    Identity only — see `RosterMember`. The array this resolver counts must come
+    from `roster_entries`, not from a board filtered for draftability.
+  */
+  readonly rosters: ReadonlyMap<string, readonly RosterMember[]>;
   readonly pool: ReadonlyMap<string, DraftablePlayer>;
   readonly shape: RosterShape;
   /*
@@ -147,7 +156,7 @@ export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
     return byTime !== 0 ? byTime : a.claimId.localeCompare(b.claimId);
   });
 
-  const working = new Map<string, DraftablePlayer[]>(
+  const working = new Map<string, RosterMember[]>(
     [...rosters].map(([teamId, roster]) => [teamId, [...roster]]),
   );
   const taken = new Set<string>();
@@ -163,8 +172,34 @@ export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
     const player = pool.get(claim.addPlayerId);
     const roster = working.get(claim.teamId) ?? [];
 
-    if (!player || taken.has(claim.addPlayerId)) {
+    /*
+      Two different facts, and they used to share a message.
+
+      `taken` means a better-priority team won him earlier in this same run —
+      the system working exactly as the rules describe. Absent from the pool
+      means he is not a player this league can acquire at all: the board filters
+      on `players.active`, which the daily sync clears for anyone the provider
+      reports as an NFL free agent.
+
+      Collapsed, the second was reported as "a team with better priority claimed
+      him first" — a statement about other managers that is simply false, told to
+      somebody who cannot check it, about a player nobody holds.
+
+      `taken` is tested first so the branch below means strictly "not in the
+      pool": a player awarded earlier in this run is necessarily in it.
+
+      **A reason, not a filter.** Whether a cut player should be claimable at all
+      is a rules question nobody has decided, and adding a pre-resolution filter
+      would decide it here. Reporting the outcome honestly does not — and it
+      makes the question countable, since `failure_reason` is permanent and the
+      answer becomes a `SELECT count(*)` rather than an extrapolation.
+    */
+    if (taken.has(claim.addPlayerId)) {
       outcomes.push({ ...base, awarded: false, reason: "PLAYER_TAKEN" });
+      continue;
+    }
+    if (!player) {
+      outcomes.push({ ...base, awarded: false, reason: "PLAYER_UNAVAILABLE" });
       continue;
     }
 
@@ -190,8 +225,10 @@ export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
       player in.
 
       Intersecting with `afterDrop` also means a player in the set who is not in
-      this array exempts nothing, which keeps the arithmetic right when the array
-      is short of rows for reasons of its own.
+      this array exempts nothing. That was a live correction while the array could
+      be short of rows for reasons of its own (#238); it is defence in depth now
+      that ownership is read straight from `roster_entries`, and it should stay —
+      it is what makes the arithmetic right rather than the shape of any caller.
     */
     const exempt = irExemptOnRoster(afterDrop, irExempt, shape.irSlots);
 

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -358,6 +358,162 @@ describe("processing", () => {
 
   const WEDNESDAY = new Date(MONDAY.getTime() + 2 * DAY);
 
+  /*
+    A rostered player his NFL club has cut. Issue #238.
+
+    `season-sync` writes `active = false` for anyone the provider reports as an
+    NFL free agent — 562 of 1,586 players carry it today, and roughly thirteen a
+    day arrive. Nothing releases such a player from a fantasy roster: he stays
+    until his manager drops him.
+
+    Set directly because no fixture can reach this through the product — the
+    column defaults true and only the daily sync writes it. Same pattern
+    `league-read.test.ts` uses to rewrite `leagues.visibility` and assert the
+    answer does not move.
+  */
+  const deactivate = (fx: Fixture, playerId: string) =>
+    fx.client.query("UPDATE players SET active = false WHERE id = $1", [playerId]);
+
+  it("counts a rostered player his club has cut — #238", async () => {
+    /*
+      **The silent direction.** The resolver built each roster by looking every
+      row up in the draft-board pool, and that board filters on `active` — so a
+      cut player fell out of the array, the team read one short of its true size,
+      and a claim with no drop was awarded past the roster limit members signed.
+
+      Nothing would have caught it afterwards: there is no capacity constraint in
+      the schema, no trigger, and nothing trims. The team simply holds one more
+      player than its rules allow, for the rest of the season.
+    */
+    const fx = await setup();
+    const claimant = fx.teams[1]!;
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [wr] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'WR'",
+      [sport!.id],
+    );
+
+    // Fill to exactly the limit, then have the provider cut one of them.
+    const roster: string[] = [];
+    for (let i = 0; i < shape.totalSlots; i++) {
+      const [row] = await fx.client.query<{ id: string }>(
+        `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+         VALUES ($1, $2, $2, $3, 'CIN') RETURNING id`,
+        [sport!.id, `roster-${i}`, wr!.id],
+      );
+      await fx.client.query(
+        `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+         VALUES ($1, $2, 'FREE_AGENT', $3)`,
+        [claimant, row!.id, MONDAY],
+      );
+      roster.push(row!.id);
+    }
+    await deactivate(fx, roster[0]!);
+
+    const wanted = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, wanted, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: wanted,
+      now: MONDAY,
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    expect(outcome.awarded).toBe(0);
+
+    /*
+      The row count, not just the outcome. Asserting `ROSTER_FULL` alone would
+      still pass against a resolver that refused for the wrong reason, and the
+      breach this test exists for is a roster one player too long.
+    */
+    const [after] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [claimant],
+    );
+    expect(after?.n).toBe(shape.totalSlots);
+  });
+
+  it("lets a manager drop a player his club has cut — #238", async () => {
+    /*
+      **The loud direction, wrongly explained.** The claim named a drop that
+      `roster_entries` says is held, and the run answered "the player you offered
+      to drop was no longer on your roster" — while the market screen, which
+      reads the roster table directly, was still showing him and still offering
+      him in the drop selector. Two panels, opposite answers, and the false one
+      decided the claim.
+    */
+    const fx = await setup();
+    const claimant = fx.teams[1]!;
+
+    const spare = fx.players.get("spare")!;
+    await addFreeAgent(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: spare,
+      now: MONDAY,
+    });
+    await deactivate(fx, spare);
+
+    const wanted = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, wanted, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: claimant,
+      addPlayerId: wanted,
+      dropPlayerId: spare,
+      now: MONDAY,
+    });
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    expect(outcome.awarded).toBe(1);
+
+    const [row] = await fx.client.query<{ released_at: string | null }>(
+      "SELECT released_at FROM roster_entries WHERE team_id = $1 AND player_id = $2",
+      [claimant, spare],
+    );
+    expect(row?.released_at).not.toBeNull();
+  });
+
+  it("says the add player is unavailable rather than blaming another team — #238", async () => {
+    /*
+      `PLAYER_TAKEN` reads "a team with better priority claimed him first". When
+      the add player is simply absent from the board, nobody claimed him at all —
+      a false statement about other managers, told to somebody who cannot check
+      it.
+
+      A reason, not a filter: the claim is still resolved, still recorded, and
+      whether such a player should be claimable stays an open question this does
+      not answer.
+    */
+    const fx = await setup();
+
+    const wanted = fx.players.get("held")!;
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, wanted, MONDAY);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[1]!,
+      addPlayerId: wanted,
+      now: MONDAY,
+    });
+    await deactivate(fx, wanted);
+
+    await processWaivers(fx.client, fx.leagueId, WEDNESDAY);
+
+    const [claim] = await fx.client.query<{ failure_reason: string | null }>(
+      "SELECT failure_reason FROM waiver_claims WHERE add_player_id = $1",
+      [wanted],
+    );
+    expect(claim?.failure_reason).toBe("PLAYER_UNAVAILABLE");
+  });
+
   it("lets a team whose only room is an IR exemption win a claim — #237", async () => {
     /*
       **The two markets disagreed, and only the priority-allocated one was

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -48,7 +48,7 @@ import {
   resolveWaiverClaims,
   waiverClearsAt,
 } from "@rostr/core";
-import type { DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
+import type { RosterMember, DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { isUniqueViolation } from "./pg-errors.js";
@@ -917,16 +917,27 @@ export async function processWaivers(
       [leagueId],
     );
 
-    const rosters = new Map<string, DraftablePlayer[]>(priority.map((teamId) => [teamId, []]));
+    const rosters = new Map<string, RosterMember[]>(priority.map((teamId) => [teamId, []]));
 
     /*
-      Built **inside the same filter** as `rosters`, and that is load-bearing.
+      Ownership comes from `rosterRows` and from nothing else.
 
-      A rostered player absent from the draft board is already missing from the
-      array the resolver counts. Exempting him as well would subtract him twice
-      and conjure a roster slot out of an unrelated gap, so an exemption is only
-      ever recorded for a player who was actually counted. One loop, one filter,
-      and the two cannot disagree.
+      This loop used to look each row up in the draft-board pool and drop it when
+      the lookup missed — and `loadDraftBoard` filters on `players.active`, which
+      the daily sync clears for anyone the provider reports as an NFL free agent.
+      So a rostered player cut by his club vanished from his own fantasy roster:
+      a valid drop was refused as `DROP_NOT_ON_ROSTER`, and a claim with no drop
+      was counted against a roster one short of its true size and awarded past
+      `totalSlots`. Issue #238. Ownership is a `roster_entries` question; the
+      pool answers availability, and they are not the same map.
+
+      **An earlier note here credited the exemption's safety to this loop's
+      shape**, claiming that exempting a pool-absent player would subtract him
+      twice. That was never what provided it: `irExemptOnRoster` intersects with
+      the array it is handed, so a set entry absent from that array exempts
+      nothing however this loop is written. The set is built from the same rows
+      as the array for a simpler reason — one source, so the two cannot disagree
+      about who is on the roster.
 
       The designation is read live, so a player who has recovered stops being
       exempt at this run. Nothing is moved or dropped to enforce that; the team
@@ -934,9 +945,7 @@ export async function processWaivers(
     */
     const irExempt = new Set<string>();
     for (const row of rosterRows) {
-      const player = pool.get(row.player_id);
-      if (!player) continue;
-      rosters.get(row.team_id)?.push(player);
+      rosters.get(row.team_id)?.push({ playerId: row.player_id });
       if (row.on_ir && isIrEligible(row.designation)) irExempt.add(row.player_id);
     }
 


### PR DESCRIPTION
`processWaivers` built each team's roster by looking every `roster_entries` row up in the draft-board pool — and that board filters on `players.active`, which the daily sync clears for anyone the provider reports as an NFL free agent. A rostered player his club had cut vanished from his own fantasy roster.

Three agents confirmed independently and converged unanimously on the fix.

## An availability map answering an ownership question

This repo already decided this once, about the lineup lock: *"who owns the player is a different question… Conflating them is what made the lock defeasible. **Do not widen `loadRosterForWeek` to fix a lock** — that map is `validateLineup`'s ownership oracle."*

`processWaivers` held the authoritative answer and then narrowed it through the board. It even uses that same answer correctly twelve lines later — `alreadyHeld` reads `rosterRows` raw. The fix isn't to find a better oracle; it's to stop discarding the one already in hand.

## Two consequences, opposite directions

| | |
|---|---|
| **Loud, and wrongly explained** | A claim naming the cut player as its drop → `DROP_NOT_ON_ROSTER`, *"the player you offered to drop was no longer on your roster"* — while the market screen, which reads `roster_entries` directly, was still showing him and still offering him in the drop selector. Two panels, opposite answers, and the false one decided the claim. |
| **Silent** | A claim with no drop from a team at capacity → the array reads one short, `canDraft` allows it, and the team ends the run holding **15 against a signed 14**. No constraint stops it: every constraint on `roster_entries` is identity- or IR-shaped, there's no trigger, and nothing trims. |

## The fix: a type that cannot lie

```ts
interface RosterMember { readonly playerId: string }
```

`canDraft`'s first parameter and `ResolveInput.rosters` narrow to it; the loop becomes `{ playerId: row.player_id }`. Three lines of logic, two signatures.

**Why not synthesise `{ playerId, positions: [], rank: MAX }`?** Because `positions` is documented as *"every position this player may fill"* — so `[]` isn't a blank, it's an **assertion that he can fill none**, and `eligible()` reads it exactly that way. That's the `isSlotLocked` collapse this repo already paid for, where `undefined` meant both "on a bye" and "not in the map". **A type with no `positions` field cannot be wrong about positions.**

**Why not widen `loadDraftBoard`?** It wouldn't touch the market — `availablePlayers` is its own query with its own filter. It would break the **draft**: 562 non-NFL players become draftable, and since `rank` is a dense `index + 1` over the board's ordering, widening renumbers every rank and silently re-orders autopick for every league.

## A false statement about other managers

`PLAYER_TAKEN` collapsed two facts: a better-priority team won him, or he's absent from the board entirely. The second was reported as *"a team with better priority claimed him first"* — false, about a player nobody holds, to somebody who cannot check it.

Split into `PLAYER_TAKEN` and `PLAYER_UNAVAILABLE`. **A reason, not a filter** — whether a cut player should be claimable at all is an undecided rules question, and a pre-resolution filter would decide it here. Reporting honestly doesn't, and it makes the question **countable**: `failure_reason` is permanent, so the answer becomes a `SELECT count(*)` rather than an extrapolation.

Deliberately *not* included for the same reason: a `submitClaim` pre-check would write no row at all, quietly deleting the evidence this split exists to gather.

## Tests

Three, both mutations caught:

```
restore the pool lookup   → 2 failed
recollapse the two reasons → 1 failed
```

The capacity test asserts the **row count** after the run, not just the outcome — asserting `ROSTER_FULL` alone would pass against a resolver refusing for the wrong reason.

No fixture could reach this state before: `players.active` defaults true and only the daily sync writes it, so every test roster was fully visible. The tests set it directly, the same way `league-read.test.ts` rewrites `leagues.visibility` to prove the answer doesn't move.

## The comment my #237 fix left behind

It claimed the loop's shape prevented a double-subtraction. It never did — `irExemptOnRoster` intersects with the array it's handed, so a set entry absent from that array exempts nothing however the loop is written. Two agents caught it independently. Corrected, and the neighbouring justification in `claims.ts` is now marked as defence in depth rather than a live correction.

## Verified against production

Both live teams hold exactly **14 of 14, zero inactive**. So this is a guard, not a repair — and the margin is zero: one deactivation among the 28 held players arms it.

## Filed, not repaired here

- [#253](https://github.com/6figpsolseeker/rostr/issues/253) — `rosterFor` has the same shape in the draft. **The fix does not transfer**: three consumers genuinely read `positions`, so an identity-only roster would make bots draft for needs they cannot see.
- [#254](https://github.com/6figpsolseeker/rostr/issues/254) — nothing reports a roster over `totalSlots` (live cause is [#250](https://github.com/6figpsolseeker/rostr/issues/250), trades), and nothing tells a manager his player was cut. **This fix makes that silence quieter**, by removing the wrong arithmetic that might eventually have surfaced it.

---

2232 tests (was 2229). Typecheck, lint, prettier clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
