### PR TITLE
build: typecheck the test files, which nothing had ever done (#257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
         if: github.event_name == 'pull_request'
         run: node scripts/check-migration-numbers.mjs "origin/${{ github.base_ref }}"
 
+      # Deliberately before install, like the migration check above: it reads
+      # JSON and needs no toolchain, so a missing project is reported in seconds.
+      # Every package must have both halves of its TypeScript project — the build
+      # config that fills `dist/`, and the `noEmit` config that checks its test
+      # files. For the repo's first year they had only the first, and 74 test
+      # files across five packages were typechecked by nothing (#257). A sixth
+      # package added by copying a fifth would inherit the hole silently, so it
+      # is asserted rather than remembered.
+      - name: Test projects are wired up
+        run: node scripts/check-test-projects.mjs
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3379,6 +3379,15 @@ pnpm lint
   everything wrong at once.
 - **Commits are conventional and explain _why_.** The what is visible in the diff.
 - Tests live beside their source as `*.test.ts`.
+- **Test files are typechecked by `packages/*/tsconfig.test.json`, not by the package's
+  own `tsconfig.json`**, which excludes them so `dist/` holds only shippable source.
+  Your editor will not know this: the language server looks for the nearest
+  `tsconfig.json`, finds the one that excludes the file, and falls back to an inferred
+  project with `noUncheckedIndexedAccess` off — so a test file can look clean in the
+  editor and fail CI. `pnpm typecheck` is the authority. Both halves of every package
+  are asserted by `scripts/check-test-projects.mjs`; if you add a package, copy both
+  configs. See #257 — for a year these files were checked by nothing at all, and one of
+  them referenced a type it never imported.
 
 ---
 

--- a/apps/web/src/lib/prize-order.test.ts
+++ b/apps/web/src/lib/prize-order.test.ts
@@ -26,11 +26,14 @@ import {
  *
  * This file is the link. It lives in `apps/web` because that is the only place both
  * packages are legitimately dependencies — it is where the anchor route maps one to the
- * other — and, more importantly, because it is the only place a type-level assertion is
- * actually checked: `packages/core` and `packages/escrow` both exclude `src/**\/*.test.ts`
- * from their tsconfig, so a compile-time guard written next to `PRIZE_ORDER` would never
- * run. `apps/web/tsconfig.json` includes `**\/*.ts`, so the block below is checked by
- * `pnpm typecheck`.
+ * other.
+ *
+ * It also used to be the only place a type-level assertion was actually checked: every
+ * package under `packages/` excluded its own tests from its tsconfig, so a compile-time
+ * guard written next to `PRIZE_ORDER` would never have run. That is no longer true —
+ * a per-package `tsconfig.test.json` checks them as of #257 — so the reason to keep this
+ * guard here has expired and it belongs next to what it guards. Moving it is a real
+ * change to a settlement path, and waits until after the season starts.
  */
 
 /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,8 +3,16 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    // The web app is typechecked and linted by Next's own toolchain; this config
-    // is type-aware over the packages and would need a separate project setup.
+    // The web app is typechecked and linted by Next's own toolchain.
+    //
+    // Note that this config is NOT type-aware: `tseslint.configs.recommended`
+    // below is the syntactic set, and there is no `projectService` or
+    // `parserOptions.project` anywhere in the repo. This comment used to claim
+    // otherwise, which mattered — it was a reason to believe test files were
+    // being checked by something. They were not, for a year (#257). What checks
+    // them is `packages/*/tsconfig.test.json`; eslint checks nothing about types,
+    // and could not have caught that defect in any configuration, because
+    // assignability is a compiler diagnostic with no lint-rule equivalent.
     ignores: [
       "**/dist/**",
       "**/node_modules/**",

--- a/packages/core/src/rules/rules.test.ts
+++ b/packages/core/src/rules/rules.test.ts
@@ -11,7 +11,7 @@ import {
   NFL_PPR_SCORING,
   NFL_WINNER_TAKE_ALL_PAYOUT,
 } from "./nfl-ppr.js";
-import type { LeagueRules, PotRules } from "./types.js";
+import type { LeagueRules, PotRules, Weekday } from "./types.js";
 import {
   draftDateProblem,
   earliestRefundUnlock,
@@ -174,9 +174,40 @@ describe("NFL PPR defaults", () => {
   });
 });
 
+/**
+ * A deeply mutable view of a rules document.
+ *
+ * `LeagueRules` is deeply `readonly`, so every test below that stages an invalid
+ * document had to cast its way past that — eight of them invented a structural
+ * subset (`d.schedule as { playoffWeeks: number[] }`) purely to get a writable
+ * property. Those casts re-declared the shape they were writing to, so a rename
+ * would have left them writing a field that no longer exists while
+ * `validateLeagueRules` returned no problems and the failure surfaced as a
+ * baffling assertion message — in the file CI pins the rules hash with.
+ *
+ * Stripping the modifier once, here, deletes all eight. It is not a widening:
+ * property types are preserved exactly, so a typo'd key, a wrong element type
+ * and an invalid enum member are all still errors. `structuredClone` below is
+ * the proof this is sound — a value it can clone is plain data, with no
+ * functions or class instances for the mapped type to mangle.
+ */
+type Mutable<T> = { -readonly [K in keyof T]: Mutable<T[K]> };
+
+/**
+ * A value the type system forbids, staged on purpose.
+ *
+ * A rules document arrives from the database and the wire as JSON, so the
+ * compiler's guarantee stops at that boundary and `validateLeagueRules` is what
+ * stands behind it. These casts are the subject of the tests that use them, not
+ * a workaround for them — which is exactly why they are named rather than
+ * written inline as `as unknown as`. In the file that pins what members sign,
+ * every deliberate lie should be greppable, and an anonymous cast is not.
+ */
+const poison = <T>(value: unknown): T => value as T;
+
 describe("validateLeagueRules", () => {
-  const mutate = (fn: (draft: LeagueRules) => void): LeagueRules => {
-    const draft = structuredClone(FIXTURE) as LeagueRules;
+  const mutate = (fn: (draft: Mutable<LeagueRules>) => void): LeagueRules => {
+    const draft = structuredClone(FIXTURE) as Mutable<LeagueRules>;
     fn(draft);
     return draft;
   };
@@ -245,7 +276,7 @@ describe("validateLeagueRules", () => {
 
   it("rejects an unknown stat key", () => {
     const bad = mutate((d) => {
-      (d.scoring as { statKey: string }[])[0]!.statKey = "touchdowns_probably";
+      d.scoring[0]!.statKey = "touchdowns_probably";
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("unknown stat key"),
@@ -255,7 +286,7 @@ describe("validateLeagueRules", () => {
   it("rejects a gap between tiers", () => {
     const bad = mutate((d) => {
       const rule = d.scoring.find((r) => r.statKey === "def_pts_allowed");
-      if (rule?.kind === "TIERED") (rule.tiers as { max: number | null }[])[0]!.max = 2;
+      if (rule?.kind === "TIERED") rule.tiers[0]!.max = 2;
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("gap or overlap"),
@@ -266,7 +297,7 @@ describe("validateLeagueRules", () => {
     const bad = mutate((d) => {
       const rule = d.scoring.find((r) => r.statKey === "def_pts_allowed");
       if (rule?.kind === "TIERED") {
-        (rule.tiers as { max: number | null }[]).at(-1)!.max = 99;
+        rule.tiers.at(-1)!.max = 99;
       }
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
@@ -532,7 +563,7 @@ describe("validateLeagueRules", () => {
 
   it("rejects payout shares that do not sum to 100%", () => {
     const bad = mutate((d) => {
-      (d.pot!.payout as { basisPoints: number }[])[0]!.basisPoints = 5000;
+      d.pot!.payout[0]!.basisPoints = 5000;
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("must be exactly 10000"),
@@ -693,9 +724,8 @@ describe("validateLeagueRules", () => {
     // The cap holds it at draft + 365 days regardless, and the honest answer is
     // that the schedule is the problem rather than the date.
     const inflated = mutate((d) => {
-      (d.schedule as { playoffWeeks: number[] }).playoffWeeks = [15, 16, 900];
-      (d.pot as { refundUnlockAt: number }).refundUnlockAt =
-        d.draft.scheduledAt + 3000 * 86_400;
+      d.schedule.playoffWeeks = [15, 16, 900];
+      d.pot!.refundUnlockAt = d.draft.scheduledAt + 3000 * 86_400;
     });
     expect(validateLeagueRules(inflated, NFL)).toContainEqual(
       expect.stringContaining("no legal value exists"),
@@ -707,8 +737,8 @@ describe("validateLeagueRules", () => {
     // its refund shut three weeks longer than one ending at 17 — and the
     // fixture's date, legal by six days at week 17, stops being legal.
     const longer = mutate((d) => {
-      (d.schedule as { regularSeasonWeeks: number }).regularSeasonWeeks = 17;
-      (d.schedule as { playoffWeeks: number[] }).playoffWeeks = [18, 19, 20];
+      d.schedule.regularSeasonWeeks = 17;
+      d.schedule.playoffWeeks = [18, 19, 20];
     });
     expect(validateLeagueRules(longer, NFL)).toContainEqual(
       expect.stringContaining("too early"),
@@ -724,7 +754,7 @@ describe("validateLeagueRules", () => {
 
   it("rejects a non-deterministic final tiebreaker", () => {
     const bad = mutate((d) => {
-      (d.schedule as { tiebreakers: string[] }).tiebreakers = ["WIN_PCT", "POINTS_FOR"];
+      d.schedule.tiebreakers = ["WIN_PCT", "POINTS_FOR"];
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(
       expect.stringContaining("must be LOWEST_TEAM_ID"),
@@ -742,7 +772,7 @@ describe("validateLeagueRules", () => {
 
   it("rejects a bracket whose rounds do not match its playoff weeks", () => {
     const bad = mutate((d) => {
-      (d.schedule as { playoffWeeks: number[] }).playoffWeeks = [15, 16];
+      d.schedule.playoffWeeks = [15, 16];
     });
     expect(validateLeagueRules(bad, NFL)).toContainEqual(expect.stringContaining("rounds"));
   });
@@ -985,9 +1015,9 @@ describe("the waiver weekday is checked against the union — #132", () => {
       ...rules,
       waivers: {
         ...rules.waivers,
-        processing: { ...rules.waivers.processing, day: "WENSDAY" },
+        processing: { ...rules.waivers.processing, day: poison<Weekday>("WENSDAY") },
       },
-    } as LeagueRules;
+    };
 
     const problems = validateLeagueRules(broken, NFL);
     expect(problems.some((p) => p.includes("WENSDAY"))).toBe(true);
@@ -999,8 +1029,11 @@ describe("the waiver weekday is checked against the union — #132", () => {
     const rules = FIXTURE;
     const broken = {
       ...rules,
-      waivers: { ...rules.waivers, weeklyLock: { ...rules.waivers.weeklyLock, day: "funday" } },
-    } as LeagueRules;
+      waivers: {
+        ...rules.waivers,
+        weeklyLock: { ...rules.waivers.weeklyLock, day: poison<Weekday>("funday") },
+      },
+    };
 
     /*
       Matched against the problem for **this** field, not against the whole
@@ -1035,9 +1068,9 @@ describe("the waiver weekday is checked against the union — #132", () => {
       ...rules,
       waivers: {
         ...rules.waivers,
-        processing: { ...rules.waivers.processing, day: "wednesday" },
+        processing: { ...rules.waivers.processing, day: poison<Weekday>("wednesday") },
       },
-    } as LeagueRules;
+    };
 
     expect(validateLeagueRules(broken, NFL).length).toBeGreaterThan(0);
   });

--- a/packages/core/src/season/autolineup-choices.test.ts
+++ b/packages/core/src/season/autolineup-choices.test.ts
@@ -3,7 +3,7 @@ import { buildRosterShape } from "../draft/roster.js";
 import { NFL } from "../sports/nfl.js";
 import { NFL_PPR_ROSTER } from "../rules/nfl-ppr.js";
 import { autolineup, autolineupChoices } from "./autolineup.js";
-import type { AutolineupCandidate } from "./autolineup.js";
+import type { AutolineupCandidate, AutolineupChoice } from "./autolineup.js";
 
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 const SUNDAY = 1_757_782_800;
@@ -37,9 +37,11 @@ const ROSTER: AutolineupCandidate[] = [
   candidate("dst1", ["DST"], 6_000),
 ];
 
-function choiceFor(choices: readonly { slotType: string; slotIndex: number }[], slot: string) {
+function choiceFor(choices: readonly AutolineupChoice[], slot: string): AutolineupChoice {
   const [slotType, index] = slot.split("#");
-  return choices.find((c) => c.slotType === slotType && c.slotIndex === Number(index));
+  const found = choices.find((c) => c.slotType === slotType && c.slotIndex === Number(index));
+  if (found === undefined) throw new Error(`no choice for slot ${slot}`);
+  return found;
 }
 
 describe("autolineupChoices", () => {
@@ -57,7 +59,7 @@ describe("autolineupChoices", () => {
 
   it("names the runner-up it passed over", () => {
     const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
-    const qb = choiceFor(choices, "QB#0") as { playerId: string; runnerUpId: string | null };
+    const qb = choiceFor(choices, "QB#0");
 
     expect(qb.playerId).toBe("qb-good");
     expect(qb.runnerUpId).toBe("qb-bad");
@@ -132,8 +134,8 @@ describe("autolineupChoices", () => {
     // offered the manager somebody already in their own lineup, described as an
     // alternative to it.
     const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
-    const rb0 = choiceFor(choices, "RB#0") as { playerId: string; runnerUpId: string | null };
-    const rb1 = choiceFor(choices, "RB#1") as { playerId: string };
+    const rb0 = choiceFor(choices, "RB#0");
+    const rb1 = choiceFor(choices, "RB#1");
 
     expect(rb0.playerId).toBe("rb1");
     expect(rb1.playerId).toBe("rb2");

--- a/packages/core/src/season/autolineup.test.ts
+++ b/packages/core/src/season/autolineup.test.ts
@@ -5,9 +5,26 @@ import { NFL_PPR_ROSTER } from "../rules/nfl-ppr.js";
 import { autolineup, seasonAverage } from "./autolineup.js";
 import type { AutolineupCandidate } from "./autolineup.js";
 import { validateLineup } from "./lineup.js";
+import type { KickoffTimes } from "./lineup.js";
 
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 const SUNDAY = 1_757_782_800;
+
+/**
+ * Kickoffs for a candidate roster, and a moment before all of them.
+ *
+ * `ValidateLineupInput.kickoffs` is required, and `lineup.ts` says why: "an
+ * optional filter that defaults to permissive is the shape that produced the
+ * `loadProjections` defect". Both calls below omitted it and compiled anyway,
+ * because no test under `packages/` was typechecked — #257. Deriving it from
+ * the roster the lineup was built from keeps the two from drifting apart, and
+ * passing `now` is what makes these assertions about the path a manager's own
+ * edit takes rather than the preview path.
+ */
+const kickoffsOf = (roster: readonly AutolineupCandidate[]): KickoffTimes =>
+  new Map(roster.map((player) => [player.playerId, player.kickoffAt]));
+
+const BEFORE_KICKOFF = SUNDAY - 3_600;
 
 function candidate(
   playerId: string,
@@ -66,7 +83,14 @@ describe("autolineup", () => {
     const roster = new Map(ROSTER.map((player) => [player.playerId, player]));
 
     expect(
-      validateLineup({ assignments: lineup, shape: SHAPE, roster, requireFull: true }),
+      validateLineup({
+        assignments: lineup,
+        shape: SHAPE,
+        roster,
+        kickoffs: kickoffsOf(ROSTER),
+        now: BEFORE_KICKOFF,
+        requireFull: true,
+      }),
     ).toEqual([]);
   });
 
@@ -375,8 +399,15 @@ describe("WEEKLY_PROJECTION", () => {
     });
     const roster = new Map(candidates.map((player) => [player.playerId, player]));
 
-    expect(validateLineup({ assignments, shape: SHAPE, roster, requireFull: true })).toEqual(
-      [],
-    );
+    expect(
+      validateLineup({
+        assignments,
+        shape: SHAPE,
+        roster,
+        kickoffs: kickoffsOf(candidates),
+        now: BEFORE_KICKOFF,
+        requireFull: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/waivers/waivers.test.ts
+++ b/packages/core/src/waivers/waivers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { NFL } from "../sports/nfl.js";
 import { NFL_DEFAULT_WAIVERS, NFL_PPR_ROSTER } from "../rules/nfl-ppr.js";
 import { buildRosterShape } from "../draft/roster.js";
-import type { DraftablePlayer } from "../draft/roster.js";
+import type { DraftablePlayer, RosterShape } from "../draft/roster.js";
 import {
   availabilityAt,
   dropDestination,

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,25 @@
+{
+  // The test files, which `./tsconfig.json` excludes so that `dist/` holds only
+  // shippable source. Excluded from emit had quietly become excluded from
+  // checking too: for the repo's first year `pnpm typecheck` reported success
+  // over 74 test files it had never read, and one of them referenced a type
+  // that does not exist. See issue #257.
+  //
+  // `include` is inherited, so this project checks the same `src/**/*.ts` the
+  // build project does — and `"exclude": []` is what lets the tests in. Source
+  // therefore arrives as source, which is what vitest itself runs: see
+  // `vitest.alias.ts`, which resolves every `@rostr/*` to `src/` because "a
+  // test exercises whatever was last built, so a run can pass against code that
+  // is not the code in front of you".
+  //
+  // `noEmit`, so this project produces nothing but a `.tsbuildinfo`. It stays
+  // `composite` by inheritance because only a composite project may appear in
+  // the root solution's `references`, which is how `pnpm typecheck` finds it
+  // without the script having to name it.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./dist/tsconfig.test.tsbuildinfo"
+  },
+  "exclude": []
+}

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -56,8 +56,22 @@ interface Fixture {
   rules: LeagueRules;
   teamId: string;
   otherTeamId: string;
-  /** Player IDs by the handle used below. */
+  /**
+   * Player IDs by the handle used below. Prefer `player()` for anything the
+   * product reads; see there for why.
+   */
   players: Map<string, string>;
+  /**
+   * A seeded player's id, by handle. Total on purpose.
+   *
+   * `players.get(handle)!` typechecks and then hands `undefined` to `setLineup`,
+   * whose `playerId` is `string | null` where null means *clear this slot*. A
+   * mistyped handle therefore stops testing the write the test is named for and
+   * starts testing the erase — silently, and green. This throws at the typo
+   * instead. Assertions may keep using `players` directly: an `undefined`
+   * reaching `expect` already fails loudly.
+   */
+  player(handle: string): string;
 }
 
 /**
@@ -157,6 +171,15 @@ async function setup(): Promise<Fixture> {
     teamId: mine.teamId,
     otherTeamId: theirs.teamId,
     players,
+    player: (handle) => {
+      const id = players.get(handle);
+      if (id === undefined) {
+        throw new Error(
+          `no seeded player "${handle}" (have: ${[...players.keys()].join(", ")})`,
+        );
+      }
+      return id;
+    },
   };
 }
 
@@ -754,7 +777,7 @@ describe("ensureLineups", () => {
       leagueId: fx.leagueId,
       teamId: fx.teamId,
       week: WEEK,
-      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
       now: BEFORE_ANYTHING,
     });
 
@@ -1267,7 +1290,7 @@ describe("the lock survives a drop", () => {
       leagueId: fx.leagueId,
       teamId: fx.teamId,
       week: WEEK,
-      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
       now: BEFORE_ANYTHING,
     });
 
@@ -1285,7 +1308,7 @@ describe("the lock survives a drop", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb")! }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
         now: AFTER_THURSDAY,
       }),
     ).rejects.toMatchObject({ code: "INVALID_LINEUP" });
@@ -1316,7 +1339,7 @@ describe("the lock survives a drop", () => {
       leagueId: fx.leagueId,
       teamId: fx.teamId,
       week: WEEK,
-      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
       now: BEFORE_ANYTHING,
     });
 
@@ -1345,7 +1368,7 @@ describe("the lock survives a drop", () => {
       leagueId: fx.leagueId,
       teamId: fx.teamId,
       week: WEEK,
-      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
       now: BEFORE_ANYTHING,
     });
 
@@ -1456,7 +1479,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
         now: BEFORE_ANYTHING,
       });
     });
@@ -1466,7 +1489,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
         now: BEFORE_ANYTHING,
       }),
     ).rejects.toSatisfy((e) => e instanceof LineupError && e.code === "LINEUP_MOVED");
@@ -1483,7 +1506,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
         now: BEFORE_ANYTHING,
       });
     });
@@ -1493,7 +1516,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
         now: BEFORE_ANYTHING,
       }),
     ).rejects.toThrow();
@@ -1524,7 +1547,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("thu-qb") }],
         now: BEFORE_ANYTHING,
       });
     });
@@ -1538,7 +1561,7 @@ describe("a lineup that moves under the manager — #100", () => {
         week: WEEK,
         assignments: [
           { slotType: "QB", slotIndex: 0, playerId: null },
-          { slotType: "RB", slotIndex: 0, playerId: fx.players.get("rb-a") },
+          { slotType: "RB", slotIndex: 0, playerId: fx.player("rb-a") },
         ],
         now: BEFORE_ANYTHING,
       }),
@@ -1568,7 +1591,7 @@ describe("a lineup that moves under the manager — #100", () => {
       leagueId: fx.leagueId,
       teamId: fx.teamId,
       week: WEEK,
-      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
       now: BEFORE_ANYTHING,
     });
 
@@ -1577,7 +1600,7 @@ describe("a lineup that moves under the manager — #100", () => {
         leagueId: fx.leagueId,
         teamId: fx.teamId,
         week: WEEK,
-        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb") }],
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.player("sun-qb") }],
         now: BEFORE_ANYTHING,
       }),
     ).resolves.toBeDefined();

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -1526,10 +1526,10 @@ describe("a veto cast while the trade is being resolved — #134", () => {
     const fx = await setupWithSecondLeague();
 
     const tradeId = await propose(fx);
-    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
 
     await expect(
-      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2], MONDAY),
+      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2]!, MONDAY),
     ).rejects.toSatisfy((e) => e instanceof TradeError && e.code === "TRADE_ALREADY_SETTLED");
   });
 
@@ -1542,9 +1542,9 @@ describe("a veto cast while the trade is being resolved — #134", () => {
     const fx = await setupWithSecondLeague();
 
     const tradeId = await propose(fx);
-    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
     await expect(
-      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2], MONDAY),
+      vetoTrade(settlingBeforeTheVote(fx), tradeId, fx.teams[2]!, MONDAY),
     ).rejects.toThrow();
 
     const rows = await fx.client.query("SELECT team_id FROM trade_vetoes WHERE trade_id = $1", [
@@ -1697,9 +1697,9 @@ describe("a veto cast while the trade is being resolved — #134", () => {
     const fx = await setupWithSecondLeague();
 
     const tradeId = await propose(fx);
-    await acceptTrade(fx.client, tradeId, fx.teams[1], MONDAY);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
 
-    await expect(vetoTrade(fx.client, tradeId, fx.teams[2], MONDAY)).resolves.toBeDefined();
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY)).resolves.toBeDefined();
 
     const rows = await fx.client.query("SELECT team_id FROM trade_vetoes WHERE trade_id = $1", [
       tradeId,

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -40,6 +40,24 @@ const MONDAY = new Date("2026-09-14T18:00:00Z");
 const HOUR = 3600 * 1000;
 const DAY = 24 * HOUR;
 
+/**
+ * The single row an aggregate always returns.
+ *
+ * `count(*)` produces a row even over an empty table, so the index is total —
+ * but `noUncheckedIndexedAccess` cannot know that, and a non-null assertion is
+ * not expressible inside a destructuring pattern anyway. Stated once here rather
+ * than at each call site, so the claim is wrong in one place if it is ever wrong.
+ */
+const countOf = async (
+  client: PGliteClient,
+  sql: string,
+  params: readonly unknown[],
+): Promise<number> => {
+  const [row] = await client.query<{ n: number }>(sql, params);
+  if (row === undefined) throw new Error(`aggregate returned no row: ${sql}`);
+  return row.n;
+};
+
 interface Fixture {
   client: PGliteClient;
   leagueId: string;
@@ -550,7 +568,8 @@ describe("processing", () => {
     }
 
     // Pad to capacity with rows the product would have written.
-    const [{ n: heldNow }] = await fx.client.query<{ n: number }>(
+    const heldNow = await countOf(
+      fx.client,
       "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
       [claimant],
     );
@@ -582,7 +601,8 @@ describe("processing", () => {
       "SELECT id FROM positions WHERE sport_id = $1 AND key = 'WR'",
       [sport!.id],
     );
-    const [{ n: counted }] = await fx.client.query<{ n: number }>(
+    const counted = await countOf(
+      fx.client,
       `SELECT count(*)::int AS n FROM roster_entries
         WHERE team_id = $1 AND released_at IS NULL AND NOT on_ir`,
       [claimant],
@@ -1667,7 +1687,7 @@ describe("choosing which leagues are due — #131", () => {
     await client.query(
       "INSERT INTO waiver_claims (league_id, team_id, add_player_id, state, created_at) " +
         "VALUES ($1, $2, $3, 'PENDING', $4)",
-      [league.id, team.teamId, player.id, MONDAY],
+      [league.id, team.teamId, player!.id, MONDAY],
     );
     return league.id;
   }

--- a/packages/db/src/week.test.ts
+++ b/packages/db/src/week.test.ts
@@ -1186,7 +1186,7 @@ describe("currentWeek is scoped to one season — #105", () => {
     await fx.client.query(
       "INSERT INTO games (sport_id, external_ref, season, week, home_team_ref, away_team_ref, kickoff_at, status) " +
         "VALUES ($1, $2, $3, $4, 'CIN', 'BAL', $5, 'FINAL')",
-      [sport.id, ref, season, week, kickoff.toISOString()],
+      [sport!.id, ref, season, week, kickoff.toISOString()],
     );
   }
 

--- a/packages/db/tsconfig.test.json
+++ b/packages/db/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  // See packages/core/tsconfig.test.json for why this file exists.
+  //
+  // `references` is restated because `extends` does not inherit it. Without
+  // these edges `tsc --build` has no ordering constraint from this project to
+  // core and stats, and db's tests would be checked against whatever stale
+  // `dist/*.d.ts` happened to be lying around — a failure that presents as a
+  // *passing* typecheck. `scripts/check-test-projects.mjs` asserts this list
+  // matches the build project's.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./dist/tsconfig.test.tsbuildinfo"
+  },
+  "exclude": [],
+  "references": [{ "path": "../core" }, { "path": "../stats" }]
+}

--- a/packages/escrow/src/scores.test.ts
+++ b/packages/escrow/src/scores.test.ts
@@ -77,6 +77,7 @@ describe("expectedScoreTerms", () => {
     // Index 0 is WIN_PCT, so a silent default would seed the whole league by win
     // percentage alone and look entirely plausible.
     const bad: ScoreTermRules = {
+      ...RULES,
       schedule: { ...RULES.schedule, tiebreakers: ["WIN_PCT", "COIN_FLIP"] },
     };
     expect(() => expectedScoreTerms(bad, 12)).toThrow(/COIN_FLIP/);

--- a/packages/escrow/tsconfig.test.json
+++ b/packages/escrow/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  // See packages/core/tsconfig.test.json for why this file exists.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./dist/tsconfig.test.tsbuildinfo"
+  },
+  "exclude": []
+}

--- a/packages/pinning/tsconfig.test.json
+++ b/packages/pinning/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  // See packages/core/tsconfig.test.json for why this file exists.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./dist/tsconfig.test.tsbuildinfo"
+  },
+  "exclude": [],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/stats/src/tank01/box-score.test.ts
+++ b/packages/stats/src/tank01/box-score.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import { indexScoringRules, NFL_PPR_SCORING, scorePlayer } from "@rostr/core";
 import type { StatLine } from "@rostr/core";
 import { translateBoxScore } from "./box-score.js";
@@ -409,7 +409,8 @@ describe("return touchdowns are credited from the main clause", () => {
   it("gives the returner six points and the quarterback none for it", () => {
     // Stated in points rather than counts, because the count is not the harm.
     const ret = NFL_PPR_SCORING.find((rule) => rule.statKey === "ret_td");
-    expect(ret?.milliPointsPerUnit).toBe(6000);
+    assert(ret?.kind === "LINEAR", "ret_td must be a linear rule");
+    expect(ret.milliPointsPerUnit).toBe(6000);
 
     const shaheed = returnGame.players.get(SHAHEED) ?? [];
     expect(scorePlayer(shaheed, RULES)).toBeGreaterThanOrEqual(6000);

--- a/packages/stats/tsconfig.test.json
+++ b/packages/stats/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  // See packages/core/tsconfig.test.json for why this file exists.
+  //
+  // `resolveJsonModule` and the `.json` glob are here and NOT in
+  // `./tsconfig.json`, which is the point of the split. The Tank01 tests import
+  // `./__fixtures__/*.json` directly; putting these in the build config instead
+  // would make tsc copy the fixture corpus into `dist/`, changing emit in order
+  // to fix a typecheck. Under `noEmit` they cost nothing.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "tsBuildInfoFile": "./dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": [],
+  "references": [{ "path": "../core" }]
+}

--- a/scripts/check-test-projects.mjs
+++ b/scripts/check-test-projects.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Every package must have both halves of its TypeScript project.
+ *
+ * Each package tsconfig excludes its own `*.test.ts` files so that `dist/` holds
+ * only shippable source. That is right, and for the repo's first year it was
+ * also the only thing standing between 74 test files and the compiler: excluded
+ * from emit had quietly become excluded from checking, and `pnpm typecheck`
+ * reported success over files it had never read. One of them referenced a type
+ * that does not exist in its scope — `waivers.test.ts` used `RosterShape`
+ * without importing it, and the file compiled under no configuration at all.
+ * Issue #257.
+ *
+ * The fix is a second `noEmit` project per package. The risk is that the sixth
+ * package gets added by copying the fifth's `tsconfig.json` and not its
+ * `tsconfig.test.json`, which fails silently and in exactly the same way — and
+ * git history shows that is how the hole spread the first time: the `exclude`
+ * was present at file creation in all five packages, and git reports the escrow
+ * one as `copy from packages/db/tsconfig.json`. It was never a decision. So it
+ * is asserted here rather than remembered.
+ *
+ * ## Why the `references` arrays must match
+ *
+ * `extends` does not inherit `references`. A test project that omits an edge its
+ * build project has still resolves the import — through the workspace symlink to
+ * `dist/*.d.ts` — so it typechecks the tests against whatever was last built
+ * rather than against source. That failure presents as a **passing** typecheck,
+ * which is the same shape as the defect this whole file exists to prevent.
+ * `vitest.alias.ts` makes the matching argument for the runtime side.
+ *
+ * Reads JSON and nothing else, so it runs before `pnpm install` and reports in
+ * seconds rather than behind a full install and build.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST_GLOB = "src/**/*.test.ts";
+
+/**
+ * A scanner rather than a regex, because these files are JSONC and a regex that
+ * strips `//` would eat half of `tsconfig.base.json`'s `$schema` URL.
+ */
+const stripJsonc = (text) => {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '"') {
+      out += c;
+      while (++i < text.length) {
+        out += text[i];
+        if (text[i] === "\\") {
+          out += text[++i];
+          continue;
+        }
+        if (text[i] === '"') break;
+      }
+      continue;
+    }
+    if (c === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++;
+      out += "\n";
+      continue;
+    }
+    if (c === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i++;
+      continue;
+    }
+    out += c;
+  }
+  return out;
+};
+
+const read = (p) => JSON.parse(stripJsonc(readFileSync(p, "utf8")));
+const paths = (refs) => (refs ?? []).map((r) => r.path).sort();
+
+const problems = [];
+const rootConfig = read(join(root, "tsconfig.json"));
+const referenced = new Set(paths(rootConfig.references));
+
+const packages = readdirSync(join(root, "packages"), { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort();
+
+for (const name of packages) {
+  const dir = join(root, "packages", name);
+  const buildPath = join(dir, "tsconfig.json");
+  const testPath = join(dir, "tsconfig.test.json");
+
+  if (!existsSync(buildPath)) continue; // Not a TypeScript package.
+
+  const build = read(buildPath);
+  if (!(build.exclude ?? []).includes(TEST_GLOB)) {
+    problems.push(
+      `packages/${name}/tsconfig.json no longer excludes ${TEST_GLOB}. Removing it makes ` +
+        `tsc emit dist/*.test.js and dist/*.test.d.ts. Tests are checked by ` +
+        `tsconfig.test.json instead.`,
+    );
+  }
+
+  if (!existsSync(testPath)) {
+    problems.push(
+      `packages/${name}/tsconfig.test.json is missing, so every *.test.ts in that package ` +
+        `is typechecked by nothing. Copy one from a sibling.`,
+    );
+    continue;
+  }
+
+  const test = read(testPath);
+  if (test.compilerOptions?.noEmit !== true) {
+    problems.push(
+      `packages/${name}/tsconfig.test.json must set "noEmit": true, or it will emit tests ` +
+        `into dist/.`,
+    );
+  }
+  if ((test.exclude ?? null) === null || test.exclude.length > 0) {
+    problems.push(
+      `packages/${name}/tsconfig.test.json must set "exclude": [], or it inherits the build ` +
+        `config's exclusion and checks no test file — the exact defect it exists to prevent.`,
+    );
+  }
+
+  const buildRefs = paths(build.references);
+  const testRefs = paths(test.references);
+  if (buildRefs.join("|") !== testRefs.join("|")) {
+    problems.push(
+      `packages/${name}/tsconfig.test.json references [${testRefs.join(", ")}] but ` +
+        `tsconfig.json references [${buildRefs.join(", ")}]. They must match: a missing edge ` +
+        `resolves through dist/*.d.ts instead of source, so the tests are checked against ` +
+        `whatever was last built and the typecheck passes anyway.`,
+    );
+  }
+
+  for (const [label, path] of [
+    ["build", `./packages/${name}`],
+    ["test", `./packages/${name}/tsconfig.test.json`],
+  ]) {
+    if (!referenced.has(path)) {
+      problems.push(
+        `tsconfig.json does not reference "${path}". pnpm typecheck runs "tsc --build" ` +
+          `against that file and nothing else, so the ${label} project for @rostr/${name} ` +
+          `is not being checked.`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`\n${problems.length} problem(s) with the TypeScript project graph:\n`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error("\nSee scripts/check-test-projects.mjs for why this is checked.\n");
+  process.exit(1);
+}
+
+console.log(`TypeScript project graph OK: ${packages.length} packages, both halves each.`);

--- a/scripts/check-test-projects.mjs
+++ b/scripts/check-test-projects.mjs
@@ -75,6 +75,27 @@ const stripJsonc = (text) => {
 };
 
 const read = (p) => JSON.parse(stripJsonc(readFileSync(p, "utf8")));
+
+/**
+ * Whether a project's own `include` can still reach a test file.
+ *
+ * The assertions below check that a test project exists, emits nothing, and is
+ * referenced. None of that is worth anything if its `include` no longer
+ * matches a test: the project compiles zero files, every check here passes, and
+ * `pnpm typecheck` goes green over code nobody is reading — which is the exact
+ * shape of the defect this script was written for (#257), one level up.
+ *
+ * Most test configs omit `include` entirely and inherit the package's, which
+ * already reaches the tests once `exclude` is reset — that case is fine. Only a
+ * config that overrides it has to prove the override still covers them.
+ * `packages/stats` does override it, to add the Tank01 JSON fixtures, so this is
+ * reachable by an ordinary edit rather than hypothetical.
+ */
+const reachesTests = (config) => {
+  const include = config.include;
+  if (include === undefined) return true; // Inherited from the build config.
+  return include.some((pattern) => pattern.includes("*") && pattern.endsWith(".ts"));
+};
 const paths = (refs) => (refs ?? []).map((r) => r.path).sort();
 
 const problems = [];
@@ -117,6 +138,14 @@ for (const name of packages) {
         `into dist/.`,
     );
   }
+  if (!reachesTests(test)) {
+    problems.push(
+      `packages/${name}/tsconfig.test.json overrides "include" with a list that cannot ` +
+        `reach a test file, so it compiles none of them and every other check here still ` +
+        `passes. If you are narrowing it deliberately, the project has no reason to exist.`,
+    );
+  }
+
   if ((test.exclude ?? null) === null || test.exclude.length > 0) {
     problems.push(
       `packages/${name}/tsconfig.test.json must set "exclude": [], or it inherits the build ` +

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,25 @@
 {
+  // Both halves of every package: the build project that fills `dist/`, and the
+  // `noEmit` project that checks the test files the build project excludes.
+  // `pnpm typecheck` runs `tsc --build --force` against this file and nothing
+  // else, so a project listed here is checked and a project that is not, is not.
+  // `scripts/check-test-projects.mjs` fails CI if the two lists diverge.
+  //
+  // Nothing on the emit path reads this file: each package's `build` script is
+  // `tsc --build` against its own `tsconfig.json`, and `vercel-build` is
+  // `pnpm --filter "@rostr/web..." build`. Test projects hung here therefore
+  // cannot reach `dist/`.
   "files": [],
   "references": [
     { "path": "./packages/core" },
+    { "path": "./packages/core/tsconfig.test.json" },
     { "path": "./packages/db" },
+    { "path": "./packages/db/tsconfig.test.json" },
     { "path": "./packages/escrow" },
+    { "path": "./packages/escrow/tsconfig.test.json" },
     { "path": "./packages/pinning" },
-    { "path": "./packages/stats" }
+    { "path": "./packages/pinning/tsconfig.test.json" },
+    { "path": "./packages/stats" },
+    { "path": "./packages/stats/tsconfig.test.json" }
   ]
 }


### PR DESCRIPTION
Closes #257.

`pnpm typecheck` runs `tsc --build` against the root solution, and every project in it excluded `src/**/*.test.ts`. So **74 test files across five packages — roughly 2,000 of the 2,258 tests — were read by no compiler.** Nothing else covered them: no vitest config sets `test.typecheck`, and eslint is the syntactic rule set with no project service, which could not catch this class in any configuration, because assignability has no lint-rule equivalent.

Turning the checking on surfaced **39 errors in 11 of the 74 files**. All 39 are fixed here. The suite is 2258 passing before and after; nothing changes what a test asserts.

## Three corrections to the issue

- **It is five packages, not four.** `pinning` carries the same exclusion (and is the only one with no errors).
- **The headline example is already fixed.** `box-scores.test.ts` was repaired by `3917d3f`, the same commit the issue came out of. It is clean today and is not cited here.
- **The `git history will say` guess is wrong — it says nothing.** The exclusion was present at file creation in all five packages, and git reports the escrow one as `copy from packages/db/tsconfig.json`. There was never a moment when tests were included and something broke. It was copy-paste, not a decision.

## The two that were real defects

- **`waivers.test.ts` annotated with `RosterShape` and never imported it.** That file compiled under *no* TypeScript configuration; it ran only because esbuild strips annotations without resolving them.
- **`scores.test.ts` built a `ScoreTermRules` with no `pot`.** `expectedScoreTerms` reads `rules.pot?.settlementOracle ?? null`, so the fixture silently staged a **free league** inside a suite whose own docstring says these tests "are the ones standing between a hostile settlement account and a drawn season". It passed because it only asserts a throw. `pot: null` would *not* have fixed it — that stages the same free league.

And `autolineup.test.ts` omitted the required `kickoffs` while claiming to run "the same validator a manager's own edit goes through" — with `kickoffs` and `now` both absent, the lock checks are skipped, so it exercised the preview path and asserted the submission path. Six scenarios were run against the built validator to check this was not hiding an autolineup/validate divergence. **It is not** — the fix is bookkeeping, and both fields are now supplied.

## The config

Each package gains a second project that inherits its build config, resets `exclude`, and emits nothing. The exclusion itself stays — it is what keeps `dist/` free of test code.

Three load-bearing choices:

- **The test projects read source, not `dist/*.d.ts`.** `vitest.alias.ts` resolves `@rostr/*` to source for the reason it states: *"a test exercises whatever was last built, so a run can pass against code that is not the code in front of you. That is not hypothetical."* Checking tests against `dist` while running them against `src` would validate a different program than the one that executes. Not theoretical here either — an early measurement of this change returned **19 errors instead of 39**, purely because `packages/db/dist` was stale.
- **`references` is restated in each test config**, because `extends` does not inherit it. A missing edge still resolves, through the workspace symlink to `dist` — so the failure mode is a **passing** typecheck. The guard asserts the two lists match for exactly that reason.
- **They hang off the root solution, not a new command.** Nothing on the emit path reads the root `tsconfig.json`, so test projects placed there cannot reach `dist/`. **`package.json` is unchanged and CI gains no typecheck step.**

## Verification

- **Emit is provably untouched:** `packages/*/dist` built from a clean checkout of this branch is **byte-for-byte identical** to the same build of `origin/main` — 408 files, no diff — and no `*.test.js` / `*.test.d.ts` is emitted anywhere.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (2258 passed / 2 skipped), `pnpm test:web` (281 passed) all green.
- **Green at each of the three commits**, not just the tip — verified by checking out each and running the typecheck.
- The guard was tested against five regressions — missing test config, unreferenced project, `references` drift, re-added `exclude`, removed `noEmit` — and refuses each.

## On technique

`as unknown as` was **rejected outright** in `rules.test.ts`, the file CI pins the rules hash through on two Node majors: it would disable checking of the value being written, in the one file where a silent wrong value is worst. Instead, `mutate`'s signature was corrected — it was handing out a `LeagueRules` when what it hands out is a fresh `structuredClone` the caller is meant to mutate — and **eight casts delete themselves**. The three remaining stage invalid enum values no mapped type can reach, and go through a named `poison<T>()` so every deliberate lie in that file is greppable.

The nine `lineups.test.ts` sites did **not** take `!`, unlike the six in `trades.test.ts` that did (that file already writes `fx.teams[N]!` 127 times — those six were simply the sites that forgot). `playerId` is `string | null` where **null means clear this slot**, and `!` is erased at runtime, so on a mistyped handle it converts "start this quarterback" into "empty this quarterback", green either way. Those go through a throwing accessor; the other 48 call sites are untouched.

**Type assertions in `packages/**/*.test.ts` fall from 232 to 221.**

## Deliberately not here

- **`programs/rostr-escrow/tests/` (8 files) is in no tsconfig either.** It needs different module resolution (`vitest.alias.ts` paths), `.js` extensions under nodenext, and an answer on Anchor's `Program<Idl>` under `exactOptionalPropertyTypes`. Different job, and it is filed separately rather than bundled.
- **`box-scores.test.ts:79`'s `as unknown as StatsProvider`** (the fake omits the required `healthCheck`). It produces no error, and it is the one file that would collide with open PR #259. Filed for after that merges. Note `listByeWeeks` on that fake is *not* a phantom — `ByeCapableProvider` is a deliberate capability interface.
- **Moving the `PRIZE_ORDER` guard home to `packages/escrow`.** Its comment is corrected here; relocating it is a real change to a settlement path and waits until after the season starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)