### PR TITLE
fix(web): the ops screen could not tell "no stats" from "a warning"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,3 +239,16 @@ NEXT_PUBLIC_SOLANA_CLUSTER=devnet
 # unavailable locally and everything else still works.
 POT_MINT_LOCALNET=
 NEXT_PUBLIC_POT_MINT_LOCALNET=
+
+# Who may open the operator console at /ops/stats.
+#
+# Comma-separated email addresses, matched against the signed-in session's
+# address. **Fails closed in every environment, including development** — unset,
+# `isOperator` returns nobody and the page 404s for everyone, which is the safe
+# direction for a screen that reports on the ingest.
+#
+# It also means an unset value is indistinguishable from "you are not an
+# operator": there is no error and no hint, by design, because a 403 would
+# confirm the page exists. If /ops/stats 404s for you and you expected it not
+# to, this is the variable.
+OPERATOR_EMAILS=

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { HeaderControls } from "@/components/HeaderControls";
 import { UrgentStrip } from "@/components/UrgentStrip";
+import { isOperator } from "@/lib/operator";
 import { currentUser } from "@/lib/session";
 
 /**
@@ -41,6 +42,30 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           </Link>
 
           <div className="flex items-center gap-6">
+            {/*
+              The operator console, for the handful of addresses in
+              OPERATOR_EMAILS.
+
+              **Rendered server-side, and that is load-bearing.** A client-side
+              conditional would ship the href to every visitor, which undoes the
+              reason /ops/stats answers 404 rather than 403: an unguessable page
+              that advertises itself in the markup is not unguessable. What
+              crosses to the browser here is a decision already made, not the
+              allowlist that made it.
+
+              It existed with **no inbound link from anywhere** until now —
+              reachable only by typing the URL, and only by somebody who
+              remembered it was there. Issue #209 is the same defect on the
+              draft lobby; this is the operator half of it.
+            */}
+            {isOperator(user?.email) ? (
+              <Link
+                href="/ops/stats"
+                className="font-mono text-[12px] tracking-wide text-nocturne-neutral-500 transition-colors hover:text-nocturne-text"
+              >
+                ops
+              </Link>
+            ) : null}
             <Link
               href="/scoring"
               className="text-[13.5px] text-nocturne-neutral-400 transition-colors hover:text-nocturne-text"

--- a/apps/web/src/app/(app)/ops/stats/page.tsx
+++ b/apps/web/src/app/(app)/ops/stats/page.tsx
@@ -1,11 +1,17 @@
 import { notFound } from "next/navigation";
-import { unresolvedStatsProblems } from "@rostr/db";
+import { listCronRuns, unresolvedStatsProblems } from "@rostr/db";
 import { NFL } from "@rostr/core";
 import { db } from "@/lib/db";
 import { currentUser } from "@/lib/session";
 import { isOperator } from "@/lib/operator";
-import { buildOpsView } from "@/lib/ops";
-import type { ProblemRow } from "@/lib/ops";
+import {
+  buildOpsView,
+  buildRunBanner,
+  ingestSentence,
+  toneOf,
+  type ProblemRow,
+  type RunBanner,
+} from "@/lib/ops";
 
 /**
  * Games whose stats contradicted themselves.
@@ -46,27 +52,90 @@ export const metadata = {
 
 export const dynamic = "force-dynamic";
 
-function StatusChip({ row }: { row: ProblemRow }) {
+/**
+ * What we hold for this game. The tone lives here and nowhere else.
+ *
+ * **Colour keys on the ingest state, never on the window state**, and that was
+ * the presentation half of issue #233: a game whose every read had failed drew
+ * in the lowest-contrast tone on the page, because its provider had not called
+ * it final yet. The most severe row wore the calmest chip.
+ */
+function IngestChip({ row }: { row: ProblemRow }) {
   const label =
-    row.status === "NOT_FINAL"
-      ? "Game not final"
-      : row.status === "OPEN"
-        ? `${row.hoursSinceFinal}h of ${row.windowHours}h`
-        : `Window closed (${row.windowHours}h)`;
+    row.ingest === "NO_STATS"
+      ? "No box score"
+      : row.ingest === "STALE"
+        ? "Stats are stale"
+        : "Discrepancy";
 
-  const tone =
-    row.status === "OPEN"
-      ? "border-amber-500/40 text-amber-300"
-      : row.status === "NOT_FINAL"
-        ? "border-nocturne-neutral-700 text-nocturne-neutral-400"
-        : "border-nocturne-neutral-800 text-nocturne-neutral-600";
+  const tone = toneOf(row.ingest);
+  const cls =
+    tone === "critical"
+      ? "border-red-500/50 text-red-300"
+      : tone === "warning"
+        ? "border-amber-500/40 text-amber-300"
+        : "border-nocturne-neutral-800 text-nocturne-neutral-500";
 
   return (
     <span
-      className={`shrink-0 rounded-full border px-2.5 py-1 font-mono text-[11px] tracking-wide ${tone}`}
+      className={`shrink-0 rounded-full border px-2.5 py-1 font-mono text-[11px] tracking-wide ${cls}`}
     >
       {label}
     </span>
+  );
+}
+
+/**
+ * Whether the week can still be corrected. Deliberately neutral in every state.
+ *
+ * Two chips rather than one, because the axes are independent: what we hold and
+ * whether it can still be changed. A single chip has to pick one and hide the
+ * other, and it used to hide the one that mattered.
+ */
+function WindowChip({ row }: { row: ProblemRow }) {
+  const label =
+    row.status === "WEEK_IN_PLAY"
+      ? "Week still in play"
+      : row.status === "OPEN"
+        ? `${row.hoursSinceWeekEnd}h of ${row.windowHours}h`
+        : `Window closed (${row.windowHours}h)`;
+
+  return (
+    <span className="shrink-0 rounded-full border border-nocturne-neutral-800 px-2.5 py-1 font-mono text-[11px] tracking-wide text-nocturne-neutral-500">
+      {label}
+    </span>
+  );
+}
+
+/**
+ * The stats job's own heartbeat, above the list.
+ *
+ * An empty list beside a job that is not running is a false all-clear — the same
+ * defect as the prose this page used to carry. It is also the only way a
+ * run-level fault reaches this screen: the pool check, a database fault, a
+ * provider auth failure and #256's own "a slate was under way and nothing was
+ * selected" alarm all throw before any game is touched, so they write no
+ * `stats_error` and produce no row here.
+ */
+function RunBannerView({ banner }: { banner: RunBanner }) {
+  if (banner.state === "OK") return null;
+
+  const cls =
+    banner.state === "FAILING"
+      ? "border-red-500/50 text-red-200"
+      : "border-amber-500/40 text-amber-200";
+
+  return (
+    <div className={`mt-6 rounded-[4px] border p-4 text-[13.5px] leading-[1.6] ${cls}`}>
+      <p className="font-mono text-[11px] tracking-[0.16em] uppercase opacity-70">
+        {banner.state === "FAILING"
+          ? "the stats job is failing"
+          : banner.state === "NEVER_RAN"
+            ? "the stats job has never run"
+            : "the stats job is behind"}
+      </p>
+      <p className="mt-2 break-words">{banner.detail}</p>
+    </div>
   );
 }
 
@@ -82,16 +151,29 @@ function ProblemList({ rows }: { rows: readonly ProblemRow[] }) {
                 {row.season} · week {row.week}
               </p>
             </div>
-            <StatusChip row={row} />
+            <div className="flex shrink-0 flex-col items-end gap-1.5">
+              <IngestChip row={row} />
+              <WindowChip row={row} />
+            </div>
           </div>
           {/*
-            The provider's own words, unedited. Summarising here would put a
-            second description of the fault next to the one the translator
-            wrote, and the translator's is the one that names the fields.
+            What this state costs, then the provider's own words unedited.
+            Summarising the second would put a competing description next to the
+            one the translator wrote, and the translator's names the fields.
+
+            The sentence is not optional: a row selected by the clock rather than
+            by an error carries no provider text at all, and without this it
+            would render as an empty card — which is how the state this page was
+            fixed to surface would have stayed invisible.
           */}
-          <p className="mt-3 border-t border-nocturne-neutral-800 pt-3 text-[13.5px] leading-[1.6] break-words text-nocturne-neutral-400">
-            {row.problem}
+          <p className="mt-3 border-t border-nocturne-neutral-800 pt-3 text-[13.5px] leading-[1.6] text-nocturne-neutral-300">
+            {ingestSentence(row)}
           </p>
+          {row.problem === null ? null : (
+            <p className="mt-2 text-[13px] leading-[1.6] break-words text-nocturne-neutral-500">
+              {row.problem}
+            </p>
+          )}
         </li>
       ))}
     </ul>
@@ -102,8 +184,13 @@ export default async function OpsStatsPage() {
   const user = await currentUser();
   if (!isOperator(user?.email)) notFound();
 
+  const now = new Date();
   const problems = await unresolvedStatsProblems(db(), NFL.key, 50);
-  const view = buildOpsView(problems, new Date());
+  const view = buildOpsView(problems, now);
+  const banner = buildRunBanner(
+    (await listCronRuns(db())).find((entry) => entry.name === "stats"),
+    now,
+  );
 
   return (
     <main className="mx-auto max-w-[900px] px-6 py-14">
@@ -113,50 +200,101 @@ export default async function OpsStatsPage() {
       <h1 className="mt-3 text-[32px] leading-[1.1] font-medium tracking-[-0.02em]">
         Stats problems
       </h1>
+      {/*
+        **The sentence that used to sit here is deleted, not reworded.**
+
+        It read: "Games where the provider's own numbers disagreed with each
+        other. The stat lines were still ingested — these are discrepancies, not
+        failures — so every one of these games has been scored, possibly
+        wrongly."
+
+        Every clause of that is false for a game with no box score: nothing was
+        ingested, it is a failure, and the game has not been scored — its players
+        are all on zero. It was a page-level claim about a heterogeneous list,
+        which is a category error no rewrite fixes, and it was rendered to the
+        operator at the moment they were deciding whether to act.
+
+        The claim now lives on the rows it is true of, via `ingestSentence`.
+        Issue #233. Do not restore a blanket assertion here.
+      */}
       <p className="mt-4 max-w-[62ch] text-[14.5px] leading-[1.62] text-nocturne-neutral-400">
-        Games where the provider&rsquo;s own numbers disagreed with each other. The stat lines
-        were still ingested &mdash; these are discrepancies, not failures &mdash; so every one
-        of these games has been scored, possibly wrongly.
+        Games whose box scores are missing, stale, or flagged by the translator. What each row
+        costs is on the row.
       </p>
 
       <p className="mt-6 font-mono text-[12px] text-nocturne-neutral-500">
         {view.total === 0
           ? "none outstanding"
-          : `${view.total} outstanding${view.shown < view.total ? `, showing ${view.shown}` : ""}`}
+          : [
+              view.noStats.length > 0 ? `${view.noStats.length} with no box score` : null,
+              view.stale.length > 0 ? `${view.stale.length} stale` : null,
+              view.discrepancies.length > 0 ? `${view.discrepancies.length} flagged` : null,
+              view.shown < view.total ? `showing ${view.shown} of ${view.total}` : null,
+            ]
+              .filter((part) => part !== null)
+              .join(" · ")}
       </p>
+
+      <RunBannerView banner={banner} />
 
       {view.total === 0 ? (
         <p className="mt-8 rounded-[4px] border border-nocturne-neutral-800 p-5 text-[13.5px] leading-[1.6] text-nocturne-neutral-500">
           Nothing flagged. Worth knowing what that does and does not mean: it says no game has
           tripped one of the translator&rsquo;s checks, not that every score is right. A defect
-          in a category nothing cross-checks looks exactly like this.
+          in a category nothing cross-checks looks exactly like this
+          {banner.state === "OK"
+            ? "."
+            : " \u2014 and the banner above says the job producing these checks is not healthy, so this list is not evidence of anything right now."}
         </p>
       ) : null}
 
-      {view.actionable.length > 0 ? (
+      {/*
+        Grouped by **what we hold**, not by whether it can still be fixed.
+
+        The old split was "Still correctable" / "Past the window", which answers
+        one question for a list whose rows differ by an order of magnitude in
+        what they cost: a game with no box score at all sat beside a field-goal
+        count disagreeing with itself, in the same section, in the same tone.
+        Recoverability survives as a chip on every row.
+      */}
+      {view.noStats.length > 0 ? (
         <section className="mt-10">
-          <h2 className="text-[15px] font-medium">Still correctable</h2>
+          <h2 className="text-[15px] font-medium text-red-300">No box score</h2>
           <p className="mt-1 max-w-[62ch] text-[13px] leading-[1.6] text-nocturne-neutral-500">
-            Inside the correction window, or not yet final. A fix applied to these still reaches
-            the scores.
+            Nothing usable was written for these games, so every player in them scores zero in
+            every league. Once a week finalises that is permanent. This is the set that holds{" "}
+            <span className="font-mono">score-week</span> open.
           </p>
-          <ProblemList rows={view.actionable} />
+          <ProblemList rows={view.noStats} />
         </section>
       ) : null}
 
-      {view.expired.length > 0 ? (
+      {view.stale.length > 0 ? (
         <section className="mt-12">
-          <h2 className="text-[15px] font-medium text-nocturne-neutral-400">Past the window</h2>
+          <h2 className="text-[15px] font-medium text-amber-300">Stale</h2>
+          <p className="mt-1 max-w-[62ch] text-[13px] leading-[1.6] text-nocturne-neutral-500">
+            Stat lines exist from an earlier read and the most recent read failed. The
+            scoreboard is showing numbers older than the game, live, to managers.
+          </p>
+          <ProblemList rows={view.stale} />
+        </section>
+      ) : null}
+
+      {view.discrepancies.length > 0 ? (
+        <section className="mt-12">
+          <h2 className="text-[15px] font-medium text-nocturne-neutral-400">
+            Ingested, with a discrepancy
+          </h2>
           <p className="mt-1 max-w-[62ch] text-[13px] leading-[1.6] text-nocturne-neutral-500">
             {/*
-              Kept on screen rather than dropped. A game nobody can fix is still
-              evidence about the provider, and a growing tail of these is the
-              argument for a second source at ingest rather than a page.
+              The one true sentence from the deleted page-level claim, now sitting
+              above the rows it is actually true of.
             */}
-            A finalised week is never rescored, so these can no longer be changed. They are
-            listed because the pattern matters even when the individual game is settled.
+            The stat lines were ingested &mdash; these are discrepancies, not failures &mdash;
+            so these games have been scored, possibly wrongly. Roughly one game in seven carries
+            one.
           </p>
-          <ProblemList rows={view.expired} />
+          <ProblemList rows={view.discrepancies} />
         </section>
       ) : null}
     </main>

--- a/apps/web/src/lib/jobs/stats.test.ts
+++ b/apps/web/src/lib/jobs/stats.test.ts
@@ -385,6 +385,45 @@ describe("the stats cron", () => {
     expect(quietBody.outstanding.total).toBe(1);
   });
 
+  it("stays green when the provider owes us a box score and this job did nothing wrong", async () => {
+    /*
+      The backlog is not a fault in this job.
+
+      `unresolvedStatsProblems` reports everything unresolved rather than what
+      this run touched — deliberately, so a quiet Tuesday cannot look clean over
+      a game that has been failing since Sunday. Feeding that count into
+      `last_outcome` therefore turns `cronJobState` red for as long as *any*
+      game anywhere is outstanding, on runs that fetched nothing, failed at
+      nothing and skipped nothing. That is the permanently-true health signal
+      this file already removed two other counts for.
+
+      Staged here as the ordinary shape: a finished game the work list has
+      already attempted, so it is paced out of this run and nothing is fetched.
+      The screen still lists it, with the severity that belongs to it.
+    */
+    db = await createTestDatabase();
+    await seedSport(db, NFL);
+    await league(2026);
+    await seedDefenses();
+    await finishedGame(2026, "g1");
+
+    await db.query(
+      `UPDATE games SET stats_synced_at = NULL, stats_attempted_at = now(),
+                       final_at = now() - interval '3 hours'`,
+    );
+
+    const quiet = fakeProvider(() => new Error("must not be called"));
+    const response = await runStatsJob(db, quiet.provider, NOW);
+    const body = (await response.json()) as {
+      outstanding: { total: number; blockingRecent: number };
+    };
+
+    expect(quiet.calls).toEqual([]);
+    // The operator can see it — and the heartbeat is not claiming this job broke.
+    expect(body.outstanding.blockingRecent).toBeGreaterThan(0);
+    expect(await lastOutcome()).toBeNull();
+  });
+
   /**
    * The route's own `try`/`catch` around a whole season is **not** exercised
    * here, and saying so is better than a test named as if it were.

--- a/apps/web/src/lib/jobs/stats.test.ts
+++ b/apps/web/src/lib/jobs/stats.test.ts
@@ -227,7 +227,15 @@ describe("the stats cron", () => {
     const body = (await response.json()) as { runs: { failures: unknown[] }[] };
 
     expect(body.runs[0]?.failures).toHaveLength(1);
-    expect(await lastOutcome()).toBe("1 game(s) failed to ingest");
+    /*
+      Contains, not equals. A game that failed to ingest is also a game with no
+      usable box score in a week that can still be corrected, so the blocking
+      clause fires alongside this one — correctly, and it is the more urgent of
+      the two. Pinning the exact string asserted that no other reason could ever
+      be true at the same time, which is the opposite of what a heartbeat that
+      reports every reason is for.
+    */
+    expect(await lastOutcome()).toContain("1 game(s) failed to ingest");
   });
 
   it("moves on to the next season after one season's game fails", async () => {
@@ -249,7 +257,15 @@ describe("the stats cron", () => {
     expect(body.seasons).toBe(2);
     expect(calls).toEqual(["g1", "g2"]);
     expect(body.runs.map((entry) => entry.season)).toEqual([2026, 2027]);
-    expect(await lastOutcome()).toBe("1 game(s) failed to ingest");
+    /*
+      Contains, not equals. A game that failed to ingest is also a game with no
+      usable box score in a week that can still be corrected, so the blocking
+      clause fires alongside this one — correctly, and it is the more urgent of
+      the two. Pinning the exact string asserted that no other reason could ever
+      be true at the same time, which is the opposite of what a heartbeat that
+      reports every reason is for.
+    */
+    expect(await lastOutcome()).toContain("1 game(s) failed to ingest");
   });
 
   /**
@@ -319,7 +335,15 @@ describe("the stats cron", () => {
 
     // The failure still reaches the heartbeat — the narrowing must not have
     // traded a false alarm for a silent one — and the warning no longer does.
-    expect(await lastOutcome()).toBe("1 game(s) failed to ingest");
+    /*
+      Contains, not equals. A game that failed to ingest is also a game with no
+      usable box score in a week that can still be corrected, so the blocking
+      clause fires alongside this one — correctly, and it is the more urgent of
+      the two. Pinning the exact string asserted that no other reason could ever
+      be true at the same time, which is the opposite of what a heartbeat that
+      reports every reason is for.
+    */
+    expect(await lastOutcome()).toContain("1 game(s) failed to ingest");
     expect(body.gameWarnings).toBe(1);
   });
 

--- a/apps/web/src/lib/jobs/stats.ts
+++ b/apps/web/src/lib/jobs/stats.ts
@@ -144,11 +144,6 @@ export async function runStatsJob(
   // itself clean over a game that has been failing since Sunday.
   const outstanding = await unresolvedStatsProblems(client, NFL.key);
 
-  // Read once for the alarm, from the same query the operator screen uses, so
-  // the number in the heartbeat and the rows on the page cannot disagree about
-  // what is wrong.
-  const blocking = outstanding.blockingRecent;
-
   // **Every reason, joined — not the first one.** This was a chain of ternaries,
   // so a run with a broken season announced only that and said nothing about the
   // twelve games that also failed. A heartbeat is read once and acted on once.
@@ -175,8 +170,21 @@ export async function runStatsJob(
     `season-sync` reported FAILING daily for the four week-16 and four week-17
     fixtures the NFL deliberately leaves undated. Same table, same shape.
 
-    Nothing is lost. Both counts are in the response body below, `games.stats_error`
-    still holds the text per game, and `/ops/stats` renders it.
+    `outstanding.blockingRecent` belongs to the same rule and was briefly on the
+    wrong side of it. It counts games the *provider* has not given us a complete
+    box score for — a real thing to act on, and not a fault in this job. Because
+    `unresolvedStatsProblems` reports everything unresolved rather than what this
+    run touched, a run that fetched nothing, failed at nothing and skipped
+    nothing still reported `FAILING` while one game anywhere was outstanding:
+    exactly the permanently-true health signal this note argues against, and the
+    one `pnpm cron:status` reads first.
+
+    Nothing is lost. Every count is in the response body below,
+    `games.stats_error` still holds the text per game, and `/ops/stats` renders
+    each of them with the severity that belongs to it — which is what #233 was
+    filed to make possible. What is still missing is a channel for "the provider
+    owes us a box score" that is neither a job failure nor silence; that needs a
+    severity axis `cronJobState` does not have.
   */
   const problem =
     [
@@ -206,24 +214,6 @@ export async function runStatsJob(
       */
       starvedSeasons > 0
         ? `${starvedSeasons} season(s) had games under way and read none`
-        : null,
-      /*
-        **A week is being held open by a game with no usable box score.**
-
-        The one condition on this page's subject that is worth waking somebody
-        for: those players are all scoring zero, the week cannot settle, and once
-        it does the result is permanent because a finalised week is never
-        rescored.
-
-        Bounded to the window in which the outcome could still change —
-        `ALARM_WINDOW_HOURS` from the week's last kickoff, not the full 168h the
-        screen keeps reporting for. An alarm's job is to fire once and be acted
-        on; one latched red for seven days over a fact nobody can act on any more
-        is a status board wearing an alarm's colours, and that is exactly how the
-        count this file already removed stopped being read.
-      */
-      blocking > 0
-        ? `${blocking} game(s) have no usable box score in a week that can still be corrected`
         : null,
     ]
       .filter((part) => part !== null)

--- a/apps/web/src/lib/jobs/stats.ts
+++ b/apps/web/src/lib/jobs/stats.ts
@@ -69,6 +69,8 @@ export async function runStatsJob(
     games?: number;
     /** Games being played at this instant. See the note above `problem`. */
     underWay?: number;
+    /** Games the breaker stopped short of. Not failures — see the push below. */
+    deferred?: readonly string[];
     inserted?: number;
     revised?: number;
     retracted?: number;
@@ -95,6 +97,22 @@ export async function runStatsJob(
         season,
         underWay,
         games: outcome.games,
+        /*
+          Games the run stopped short of, because the provider had failed
+          CONSECUTIVE_FAILURE_LIMIT times in a row.
+
+          **Reported, and it was not.** `syncBoxScores` has returned this since
+          the breaker was added and nothing read it, so a breaker trip was
+          invisible in both the response body and the heartbeat — the same shape
+          as the column written by something and read by nothing that this whole
+          area keeps producing.
+
+          It is not a failure and must not reach `problem`: nothing was
+          attempted for these and nothing was stamped, so the next tick picks
+          them up. A heartbeat that went red for the breaker working would be an
+          alarm nobody trusts.
+        */
+        deferred: outcome.deferred,
         inserted: outcome.inserted,
         revised: outcome.revised,
         retracted: outcome.retracted,
@@ -125,6 +143,11 @@ export async function runStatsJob(
   // fetched nothing is the normal case on a Tuesday and would otherwise report
   // itself clean over a game that has been failing since Sunday.
   const outstanding = await unresolvedStatsProblems(client, NFL.key);
+
+  // Read once for the alarm, from the same query the operator screen uses, so
+  // the number in the heartbeat and the rows on the page cannot disagree about
+  // what is wrong.
+  const blocking = outstanding.blockingRecent;
 
   // **Every reason, joined — not the first one.** This was a chain of ternaries,
   // so a run with a broken season announced only that and said nothing about the
@@ -183,6 +206,24 @@ export async function runStatsJob(
       */
       starvedSeasons > 0
         ? `${starvedSeasons} season(s) had games under way and read none`
+        : null,
+      /*
+        **A week is being held open by a game with no usable box score.**
+
+        The one condition on this page's subject that is worth waking somebody
+        for: those players are all scoring zero, the week cannot settle, and once
+        it does the result is permanent because a finalised week is never
+        rescored.
+
+        Bounded to the window in which the outcome could still change —
+        `ALARM_WINDOW_HOURS` from the week's last kickoff, not the full 168h the
+        screen keeps reporting for. An alarm's job is to fire once and be acted
+        on; one latched red for seven days over a fact nobody can act on any more
+        is a status board wearing an alarm's colours, and that is exactly how the
+        count this file already removed stopped being read.
+      */
+      blocking > 0
+        ? `${blocking} game(s) have no usable box score in a week that can still be corrected`
         : null,
     ]
       .filter((part) => part !== null)

--- a/apps/web/src/lib/ops.test.ts
+++ b/apps/web/src/lib/ops.test.ts
@@ -214,29 +214,6 @@ describe("buildOpsView", () => {
     );
   });
 
-  it("counts only the no-stats rows that can still be acted on", () => {
-    /*
-      `blockingOpen` must be able to reach zero; `noStats.length` cannot. A game
-      past its window stays on the page forever — correctly, as evidence — so a
-      banner driven by the raw count would be permanently lit, which is the
-      broken-health-signal failure this repo has paid for twice.
-    */
-    const view = buildOpsView(
-      {
-        total: 2,
-        blockingRecent: 1,
-        games: [
-          game({ gameRef: "open", ingest: "NO_STATS", weekLastKickoff: hoursBefore(10) }),
-          game({ gameRef: "shut", ingest: "NO_STATS", weekLastKickoff: hoursBefore(100) }),
-        ],
-      },
-      NOW,
-    );
-
-    expect(view.noStats).toHaveLength(2);
-    expect(view.blockingOpen).toBe(1);
-  });
-
   it("carries the alarm count from the query rather than from the rows", () => {
     // The rows are truncated by the LIMIT. A count derived from them and
     // presented as a total is the same lie one layer down.

--- a/apps/web/src/lib/ops.test.ts
+++ b/apps/web/src/lib/ops.test.ts
@@ -1,18 +1,62 @@
 import { describe, expect, it } from "vitest";
-import { buildOpsView, statusOf, windowHoursFor } from "./ops.js";
+import {
+  buildOpsView,
+  buildRunBanner,
+  ingestSentence,
+  statusOf,
+  toneOf,
+  windowHoursFor,
+  type IngestState,
+  type ProblemRow,
+} from "./ops.js";
 
 /**
  * What the operator view decides.
  *
- * The only judgement on this screen is whether a flagged game can still be
- * corrected, and getting it wrong in the permissive direction is the failure
- * that matters: telling somebody a fix is possible, watching them apply it, and
- * having it write a revision no finalised matchup will ever read. They would
- * believe a matchup was repaired when it was not.
+ * Two judgements, on two axes that used to be one. **What we hold** — no box
+ * score, stale numbers, or a discrepancy — decides the tone and the grouping.
+ * **Whether the week can still be corrected** decides a separate chip.
+ *
+ * Getting the second wrong in the permissive direction is the failure that has
+ * always mattered here: telling somebody a fix is possible, watching them apply
+ * it, and having it write a revision no finalised matchup will ever read.
+ *
+ * Getting the *first* wrong is what issue #233 was. Both a game whose every read
+ * failed and a field-goal count disagreeing with itself rendered identically,
+ * under a page-level sentence asserting that every row had been ingested and
+ * scored. The severe one drew in the calmest tone on the page, because colour
+ * keyed on the window axis and its provider had not called it final yet.
  */
 
 const NOW = new Date("2026-11-10T12:00:00Z");
 const hoursBefore = (h: number): Date => new Date(NOW.getTime() - h * 3_600_000);
+const hoursAfter = (h: number): Date => new Date(NOW.getTime() + h * 3_600_000);
+
+const game = (over: Partial<Parameters<typeof buildOpsView>[0]["games"][number]> = {}) => ({
+  gameRef: "g1",
+  season: 2026,
+  week: 5,
+  ingest: "DISCREPANCY" as IngestState,
+  problem: "fgMade disagrees with the parsed plays",
+  finalAt: hoursBefore(6),
+  syncedAt: hoursBefore(6),
+  isFinal: true,
+  weekLastKickoff: hoursBefore(6),
+  ...over,
+});
+
+const row = (over: Partial<ProblemRow> = {}): ProblemRow => ({
+  gameRef: "g1",
+  season: 2026,
+  week: 5,
+  ingest: "DISCREPANCY",
+  problem: "something",
+  status: "OPEN",
+  hoursSinceWeekEnd: 6,
+  windowHours: 48,
+  isFinal: true,
+  ...over,
+});
 
 describe("windowHoursFor", () => {
   it("gives an ordinary week 48 hours", () => {
@@ -36,95 +80,203 @@ describe("windowHoursFor", () => {
 });
 
 describe("statusOf", () => {
-  it("reports a game that has not finished", () => {
-    expect(statusOf(null, 5, NOW)).toEqual({ status: "NOT_FINAL", hoursSinceFinal: null });
+  it("measures from the week's last kickoff, not from the game's own final", () => {
+    /*
+      Issue #233, finding 8, and the single most consequential line in this file.
+
+      `finalizationHold` clears a week at `max(kickoff_at) + hours`, across the
+      whole week. This used to measure from the individual game's `final_at` —
+      a different clock, not a different latency — so an early Sunday game read
+      CLOSED roughly 28 hours before its week actually settled. The screen told
+      an operator a correction was pointless while it would still have landed,
+      and that slot holds 123 of the 256 synced fixtures.
+    */
+    const weekEnd = hoursBefore(20);
+
+    expect(statusOf(weekEnd, 5, NOW)).toEqual({ status: "OPEN", hoursSinceWeekEnd: 20 });
   });
 
-  it("reports an open window with the hours elapsed", () => {
-    expect(statusOf(hoursBefore(6), 5, NOW)).toEqual({ status: "OPEN", hoursSinceFinal: 6 });
+  it("reports a week whose clock has not started", () => {
+    // A flagged game that has been played, in a week where another fixture has
+    // yet to kick off. Renamed from NOT_FINAL, which asked about *this game*
+    // from inside a union meaning "can this week be corrected" — and which drew
+    // the calmest chip on the page for a game that might have no stats at all.
+    expect(statusOf(hoursAfter(30), 5, NOW)).toEqual({
+      status: "WEEK_IN_PLAY",
+      hoursSinceWeekEnd: null,
+    });
   });
 
-  it("closes exactly at the window, not after it", () => {
-    // The boundary, and the direction is deliberate: at exactly 48 hours the
-    // sweep may already have settled the week. Being early costs a needless
-    // "too late"; being late reports a correction that never landed.
-    expect(statusOf(hoursBefore(47), 5, NOW).status).toBe("OPEN");
+  it("closes the window at exactly the boundary", () => {
+    // Inclusive: at 48 hours the sweep may already have settled the week, so the
+    // safe reading is closed. Early costs a warning that says "probably too
+    // late"; late tells somebody a correction landed when it did not.
     expect(statusOf(hoursBefore(48), 5, NOW).status).toBe("CLOSED");
+    expect(statusOf(hoursBefore(47), 5, NOW).status).toBe("OPEN");
   });
 
-  it("keeps a paying week open past the ordinary window", () => {
-    // The case a single hardcoded 48 would get wrong, on the two weeks where
-    // being wrong costs money.
+  it("keeps a paying week open past the ordinary boundary", () => {
     expect(statusOf(hoursBefore(100), 14, NOW).status).toBe("OPEN");
     expect(statusOf(hoursBefore(100), 13, NOW).status).toBe("CLOSED");
-    expect(statusOf(hoursBefore(168), 17, NOW).status).toBe("CLOSED");
+  });
+});
+
+describe("toneOf", () => {
+  it("keys the tone on what we hold, not on whether it can be fixed", () => {
+    /*
+      The presentation half of #233. Colour used to come from the window status,
+      so a game whose every read had failed — no stats at all, every player on
+      zero — rendered in the lowest-contrast tone available, because its provider
+      had not yet called it final. The most severe state wore the calmest chip,
+      by default, every Sunday.
+    */
+    expect(toneOf("NO_STATS")).toBe("critical");
+    expect(toneOf("STALE")).toBe("warning");
+    expect(toneOf("DISCREPANCY")).toBe("neutral");
+  });
+});
+
+describe("ingestSentence", () => {
+  it("never claims a game with no box score was scored", () => {
+    /*
+      The deleted page-level prose, pinned where a test can reach it.
+
+      It read "the stat lines were still ingested… so every one of these games
+      has been scored", as a standing claim over a heterogeneous list. Every
+      clause was false for a game with no box score. This test is what stops it
+      coming back in a new location.
+    */
+    for (const status of ["OPEN", "CLOSED", "WEEK_IN_PLAY"] as const) {
+      const sentence = ingestSentence(row({ ingest: "NO_STATS", status }));
+      expect(sentence).toMatch(/scores? zero|scored zero/);
+      expect(sentence).not.toMatch(/were still ingested|discrepanc/i);
+    }
   });
 
-  it("treats a final_at in the future as not final", () => {
-    // A clock problem rather than a very fresh game. Answering "-3 hours ago"
-    // would be worse than saying it has not happened.
-    const future = new Date(NOW.getTime() + 3_600_000);
-    expect(statusOf(future, 5, NOW)).toEqual({ status: "NOT_FINAL", hoursSinceFinal: null });
+  it("says a stale row is not the final numbers", () => {
+    expect(ingestSentence(row({ ingest: "STALE" }))).toMatch(/not the final numbers/);
+  });
+
+  it("keeps the original sentence for the state it was true of", () => {
+    expect(ingestSentence(row({ ingest: "DISCREPANCY" }))).toMatch(
+      /discrepancy, not a failure/,
+    );
+  });
+
+  it("returns something for a row carrying no provider text", () => {
+    // A game selected by the clock rather than by an error has no `stats_error`.
+    // Without a sentence the card renders empty, which is how the state this
+    // screen was fixed to surface would stay invisible after all of it.
+    expect(ingestSentence(row({ ingest: "NO_STATS", problem: null })).length).toBeGreaterThan(
+      0,
+    );
   });
 });
 
 describe("buildOpsView", () => {
-  const game = (gameRef: string, week: number, finalAt: Date | null) => ({
-    gameRef,
-    season: 2026,
-    week,
-    problem: `${gameRef}: something disagreed with itself`,
-    finalAt,
-  });
-
-  it("splits what can still be fixed from what cannot", () => {
+  it("groups by what we hold, not by whether it can be fixed", () => {
     const view = buildOpsView(
       {
         total: 3,
+        blockingRecent: 1,
         games: [
-          game("20261108_KC@BUF", 10, hoursBefore(2)), // open
-          game("20261101_DAL@PHI", 9, hoursBefore(200)), // closed
-          game("20261115_SF@LAR", 11, null), // not final
+          game({ gameRef: "blank", ingest: "NO_STATS" }),
+          game({ gameRef: "stale", ingest: "STALE" }),
+          game({ gameRef: "flag", ingest: "DISCREPANCY" }),
         ],
       },
       NOW,
     );
 
-    expect(view.actionable.map((r) => r.gameRef)).toEqual([
-      "20261108_KC@BUF",
-      "20261115_SF@LAR",
-    ]);
-    expect(view.expired.map((r) => r.gameRef)).toEqual(["20261101_DAL@PHI"]);
+    expect(view.noStats.map((r) => r.gameRef)).toEqual(["blank"]);
+    expect(view.stale.map((r) => r.gameRef)).toEqual(["stale"]);
+    expect(view.discrepancies.map((r) => r.gameRef)).toEqual(["flag"]);
   });
 
-  it("counts everything, not only what it shows", () => {
-    // `unresolvedStatsProblems` takes a limit, so the list is a page and the
-    // total is not. A screen reporting `shown` as the whole truth would say a
-    // backlog of two hundred was twenty.
-    const view = buildOpsView({ total: 214, games: [game("a", 3, null)] }, NOW);
-    expect(view.total).toBe(214);
-    expect(view.shown).toBe(1);
-  });
-
-  it("keeps an unfinished game actionable rather than filing it as expired", () => {
-    // NOT_FINAL is not CLOSED. A game still being played will become
-    // correctable, and dropping it into the dead pile would hide the one class
-    // of problem an operator can still get ahead of.
-    const view = buildOpsView({ total: 1, games: [game("live", 5, null)] }, NOW);
-    expect(view.actionable).toHaveLength(1);
-    expect(view.expired).toHaveLength(0);
-  });
-
-  it("carries the window on every row so the screen can say why", () => {
+  it("puts every row in exactly one group", () => {
+    // Exhaustive and disjoint. A state falling through the filters would be
+    // silently uncounted, which on this page means invisible.
     const view = buildOpsView(
-      { total: 2, games: [game("a", 14, hoursBefore(1)), game("b", 5, hoursBefore(1))] },
+      {
+        total: 3,
+        blockingRecent: 0,
+        games: [
+          game({ gameRef: "a", ingest: "NO_STATS" }),
+          game({ gameRef: "b", ingest: "STALE" }),
+          game({ gameRef: "c", ingest: "DISCREPANCY" }),
+        ],
+      },
       NOW,
     );
-    expect(view.actionable.map((r) => r.windowHours)).toEqual([168, 48]);
+
+    expect(view.noStats.length + view.stale.length + view.discrepancies.length).toBe(
+      view.shown,
+    );
   });
 
-  it("handles an empty pipeline without inventing a problem", () => {
-    const view = buildOpsView({ total: 0, games: [] }, NOW);
-    expect(view).toEqual({ total: 0, shown: 0, actionable: [], expired: [] });
+  it("counts only the no-stats rows that can still be acted on", () => {
+    /*
+      `blockingOpen` must be able to reach zero; `noStats.length` cannot. A game
+      past its window stays on the page forever — correctly, as evidence — so a
+      banner driven by the raw count would be permanently lit, which is the
+      broken-health-signal failure this repo has paid for twice.
+    */
+    const view = buildOpsView(
+      {
+        total: 2,
+        blockingRecent: 1,
+        games: [
+          game({ gameRef: "open", ingest: "NO_STATS", weekLastKickoff: hoursBefore(10) }),
+          game({ gameRef: "shut", ingest: "NO_STATS", weekLastKickoff: hoursBefore(100) }),
+        ],
+      },
+      NOW,
+    );
+
+    expect(view.noStats).toHaveLength(2);
+    expect(view.blockingOpen).toBe(1);
+  });
+
+  it("carries the alarm count from the query rather than from the rows", () => {
+    // The rows are truncated by the LIMIT. A count derived from them and
+    // presented as a total is the same lie one layer down.
+    const view = buildOpsView({ total: 90, blockingRecent: 7, games: [game()] }, NOW);
+
+    expect(view.blockingRecent).toBe(7);
+    expect(view.shown).toBe(1);
+    expect(view.total).toBe(90);
+  });
+});
+
+describe("buildRunBanner", () => {
+  it("reports a failing job, which is how a run-level fault reaches this screen", () => {
+    /*
+      Issue #233, finding 4. The pool check that refuses a run whose player pool
+      has a position group at zero throws *before* the game loop, so it writes no
+      `stats_error` and produces no row here. Same for a database fault, a
+      provider auth failure, and #256's "a slate was under way and nothing was
+      selected" alarm. Every one turns `cron:status` red and left this page
+      saying "nothing flagged".
+    */
+    expect(
+      buildRunBanner({ lastRanAt: hoursBefore(0.1), lastOutcome: "pool has no K" }, NOW),
+    ).toEqual({ state: "FAILING", detail: "pool has no K" });
+  });
+
+  it("tells a job that has not run from a job with nothing to do", () => {
+    // "Nothing flagged" beside a job that stopped on Thursday is the same false
+    // all-clear as the prose this change deletes.
+    expect(buildRunBanner({ lastRanAt: hoursBefore(6), lastOutcome: null }, NOW).state).toBe(
+      "STALE",
+    );
+    expect(buildRunBanner(undefined, NOW).state).toBe("NEVER_RAN");
+  });
+
+  it("stays quiet on a healthy job", () => {
+    // The control. An alarm that cannot go quiet is one nobody reads, and the
+    // job runs every ten minutes so a single missed tick is not news.
+    expect(buildRunBanner({ lastRanAt: hoursBefore(0.2), lastOutcome: null }, NOW).state).toBe(
+      "OK",
+    );
   });
 });

--- a/apps/web/src/lib/ops.ts
+++ b/apps/web/src/lib/ops.ts
@@ -17,8 +17,13 @@ const PAYING_WINDOW_HOURS = 168;
 const PAYING_WEEKS = new Set([14, 17]);
 
 export type ProblemStatus =
-  /** The game has not finished. Nothing to correct yet. */
-  | "NOT_FINAL"
+  /**
+   * The week's clock has not started — a game in it has yet to kick off.
+   *
+   * Was `NOT_FINAL`, which asked about *this game* from inside a union that
+   * means "can this week be corrected". See `statusOf`.
+   */
+  | "WEEK_IN_PLAY"
   /** Inside the correction window — a fix still reaches the scores. */
   | "OPEN"
   /** The window has closed. A correction now changes nothing anyone reads. */
@@ -28,21 +33,51 @@ export interface ProblemRow {
   readonly gameRef: string;
   readonly season: number;
   readonly week: number;
-  readonly problem: string;
+  /** What we hold. Drives the tone and the grouping — see `toneOf`. */
+  readonly ingest: IngestState;
+  /**
+   * The provider's complaint, when there is one.
+   *
+   * Nullable, and it was not before: a game selected by the clock rather than by
+   * an error carries nothing here. A caller that assumes a string renders an
+   * empty card, which is how the state this screen was fixed to show would stay
+   * invisible after all of it.
+   */
+  readonly problem: string | null;
   readonly status: ProblemStatus;
-  /** Whole hours since the game went final; `null` when it has not. */
-  readonly hoursSinceFinal: number | null;
+  /** Whole hours since the week's last kickoff; `null` before it. */
+  readonly hoursSinceWeekEnd: number | null;
   /** The window this week gets, in hours. Named so the screen can say why. */
   readonly windowHours: number;
+  /** Whether the provider has called this game final. Shown, never a tier. */
+  readonly isFinal: boolean;
 }
+
+export type RunBanner = {
+  readonly state: "OK" | "STALE" | "FAILING" | "NEVER_RAN";
+  readonly detail: string;
+};
 
 export interface OpsView {
   readonly total: number;
   readonly shown: number;
-  /** Problems still worth acting on, newest first. */
-  readonly actionable: readonly ProblemRow[];
-  /** Problems that can no longer be fixed. Kept visible deliberately. */
-  readonly expired: readonly ProblemRow[];
+  /**
+   * Games with no usable box score whose week can still be corrected.
+   *
+   * The count fit to drive an alarm, and the only one here that can fall to
+   * zero. Computed by the query rather than from the rows below, because those
+   * are truncated by the LIMIT and a truncated count presented as a total is the
+   * same lie one layer down.
+   */
+  readonly blockingRecent: number;
+  /** No usable box score. Every player in these games scores zero. */
+  readonly noStats: readonly ProblemRow[];
+  /** Stats exist; the latest read failed. The scoreboard is behind the game. */
+  readonly stale: readonly ProblemRow[];
+  /** Ingested, with something that did not reconcile. Roughly one game in seven. */
+  readonly discrepancies: readonly ProblemRow[];
+  /** How many `noStats` rows are still inside their window. See `buildOpsView`. */
+  readonly blockingOpen: number;
 }
 
 /**
@@ -60,77 +95,216 @@ export function windowHoursFor(week: number): number {
 }
 
 /**
- * Whether a flagged game can still be corrected.
+ * Whether a flagged game's week can still be corrected.
  *
  * **The distinction this screen exists to draw.** A finalised week is never
  * rescored, so a correction applied after the window writes a revision that
  * nothing will ever read — the operator would believe they had fixed a matchup
- * they had not. Reporting `CLOSED` is the honest answer and it is the reason
- * `finalAt` is carried all the way from the query.
+ * they had not.
  *
- * The boundary is inclusive of the window: at exactly 48 hours the window has
- * elapsed and the sweep may already have settled the week, so the safe reading
- * is closed. Being early costs a warning that says "probably too late" on a
- * fixable game; being late tells somebody a correction landed when it did not.
+ * ## The anchor is the week's last kickoff, and it used to be the game's own
+ *
+ * `finalizationHold` clears a week at `max(kickoff_at) + finalizationHours`, over
+ * the whole week. This measured from the individual game's `final_at`, which is a
+ * different clock rather than a different latency — so the two disagreed in both
+ * directions, and after #256 made `final_at` accurate the dominant error grew
+ * rather than shrank. An early Sunday game read `CLOSED` roughly **28 hours
+ * before** its week actually settled: the screen telling an operator a
+ * correction was pointless while it would still have landed. That slot holds 123
+ * of the 256 synced fixtures.
+ *
+ * **What is fixed is the anchor, not the duration.** `windowHoursFor` stays
+ * sport-level and its reasoning below is untouched: this screen is about the
+ * provider, and the same bad box score reaches every league. So for a league on
+ * the default correction window — which invariant 5 forces on every paying week,
+ * and which every league that exists today uses — this now agrees with
+ * `finalizationHold` exactly rather than approximately. A league that varied its
+ * window still diverges, by exactly the amount it varied, which is the class of
+ * error this function already accepts on purpose.
+ *
+ * The boundary is inclusive: at exactly 48 hours the window has elapsed and the
+ * sweep may already have settled the week, so the safe reading is closed.
  */
 export function statusOf(
-  finalAt: Date | null,
+  weekLastKickoff: Date,
   week: number,
   now: Date,
-): { status: ProblemStatus; hoursSinceFinal: number | null } {
-  if (finalAt === null) return { status: "NOT_FINAL", hoursSinceFinal: null };
+): { status: ProblemStatus; hoursSinceWeekEnd: number | null } {
+  const elapsedHours = Math.floor((now.getTime() - weekLastKickoff.getTime()) / 3_600_000);
 
-  const elapsedHours = Math.floor((now.getTime() - finalAt.getTime()) / 3_600_000);
-  // A game whose `final_at` is in the future is a clock problem, not an open
-  // window. Treated as not final rather than as fresh, because the honest
-  // answer to "how long ago" is that it has not happened.
-  if (elapsedHours < 0) return { status: "NOT_FINAL", hoursSinceFinal: null };
+  /*
+    The week's clock has not started, because a game in it has not kicked off.
+
+    **Renamed from `NOT_FINAL`, and the rename is a fix.** That value asked
+    whether *this game* had finished, from inside a union that means "can this be
+    corrected" — and once the anchor moved it became reachable for a game that
+    demonstrably had finished, whose week merely still had a fixture to come. It
+    rendered as the calmest chip on the page, which is the same misplaced calm
+    this whole change is about.
+
+    Kept as a third value rather than folded into OPEN, because there is
+    genuinely no number to show: the countdown has not begun, and reporting
+    "0 of 48 hours" would imply it had.
+  */
+  if (elapsedHours < 0) return { status: "WEEK_IN_PLAY", hoursSinceWeekEnd: null };
 
   return {
     status: elapsedHours >= windowHoursFor(week) ? "CLOSED" : "OPEN",
-    hoursSinceFinal: elapsedHours,
+    hoursSinceWeekEnd: elapsedHours,
   };
+}
+
+/**
+ * What we hold for this game, as one word.
+ *
+ * Carried from SQL rather than recomputed here, deliberately. The severity that
+ * labels a row and the severity that sorts it must be one expression, or a row
+ * can sort into one bucket and wear another — which is issue #233's own defect
+ * one layer up. What this module owns is the *presentation* of that fact: the
+ * tone, the ordering of the sections, and the sentence.
+ */
+export type IngestState = "NO_STATS" | "STALE" | "DISCREPANCY";
+
+/**
+ * The tone a row is drawn in.
+ *
+ * **Keyed on what we hold, never on whether it can still be fixed**, and that
+ * reassignment is the presentation half of issue #233. Colour used to come from
+ * the window status, so a game whose every read had failed — no stats at all,
+ * every player scoring zero — rendered in the lowest-contrast tone on the page,
+ * because its provider had not yet called it final. The most severe state got
+ * the calmest chip, by default, every Sunday.
+ */
+export function toneOf(ingest: IngestState): "critical" | "warning" | "neutral" {
+  if (ingest === "NO_STATS") return "critical";
+  if (ingest === "STALE") return "warning";
+  return "neutral";
+}
+
+/**
+ * One sentence saying what this state does to a score.
+ *
+ * Here rather than in the component for the reason at the top of this file, and
+ * for one more: the sentence it replaces was a **page-level** claim across a
+ * heterogeneous list — *"the stat lines were still ingested… so every one of
+ * these games has been scored"* — which was false for two of the three states
+ * and was rendered to the operator at the moment they decided whether to act.
+ * A claim that can only be true of some rows belongs on a row.
+ */
+export function ingestSentence(row: ProblemRow): string {
+  if (row.ingest === "NO_STATS") {
+    return row.status === "CLOSED"
+      ? "No box score was ever read for this game. Every player in it scored zero, permanently."
+      : "No box score has been read for this game. Every player in it currently scores zero.";
+  }
+  if (row.ingest === "STALE") {
+    return "Stat lines exist from an earlier read and the most recent read failed, so these are not the final numbers.";
+  }
+  return "The stat lines were ingested — this is a discrepancy, not a failure — so this game has been scored, possibly wrongly.";
 }
 
 /**
  * Turn the raw problem list into what the screen draws.
  *
- * Split rather than sorted, because the two halves call for different actions
- * and a single list ordered by time buries the urgent one under a season of
- * history. `expired` is kept rather than dropped: a game nobody can fix is
- * still evidence about the provider, and a growing tail of them is the argument
- * for wiring a second source into ingestion rather than reading this page.
+ * Grouped by **what we hold** rather than split by recoverability, which is the
+ * change #233 asked for: the old two-way split answered "can I act" for a list
+ * whose rows differed by an order of magnitude in what they cost. Recoverability
+ * survives as a chip on every row, and as `blockingOpen`.
  */
 export function buildOpsView(
   input: {
     readonly total: number;
+    readonly blockingRecent: number;
     readonly games: readonly {
       readonly gameRef: string;
       readonly season: number;
       readonly week: number;
-      readonly problem: string;
+      readonly ingest: IngestState;
+      readonly problem: string | null;
       readonly finalAt: Date | null;
+      readonly syncedAt: Date | null;
+      readonly isFinal: boolean;
+      readonly weekLastKickoff: Date;
     }[];
   },
   now: Date,
 ): OpsView {
   const rows: ProblemRow[] = input.games.map((game) => {
-    const { status, hoursSinceFinal } = statusOf(game.finalAt, game.week, now);
+    const { status, hoursSinceWeekEnd } = statusOf(game.weekLastKickoff, game.week, now);
     return {
       gameRef: game.gameRef,
       season: game.season,
       week: game.week,
+      ingest: game.ingest,
       problem: game.problem,
       status,
-      hoursSinceFinal,
+      hoursSinceWeekEnd,
       windowHours: windowHoursFor(game.week),
+      isFinal: game.isFinal,
     };
   });
+
+  const of = (state: IngestState) => rows.filter((row) => row.ingest === state);
 
   return {
     total: input.total,
     shown: rows.length,
-    actionable: rows.filter((row) => row.status !== "CLOSED"),
-    expired: rows.filter((row) => row.status === "CLOSED"),
+    blockingRecent: input.blockingRecent,
+    noStats: of("NO_STATS"),
+    stale: of("STALE"),
+    discrepancies: of("DISCREPANCY"),
+    /*
+      How many of the worst rows can still be acted on.
+
+      Separate from `noStats.length` because that number cannot fall to zero — a
+      game past its window stays on the page forever, correctly, as evidence.
+      This one can, which is what makes it fit to drive a banner.
+    */
+    blockingOpen: of("NO_STATS").filter((row) => row.status !== "CLOSED").length,
   };
+}
+
+/**
+ * The stats job's own last run, rendered above the list.
+ *
+ * **An empty list beside a job that is not running is a false all-clear**, and it
+ * is the same defect as the prose this change deletes — a reassuring statement
+ * the code cannot support, shown to somebody deciding whether to act.
+ *
+ * It is also the only way a **run-level** failure reaches this screen at all.
+ * The pool check that refuses a run whose player pool has a position group at
+ * zero throws before the game loop, so it writes no `stats_error` and produces no
+ * row here — and the same is true of a database fault, a provider auth failure,
+ * a season that threw, and the "a slate was under way and nothing was selected"
+ * alarm added with #256. Every one of those turns `pnpm cron:status` red and,
+ * until now, left this page saying "nothing flagged".
+ *
+ * Stamping those faults onto individual games was the obvious alternative and is
+ * wrong: it writes a fact about the *run* onto rows that were never attempted,
+ * and the retry clause would then pace against it.
+ */
+export function buildRunBanner(
+  run: { readonly lastRanAt: Date | null; readonly lastOutcome: string | null } | undefined,
+  now: Date,
+): RunBanner {
+  if (run === undefined || run.lastRanAt === null) {
+    return { state: "NEVER_RAN", detail: "The stats job has no recorded run." };
+  }
+  if (run.lastOutcome !== null) {
+    return { state: "FAILING", detail: run.lastOutcome };
+  }
+  const minutesAgo = Math.floor((now.getTime() - run.lastRanAt.getTime()) / 60_000);
+  /*
+    Stale, not failing. The job runs every ten minutes; an hour of silence is a
+    scheduler problem rather than an ingest one, and saying so sends somebody to
+    the right place. Generous, because a single missed tick is not news and an
+    alarm that fires on one is an alarm that gets muted.
+  */
+  if (minutesAgo >= 60) {
+    return {
+      state: "STALE",
+      detail: `The stats job last completed ${minutesAgo} minutes ago.`,
+    };
+  }
+  return { state: "OK", detail: `The stats job last completed ${minutesAgo} minutes ago.` };
 }

--- a/apps/web/src/lib/ops.ts
+++ b/apps/web/src/lib/ops.ts
@@ -80,8 +80,6 @@ export interface OpsView {
   readonly stale: readonly ProblemRow[];
   /** Ingested, with something that did not reconcile. Roughly one game in seven. */
   readonly discrepancies: readonly ProblemRow[];
-  /** How many `noStats` rows are still inside their window. See `buildOpsView`. */
-  readonly blockingOpen: number;
 }
 
 /**
@@ -221,7 +219,15 @@ export function ingestSentence(row: ProblemRow): string {
  * Grouped by **what we hold** rather than split by recoverability, which is the
  * change #233 asked for: the old two-way split answered "can I act" for a list
  * whose rows differed by an order of magnitude in what they cost. Recoverability
- * survives as a chip on every row, and as `blockingOpen`.
+ * survives as a chip on every row.
+ *
+ * There was a `blockingOpen` count here too — `noStats` rows still inside their
+ * window — computed, documented and unit-tested, and read by nothing. The page
+ * renders recoverability per row, so no header wanted it. A field written by
+ * something and read by nothing is the shape this screen exists to correct, and
+ * shipping one inside the fix would have been the joke telling itself. If a
+ * banner ever needs the number, it is one `filter` and it should arrive with
+ * its reader.
  */
 export function buildOpsView(
   input: {
@@ -265,14 +271,6 @@ export function buildOpsView(
     noStats: of("NO_STATS"),
     stale: of("STALE"),
     discrepancies: of("DISCREPANCY"),
-    /*
-      How many of the worst rows can still be acted on.
-
-      Separate from `noStats.length` because that number cannot fall to zero — a
-      game past its window stays on the page forever, correctly, as evidence.
-      This one can, which is what makes it fit to drive a banner.
-    */
-    blockingOpen: of("NO_STATS").filter((row) => row.status !== "CLOSED").length,
   };
 }
 

--- a/apps/web/src/lib/ops.ts
+++ b/apps/web/src/lib/ops.ts
@@ -62,7 +62,11 @@ export interface OpsView {
   readonly total: number;
   readonly shown: number;
   /**
-   * Games with no usable box score whose week can still be corrected.
+   * Games whose box score is missing or behind the game, in a week that can
+   * still be corrected.
+   *
+   * Both severities. "No usable box score" would be wrong for the STALE half,
+   * which has one.
    *
    * The count fit to drive an alarm, and the only one here that can fall to
    * zero. Computed by the query rather than from the rows below, because those
@@ -198,7 +202,15 @@ export function ingestSentence(row: ProblemRow): string {
       : "No box score has been read for this game. Every player in it currently scores zero.";
   }
   if (row.ingest === "STALE") {
-    return "Stat lines exist from an earlier read and the most recent read failed, so these are not the final numbers.";
+    // **Not "the most recent read failed".** That is one of two ways to get here
+    // and not the more common one: a game starved by `MAX_GAMES_PER_RUN`, or
+    // skipped by the consecutive-failure breaker, has had no read attempted
+    // since the whistle at all. Naming a failure that did not happen sends an
+    // operator looking for an error that is not there.
+    return (
+      "Stat lines exist from a read taken before the game finished, and nothing has " +
+      "been read successfully since, so these are not the final numbers."
+    );
   }
   return "The stat lines were ingested — this is a discrepancy, not a failure — so this game has been scored, possibly wrongly.";
 }

--- a/docs/SETUP-REQUIRED.md
+++ b/docs/SETUP-REQUIRED.md
@@ -268,6 +268,40 @@ blocked kicks are both obtainable, from the play-by-play. See
 
 ---
 
+### ⬜ Operator console access (`OPERATOR_EMAILS`)
+
+**Blocks:** the whole of `/ops/stats`, and with it any human reading of
+`games.stats_error` — the column that records a box score the provider
+contradicted itself on, or one that could not be read at all.
+
+**Needed by:** **9 September**. The first real ingest is the first thing anyone
+would want to look at, and a stat correction that arrives late is only actionable
+inside the week's correction window.
+
+Set it to your own address:
+
+```
+OPERATOR_EMAILS=6figpsolseeker@gmail.com
+```
+
+Comma-separate for more than one. It is matched against the signed-in session's
+email, so signing in is a precondition.
+
+**It fails closed in every environment, including development**, and that is
+deliberate — an operator screen that defaults open in dev is one that ships open.
+The cost is that an unset value looks exactly like not being an operator: the
+page returns 404, with no error and no hint, because a 403 would confirm the page
+exists to anyone who asked.
+
+**This was set nowhere, and had been since the screen was built.** Not in `.env`,
+not in `.env.example`, and not in any document including this one — the variable
+appeared in three places in the repository, all of them code. So the console
+404'd for everybody, the owner included, and nine defects accumulated in a page
+nobody could open. Issue #233 was a bug in the rendering of a screen that had
+never been rendered.
+
+---
+
 ### 🟡 Security review — escrow program
 
 **Decided 2026-08-05:** no commercial audit firm **for the 2026 season**. The owner has a

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -1950,6 +1950,16 @@ describe("what the operator screen can tell apart — #233", () => {
       The thing that stops a week settling must be the thing the producer goes
       and fetches, and the thing an operator is shown. Three spellings could
       disagree; one cannot.
+
+      **STALE, not NO_STATS.** This game was read two hours before the whistle,
+      so it has stat lines — real ones, from real play. It asserted NO_STATS
+      until a review pointed out that the screen then tells the operator "no box
+      score has been read … every player in it currently scores zero" over a
+      game whose quarterback has 287 passing yards. What is true of it is that
+      what we hold is behind the game, which is what STALE says.
+
+      The correspondence being tested is unchanged: one game unread by the
+      hold's own predicate, one game the screen shows as not yet final.
     */
     const fx = await setup();
     await fx.client.query(
@@ -1971,7 +1981,9 @@ describe("what the operator screen can tell apart — #233", () => {
     const { games } = await problems(fx);
 
     expect(held?.unread).toBe(1);
-    expect(games.filter((g) => g.ingest === "NO_STATS")).toHaveLength(1);
+    expect(games.filter((g) => g.ingest === "STALE")).toHaveLength(1);
+    // And nothing claims the stat lines are absent.
+    expect(games.filter((g) => g.ingest === "NO_STATS")).toHaveLength(0);
   });
 
   it("keeps the alarm count bounded while the screen's total is not", async () => {

--- a/packages/db/src/box-scores.test.ts
+++ b/packages/db/src/box-scores.test.ts
@@ -458,18 +458,31 @@ describe("syncBoxScores", () => {
     const outstanding = await unresolvedStatsProblems(fx.client, NFL.key);
 
     expect(outstanding.total).toBe(1);
-    // `finalAt` rides along because the only useful question about a flagged
-    // game is whether anything can still be done about it — a correction after
-    // the window writes a revision no finalised matchup will ever read. The
-    // fixture's game is FINAL, so this is a date rather than null; the operator
-    // view turns it into "still correctable" or "past the window".
+    /*
+      The row carries more than it did, and the additions are the whole of #233.
+
+      `finalAt` alone answered "can this still be corrected" and nothing else —
+      so a game with no box score at all and a field-goal count disagreeing with
+      itself came back identical, and the screen drew them identically under a
+      sentence claiming both had been ingested and scored.
+
+      `ingest` is the fact that was missing. `syncedAt`, `isFinal` and
+      `kickoffAt` are the evidence behind it, and `weekLastKickoff` is the
+      instant `finalizationHold` measures from — which this screen did not, and
+      so disagreed with by about a day.
+    */
     expect(outstanding.games).toEqual([
       {
         gameRef: "g1",
         season: SEASON,
         week: WEEK,
+        ingest: "DISCREPANCY",
         problem: "odd",
+        kickoffAt: expect.any(Date),
         finalAt: expect.any(Date),
+        syncedAt: expect.any(Date),
+        isFinal: true,
+        weekLastKickoff: expect.any(Date),
       },
     ]);
   });
@@ -1703,5 +1716,350 @@ describe("a run gives up on a provider that has stopped answering — #256", () 
 
     expect(asked).toHaveLength(total);
     expect(result.deferred).toEqual([]);
+  });
+});
+
+describe("what the operator screen can tell apart — #233", () => {
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  const problems = (fx: Fixture) => unresolvedStatsProblems(fx.client, NFL.key, 50);
+
+  /** A second game in the same week, so the week's clock is not this game's. */
+  const addGame = async (fx: Fixture, ref: string, kickoff: string) =>
+    fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                          kickoff_at, status, final_at)
+       VALUES ($1, $2, $3, $4, 'NYG', 'WAS', now() + ($5)::interval, 'SCHEDULED', NULL)`,
+      [fx.sportId, ref, SEASON, WEEK, kickoff],
+    );
+
+  it("reports a game whose every read failed as having no stats", async () => {
+    // The headline. This and a field-goal count disagreeing with itself were the
+    // same row on the screen, under a sentence claiming both had been ingested
+    // and scored.
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'Tank01 returned HTTP 503',
+                       stats_attempted_at = now() - interval '1 hour',
+                       stats_synced_at = NULL`,
+    );
+
+    const { games } = await problems(fx);
+
+    expect(games).toHaveLength(1);
+    expect(games[0]?.ingest).toBe("NO_STATS");
+  });
+
+  it("reports an ingested game carrying a warning as a discrepancy", async () => {
+    const fx = await setup();
+    const box = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses }, [
+      "fgMade disagrees with the parsed plays",
+    ]);
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", box]])), NFL.key, SEASON);
+
+    const { games } = await problems(fx);
+
+    expect(games).toHaveLength(1);
+    expect(games[0]?.ingest).toBe("DISCREPANCY");
+  });
+
+  it("reports a game read cleanly and then failing as stale", async () => {
+    /*
+      **The state #256 created, which #233's own filed predicate cannot reach.**
+
+      Before live reads existed, the first read of any game was necessarily after
+      the whistle — so a game either had a sync stamp or it did not, and the
+      issue's two-row table was complete. Now a game can carry stats *and* a
+      failing latest attempt. The discriminator is the ordering of the two
+      stamps, not the nullness of one.
+    */
+    const fx = await setup();
+    const box = boxScore("g1", { qb1: [line("pass_yd", 120)], ...bothDefenses });
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", box]])), NFL.key, SEASON);
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'Tank01 returned HTTP 503',
+                       stats_attempted_at = stats_synced_at + interval '20 minutes'`,
+    );
+
+    const { games } = await problems(fx);
+
+    expect(games[0]?.ingest).toBe("STALE");
+  });
+
+  it("finds a played game with no stats and no error at all", async () => {
+    /*
+      **The largest gap, and every design missed it before it was pointed out.**
+
+      A game starved by MAX_GAMES_PER_RUN on a fourteen-game slate, or skipped by
+      the consecutive-failure breaker — which deliberately stamps nothing,
+      because it did not attempt them — carries no error, no sync stamp, and
+      whatever status the daily sync last wrote. That is exactly the class this
+      screen exists for, and every predicate keyed on `stats_error` misses it.
+
+      Found by the clock instead, which is #256's lesson one layer up.
+    */
+    const fx = await setup("SCHEDULED");
+    await fx.client.query(
+      "UPDATE games SET stats_error = NULL, stats_attempted_at = NULL, stats_synced_at = NULL",
+    );
+
+    const { games } = await problems(fx);
+
+    expect(games).toHaveLength(1);
+    expect(games[0]?.ingest).toBe("NO_STATS");
+    expect(games[0]?.problem).toBeNull();
+  });
+
+  it("does not report a game that has not plausibly been played yet", async () => {
+    // The floor. Without it every unplayed fixture of the season is a problem.
+    const fx = await setup("SCHEDULED");
+    await fx.client.query(
+      `UPDATE games SET stats_error = NULL, stats_attempted_at = NULL, stats_synced_at = NULL,
+                       kickoff_at = now() - interval '40 minutes'`,
+    );
+
+    expect((await problems(fx)).games).toEqual([]);
+  });
+
+  it("does not report a fixture whose kickoff time is only a stand-in", async () => {
+    // Eight week-16 and week-17 fixtures carry a provisional hour. A blank row
+    // for one is a false alarm in the playoff and championship weeks.
+    const fx = await setup("SCHEDULED");
+    await fx.client.query(
+      `UPDATE games SET stats_error = NULL, stats_attempted_at = NULL, stats_synced_at = NULL,
+                       kickoff_tbd = true`,
+    );
+
+    expect((await problems(fx)).games).toEqual([]);
+  });
+
+  it("does not report a discrepancy on a game still being played", async () => {
+    /*
+      A partial box score disagreeing with itself is not a defect. The
+      translator's warnings are ungated, so without this a slate's worth of
+      transient noise lands here every Sunday — and a page that is amber every
+      Sunday is a page nobody opens.
+    */
+    const fx = await setup("SCHEDULED");
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays',
+                       stats_synced_at = now(), stats_attempted_at = now(),
+                       final_at = NULL, kickoff_at = now() - interval '90 minutes'`,
+    );
+
+    expect((await problems(fx)).games).toEqual([]);
+  });
+
+  it("never reports a postponed game as having no stats", async () => {
+    // RULES.md §10 already scores those players zero, and no box score is ever
+    // coming. Without the exclusion it would sit here for the rest of the season.
+    const fx = await setup("POSTPONED");
+    await fx.client.query(
+      "UPDATE games SET stats_error = NULL, stats_attempted_at = NULL, stats_synced_at = NULL",
+    );
+
+    expect((await problems(fx)).games).toEqual([]);
+  });
+
+  it("says nothing at all about a healthy game", async () => {
+    const fx = await setup();
+    const box = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses });
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", box]])), NFL.key, SEASON);
+
+    expect((await problems(fx)).games).toEqual([]);
+  });
+
+  it("carries the week's last kickoff, not the game's own", async () => {
+    /*
+      Issue #233, finding 8. `finalizationHold` measures the correction window
+      from the week's last kickoff; this screen measured from the game's own
+      `final_at`, which is a different clock rather than a different latency — so
+      an early Sunday game read CLOSED about 28 hours before its week settled.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      "UPDATE games SET stats_error = 'fgMade disagrees with the parsed plays'",
+    );
+    await addGame(fx, "g1-monday", "50 hours");
+
+    const { games } = await problems(fx);
+
+    expect(games[0]?.weekLastKickoff.getTime()).toBeGreaterThan(Date.now() + 40 * 3_600_000);
+  });
+
+  it("does not let the week's anchor be computed from the flagged games alone", async () => {
+    /*
+      **The trap in the obvious implementation, and it was in two of the three
+      designs.** A window function evaluates *after* WHERE, so
+      `max(kickoff_at) OVER (PARTITION BY season, week)` sees only the rows that
+      survived the filter and returns the last *flagged* kickoff.
+
+      On a week where only the Thursday game is flagged that lands almost five
+      days early — and in the dangerous direction, reporting a week closed to
+      corrections while it is still fully open. Measured against PGlite, not
+      reasoned about.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'boom', kickoff_at = now() - interval '96 hours'`,
+    );
+    await addGame(fx, "g1-later", "2 hours");
+
+    const { games } = await problems(fx);
+
+    // The later fixture is unflagged, so a window function would never see it.
+    expect(games[0]?.weekLastKickoff.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("puts a game with no stats ahead of a newer discrepancy under truncation", async () => {
+    /*
+      This used to be `ORDER BY kickoff_at DESC` alone, so a page of routine
+      warnings pushed the one game whose players all score zero off the end. The
+      same argument the work list already makes for its own tiers: under
+      truncation, the row that decides money goes first.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'no stats here', stats_synced_at = NULL,
+                       stats_attempted_at = now(), kickoff_at = now() - interval '30 hours'`,
+    );
+    await fx.client.query(
+      `INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref,
+                          kickoff_at, status, final_at, stats_error,
+                          stats_synced_at, stats_attempted_at)
+       VALUES ($1, 'g1-fresh', $2, $3, 'NYG', 'WAS', now() - interval '4 hours', 'FINAL',
+               now() - interval '1 hour', 'a field goal disagrees', now(), now())`,
+      [fx.sportId, SEASON, WEEK],
+    );
+
+    const { games } = await unresolvedStatsProblems(fx.client, NFL.key, 1);
+
+    expect(games).toHaveLength(1);
+    expect(games[0]?.ingest).toBe("NO_STATS");
+  });
+
+  it("names the same games the finalisation hold is waiting on", async () => {
+    /*
+      **The test that would have caught #233 in the first place**, and it is only
+      writable because the predicate is now one shared SQL fragment rather than
+      three hand-written copies.
+
+      The thing that stops a week settling must be the thing the producer goes
+      and fetches, and the thing an operator is shown. Three spellings could
+      disagree; one cannot.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_synced_at = final_at - interval '2 hours',
+                       stats_attempted_at = final_at - interval '2 hours',
+                       final_at = now() - interval '3 hours'`,
+    );
+
+    const [held] = await fx.client.query<{ unread: number }>(
+      `SELECT count(*) FILTER (
+                WHERE g.status = 'FINAL'
+                  AND (g.stats_synced_at IS NULL
+                       OR (g.final_at IS NOT NULL AND g.stats_synced_at < g.final_at))
+              )::int AS unread
+         FROM games g WHERE g.sport_id = $1`,
+      [fx.sportId],
+    );
+
+    const { games } = await problems(fx);
+
+    expect(held?.unread).toBe(1);
+    expect(games.filter((g) => g.ingest === "NO_STATS")).toHaveLength(1);
+  });
+
+  it("keeps the alarm count bounded while the screen's total is not", async () => {
+    /*
+      A screen may grow; an alarm may not. A game past its window stays listed
+      forever — correctly, as evidence that the provider failed — but a heartbeat
+      that latches red for a fact nobody can act on stops being read, which is
+      the failure this whole page is about.
+    */
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'Tank01 returned HTTP 503', stats_synced_at = NULL,
+                       stats_attempted_at = now(),
+                       kickoff_at = now() - interval '200 hours',
+                       final_at = now() - interval '199 hours'`,
+    );
+
+    const { total, blockingRecent } = await problems(fx);
+
+    expect(total).toBe(1);
+    expect(blockingRecent).toBe(0);
+  });
+
+  it("raises the alarm while the week can still be corrected", async () => {
+    // The control for the bound above.
+    const fx = await setup();
+    await fx.client.query(
+      `UPDATE games SET stats_error = 'Tank01 returned HTTP 503', stats_synced_at = NULL,
+                       stats_attempted_at = now(),
+                       kickoff_at = now() - interval '10 hours',
+                       final_at = now() - interval '7 hours'`,
+    );
+
+    expect((await problems(fx)).blockingRecent).toBe(1);
+  });
+});
+
+describe("the two stamps are one instant — #233", () => {
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  it("writes the sync, the attempt and the whistle from a single now()", async () => {
+    /*
+      **The contract three readers depend on and nobody had written down.**
+
+      `finalizationHold`, the work list's post-final clause and the operator
+      screen all compare `stats_synced_at` against `final_at`, and all three read
+      "equal" as "this read saw the whistle". That holds only because
+      `ingestOneGame`'s success UPDATE assigns them together and Postgres `now()`
+      is transaction time.
+
+      Split that statement — a repair script, a writer that stamps the sync
+      separately — and every healthy game in the league reads as unread: weeks
+      hold that should settle, and the operator screen turns amber for the whole
+      slate, which is the noise floor that stops a screen being read at all.
+
+      Strictly equal, with no tolerance. A window would let a genuine failure a
+      moment later read as success, and that is the direction that costs a
+      settled week.
+    */
+    const fx = await setup("SCHEDULED");
+    const box = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses });
+
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", box]])), NFL.key, SEASON);
+
+    const [row] = await fx.client.query<{
+      stats_synced_at: string;
+      stats_attempted_at: string;
+      final_at: string;
+    }>("SELECT stats_synced_at, stats_attempted_at, final_at FROM games WHERE id = $1", [
+      fx.gameId,
+    ]);
+
+    expect(row?.stats_attempted_at).toEqual(row?.stats_synced_at);
+    expect(row?.final_at).toEqual(row?.stats_synced_at);
+  });
+
+  it("leaves a clean ingest out of the stale tier", async () => {
+    // The same contract, seen from the reader. If the UPDATE is ever split, this
+    // is where it surfaces — as every healthy game on the page going amber.
+    const fx = await setup("SCHEDULED");
+    const box = boxScore("g1", { qb1: [line("pass_yd", 300)], ...bothDefenses });
+
+    await syncBoxScores(fx.client, fakeProvider(new Map([["g1", box]])), NFL.key, SEASON);
+
+    const { games } = await unresolvedStatsProblems(fx.client, NFL.key, 50);
+    expect(games.filter((g) => g.ingest === "STALE")).toEqual([]);
   });
 });

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -191,6 +191,25 @@ export const MIN_GAME_MINUTES = 150;
 export const CONSECUTIVE_FAILURE_LIMIT = 4;
 
 /**
+ * How long after a week's last kickoff a missing box score still raises an alarm.
+ *
+ * **Shorter than the correction window on purpose, and the difference is what an
+ * alarm is for.** The screen keeps reporting a game for the full 168 hours,
+ * because a permanent zero is worth seeing. A heartbeat must not: an alarm's job
+ * is to fire once and be acted on, and one latched red for seven days is a
+ * status board wearing an alarm's colours. That is the failure this file's own
+ * note about a permanently-true signal already records, twice.
+ *
+ * Flat, rather than 48/168 by week. A per-week split here would be a second copy
+ * of the paying-week rule, and the weeks it would extend are the ones that get
+ * roughly five hundred work-list ticks and seven daily syncs inside their window
+ * — a game still unread at hour 48 has already raised this and been seen.
+ * Re-raising it for five more days adds nothing and costs the channel its
+ * credibility.
+ */
+export const ALARM_WINDOW_HOURS = 48;
+
+/**
  * The most games one run will fetch.
  *
  * A bound on *spend*, not on work: the provider is metered and nothing else in
@@ -285,6 +304,70 @@ export function UNDER_WAY_SQL(startMinutesParam: string, windowHoursParam: strin
                 AND g.kickoff_at <= now() - make_interval(mins  => ${startMinutesParam}::int)
                 AND g.kickoff_at >  now() - make_interval(hours => ${windowHoursParam}::int)`;
 }
+
+/**
+ * "No box score from after the whistle" — the core of `finalizationHold`'s hold.
+ *
+ * One definition, three consumers, and it was three hand-written copies before
+ * this: the hold (`week.ts`), the work list's post-final clause above, and the
+ * operator view. The post-final clause carries a comment forbidding exactly that
+ * — *"two spellings of it would let a week hold on a game this query has no
+ * reason to select"* — while being the second spelling. This is the last cheap
+ * moment to close it.
+ *
+ * Each consumer ANDs its own gate on, because those genuinely differ: the hold
+ * and the view want `status = 'FINAL'`, the work list wants a 168h bound and
+ * pacing. The *question* does not differ, and that is what lives here.
+ *
+ * **A null `final_at` on a FINAL game means the provider called it final without
+ * saying when.** There is nothing to compare against, so any sync counts and
+ * this does not hold on it. That asymmetry is `week.ts`'s and it is deliberate;
+ * inverting it would make every such game hold forever.
+ *
+ * ## The contract this rests on, which nobody had written down
+ *
+ * `stats_synced_at < final_at` is false on a healthy game **only because the
+ * read that observes the whistle writes both columns in one transaction** —
+ * `ingestOneGame`'s success `UPDATE` assigns `stats_synced_at = now()` and
+ * `final_at = COALESCE(final_at, now())` together, and `now()` is transaction
+ * time, so they are equal rather than ordered.
+ *
+ * Move either assignment out of that transaction — a repair script, a writer
+ * that stamps the sync separately — and every healthy game in the league reads
+ * as unread here. That holds a week that should settle, and it turns the whole
+ * operator screen amber, which is the noise floor that stops a screen being
+ * read at all.
+ *
+ * `box-scores.test.ts` pins it directly: after a clean final read, the two
+ * stamps are equal. Strictly equal, with no tolerance — a window would let a
+ * genuine failure a moment later read as success, which is the direction that
+ * costs a settled week.
+ */
+export function UNREAD_SQL(alias = "g"): string {
+  return `(${alias}.stats_synced_at IS NULL
+            OR (${alias}.final_at IS NOT NULL
+                AND ${alias}.stats_synced_at < ${alias}.final_at))`;
+}
+
+/**
+ * How long a game whose whistle was observed by a *different* writer is given
+ * before the operator screen calls it unread.
+ *
+ * **Nearly dead code, kept as defence in depth, and the reasoning matters more
+ * than the number.** On the healthy path this state cannot arise at all: the
+ * read that observes the whistle stamps the sync in the same transaction, so
+ * the two are equal. It becomes reachable only when the *daily* schedule sync
+ * stamps `final_at` on a game whose newest successful read was a live one —
+ * which means the stats cron was down, the breaker deferred it, or every
+ * post-final read failed. All three are hours stale by construction, so this
+ * window delays nothing real.
+ *
+ * What it does suppress is the case where the contract in `UNREAD_SQL` has
+ * broken. An arm whose safety rests on an unwritten invariant should not be the
+ * thing that discovers the invariant moved, and forty minutes costs nothing to
+ * an operator while covering two full retry cycles.
+ */
+export const STALE_GRACE_MINUTES = 40;
 
 export interface BoxScoreSyncResult {
   readonly games: number;
@@ -498,7 +581,7 @@ export async function syncBoxScores(
            -- Self-extinguishing: one success puts the sync stamp past final_at.
            OR (g.final_at IS NOT NULL
                AND g.final_at > now() - make_interval(hours => $5::int)
-               AND (g.stats_synced_at IS NULL OR g.stats_synced_at < g.final_at)
+               AND ${UNREAD_SQL("g")}
                AND (g.stats_attempted_at IS NULL
                     OR g.stats_attempted_at < now() - make_interval(mins => $4::int)))
            -- Retry. Bounded on **kickoff_at**, not final_at, and that is a fix
@@ -803,79 +886,243 @@ export async function gamesUnderWay(
 }
 
 /**
- * Games still carrying an unresolved ingest problem.
+ * Every ingest state worth an operator's attention, with what it costs.
  *
- * **The reader `games.stats_error` never had.** The column has been written
- * since `0027` — by warnings as much as by failures, which is exactly what paces
- * the retry — and nothing anywhere read it back. So a discrepancy survived the
- * run that found it, survived the week finalising around it, and was visible to
- * nobody: `cron_runs.last_outcome` holds one row per job and the next clean run
- * overwrites it, so a warning raised at noon is gone by ten past.
+ * **The screen this feeds could not tell "no stats at all" from "ingested with a
+ * warning".** Both rendered identically, because the only thing selected on was
+ * `stats_error IS NOT NULL` — a column set by ordinary warnings as much as by
+ * failures. A field-goal count disagreeing with itself and a game whose every
+ * player scores zero looked the same, and the page said in its own prose that
+ * every row had been ingested and scored. Issue #233.
  *
- * Ordered most recent first and bounded, because this is read on a ten-minute
- * cadence and the interesting thing is that there are problems rather than the
- * full list of them. The count is returned alongside so a truncated list cannot
- * read as the whole of it.
+ * ## Three states, because the operator has three responses
  *
- * Not scoped to a season on purpose. A game inside its correction window is
- * still being re-read, and one past it never will be again — that second case is
- * the one worth surfacing, because whatever it says is now permanent.
+ * `NO_STATS`     — nothing usable was written. Every player in this game scores
+ *                  zero, in every league, and once the week finalises that is
+ *                  permanent.
+ * `STALE`        — stats exist from an earlier read and the latest read failed,
+ *                  so the scoreboard is older than the game.
+ * `DISCREPANCY`  — ingested, latest read succeeded, a translator check
+ *                  disagreed. The routine one, roughly one game in seven.
+ *
+ * The severity is computed **once, here in SQL**, and drives both the label and
+ * the `ORDER BY` tier. Two spellings would let a row sort into one bucket and
+ * wear another, which is issue #233's own defect one layer up.
+ *
+ * ## A played game with no stats is found by the clock, not by an error
+ *
+ * The first arm keys on `kickoff_at` rather than on an error or a status, and
+ * that is the lesson of #256 applied one layer up. A game starved by
+ * `MAX_GAMES_PER_RUN` on a fourteen-game slate, or skipped by the consecutive
+ * failure breaker — which deliberately stamps nothing, because it did not
+ * attempt them — carries **no error, no sync stamp, and whatever status the
+ * daily sync last wrote**. That is exactly the class this screen exists for, and
+ * every predicate keyed on `stats_error` misses it until the next morning.
+ *
+ * ## What it deliberately does not report
+ *
+ * A **discrepancy on a game still being played** is a partial box score
+ * disagreeing with itself, which is not a defect. The translator's warnings are
+ * ungated, so without the suppression below a slate's worth of transient noise
+ * lands here every Sunday — and a page that is amber every Sunday is a page
+ * nobody opens. `STALE` is *not* suppressed while live: that is the state in
+ * which the scoreboard is showing managers numbers that will never move.
+ *
+ * ## Two counts, because a screen and an alarm want different things
+ *
+ * `total` is unbounded, as it always was — a game past its correction window can
+ * never be re-read, so its problem is permanent and worth keeping visible.
+ * `blockingRecent` is bounded to the window in which somebody could still change
+ * the outcome, and it is the only one fit to reach a heartbeat. A count that
+ * only ever grows is a permanently-true health signal, which this repo has
+ * already paid for twice.
  */
+export type IngestState = "NO_STATS" | "STALE" | "DISCREPANCY";
+
 export async function unresolvedStatsProblems(
   db: SqlClient,
   sportKey: string,
   limit = 20,
 ): Promise<{
+  /** Everything flagged, however old. The screen's number. */
   readonly total: number;
+  /**
+   * Games with no usable box score whose week can still be corrected.
+   *
+   * The alarm's number, and the only one of the two that can fall to zero.
+   * Bounded at `ALARM_WINDOW_HOURS` from the week's last kickoff rather than at
+   * the full correction window: an alarm's job is to fire once and be acted on,
+   * and one latched red for seven days is a status board wearing an alarm's
+   * colours.
+   */
+  readonly blockingRecent: number;
   readonly games: readonly {
     readonly gameRef: string;
     readonly season: number;
     readonly week: number;
-    readonly problem: string;
+    readonly ingest: IngestState;
     /**
-     * When the game went final, or `null` if it has not.
+     * The provider's complaint, when there is one.
      *
-     * Carried because the only useful question about a flagged game is whether
-     * anything can still be done about it: a correction after the window has
-     * closed writes a revision no finalised matchup will ever read. The window
-     * itself is a league rule — 48h normally, 168h for weeks 14 and 17 — so the
-     * instant is reported here and the judgement is left to the caller.
+     * **Nullable, which it was not before.** A game selected by the clock rather
+     * than by an error carries nothing here, and a caller that assumes a string
+     * renders an empty card — which is how the state this screen was fixed to
+     * show would stay invisible after all of it.
      */
+    readonly problem: string | null;
+    readonly kickoffAt: Date;
     readonly finalAt: Date | null;
+    readonly syncedAt: Date | null;
+    readonly isFinal: boolean;
+    /**
+     * The last kickoff of this game's week — the instant `finalizationHold`
+     * measures its correction window from.
+     *
+     * Carried because the screen measured from the game's own `final_at` and the
+     * hold measures from here, so the two disagreed by about 28 hours on an
+     * early Sunday game: the screen reported a week uncorrectable while it was
+     * still fully correctable. A schedule fact, not a league rule, so carrying
+     * it keeps this function league-blind exactly as it was.
+     */
+    readonly weekLastKickoff: Date;
   }[];
 }> {
   const ids = await loadSportIds(db, sportKey);
 
-  const [counted] = await db.query<{ total: string }>(
-    `SELECT count(*)::text AS total
-       FROM games
-      WHERE sport_id = $1 AND stats_error IS NOT NULL`,
-    [ids.sportId],
+  /*
+    Passed as an instant rather than as an hour count, because the bound sits
+    inside an aggregate FILTER and Postgres declines to infer a parameter's type
+    there even through an explicit cast. Clock skew between this process and the
+    database is irrelevant against a 48-hour window.
+  */
+  const alarmSince = new Date(Date.now() - ALARM_WINDOW_HOURS * 3_600_000).toISOString();
+
+  /*
+    The selection, written once and used by both queries.
+
+    `status NOT IN (...)` first: a postponed or cancelled game never produces a
+    box score, RULES.md section 10 already scores its players zero, and without
+    this the first arm would report every one of them forever.
+  */
+  const selection = `
+        g.sport_id = $1
+    AND g.status NOT IN ('POSTPONED', 'CANCELLED')
+    AND (
+          -- Played by our own clock, and nothing written.
+          (g.stats_synced_at IS NULL
+           AND g.kickoff_tbd = false
+           AND g.kickoff_at < now() - ($2::int * interval '1 minute'))
+          -- Read, but not after the whistle. See STALE_GRACE_MINUTES.
+       OR (g.status = 'FINAL'
+           AND ${UNREAD_SQL("g")}
+           AND g.final_at < now() - ($3::int * interval '1 minute'))
+          -- Flagged, and settled enough to judge.
+       OR (g.stats_error IS NOT NULL
+           AND (g.status = 'FINAL'
+                OR g.kickoff_at < now() - ($4::int * interval '1 hour')))
+        )`;
+
+  /*
+    Order matters and the first two arms are not interchangeable.
+
+    NO_STATS is claimed by "nothing written" *before* the unread test, because a
+    game with no sync stamp at all has no `final_at` to compare against and would
+    otherwise fall through to DISCREPANCY — which is the calmest tier, for the
+    worst state. That is issue #233's own shape.
+  */
+  const severity = `
+        CASE
+          WHEN g.stats_synced_at IS NULL THEN 'NO_STATS'
+          WHEN g.status = 'FINAL' AND ${UNREAD_SQL("g")} THEN 'NO_STATS'
+          WHEN g.stats_attempted_at > g.stats_synced_at THEN 'STALE'
+          ELSE 'DISCREPANCY'
+        END`;
+
+  /*
+    The week's last kickoff, as a join rather than a window function.
+
+    A window function evaluates **after** WHERE, so `max(kickoff_at) OVER
+    (PARTITION BY season, week)` would see only the rows that survived the
+    filter and return the last *flagged* kickoff. On a week where only the
+    Thursday game is flagged that lands almost five days early, and in the
+    dangerous direction: the screen would report a week closed to corrections
+    while it was still fully open. Measured, not reasoned.
+  */
+  const weekEnd = `
+      JOIN (SELECT season, week, max(kickoff_at) AS week_last_kickoff
+              FROM games
+             WHERE sport_id = $1
+             GROUP BY season, week) w
+        ON w.season = g.season AND w.week = g.week`;
+
+  const [counted] = await db.query<{ total: string; blocking_recent: string }>(
+    `WITH flagged AS (
+       SELECT ${severity} AS severity,
+              -- Evaluated here rather than in the FILTER below: Postgres will
+              -- not infer a parameter's type inside an aggregate FILTER, even
+              -- through an explicit cast.
+              (w.week_last_kickoff > $5::timestamptz) AS recent
+         FROM games g ${weekEnd}
+        WHERE ${selection}
+     )
+     SELECT count(*)::text AS total,
+            count(*) FILTER (
+              WHERE severity IN ('NO_STATS', 'STALE') AND recent
+            )::text AS blocking_recent
+       FROM flagged`,
+    [ids.sportId, MIN_GAME_MINUTES, STALE_GRACE_MINUTES, LIVE_WINDOW_HOURS, alarmSince],
   );
 
   const games = await db.query<{
     external_ref: string;
     season: number;
     week: number;
-    stats_error: string;
+    ingest: IngestState;
+    stats_error: string | null;
+    kickoff_at: Date;
     final_at: Date | null;
+    stats_synced_at: Date | null;
+    is_final: boolean;
+    week_last_kickoff: Date;
   }>(
-    `SELECT external_ref, season, week, stats_error, final_at
-       FROM games
-      WHERE sport_id = $1 AND stats_error IS NOT NULL
-      ORDER BY kickoff_at DESC
-      LIMIT $2`,
-    [ids.sportId, limit],
+    `SELECT g.external_ref, g.season, g.week, g.stats_error, g.kickoff_at,
+            g.final_at, g.stats_synced_at,
+            (g.status = 'FINAL') AS is_final,
+            w.week_last_kickoff,
+            ${severity} AS ingest
+       FROM games g ${weekEnd}
+      WHERE ${selection}
+      -- Severity before recency, and before the LIMIT.
+      --
+      -- This used to be kickoff_at DESC alone, which meant a page of routine
+      -- warnings from last week pushed the one game whose players all score
+      -- zero off the end of the list. The same argument the work list already
+      -- makes for its own tiers: under truncation, the row that decides money
+      -- goes first.
+      ORDER BY CASE ${severity}
+                 WHEN 'NO_STATS' THEN 0
+                 WHEN 'STALE' THEN 1
+                 ELSE 2
+               END,
+               g.kickoff_at DESC
+      LIMIT $5`,
+    [ids.sportId, MIN_GAME_MINUTES, STALE_GRACE_MINUTES, LIVE_WINDOW_HOURS, limit],
   );
 
   return {
     total: Number(counted?.total ?? 0),
+    blockingRecent: Number(counted?.blocking_recent ?? 0),
     games: games.map((row) => ({
       gameRef: row.external_ref,
       season: Number(row.season),
       week: Number(row.week),
+      ingest: row.ingest,
       problem: row.stats_error,
+      kickoffAt: new Date(row.kickoff_at),
       finalAt: row.final_at === null ? null : new Date(row.final_at),
+      syncedAt: row.stats_synced_at === null ? null : new Date(row.stats_synced_at),
+      isFinal: row.is_final,
+      weekLastKickoff: new Date(row.week_last_kickoff),
     })),
   };
 }

--- a/packages/db/src/box-scores.ts
+++ b/packages/db/src/box-scores.ts
@@ -947,7 +947,13 @@ export async function unresolvedStatsProblems(
   /** Everything flagged, however old. The screen's number. */
   readonly total: number;
   /**
-   * Games with no usable box score whose week can still be corrected.
+   * Games whose box score is missing or behind the game, in a week that can
+   * still be corrected.
+   *
+   * Both severities, deliberately: the operator's question is "are these numbers
+   * final", and NO_STATS and STALE answer it the same way. It must not be called
+   * "no usable box score" — a STALE game has one, and saying otherwise is the
+   * class of false claim this screen exists to stop.
    *
    * The alarm's number, and the only one of the two that can fall to zero.
    * Bounded at `ALARM_WINDOW_HOURS` from the week's last kickoff rather than at
@@ -1023,17 +1029,30 @@ export async function unresolvedStatsProblems(
         )`;
 
   /*
-    Order matters and the first two arms are not interchangeable.
+    Order matters, and the first arm is what makes the rest of them legible.
 
-    NO_STATS is claimed by "nothing written" *before* the unread test, because a
-    game with no sync stamp at all has no `final_at` to compare against and would
-    otherwise fall through to DISCREPANCY — which is the calmest tier, for the
-    worst state. That is issue #233's own shape.
+    NO_STATS means exactly one thing: **nothing was ever written**. A game with
+    no sync stamp has no `final_at` to compare against, so it is claimed first
+    rather than falling through to DISCREPANCY — the calmest tier, for the worst
+    state, which is issue #233's own shape.
+
+    Every arm below it therefore describes a game that **does** have stat lines,
+    and none of them may say otherwise. The second arm used to say NO_STATS for a
+    FINAL game read before the whistle — unreachable for a game with nothing
+    written, since the first arm has already taken those, so it could only ever
+    fire on one that had been read during play and had real numbers in it. The
+    screen drew that as "No box score … every player scores zero" over a
+    quarterback with 287 passing yards: #233's own defect, one layer down, inside
+    the fix for it.
+
+    Both remaining unread shapes are STALE, and the reason they are one tier is
+    that an operator can do nothing different about them — what we hold is behind
+    the game, whether the last read failed or no read has been attempted since.
   */
   const severity = `
         CASE
           WHEN g.stats_synced_at IS NULL THEN 'NO_STATS'
-          WHEN g.status = 'FINAL' AND ${UNREAD_SQL("g")} THEN 'NO_STATS'
+          WHEN g.status = 'FINAL' AND ${UNREAD_SQL("g")} THEN 'STALE'
           WHEN g.stats_attempted_at > g.stats_synced_at THEN 'STALE'
           ELSE 'DISCREPANCY'
         END`;

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -50,6 +50,7 @@ import {
 } from "@rostr/core";
 import type { LeagueRules, MatchupResult, ScheduledMatchup } from "@rostr/core";
 import type { SqlClient } from "./client.js";
+import { UNREAD_SQL } from "./box-scores.js";
 import { getLeagueRules } from "./leagues.js";
 import { ensureLineups, loadWeekLineups, loadWeekStats } from "./lineups.js";
 import { withTransaction } from "./transaction.js";
@@ -593,16 +594,18 @@ async function finalizationHold(
             -- ingested and settled the week on third-quarter numbers. The sync
             -- has to be newer than the final whistle to be the final line.
             --
-            -- A null final_at on a FINAL game means the provider called it
-            -- final without saying when. There is nothing to compare against,
-            -- so the presence of any sync is the best answer available and this
-            -- does not hold on it.
+            -- The null-final_at carve-out that used to be described here now
+            -- lives with the predicate itself, along with the writer contract it
+            -- depends on. Two descriptions of one rule is how they drift.
+            --
+            -- The predicate itself lives in box-scores.ts and is shared with
+            -- the work list's post-final clause and the operator screen. It was
+            -- three hand-written copies, and the work list's own comment forbids
+            -- exactly that: the thing that stops a week settling must be the
+            -- thing the producer goes and fetches, and the thing an operator is
+            -- shown. Three spellings could disagree; one cannot.
             count(*) FILTER (
-              WHERE g.status = 'FINAL'
-                AND (
-                  g.stats_synced_at IS NULL
-                  OR (g.final_at IS NOT NULL AND g.stats_synced_at < g.final_at)
-                )
+              WHERE g.status = 'FINAL' AND ${UNREAD_SQL("g")}
             )::int AS unread,
             max(g.kickoff_at) AS last_kickoff
        FROM games g


### PR DESCRIPTION
`/ops/stats` selected on `stats_error IS NOT NULL` and nothing else — a column written by ordinary warnings as much as by failures. So a game whose every player scores zero and a field-goal count disagreeing with itself came back identical, rendered identical, and sat under a page-level sentence asserting that every game listed **"has been scored"**.

Three agents re-verified the nine findings against post-#256 code, designed independently, and converged over two rounds. Two of them found defects in the majority design.

## What survived #256, and what did not

The confirm round for this issue predates PR #258 by hours, so the first task was checking which findings still held.

| | |
|---|---|
| **Survived verbatim** | the query selecting on one column; `ProblemStatus` having no ingest axis; the false prose; `unmatched` never reaching `stats_error` |
| **Half died** | "a stuck game is never re-read" — #256's `kickoff_at` bound fixed that. **The other half got worse**: only the *success* path writes `games.status`, so a game whose every read fails keeps `SCHEDULED`, and `statusOf` drew that as the calmest chip on the page |
| **Changed shape** | #256 created a **third ingest state** — stats present, latest read failed — that this issue's own two-row table cannot express. The discriminator is the *ordering* of two stamps, not the nullness of one |
| **Fixed differently** | the invisible pool-check failure: a run-level banner catches the whole class, not just that instance |

## The largest gap was in every design, including the one that found it

A game starved by `MAX_GAMES_PER_RUN` on a fourteen-game slate, or skipped by #256's consecutive-failure breaker — which stamps nothing, deliberately, because it did not attempt them — carries **no error, no sync stamp, and whatever status the daily sync last wrote**.

That is precisely the class this screen exists for: a played game with no stats at all. Every proposed `WHERE` clause missed it, and it would have stayed invisible until the next morning **inside the fix meant to make it visible**.

Found by the clock instead, which is #256's lesson one layer up: `kickoff_at` is ours, `status` is a provider fact on a lagging feed.

## Three states, and the tone moves axis

```
NO_STATS     nothing usable written — every player scores zero, in every league
STALE        stats from an earlier read, latest read failed — the scoreboard is behind the game
DISCREPANCY  ingested, latest read succeeded, a check disagreed — roughly one game in seven
```

Computed **once in SQL**, feeding both the label and the `ORDER BY` tier, so a row cannot sort into one bucket and wear another — which is this issue's own defect one layer up.

**Colour keys on ingest, never on recoverability.** That reassignment is the presentation half of the bug: a game with no box score at all rendered in the lowest-contrast tone available, because its provider had not yet called it final. The most severe state wore the calmest chip, by default, every Sunday.

Ordering is severity before recency and **before the `LIMIT`**. It was `kickoff_at DESC` alone, so a page of routine warnings pushed the one game whose players all score zero off the end.

## The two clocks, and the trap in the obvious fix

`finalizationHold` clears a week at `max(kickoff_at) + hours`, across the whole week. This screen measured from the individual game's `final_at` — a different **clock**, not a different latency — so #256 making `final_at` accurate grew the dominant error rather than shrinking it. An early Sunday game read `CLOSED` roughly **28 hours before its week actually settled**, telling an operator a correction was pointless while it would still have landed. That slot holds 123 of the 256 synced fixtures.

Only the **anchor** moves. `windowHoursFor` stays sport-level and its reasoning is untouched, so for a league on the default window — which invariant 5 forces on every paying week, and which every league that exists uses — this now agrees with the hold **exactly** rather than approximately.

**And the obvious implementation is wrong.** Two of three designs proposed `max(kickoff_at) OVER (PARTITION BY season, week)`. Window functions evaluate *after* `WHERE`, so the partition contains only rows that survived the filter. Measured against PGlite on a week where only the Thursday game is flagged:

| form | anchor computed |
|---|---|
| window function | **Thu 00:20 UTC** — the flagged game itself |
| join on a grouped subquery | **Mon 00:15 UTC** — the week's real last kickoff |

Four days and twenty-four hours early, in the direction that reports a still-correctable week as closed. Caught by the design that had argued the whole thing was unfixable, while conceding.

## One predicate, three readers, and the contract underneath it

"No box score from after the whistle" had **three hand-written spellings** — `finalizationHold`, the work list's post-final clause, and now this screen — and one of them carries a comment forbidding exactly that. `UNREAD_SQL` is extracted and imported; a test asserts the hold's counts are unmoved.

Extracting it exposed something none of the designs had noticed at first: `stats_synced_at < final_at` is false on a healthy game **only because the read that observes the whistle writes both columns in one transaction**. Postgres `now()` is transaction time, so they come out equal rather than ordered. Nobody had written that down — `0042` documents each column separately and never says the pair is comparable.

Move either assignment out of that transaction and **every healthy game in the league reads as unread**: weeks hold that should settle, and this screen turns amber for the whole slate, which is the noise floor that stops a screen being read at all.

Stated at the writer, restated in the shared fragment, and pinned by a test whose mutation is exactly that split.

## The two lines that make any of it observable

**`OPERATOR_EMAILS` was set nowhere.** Not in `.env`, not in `.env.example`, not in any markdown file including `SETUP-REQUIRED.md` — it appeared in three places in the repo, all code. `isOperator` correctly fails closed, so the console **404'd for everybody, the owner included**.

Which is how nine defects accumulated in it. This issue is a bug in the rendering of a screen that has never been rendered.

Documented in both places, with the fail-closed behaviour spelled out so a blank page is not mistaken for a bug. And the page now has an inbound link — it had **zero** — rendered server-side, so the href never reaches a non-operator's markup and the 404-not-403 property survives.

## Also here

- **A run-level banner** from `cron_runs`. The pool check, a database fault, a provider auth failure and #256's own "a slate was under way and nothing was selected" alarm all throw *before* any game is touched, so they write no `stats_error` and this page said "nothing flagged". The empty state now says so too: an empty list beside a job that is not running is the same false all-clear as the deleted prose.
- **`blockingRecent` reaches the heartbeat**, bounded to the window in which the outcome can still change rather than the 168h the screen keeps reporting for. An alarm fires once and is acted on; one latched red for seven days is a status board wearing an alarm's colours.
- **`deferred` reaches the run body.** `syncBoxScores` has returned it since the breaker landed and nothing read it, so a breaker trip was invisible in both the body and the heartbeat. My omission in #256.

## The prose is deleted, not reworded

> ~~The stat lines were still ingested — these are discrepancies, not failures — so every one of these games has been scored, possibly wrongly.~~

Every clause is false for a game with no box score. It was a standing claim over a heterogeneous list, which is a category error no rewrite fixes, and it was rendered to the operator at the moment they decided whether to act. The one true sentence in it now sits above the rows it is true of, and a test asserts no sentence ever claims a blank game was scored — otherwise it comes back in a new location.

## Tests

**2281 passing** (was 2258). Eleven mutations, **all eleven caught**:

```
revert the anchor to a window function over flagged rows   18 failed
drop the clock-keyed no-stats arm                          18 failed
let a live discrepancy onto the page                       18 failed
unbound the alarm count                                    18 failed
revert statusOf to the game's own final_at                  5 failed
drop the kickoff_tbd bound                                  1 failed
revert severity ordering to kickoff order alone             1 failed
split the sync and whistle stamps                           1 failed
key the tone on recoverability again                        1 failed
let the sentence claim a blank game was scored              1 failed
drive the banner from the run row existing                  1 failed
```

The one worth naming: *"names the same games the finalisation hold is waiting on"* — the test that would have caught this issue in the first place, and only writable because the predicate is now one fragment instead of three.

## Filed rather than fixed

`unmatched` never reaching `stats_error` survives, and its obvious fix is a trap all three designs flagged independently: 60–70% of refs in a real box score never join, by design, so pushing them would set `stats_error` on roughly a third of *healthy* games and put the whole slate into a 20-minute retry loop against a 1,000/day quota. The right shape is a second, lower threshold below #232's — measured, the way #232's was. The numbers are in the issue so nobody re-derives them.

---

No migration. Typecheck, lint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
