### PR TITLE
fix(core): the autofill started players who were already playing (#240)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1508,8 +1508,32 @@ reproducibility and for independence from roster order.
 **Scarcest slot first.** With one tight end on the roster, filling FLEX first takes him
 and leaves TE empty. There is a test.
 
-An unavailable player still gets started when there is nobody else: an empty slot and an
-inactive player both score nothing, but only one keeps the lineup legal.
+**An unavailable player still gets started when there is nobody else. A player whose game
+has kicked off does not.** Those read as the same rule and are not, which is why this is a
+paragraph rather than a line.
+
+Unavailable is about whether he can _score_: a bye or an OUT designation and an empty slot
+both produce nothing, so starting him costs the manager nothing he had. Kicked off is about
+whether the manager still held the _choice_, and there the two come apart. Filling an empty
+slot from a player already playing locks it from that instant, so a slot the manager had
+three more hours to decide is decided for him, from a performance already half or wholly
+known, with no undo — the stored occupant is what locks, so he cannot even blank it back.
+
+**And it was never ours to do.** `validateLineup` already refuses that placement from every
+other writer — `PLAYER_LOCKED`, whose comment says why: _"an empty slot — which never locks —
+would let a manager start a player after watching him score."_ The autofill got through only
+because `setLineupUnchecked` skips validation, and that bypass is justified on shape,
+ownership and being allowed to leave slots empty, not on locks. It already honoured
+`SLOT_LOCKED`. Honouring one half of a documented pair was the whole of the defect.
+
+So it is a **hard exclusion, not a sort key**, and a slot with no unstarted candidate left is
+**written empty** — legal everywhere, scored as zero like any empty slot, and still fillable
+from free agency, which a locked player would have ended.
+
+**Do not "improve" this by ranking him last instead.** The equality that makes the
+availability rule free — both score nothing — does not hold for a player who is out there
+playing, so the case for excluding him is not that it is cheap. It is that no manager in
+this league is permitted to make that start.
 
 **Persistence is `packages/db/src/lineups.ts`.** The lock is enforced there, not just
 greyed out in the UI — `setLineup` loads what is _currently stored_, works out which slots

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -126,7 +126,11 @@ export async function GET(
       The screen used to offer a checkbox and no account of what turning it on
       does — which is the one thing worth knowing before trusting it with a week
       that counts. `autolineupChoices` is the same function `autoFillLineup`
-      fills with, so the preview cannot name a different player from the write.
+      fills with, so the preview cannot name a different player from the write
+      **for the same inputs** — and one of those inputs is the clock below. This
+      one passes request time and the write passes whenever the cron ran, so a
+      preview taken before a kickoff can name a player the write is no longer
+      allowed to start. That is a forecast decaying, not the two disagreeing.
 
       **Locked slots are passed in, not filtered out.** A locked player is
       unavailable to every other slot, so omitting them would let the preview
@@ -155,6 +159,10 @@ export async function GET(
         ),
       mode: context.rules.roster.autofill,
       locked: currentAssignments.filter((entry) => slotIsLocked(entry, kickoffs, now)),
+      // The same instant the locks above are read at. The autofill will not put
+      // a player whose game has started into a slot it finds empty, so neither
+      // may the preview of it.
+      now,
     });
 
     /*
@@ -168,7 +176,18 @@ export async function GET(
       const current = currentAssignments.find(
         (entry) => entry.slotType === choice.slotType && entry.slotIndex === choice.slotIndex,
       );
-      return current?.playerId == null && choice.playerId !== null;
+      /*
+        A slot the autofill will leave empty stays in the list, with a null
+        player. It used to be filtered out here, which rendered it identically
+        to a slot already set — nothing — under a heading whose whole job is
+        naming what the autofill will do.
+
+        That is the one case where the manager has to act himself: everyone who
+        could fill the slot is already playing, so the remaining move is a free
+        agent whose game has not kicked off. Hiding it removed the only signal
+        that the move existed.
+      */
+      return current?.playerId == null;
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -172,6 +172,27 @@ export async function GET(
       so — and a preview covering filled slots would read as a threat to replace
       a starter somebody deliberately chose.
     */
+    /*
+      The roster a slot could draw on, ignoring the clock.
+
+      `autolineupChoices` reports that a slot is going unfilled, not why, and the
+      two reasons need different words in front of a manager. This asks the
+      narrower question the screen needs: does he roster anybody who plays there?
+    */
+    const eligibleForSlot = (slotType: string) => {
+      const slot = startingSlots(shape).find((entry) => entry.slotType === slotType);
+      if (!slot) return [];
+      return [...roster.values()]
+        .filter((player) => !player.onIr)
+        .filter((player) =>
+          player.positions.some((position) => slot.eligiblePositions.includes(position)),
+        );
+    };
+
+    /** The same test `autolineup` filters the pool with, at the same instant. */
+    const hasKickedOff = (player: { kickoffAt: number | null }): boolean =>
+      player.kickoffAt !== null && now >= player.kickoffAt;
+
     const preview = choices.filter((choice) => {
       const current = currentAssignments.find(
         (entry) => entry.slotType === choice.slotType && entry.slotIndex === choice.slotIndex,
@@ -182,10 +203,9 @@ export async function GET(
         to a slot already set — nothing — under a heading whose whole job is
         naming what the autofill will do.
 
-        That is the one case where the manager has to act himself: everyone who
-        could fill the slot is already playing, so the remaining move is a free
-        agent whose game has not kicked off. Hiding it removed the only signal
-        that the move existed.
+        Those are the slots the manager has to act on himself, and there are two
+        reasons a slot reaches that state — see `emptyReason` below. Hiding them
+        removed the only signal that anything was outstanding.
       */
       return current?.playerId == null;
     });
@@ -207,6 +227,27 @@ export async function GET(
           playerId: choice.playerId,
           runnerUpId: choice.runnerUpId,
           runnerUpReason: choice.runnerUpReason,
+          /*
+            Why a slot is being left empty, because the two reasons ask the
+            manager for different things and the screen must not guess.
+
+            ALL_PLAYING — he rosters somebody who could fill it, and every one
+            of them has kicked off. The move is a free agent whose game has not.
+            NONE_ELIGIBLE — nobody on the roster plays that position at all, or
+            the ones who do are already starting elsewhere. Signing a free agent
+            of the right position is the move, and it is not urgent in the same
+            way.
+
+            Computed here rather than in `autolineupChoices` because it is a
+            question about this screen, not about the fill: the autofill's answer
+            is the same either way.
+          */
+          emptyReason:
+            choice.playerId !== null
+              ? null
+              : eligibleForSlot(choice.slotType).some((player) => !hasKickedOff(player))
+                ? ("NONE_ELIGIBLE" as const)
+                : ("ALL_PLAYING" as const),
         })),
         /** Frozen in the league's rules, so it is the same for everybody. */
         mode: context.rules.roster.autofill,

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -354,13 +354,14 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
           className="mt-0.5"
         />
         <span>
-          <span className="block">Fill my empty slots at kickoff</span>
+          <span className="block">Fill my empty slots for me</span>
           <span className="block text-xs text-nocturne-neutral-600">
             {data.autofill.mode === "WEEKLY_PROJECTION"
               ? "Uses this week's projections. "
               : "Uses each player's season average. "}
             {data.autofill.enabled
-              ? "You can still change anything yourself — this only touches slots you leave empty."
+              ? "You can still change anything yourself — this only touches slots you leave empty, " +
+                "and it never starts a player whose game has already kicked off."
               : "Off: an empty slot stays empty and scores nothing."}
           </span>
         </span>
@@ -371,7 +372,10 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
 
         The checkbox alone asks a manager to trust a decision taken while they
         are asleep, on a week that counts. This is the same `autolineupChoices`
-        the write uses, so the names here are the names that get started.
+        the write uses, so the names here are the names that get started if
+        nothing kicks off first. A kickoff changes it: a player already playing
+        drops off this list, because the autofill may not start him any more
+        than the manager may.
 
         Rendered whether autofill is on or off, and saying different things: on,
         it is a prediction; off, an empty slot scores nothing and that is the
@@ -388,6 +392,27 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
               {data.autofill.preview.map((choice) => {
                 const starter = byId.get(choice.playerId);
                 const passed = choice.runnerUpId ? byId.get(choice.runnerUpId) : null;
+
+                /*
+                  A slot the autofill will leave empty, because everyone who
+                  could fill it is already playing.
+
+                  This used to render as nothing, which read exactly like a slot
+                  already set. It is the one row here a manager has to act on:
+                  the remaining move is a free agent whose game has not started,
+                  and nothing else on this screen would tell him so.
+                */
+                if (choice.playerId === null) {
+                  return (
+                    <li key={`${choice.slotType}#${choice.slotIndex}`} className="text-[13px]">
+                      <span className="text-nocturne-neutral-600">{choice.slotType}</span>{" "}
+                      <span className="text-amber-300">
+                        stays empty — everyone eligible is already playing
+                      </span>
+                    </li>
+                  );
+                }
+
                 if (!starter) return null;
 
                 return (

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -72,13 +72,21 @@ interface LineupResponse {
   autofill: {
     enabled: boolean;
     mode: "WEEKLY_PROJECTION" | "SEASON_AVERAGE";
-    /** Per empty slot: who it would start, and who it left on the bench. */
+    /**
+     * Per empty slot: who it would start, and who it left on the bench.
+     *
+     * `playerId` is nullable because a slot the autofill cannot fill is part of
+     * the answer — it used to be filtered out of this list, which rendered it
+     * identically to a slot already set.
+     */
     preview: {
       slotType: string;
       slotIndex: number;
-      playerId: string;
+      playerId: string | null;
       runnerUpId: string | null;
       runnerUpReason: "LOWER_RANKED" | "UNAVAILABLE" | "NO_DATA" | null;
+      /** Why the slot is being left empty; null when it is being filled. */
+      emptyReason: "ALL_PLAYING" | "NONE_ELIGIBLE" | null;
     }[];
   };
   slots: Slot[];
@@ -288,10 +296,10 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
   /*
     Counted from the slots, not from the preview's length.
 
-    The preview only covers slots the autofill can actually fill; a slot with no
-    eligible player left produces no entry. Deriving the count from it would
-    quietly under-report — the manager would be told two slots are empty while
-    three score nothing.
+    The preview covers every empty slot, including the ones the autofill will
+    leave empty — but it is a preview, computed against this instant, and the
+    count above the box is a statement about the lineup as stored. Deriving one
+    from the other would make the count move as games kick off.
   */
   const emptySlots = data.slots.filter((slot) => slot.playerId === null).length;
   const heading = previewHeading({ enabled: data.autofill.enabled, emptySlots });
@@ -390,28 +398,34 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
           {data.autofill.enabled && (
             <ul className="space-y-1.5">
               {data.autofill.preview.map((choice) => {
-                const starter = byId.get(choice.playerId);
-                const passed = choice.runnerUpId ? byId.get(choice.runnerUpId) : null;
-
                 /*
-                  A slot the autofill will leave empty, because everyone who
-                  could fill it is already playing.
+                  A slot the autofill will leave empty.
 
                   This used to render as nothing, which read exactly like a slot
-                  already set. It is the one row here a manager has to act on:
-                  the remaining move is a free agent whose game has not started,
-                  and nothing else on this screen would tell him so.
+                  already set — under a heading whose whole job is naming what
+                  the autofill will do. It is the row a manager has to act on.
+
+                  The two reasons ask him for different things, so the server
+                  says which it is rather than the screen assuming. Guessing
+                  wrong is worse than saying less: "everyone is already playing"
+                  on a Wednesday, to a manager who simply rosters no kicker,
+                  sends him looking for a problem that is not there.
                 */
                 if (choice.playerId === null) {
                   return (
                     <li key={`${choice.slotType}#${choice.slotIndex}`} className="text-[13px]">
                       <span className="text-nocturne-neutral-600">{choice.slotType}</span>{" "}
                       <span className="text-amber-300">
-                        stays empty — everyone eligible is already playing
+                        {choice.emptyReason === "ALL_PLAYING"
+                          ? "stays empty — everyone who could fill it is already playing"
+                          : "stays empty — nobody on your roster can fill it"}
                       </span>
                     </li>
                   );
                 }
+
+                const starter = byId.get(choice.playerId);
+                const passed = choice.runnerUpId ? byId.get(choice.runnerUpId) : null;
 
                 if (!starter) return null;
 

--- a/apps/web/src/components/UrgentStrip.tsx
+++ b/apps/web/src/components/UrgentStrip.tsx
@@ -42,9 +42,15 @@ const fetcher = async (url: string): Promise<Notification[]> => {
  * Which kinds are urgent enough to occupy the page.
  *
  * Not everything the bell holds belongs here. An invitation has no deadline and
- * an unset lineup is covered by the autofill; putting either in a strip would
+ * an unset lineup is usually covered by the autofill; putting either in a strip would
  * make the strip permanent, and a permanent strip is furniture. What is left is
  * the set with a clock actually running.
+ *
+ * "Usually" is doing real work since the autofill stopped starting players whose
+ * games have begun: a slot it declines is one the manager has to fill himself, and
+ * nothing here or in the bell says so. The lineup screen names it; this does not.
+ * Tracked separately — the query cannot yet tell a declined slot from one the
+ * autofill has simply not reached.
  */
 const URGENT = new Set(["ON_THE_CLOCK", "TRADE_AWAITING_YOU", "VETO_WINDOW", "DRAFT_SOON"]);
 

--- a/apps/web/src/lib/autofill.test.ts
+++ b/apps/web/src/lib/autofill.test.ts
@@ -31,8 +31,21 @@ describe("previewHeading", () => {
 
   it("describes what will happen when autofill is on", () => {
     expect(previewHeading({ enabled: true, emptySlots: 2 })).toBe(
-      "Autofill will fill 2 empty slots at kickoff:",
+      "2 empty slots, and what autofill would do with them:",
     );
+  });
+
+  it("does not promise every empty slot gets filled", () => {
+    /*
+      It used to say "Autofill will fill 2 empty slots at kickoff". Both halves
+      were wrong once the autofill stopped starting players whose games had
+      kicked off: the list below can now say a slot stays empty, and the fill
+      does not run at kickoff — it runs on the scoring passes through the week.
+      A heading that contradicts the list under it is worse than a vague one.
+    */
+    const heading = previewHeading({ enabled: true, emptySlots: 2 });
+    expect(heading).not.toContain("will fill");
+    expect(heading).not.toContain("at kickoff");
   });
 
   it("warns rather than predicts when autofill is off", () => {
@@ -45,7 +58,7 @@ describe("previewHeading", () => {
   });
 
   it("counts one slot in the singular, both ways round", () => {
-    expect(previewHeading({ enabled: true, emptySlots: 1 })).toContain("1 empty slot at");
+    expect(previewHeading({ enabled: true, emptySlots: 1 })).toContain("1 empty slot,");
     expect(previewHeading({ enabled: false, emptySlots: 1 })).toContain("1 slot is empty");
   });
 });

--- a/apps/web/src/lib/autofill.ts
+++ b/apps/web/src/lib/autofill.ts
@@ -60,7 +60,11 @@ export function previewHeading(input: {
       : `${input.emptySlots} slots are empty and will score nothing — autofill is off.`;
   }
 
+  // Not "will fill": the list below may say a slot stays empty, because the
+  // autofill will not start a player whose game has already kicked off and may
+  // have nobody left who has not. Nor "at kickoff" — the fill runs through the
+  // week, and the checkbox above no longer claims otherwise either.
   return input.emptySlots === 1
-    ? "Autofill will fill 1 empty slot at kickoff:"
-    : `Autofill will fill ${input.emptySlots} empty slots at kickoff:`;
+    ? "1 empty slot, and what autofill would do with it:"
+    : `${input.emptySlots} empty slots, and what autofill would do with them:`;
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -215,6 +215,26 @@ worth fixing.
 noise, and the on-chain warning at strikes 1 and 2 was only ever there because money was
 at stake at strike 3.
 
+**Amended 2026-08-27: the autofill's reach is bounded by the lock.**
+
+The reasoning above rests on "the autofill keeps their team competitive". It still does,
+with one limit now explicit: it will not start a player whose own game has kicked off,
+because `validateLineup` forbids that placement from every other writer and the autofill
+is the one writer that skips validation.
+
+The limit bites on Thursday night. `score-week` names its week from `currentWeek` — the
+week of the most recent kickoff — so the first autofill pass for a week does not run until
+that week's first game is already under way. A Thursday player in an empty slot is
+therefore out of the pool every week, for every team. Usually the slot is filled by the
+next-best player who has not started; it goes empty only where the Thursday player was the
+sole eligible body for it.
+
+The fix is not to relax the lock. It is to run the autofill **when § 8 already says it
+runs** — before each player's own lock — rather than on the first scoring pass after the
+week has begun. Until that lands, an abandoned team can lose a Thursday-only starter to an
+empty slot. Recorded here rather than only in the issue because it qualifies a premise
+this decision was made on.
+
 ### The autofill ranks on projections, and that is allowed
 
 Same change. The autofill previously used season-to-date average and `RULES.md` explicitly

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -619,13 +619,30 @@ needs to happen.
 and no forfeiture. A manager who stops setting lineups is not defrauding anyone, and a
 rule people would only discover by losing money to it is the wrong rule to have.
 
-Instead, **a slot you leave empty gets filled for you at lock**, and it is on by default.
+Instead, **a slot you leave empty gets filled for you**, and it is on by default. The fill
+runs through the week and always before your week is scored. It never starts a player whose
+own game has kicked off, so a slot you leave empty past a player's lock will not be filled
+with him — the same rule that stops you starting him yourself.
 
 **Selection is deterministic**, because a filled team's results move other people's
-playoff seeds and, in a pot league, decide who gets paid: the highest-ranked player
-eligible for each slot, ties broken by ascending player ID. Scarce slots are filled first,
-so a tight end who also qualifies for the FLEX is considered for TE first rather than
-being taken by the FLEX and leaving TE empty.
+playoff seeds and, in a pot league, decide who gets paid.
+
+**Who is eligible.** Every player on your active roster who can fill the slot. A player
+stashed on IR is not — that is what the slot is for. **Nor is a player whose own game has
+already kicked off**, because § 2's lock forbids moving him into a slot he was not already
+in. The autofill is held to that lock exactly as you are: it may leave a player whose game
+has started where he already stands, and it may not start him anywhere new.
+
+**Who gets the slot.** Among those eligible, a player with a game this week who is not
+ruled out comes first, because a player on a bye or officially out cannot score at all.
+Then the highest-ranked of those, ties broken by ascending player ID. Scarce slots are
+filled first, so a tight end who also qualifies for the FLEX is considered for TE first
+rather than being taken by the FLEX and leaving TE empty.
+
+**A slot with nobody eligible left stays empty** and scores nothing. That is the honest
+outcome once everyone who could have filled it is already playing, and it is the better
+one: an empty slot never locks, so it is still yours to fill from free agency with anyone
+whose own game has not kicked off, where a started player would have locked it for the week.
 
 **The ranking is that week's projection**, scored under this league's own frozen rules
 rather than the provider's. A season average cannot know that this week's opponent is the
@@ -647,7 +664,8 @@ and changeable whenever you like. Off means an empty slot stays empty and scores
 which is the honest meaning of the switch, and why it is not the default.
 
 Setting your own lineup always overrides it. Autofill only ever touches slots you left
-empty, and never a slot that has already locked.
+empty, never a slot that has already locked, and never _puts_ a player whose game has
+kicked off into a slot either.
 
 ---
 

--- a/packages/core/src/season/autolineup-choices.test.ts
+++ b/packages/core/src/season/autolineup-choices.test.ts
@@ -8,17 +8,28 @@ import type { AutolineupCandidate } from "./autolineup.js";
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 const SUNDAY = 1_757_782_800;
 
+/**
+ * An hour before the fixtures kick off.
+ *
+ * `autolineup` requires a clock so it can refuse to start a player whose game
+ * is already under way. Every candidate below kicks off at `SUNDAY` unless it
+ * says otherwise, so running the suite an hour earlier leaves every existing
+ * expectation about ranking and scarcity exactly as it was. The cases that
+ * exercise the clock name their own moment.
+ */
+const BEFORE_KICKOFF = SUNDAY - 3_600;
+
 function candidate(
   playerId: string,
   positions: string[],
   averageMilliPoints: number | null,
-  extra: { unavailable?: boolean } = {},
+  extra: { unavailable?: boolean; kickoffAt?: number | null } = {},
 ): AutolineupCandidate {
   return {
     playerId,
     positions,
     averageMilliPoints,
-    kickoffAt: SUNDAY,
+    kickoffAt: extra.kickoffAt === undefined ? SUNDAY : extra.kickoffAt,
     ...(extra.unavailable !== undefined ? { unavailable: extra.unavailable } : {}),
   };
 }
@@ -47,8 +58,8 @@ describe("autolineupChoices", () => {
     // The property that makes a preview safe to show: the screen and the
     // Sunday-morning write cannot name different players, because one is a
     // projection of the other rather than a second implementation.
-    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(
       choices.map(({ slotType, slotIndex, playerId }) => ({ slotType, slotIndex, playerId })),
@@ -56,7 +67,7 @@ describe("autolineupChoices", () => {
   });
 
   it("names the runner-up it passed over", () => {
-    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     const qb = choiceFor(choices, "QB#0") as { playerId: string; runnerUpId: string | null };
 
     expect(qb.playerId).toBe("qb-good");
@@ -64,7 +75,7 @@ describe("autolineupChoices", () => {
   });
 
   it("says the runner-up was ranked lower when that is the reason", () => {
-    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     expect(choiceFor(choices, "QB#0")).toMatchObject({ runnerUpReason: "LOWER_RANKED" });
   });
 
@@ -74,7 +85,9 @@ describe("autolineupChoices", () => {
     const roster = ROSTER.map((player) =>
       player.playerId === "qb-bad" ? { ...player, unavailable: true } : player,
     );
-    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+    expect(
+      choiceFor(autolineupChoices({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB#0"),
+    ).toMatchObject({
       runnerUpId: "qb-bad",
       runnerUpReason: "UNAVAILABLE",
     });
@@ -87,7 +100,9 @@ describe("autolineupChoices", () => {
     const roster = ROSTER.map((player) =>
       player.positions[0] === "QB" ? { ...player, unavailable: true } : player,
     );
-    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+    expect(
+      choiceFor(autolineupChoices({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB#0"),
+    ).toMatchObject({
       runnerUpReason: "LOWER_RANKED",
     });
   });
@@ -98,7 +113,9 @@ describe("autolineupChoices", () => {
     const roster = ROSTER.map((player) =>
       player.playerId === "qb-bad" ? { ...player, averageMilliPoints: null } : player,
     );
-    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+    expect(
+      choiceFor(autolineupChoices({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB#0"),
+    ).toMatchObject({
       runnerUpId: "qb-bad",
       runnerUpReason: "NO_DATA",
     });
@@ -106,7 +123,9 @@ describe("autolineupChoices", () => {
 
   it("reports no runner-up when the slot had only one candidate", () => {
     const roster = ROSTER.filter((player) => player.playerId !== "qb-bad");
-    expect(choiceFor(autolineupChoices({ shape: SHAPE, roster }), "QB#0")).toMatchObject({
+    expect(
+      choiceFor(autolineupChoices({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB#0"),
+    ).toMatchObject({
       playerId: "qb-good",
       runnerUpId: null,
       runnerUpReason: null,
@@ -117,7 +136,7 @@ describe("autolineupChoices", () => {
     // The reason the runner-up is computed inside the fill loop. Scarcest slot
     // first means TE takes the only tight end before FLEX is considered, so
     // naming him as FLEX's alternative would describe a choice nobody can make.
-    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     const taken = new Set(choices.map((c) => c.playerId).filter(Boolean));
 
     for (const choice of choices) {
@@ -131,7 +150,7 @@ describe("autolineupChoices", () => {
     // RB#0's runner-up is rb2 — who RB#1 then starts. The screen would have
     // offered the manager somebody already in their own lineup, described as an
     // alternative to it.
-    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER });
+    const choices = autolineupChoices({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     const rb0 = choiceFor(choices, "RB#0") as { playerId: string; runnerUpId: string | null };
     const rb1 = choiceFor(choices, "RB#1") as { playerId: string };
 
@@ -147,11 +166,45 @@ describe("autolineupChoices", () => {
       shape: SHAPE,
       roster: ROSTER,
       locked: [{ slotType: "QB", slotIndex: 0, playerId: "qb-bad" }],
+      now: BEFORE_KICKOFF,
     });
     expect(choiceFor(choices, "QB#0")).toMatchObject({
       playerId: "qb-bad",
       runnerUpId: null,
       runnerUpReason: null,
     });
+  });
+});
+
+describe("a player whose game has started is never offered", () => {
+  const LATE = SUNDAY + 3 * 3_600;
+
+  it("never names a player whose game has started as the runner-up", () => {
+    /*
+      The screen must not suggest a move the server would refuse.
+
+      A runner-up is an alternative the manager could take instead. Once a
+      player's game has kicked off he is not one — `validateLineup` answers
+      `PLAYER_LOCKED` to anyone who tries. Naming him would be the preview
+      offering a road that is closed.
+    */
+    const roster = [
+      candidate("wr-early", ["WR"], 20_000),
+      candidate("wr-late", ["WR"], 12_000, { kickoffAt: LATE }),
+      candidate("wr-later", ["WR"], 11_000, { kickoffAt: LATE }),
+    ];
+
+    const choices = autolineupChoices({
+      shape: SHAPE,
+      roster,
+      now: SUNDAY + 25 * 60,
+      mode: "SEASON_AVERAGE",
+    });
+
+    const named = choices.flatMap((choice) =>
+      [choice.playerId, choice.runnerUpId].filter((id): id is string => id !== null),
+    );
+
+    expect(named).not.toContain("wr-early");
   });
 });

--- a/packages/core/src/season/autolineup.test.ts
+++ b/packages/core/src/season/autolineup.test.ts
@@ -9,6 +9,17 @@ import { validateLineup } from "./lineup.js";
 const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
 const SUNDAY = 1_757_782_800;
 
+/**
+ * An hour before the fixtures kick off.
+ *
+ * `autolineup` requires a clock so it can refuse to start a player whose game
+ * is already under way. Every candidate below kicks off at `SUNDAY` unless it
+ * says otherwise, so running the suite an hour earlier leaves every existing
+ * expectation about ranking and scarcity exactly as it was. The cases that
+ * exercise the clock name their own moment.
+ */
+const BEFORE_KICKOFF = SUNDAY - 3_600;
+
 function candidate(
   playerId: string,
   positions: string[],
@@ -52,7 +63,7 @@ const at = (
 
 describe("autolineup", () => {
   it("fills every starting slot", () => {
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(lineup).toHaveLength(9);
     expect(lineup.every((entry) => entry.playerId !== null)).toBe(true);
@@ -62,7 +73,7 @@ describe("autolineup", () => {
     // The same validator a manager's own edit goes through. If these two ever
     // disagreed, a team could be auto-set into a lineup it was not allowed to
     // choose for itself.
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     const roster = new Map(ROSTER.map((player) => [player.playerId, player]));
 
     expect(
@@ -71,7 +82,7 @@ describe("autolineup", () => {
   });
 
   it("starts the best player at each position", () => {
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(at(lineup, "QB")).toBe("qb-good");
     expect(at(lineup, "K")).toBe("k-a");
@@ -79,13 +90,13 @@ describe("autolineup", () => {
   });
 
   it("starts both running backs in order", () => {
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect([at(lineup, "RB", 0), at(lineup, "RB", 1)].sort()).toEqual(["rb-a", "rb-b"]);
   });
 
   it("never starts a player twice", () => {
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
     const filled = lineup.map((entry) => entry.playerId).filter(Boolean);
 
     expect(new Set(filled).size).toBe(filled.length);
@@ -93,7 +104,7 @@ describe("autolineup", () => {
 
   it("fills the flex from whoever is left", () => {
     // rb-c, wr-c, wr-d and te-b are the leftovers; wr-c is the best of them.
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(at(lineup, "FLEX")).toBe("wr-c");
   });
@@ -102,7 +113,7 @@ describe("autolineup", () => {
     // The ordering bug this exists to prevent: with one tight end on the roster,
     // filling FLEX first takes him and leaves TE empty.
     const thin = ROSTER.filter((player) => player.playerId !== "te-b");
-    const lineup = autolineup({ shape: SHAPE, roster: thin });
+    const lineup = autolineup({ shape: SHAPE, roster: thin, now: BEFORE_KICKOFF });
 
     expect(at(lineup, "TE")).toBe("te-a");
     expect(at(lineup, "FLEX")).not.toBe("te-a");
@@ -110,7 +121,7 @@ describe("autolineup", () => {
 
   it("leaves a slot empty when nobody can fill it", () => {
     const noKicker = ROSTER.filter((player) => !player.positions.includes("K"));
-    const lineup = autolineup({ shape: SHAPE, roster: noKicker });
+    const lineup = autolineup({ shape: SHAPE, roster: noKicker, now: BEFORE_KICKOFF });
 
     expect(at(lineup, "K")).toBeNull();
     // And the rest of the lineup is still set.
@@ -119,7 +130,7 @@ describe("autolineup", () => {
 
   it("returns slots in roster order, not fill order", () => {
     // Filling runs scarcest-first; a human reads QB, RB, RB, WR…
-    const lineup = autolineup({ shape: SHAPE, roster: ROSTER });
+    const lineup = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(lineup.map((entry) => entry.slotType)).toEqual([
       "QB",
@@ -140,16 +151,20 @@ describe("determinism", () => {
   // playoff seeds — which in a pot league decides who gets paid. "The computer
   // picked" has to be something anyone can recompute.
   it("is reproducible", () => {
-    const first = autolineup({ shape: SHAPE, roster: ROSTER });
-    const second = autolineup({ shape: SHAPE, roster: ROSTER });
+    const first = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
+    const second = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
 
     expect(first).toEqual(second);
   });
 
   it("does not depend on roster order", () => {
     // Otherwise the lineup would move with however the database returned rows.
-    const forwards = autolineup({ shape: SHAPE, roster: ROSTER });
-    const backwards = autolineup({ shape: SHAPE, roster: [...ROSTER].reverse() });
+    const forwards = autolineup({ shape: SHAPE, roster: ROSTER, now: BEFORE_KICKOFF });
+    const backwards = autolineup({
+      shape: SHAPE,
+      roster: [...ROSTER].reverse(),
+      now: BEFORE_KICKOFF,
+    });
 
     expect(forwards).toEqual(backwards);
   });
@@ -160,7 +175,9 @@ describe("determinism", () => {
       candidate("aaa", ["QB"], 10_000),
     ];
 
-    expect(at(autolineup({ shape: SHAPE, roster: tied }), "QB")).toBe("aaa");
+    expect(at(autolineup({ shape: SHAPE, roster: tied, now: BEFORE_KICKOFF }), "QB")).toBe(
+      "aaa",
+    );
   });
 });
 
@@ -172,7 +189,7 @@ describe("availability", () => {
       candidate("backup", ["QB"], 9_000),
     ];
 
-    expect(at(autolineup({ shape: SHAPE, roster }), "QB")).toBe("backup");
+    expect(at(autolineup({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB")).toBe("backup");
   });
 
   it("still starts an unavailable player rather than nobody", () => {
@@ -181,19 +198,19 @@ describe("availability", () => {
     // legal.
     const roster = [candidate("only-qb", ["QB"], 25_000, { unavailable: true })];
 
-    expect(at(autolineup({ shape: SHAPE, roster }), "QB")).toBe("only-qb");
+    expect(at(autolineup({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB")).toBe("only-qb");
   });
 
   it("prefers a player with a record to one without", () => {
     const roster = [candidate("rookie", ["QB"], null), candidate("veteran", ["QB"], 4_000)];
 
-    expect(at(autolineup({ shape: SHAPE, roster }), "QB")).toBe("veteran");
+    expect(at(autolineup({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB")).toBe("veteran");
   });
 
   it("still starts an unplayed player over nobody", () => {
     const roster = [candidate("rookie", ["QB"], null)];
 
-    expect(at(autolineup({ shape: SHAPE, roster }), "QB")).toBe("rookie");
+    expect(at(autolineup({ shape: SHAPE, roster, now: BEFORE_KICKOFF }), "QB")).toBe("rookie");
   });
 });
 
@@ -204,6 +221,7 @@ describe("locked slots", () => {
       shape: SHAPE,
       roster: ROSTER,
       locked: [{ slotType: "QB", slotIndex: 0, playerId: "qb-bad" }],
+      now: BEFORE_KICKOFF,
     });
 
     expect(at(lineup, "QB")).toBe("qb-bad");
@@ -214,6 +232,7 @@ describe("locked slots", () => {
       shape: SHAPE,
       roster: ROSTER,
       locked: [{ slotType: "FLEX", slotIndex: 0, playerId: "rb-a" }],
+      now: BEFORE_KICKOFF,
     });
 
     expect([at(lineup, "RB", 0), at(lineup, "RB", 1)]).not.toContain("rb-a");
@@ -225,6 +244,7 @@ describe("locked slots", () => {
       shape: SHAPE,
       roster: ROSTER,
       locked: [{ slotType: "K", slotIndex: 0, playerId: null }],
+      now: BEFORE_KICKOFF,
     });
 
     expect(at(lineup, "K")).toBeNull();
@@ -281,6 +301,7 @@ describe("WEEKLY_PROJECTION", () => {
       shape: SHAPE,
       roster,
       mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
     }).filter((a) => a.slotType === "QB");
     expect(byProjection?.playerId).toBe("qb-spot");
 
@@ -290,6 +311,7 @@ describe("WEEKLY_PROJECTION", () => {
       shape: SHAPE,
       roster,
       mode: "SEASON_AVERAGE",
+      now: BEFORE_KICKOFF,
     }).filter((a) => a.slotType === "QB");
     expect(byAverage?.playerId).toBe("qb-steady");
   });
@@ -301,7 +323,9 @@ describe("WEEKLY_PROJECTION", () => {
       projected("qb-steady", ["QB"], 22_000, 15_000),
       projected("qb-spot", ["QB"], 9_000, 26_000),
     ];
-    const [chosen] = autolineup({ shape: SHAPE, roster }).filter((a) => a.slotType === "QB");
+    const [chosen] = autolineup({ shape: SHAPE, roster, now: BEFORE_KICKOFF }).filter(
+      (a) => a.slotType === "QB",
+    );
     expect(chosen?.playerId).toBe("qb-steady");
   });
 
@@ -319,6 +343,7 @@ describe("WEEKLY_PROJECTION", () => {
       shape: SHAPE,
       roster,
       mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
     }).filter((a) => a.slotType === "QB");
 
     // Ranked on 25_000, his average — not dumped below the projected player.
@@ -337,6 +362,7 @@ describe("WEEKLY_PROJECTION", () => {
       shape: SHAPE,
       roster,
       mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
     }).filter((a) => a.slotType === "QB");
     expect(chosen?.playerId).toBe("qb-playing");
   });
@@ -347,11 +373,17 @@ describe("WEEKLY_PROJECTION", () => {
       projectedMilliPoints: 20_000 - c.playerId.length,
     }));
 
-    const once = autolineup({ shape: SHAPE, roster, mode: "WEEKLY_PROJECTION" });
+    const once = autolineup({
+      shape: SHAPE,
+      roster,
+      mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
+    });
     const twice = autolineup({
       shape: SHAPE,
       roster: [...roster].reverse(),
       mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
     });
 
     // Same inputs in a different order give the same lineup: these results move
@@ -372,6 +404,7 @@ describe("WEEKLY_PROJECTION", () => {
       shape: SHAPE,
       roster: candidates,
       mode: "WEEKLY_PROJECTION",
+      now: BEFORE_KICKOFF,
     });
     const roster = new Map(candidates.map((player) => [player.playerId, player]));
 
@@ -379,4 +412,159 @@ describe("WEEKLY_PROJECTION", () => {
       [],
     );
   });
+});
+
+describe("a player whose game has started is not a candidate", () => {
+  const LATE = SUNDAY + 3 * 3_600;
+
+  /*
+    Enough of a roster to fill the FLEX two ways: one man already playing and
+    better, one kicking off later and worse. Ranking alone would take the first.
+  */
+  const POOL: AutolineupCandidate[] = [
+    candidate("qb", ["QB"], 20_000),
+    candidate("rb1", ["RB"], 18_000),
+    candidate("rb2", ["RB"], 17_000),
+    candidate("wr1", ["WR"], 16_000),
+    candidate("wr2", ["WR"], 15_000),
+    candidate("te", ["TE"], 10_000),
+    candidate("k", ["K"], 8_000),
+    candidate("dst", ["DST"], 7_000),
+    candidate("flex-early", ["WR"], 14_000),
+    candidate("flex-late", ["WR"], 9_000, { kickoffAt: LATE }),
+  ];
+
+  const flexOf = (now: number) =>
+    autolineup({ shape: SHAPE, roster: POOL, now }).find((e) => e.slotType === "FLEX")
+      ?.playerId;
+
+  it("does not fill an empty slot from a player whose game has started", () => {
+    // Twenty-five minutes into the early games. `flex-early` outranks
+    // `flex-late` by five points and is not eligible for the slot any more:
+    // writing him there would lock it, and the manager still has until the late
+    // kickoff to decide it himself.
+    expect(flexOf(SUNDAY + 25 * 60)).toBe("flex-late");
+  });
+
+  it("still prefers him before his game starts", () => {
+    // The same two players, a minute earlier. Ranking is untouched by this
+    // change — only the clock decides who is in the pool.
+    expect(flexOf(SUNDAY - 60)).toBe("flex-early");
+  });
+
+  it("leaves the slot empty when every candidate has already started", () => {
+    const lineup = autolineup({ shape: SHAPE, roster: POOL, now: LATE + 3_600 });
+
+    // Empty is the honest answer and the better one: an empty slot never locks,
+    // so it can still be filled from free agency with someone yet to kick off.
+    expect(lineup.every((entry) => entry.playerId === null)).toBe(true);
+  });
+
+  it("keeps a player who is already standing in a slot when his game starts", () => {
+    // The mirror of the rule. `SLOT_LOCKED` says a locked slot keeps its player;
+    // this change only governs which slots get *filled*, never which are kept.
+    const lineup = autolineup({
+      shape: SHAPE,
+      roster: POOL,
+      now: SUNDAY + 25 * 60,
+      locked: [{ slotType: "WR", slotIndex: 0, playerId: "wr1" }],
+    });
+
+    expect(lineup.find((e) => e.slotType === "WR" && e.slotIndex === 0)?.playerId).toBe("wr1");
+  });
+
+  it("still starts a player on a bye", () => {
+    // `kickoffAt === null` is a bye, not a game in progress. There is nothing to
+    // have started, the slot never locks, and the manager loses no option.
+    const roster = [
+      ...POOL.filter((c) => c.playerId !== "flex-early" && c.playerId !== "flex-late"),
+      candidate("bye-wr", ["WR"], 12_000, { kickoffAt: null }),
+    ];
+    const lineup = autolineup({ shape: SHAPE, roster, now: SUNDAY + 25 * 60 });
+
+    expect(lineup.find((e) => e.slotType === "FLEX")?.playerId).toBe("bye-wr");
+  });
+
+  it("still starts a player ruled out of a game that has not kicked off", () => {
+    /*
+      The trap this rule must not fall into.
+
+      A player ruled OUT of a 16:25 game is `unavailable`, and `unavailable` is
+      the flag that already sorts a bye or an inactive player last. It is the
+      wrong key for this exclusion: he has not started, his slot does not lock,
+      and starting him takes nothing from anyone. A fix keyed on the flag rather
+      than on the clock bars him and puts nobody in his place.
+    */
+    const roster = [
+      ...POOL.filter((c) => c.playerId !== "flex-early" && c.playerId !== "flex-late"),
+      candidate("out-late-wr", ["WR"], 12_000, { kickoffAt: LATE, unavailable: true }),
+    ];
+    const lineup = autolineup({ shape: SHAPE, roster, now: SUNDAY + 25 * 60 });
+
+    expect(lineup.find((e) => e.slotType === "FLEX")?.playerId).toBe("out-late-wr");
+  });
+});
+
+describe("the autofill may never produce a lineup a manager could not submit", () => {
+  /*
+    The invariant, and the test that would have caught this.
+
+    Every scenario above is a case; this is the rule. `validateLineup` refuses to
+    move a player into a slot once his own game has kicked off, and the autofill
+    reaches the table through `setLineupUnchecked`, which skips validation. So
+    the only thing standing between the autofill and a lineup no manager could
+    have submitted is that it declines to build one.
+
+    Checked at nine moments across a game week rather than one, because the
+    interesting failures are at the boundaries — and because on the unfixed code
+    this fails from the Thursday kickoff onward, which is the very first pass the
+    cron can ever make.
+  */
+  const THURSDAY = SUNDAY - 3 * 86_400;
+  const LATE = SUNDAY + 3 * 3_600;
+
+  const POOL: AutolineupCandidate[] = [
+    candidate("thu-rb", ["RB"], 19_000, { kickoffAt: THURSDAY }),
+    candidate("qb", ["QB"], 20_000),
+    candidate("rb2", ["RB"], 17_000),
+    candidate("wr1", ["WR"], 16_000),
+    candidate("wr2", ["WR"], 15_000),
+    candidate("bye-te", ["TE"], 11_000, { kickoffAt: null }),
+    candidate("out-wr", ["WR"], 13_000, { kickoffAt: LATE, unavailable: true }),
+    candidate("k", ["K"], 8_000),
+    candidate("dst", ["DST"], 7_000),
+    candidate("late-wr", ["WR"], 9_000, { kickoffAt: LATE }),
+  ];
+
+  const kickoffsOf = (roster: readonly AutolineupCandidate[]) =>
+    new Map(roster.map((player) => [player.playerId, player.kickoffAt]));
+
+  const MOMENTS: readonly (readonly [string, number])[] = [
+    ["before the week", THURSDAY - 3_600],
+    ["at the Thursday kickoff", THURSDAY],
+    ["Friday", THURSDAY + 86_400],
+    ["just before the early games", SUNDAY - 1],
+    ["at the early kickoff", SUNDAY],
+    ["mid-afternoon", SUNDAY + 25 * 60],
+    ["just before the late games", LATE - 1],
+    ["at the late kickoff", LATE],
+    ["after everything", LATE + 4 * 3_600],
+  ];
+
+  for (const [when, now] of MOMENTS) {
+    it(`is submittable ${when}`, () => {
+      const assignments = autolineup({ shape: SHAPE, roster: POOL, now });
+
+      const problems = validateLineup({
+        assignments,
+        shape: SHAPE,
+        roster: new Map(POOL.map((c) => [c.playerId, c])),
+        kickoffs: kickoffsOf(POOL),
+        current: [],
+        now,
+      });
+
+      expect(problems).toEqual([]);
+    });
+  }
 });

--- a/packages/core/src/season/autolineup.ts
+++ b/packages/core/src/season/autolineup.ts
@@ -93,6 +93,22 @@ export interface AutolineupInput {
    * must not try.
    */
   readonly locked?: readonly LineupAssignment[];
+  /**
+   * Unix seconds, at the moment the fill is being decided.
+   *
+   * **Required, not optional-with-a-fallback**, for the reason `lineup.ts` gives
+   * about `KickoffTimes`: an optional filter that defaults to permissive is the
+   * shape of the defect, and here the permissive default *is* the bug. A
+   * clockless autofill is what let an empty slot be filled from a player whose
+   * game had already started, which locked the slot around him and refused the
+   * manager his own edit to it.
+   *
+   * `mode` and `locked` are optional because their defaults are conservative
+   * and say so. A clock has no conservative default: the only value meaning "no
+   * clock" is the one that admits every player already playing. This file is
+   * pure and cannot obtain one itself, so it has to be given one.
+   */
+  readonly now: number;
 }
 
 /**
@@ -180,8 +196,51 @@ export interface AutolineupChoice extends LineupAssignment {
  * end taken by TE is genuinely not available to FLEX, and reporting him as
  * FLEX's runner-up would describe a choice nobody could make.
  */
+/**
+ * Whether this player’s own game has already begun.
+ *
+ * Deliberately the same three answers `isSlotLocked` gives, because this is the
+ * same rule seen from the other side.
+ *
+ * A bye is **not** started: `kickoffAt === null` means there is no game to have
+ * begun, the slot never locks, and the manager keeps every option he had.
+ *
+ * **Not keyed on `unavailable`.** That flag conflates a bye with an OUT
+ * designation, and a player ruled out of a 16:25 game has not started — he is a
+ * legal fill, and the ranking already puts him last. Keying the exclusion on the
+ * flag would bar him and admit nobody in his place.
+ */
+function hasStarted(candidate: AutolineupCandidate, now: number): boolean {
+  return candidate.kickoffAt !== null && now >= candidate.kickoffAt;
+}
+
 export function autolineupChoices(input: AutolineupInput): readonly AutolineupChoice[] {
-  const { shape, roster, locked, mode = "SEASON_AVERAGE" } = input;
+  const { shape, roster: allCandidates, locked, now, mode = "SEASON_AVERAGE" } = input;
+
+  /*
+    The pool, with anyone already playing removed — and removed here, before a
+    single slot is looked at.
+
+    `validateLineup` already refuses this move for a manager, and its comment
+    says why: "an empty slot — which never locks — would let a manager start a
+    player after watching him score." An empty slot is exactly what this function
+    fills, and `setLineupUnchecked` writes the result without validating it, so
+    this is the only writer in the system able to do what that check exists to
+    prevent. This closes a bypass rather than choosing a policy.
+
+    A hard exclusion, not a demotion in `compare`, and the difference is
+    load-bearing three times over. A filtered player cannot be picked; cannot be
+    named as a runner-up, which would offer an alternative the server would
+    refuse; and cannot inflate `eligibleCount`, which decides the order slots
+    are filled in and would otherwise make a slot look less scarce than it is.
+
+    Locked slots are unaffected: they come from `locked` and are copied through
+    below without consulting the pool, so a player already standing in a slot
+    when his game starts stays exactly where he is. This governs which slots the
+    autofill *fills*, never which it preserves — the same asymmetry
+    `PLAYER_LOCKED` and `SLOT_LOCKED` describe as a pair.
+  */
+  const roster = allCandidates.filter((candidate) => !hasStarted(candidate, now));
 
   const slots = startingSlots(shape);
 

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -110,6 +110,9 @@ async function setup(): Promise<Fixture> {
 
   const roster: [string, string, string | null][] = [
     ["thu-qb", "QB", "PIT"],
+    // FLEX-eligible and in the Thursday game. Without him no empty slot can be
+    // offered a player who is already playing, which is the whole of #240.
+    ["thu-wr", "WR", "PIT"],
     ["sun-qb", "QB", "CIN"],
     ["rb-a", "RB", "CIN"],
     ["rb-b", "RB", "BAL"],
@@ -187,7 +190,7 @@ describe("loadRosterForWeek", () => {
     const fx = await setup();
     const roster = await loadRosterForWeek(fx.client, fx.teamId, SEASON, WEEK);
 
-    expect(roster.size).toBe(12);
+    expect(roster.size).toBe(13);
   });
 
   it("carries each player's own kickoff", async () => {
@@ -876,8 +879,8 @@ describe("scoring a week end to end", () => {
     const lineups = await loadWeekLineups(fx.client, fx.leagueId, WEEK);
     const mine = lineups.find((lineup) => lineup.teamId === fx.teamId);
 
-    // Twelve rostered, nine starting.
-    expect(mine?.bench).toHaveLength(3);
+    // Thirteen rostered, nine starting.
+    expect(mine?.bench).toHaveLength(4);
     expect(mine?.bench).toContain(fx.players.get("thu-qb"));
   });
 });
@@ -1581,5 +1584,110 @@ describe("a lineup that moves under the manager — #100", () => {
         now: BEFORE_ANYTHING,
       }),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("the autofill will not take a slot the manager still holds", () => {
+  /*
+    Issue #240, end to end on the path the cron actually walks.
+
+    The sequence needs no race. A manager empties a slot while its intended
+    replacement has not kicked off yet — legal, and performed below through the
+    real `setLineup`. The autofill then runs on the next scoring pass and, before
+    this was fixed, filled that slot from whoever ranked highest among everyone
+    left, including a player already playing. From that instant the slot is
+    locked around him and the manager's own edit is refused — and it is
+    `SLOT_LOCKED`, not `PLAYER_LOCKED`, so he cannot even blank it back to empty.
+
+    The projections below are the point of the fixture, not decoration. Ranking
+    is `WEEKLY_PROJECTION` and an unprojected pool is all nulls, where ties break
+    on player id — a UUID coin toss that would make these tests pass or fail for
+    reasons having nothing to do with the clock. Projected, `thu-wr` is
+    unambiguously the best remaining FLEX and the unfixed autofill takes him
+    every time.
+  */
+  const projectionStatId = async (fx: Fixture): Promise<string> => {
+    const [row] = await fx.client.query<{ id: string }>(
+      `SELECT k.id FROM stat_keys k JOIN sports s ON s.id = k.sport_id
+        WHERE s.key = $1 AND k.key = 'rec_yd'`,
+      [NFL.key],
+    );
+    return row!.id;
+  };
+
+  /** `thu-wr` outprojects every other FLEX-eligible player on the roster. */
+  const seedProjections = async (fx: Fixture): Promise<void> => {
+    const statKeyId = await projectionStatId(fx);
+    for (const [handle, value] of [
+      ["thu-wr", 120],
+      ["wr-c", 40],
+      ["rb-c", 30],
+    ] as const) {
+      await fx.client.query(
+        `INSERT INTO player_projections (player_id, season, week, source, stat_key_id, value)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [fx.players.get(handle), SEASON, WEEK, PRIMARY_PROJECTION_SOURCE, statKeyId, value],
+      );
+    }
+  };
+
+  /** A full lineup, then FLEX emptied after the Thursday game has kicked off. */
+  const emptyTheFlexAfterThursday = async (fx: Fixture): Promise<void> => {
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, FULL),
+      now: BEFORE_ANYTHING,
+    });
+
+    // Legal: his replacement plays Sunday, so the slot is still his to decide.
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, { ...FULL, "FLEX:0": null }),
+      now: AFTER_THURSDAY,
+    });
+  };
+
+  const flexAfter = async (fx: Fixture): Promise<string | null | undefined> => {
+    const lineups = await loadWeekLineups(fx.client, fx.leagueId, WEEK);
+    return lineups
+      .find((lineup) => lineup.teamId === fx.teamId)
+      ?.assignments.find((entry) => entry.slotType === "FLEX")?.playerId;
+  };
+
+  it("does not fill an empty slot with a player whose game has started", async () => {
+    const fx = await setup();
+    await seedProjections(fx);
+    await emptyTheFlexAfterThursday(fx);
+
+    await ensureLineups(fx.client, fx.leagueId, WEEK, AFTER_THURSDAY);
+
+    // thu-wr projects highest by a distance and is already playing, so he is not
+    // a candidate. The next best whose game has not started takes the slot.
+    expect(await flexAfter(fx)).toBe(fx.players.get("wr-c"));
+  });
+
+  it("leaves the manager able to change it afterwards", async () => {
+    const fx = await setup();
+    await seedProjections(fx);
+    await emptyTheFlexAfterThursday(fx);
+
+    await ensureLineups(fx.client, fx.leagueId, WEEK, AFTER_THURSDAY);
+
+    // The half that actually cost the manager something. Before the fix this
+    // threw INVALID_LINEUP carrying SLOT_LOCKED, because the autofill had put a
+    // player already on the field into a slot with hours left to run.
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: lineupOf(fx, { ...FULL, "FLEX:0": "rb-c" }),
+      now: AFTER_THURSDAY + 60,
+    });
+
+    expect(await flexAfter(fx)).toBe(fx.players.get("rb-c"));
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -1074,6 +1074,15 @@ export async function autoFillLineup(
       roster: candidates,
       mode,
       locked: [...keep.values()],
+      // The same clock the lock check above already used. A player whose game
+      // has begun is not a candidate for a slot that is still open: writing him
+      // there locks the slot around him, and the manager who was entitled to
+      // decide it for another three hours is then refused by SLOT_LOCKED.
+      //
+      // Read inside the transaction, like everything else here. Hoisting the
+      // pool out to save a read would make it a function of a pre-transaction
+      // clock, which is the stale-snapshot shape #224 closed.
+      now,
     });
 
     return setLineupUnchecked(tx, teamId, week, filled, current, slotTypeIds, stored.rules);
@@ -1086,7 +1095,17 @@ export async function autoFillLineup(
  * Only for the autolineup, whose output is already produced from this league's
  * own shape and this team's own roster, and which must succeed even when a
  * manager's own lineup would be rejected — an abandoned team still has to be
- * given one.
+ * given one, and `requireFull` is the check it has to be exempt from.
+ *
+ * **That exemption covers shape, ownership and empty slots. It has never covered
+ * locks.** `validateLineup` refuses to move a player into a slot once his own
+ * game has kicked off, and every path through here skips that refusal — so the
+ * caller owns the lock on both sides: `autoFillLineup` preserves an
+ * already-locked slot by passing it in `locked`, and `autolineup` keeps a
+ * started player out of the candidate pool with the `now` it requires. Neither
+ * half is optional, and nothing below this line will catch a caller who forgets
+ * one: the write is a compare-and-swap on the previous value, and a
+ * compare-and-swap cannot tell a legal fill from an illegal one.
  *
  * **Runs inside a transaction its caller opened**, rather than opening one, so
  * that the lock and the read the write is conditioned on are inside the same

--- a/packages/db/src/notifications.ts
+++ b/packages/db/src/notifications.ts
@@ -316,10 +316,22 @@ async function invitationNotifications(db: SqlClient, userId: string): Promise<N
  * An empty starting slot, in a league where nothing will fill it.
  *
  * **Only when autofill is off**, which is the whole of this check. The autofill
- * is on by default and fills every empty slot at lock, deterministically — so an
- * unset lineup normally costs a manager nothing, and warning about it would be
- * warning about a thing the product already handles. With it off, an empty slot
- * scores zero and the warning is true.
+ * is on by default and fills empty slots deterministically — so an unset lineup
+ * normally costs a manager nothing, and warning about it would be warning about
+ * a thing the product already handles. With it off, an empty slot scores zero
+ * and the warning is true.
+ *
+ * **That premise is now conditional and this filter has not caught up.** The
+ * autofill will not start a player whose own game has kicked off, so a slot
+ * where everyone eligible is already playing is left empty on purpose — on an
+ * autofill-*on* team, which this query never looks at. That manager is told
+ * nothing, while the slot is still fillable from free agency.
+ *
+ * The one-line widening is worse than the gap: the join above already selects
+ * only `player_id IS NULL` rows, so dropping the autofill predicate warns every
+ * team with any empty row — which, before the week's first kickoff, is every
+ * autofill-on team every week. Telling the two apart needs a record of what the
+ * autofill decided, and nothing stores one. Tracked separately.
  */
 async function unsetLineups(db: SqlClient, userId: string): Promise<Notification[]> {
   const rows = await db.query<{


### PR DESCRIPTION
Closes #240.

An empty starting slot could be filled from any rostered player, including one whose game had kicked off hours earlier. The slot locks around whoever is written into it, so from that instant the manager could not change it — and the error is `SLOT_LOCKED`, not `PLAYER_LOCKED`, so he could not even blank it back to empty.

No race is required. A manager empties FLEX at 13:05 because his replacement kicks at 16:25 — legal, and the product accepts it. The ten-minute cron runs at 13:25 and fills the slot from whoever ranks highest among everyone left. If that player kicked off at 13:00, the slot is gone.

## It is not the policy question the issue describes — including the one I wrote

The issue frames this as a preference: *should* the autofill prefer un-started players? It shouldn't need to prefer anything, because **`validateLineup` already forbids the move**:

> A player whose own game has kicked off can only be kept where he already is, never moved into a slot. The check above guards the player leaving a slot; without this one, an empty slot — which never locks — would let a manager start a player after watching him score.

That is `PLAYER_LOCKED`. Every other writer is bound by it. The autofill escaped only because `setLineupUnchecked` skips validation, and that bypass is justified on shape, ownership and being allowed to leave slots empty — never on locks. `SLOT_LOCKED` and `PLAYER_LOCKED` are a documented pair guarding two directions of one rule, and the autofill honoured one half.

So this closes a bypass rather than choosing a policy. It re-opens no settled decision: "autofill ranks on weekly projections" governs *which number ranks the pool*; this changes *who is in the pool*. The ranking function is untouched, no rule field is added, and no hash moves.

## Three claims in the issue are inaccurate

- **"The only exclusion applied when the candidate list is built is `unavailable`."** `unavailable` is not an exclusion at all — it is a sort key, as the issue itself later says correctly — and it is not the only filter: `!onIr` and `released_at IS NULL` are both real.
- **The lock-out is worse than described.** It is `SLOT_LOCKED`, not `PLAYER_LOCKED`: the stored occupant is what locks the slot, so the manager cannot blank it back to empty either. There is no undo at all.
- **A scope limit is missing.** A manager who turns autofill off is immune. Bots cannot opt out.

## The rule

A **hard exclusion** from the candidate pool, applied once before a single slot is looked at, keyed on `kickoffAt` and the clock:

- **Not a demotion in `compare`.** Sorted last he is still started whenever he is the only eligible body — precisely the case that locks the manager out. A filtered player also cannot be named as a runner-up (offering a move the server would refuse) and cannot inflate `eligibleCount`, which decides fill order.
- **Not keyed on `unavailable`.** That flag conflates a bye with an OUT designation, and a player ruled out of a 16:25 game **has not started** — he is a legal fill and the ranking already puts him last. Keying on the flag bars him and puts nobody in his place. There is a test for exactly this.
- **A bye is not excluded.** `kickoffAt === null` means no game to have begun; the slot never locks.
- **A slot with nobody left is written empty**, through the path that already existed for that case. Empty is legal everywhere, scores zero, and stays fillable from free agency — which a locked player would have ended.
- **`now` is required, not optional.** The reason `lineup.ts` gives about `KickoffTimes` applies verbatim: the permissive default *is* the bug. `mode` and `locked` are optional because their defaults are conservative and say so; a clock has no conservative default.

## The test that would have caught this

Nine moments across a game week, feeding `autolineup`'s output back through `validateLineup` and asserting no lock problems. On the old code it fails at **eight of nine — starting at the Thursday kickoff**, the first pass the cron can ever make:

```
+ "code": "PLAYER_LOCKED",
+ "message": "thu-rb's game has kicked off — they can no longer be started in RB slot 1"
```

Plus two end-to-end tests on the real cron path. Without the change the second fails with the production error:

```
→ That lineup is not legal: FLEX slot 1 is locked — that player's game has kicked off
```

Their projections are seeded deliberately: ranking is `WEEKLY_PROJECTION`, and an unprojected pool is all nulls where ties break on player id — a UUID coin toss that would have made these tests pass or fail for reasons unrelated to the clock. An earlier draft did exactly that and passed against unfixed code.

## Verified

`pnpm test` **2276 passed** (up from 2258), `pnpm test:web` 281 passed, typecheck, lint and format clean. Every new test was also run against the unfixed code to confirm it fails: 10 core, 2 end-to-end.

## What this costs, stated rather than discovered later

**Thursday-night players leave the autofill's pool every week, for every team.** `ensureLineups` runs only from `resolveWeek`, and `score-week` takes its week from `currentWeek` — the week of the most recent kickoff — so the first pass for a week never precedes that week's first game.

That is the rules being applied, not a regression: no human can start a TNF player at 20:25 either. But it means `RULES.md`'s promise that empty slots fill "at lock" and the checkbox's "at kickoff" were **already false**, and the honest end state is running the fill before each player's own lock, at which point this cost goes to zero. Filed separately, and the wording now claims only what is honoured.

Note the order matters: this change alone is strictly more conservative, since it can only ever remove a start no manager could legally make. Running the fill earlier *without* it would fill more slots from kicked-off players in more weeks.

## Deliberately not here

- **Warning a manager about a slot the autofill declined.** `unsetLineups` and `UrgentStrip` stay quiet on the premise that "the autofill covers it", which is now conditional. The obvious one-line widening is worse than the gap: the query already selects only null rows, so dropping the autofill predicate warns every team with any empty slot — which before the week's first kickoff is every autofill-on team, every week. An earlier draft of this PR contained that predicate; it was withdrawn after it broke an existing test proving exactly that. Telling a declined slot from an unreached one needs a record of what the autofill decided, and nothing stores one. Both comments now say so, and it is filed.
- **Recording the autofill's decision.** `RULES.md` §8, `autolineup.ts` and `DECISIONS.md` all claim the projection used is recorded with the lineup. Nothing records it — `lineups` has no column for it, and `player_projections` is overwritten in place by each resync, so the value ranked on is destroyed. The `DECISIONS.md` instance is the argument that *overturned* RULES.md's prior refusal of projections, so it is the premise under a settled decision. Left untouched here deliberately, and filed: it is a rules-content decision for the owner, not a rider on a lock fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
