### PR TITLE
fix(core): a player on injured reserve could not be put on injured reserve (#251)

### DIFF
--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -129,8 +129,6 @@ function untilLock(locksAt: number | null, now: number): string {
   return `in ${minutes}m`;
 }
 
-const OUT_STATUSES = new Set(["OUT", "IR", "INACTIVE", "SUSPENDED", "DOUBTFUL", "PUP", "NFI"]);
-
 export function LineupEditor({ leagueId, week }: { leagueId: string; week: number }) {
   const { data, error, mutate } = useSWR<LineupResponse>(
     `/api/leagues/${leagueId}/lineup?week=${week}`,
@@ -554,9 +552,7 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                         candidate.availability === "TIME_TBD"
                           ? " — TBD"
                           : ""}
-                        {OUT_STATUSES.has(candidate.status.toUpperCase())
-                          ? ` — ${candidate.status}`
-                          : ""}
+                        {candidate.injuryDesignation ? ` — ${candidate.injuryDesignation}` : ""}
                       </option>
                     );
                   })}
@@ -634,8 +630,24 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                   </span>
                 </span>
               </button>
-              {OUT_STATUSES.has(player.status.toUpperCase()) && (
-                <span className="text-amber-400/70">{player.status}</span>
+              {/*
+                The bench row's only injury marker, and it showed nothing at all
+                until now: it read `player.status`, a column no code in this repo
+                has ever written, so the test was `"ACTIVE"` against a set of out
+                designations and never matched. `injuryBadge` reads the column the
+                provider actually fills, and is what the starter rows above have
+                been using all along.
+
+                Worth having beyond tidiness: the "To IR" button below is hidden
+                for a player the server would refuse, so a manager whose player is
+                wrongly ineligible sees no badge and no button — nothing to notice
+                and nothing to report. The badge is the half that makes a
+                disagreement visible.
+              */}
+              {player.injuryDesignation && (
+                <span className={injuryTone(player.injuryDesignation)}>
+                  {injuryBadge(player.injuryDesignation)}
+                </span>
               )}
               {/*
                 Offered only to a player the server would actually accept. The

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -147,8 +147,18 @@ the exact definition is ESPN's and is recorded with the alignment work in
 | IR               | 2             |
 | **Total roster** | **14 + 2 IR** |
 
-IR slots hold only players officially designated out or on injured reserve, and do not
-count against the roster limit.
+IR slots hold players the provider has designated as carrying an injury, and do not count
+against the roster limit. A player whose designation says he may still play — questionable —
+is not eligible; a designation nobody here recognises **admits** him rather than refusing.
+That direction is chosen. The cost of admitting someone who turns out to play is an IR slot
+his own manager decided to spend, and there are only ever `irSlots` of them. The cost of
+refusing is that a player literally on injured reserve cannot be put on injured reserve.
+
+The check is continuous, not just at the moment you stash him: whenever your roster is
+counted, the exemption is re-read from his current designation. **An injury getting worse
+never costs you the slot** — if his designation moves from out to injured reserve, he stays
+exempt. If he recovers, he counts against your roster again, and nothing is forced off:
+activating him is never refused for capacity.
 
 **Lineup lock:** each slot locks individually at the kickoff of that player's game.
 A player already locked cannot be moved for that week.

--- a/docs/TANK01.md
+++ b/docs/TANK01.md
@@ -203,6 +203,60 @@ curl --url 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.
 
 ---
 
+## `injury.designation` — four values, and a rule reads this field
+
+Captured live on 2026-08-27 from `getNFLPlayerList`, verbatim. **383 of 3,870**
+**players carried a designation.**
+
+| `injury.designation` | players |
+| -------------------- | ------- |
+| `"Questionable"`     | 240     |
+| `"Injured Reserve"`  | 101     |
+| `"Out"`              | 40      |
+| `"Doubtful"`         | 2       |
+
+**These are the only four values in the field.** Nothing else appears — no
+practice-report wording, no `"None"` or `"N/A"` sentinel on a fit player, and none
+of the short codes the rule layer was written against.
+
+**The wording is the whole point.** `players.injury_designation` holds this string
+verbatim — the adapter trims and nothing normalises — and `isIrEligible` matches
+against it to decide whether a player may be stashed on injured reserve. That rule
+was written from a guessed vocabulary of short codes, so `"Injured Reserve"` — the
+second most common value in the field, and the one the feature exists for — did not
+match it. See issue 251.
+
+**Exactly one value means “may still play”:** `"Questionable"`. That is what makes a
+deny-list expressible at all: the eligible side of this vocabulary is open-ended
+and the ineligible side is one word.
+
+**The sample is unusually rich, and that is worth knowing.** The NFL cutdown
+deadline was 2026-08-26, the day before this capture — rosters had just been cut to
+53 and injured players moved to reserve. Compare the survey of the same endpoint
+recorded in `packages/stats/src/tank01/adapter.ts` on 2026-08-18: 4,202 entries, 185
+designated. Fewer players and more than twice the designations, a week apart, from
+one roster deadline. Do not read these counts as a season-typical distribution.
+
+**Not yet observed, and honestly outstanding:** `"Physically Unable To Perform"`,
+`"Suspension"`, and any in-season wording an August snapshot cannot reach.
+`injuryBadge` (`apps/web/src/lib/player.ts`) maps the first two, and this capture is
+evidence that somebody believed in them rather than evidence they exist — late
+August is when PUP and suspensions would be most likely to appear, and they did
+not. Treat those two entries as unattested until a capture shows them.
+
+`syncInjuries` warns on any designation absent from this table, so the next value
+arrives in the logs rather than in a rule.
+
+Reproduce with `pnpm stats:probe` — the histogram reuses the `getNFLPlayerList`
+response the probe already fetches, so it costs no extra call. Or:
+
+```
+curl --url 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLPlayerList' \
+     --header 'x-rapidapi-key: <key>'
+```
+
+---
+
 ## The shape of a box score
 
 `getNFLBoxScore` returns one object with these parts:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -281,7 +281,7 @@ export {
   countedRosterSize,
   irExemptCount,
   irExemptOnRoster,
-  IR_ELIGIBLE_DESIGNATIONS,
+  MAY_STILL_PLAY,
   isIrEligible,
   refuseIrPlacement,
   type IrPlacementRefusal,

--- a/packages/core/src/season/injured-reserve.test.ts
+++ b/packages/core/src/season/injured-reserve.test.ts
@@ -16,10 +16,36 @@ function entry(
 }
 
 describe("isIrEligible", () => {
-  it("accepts the designations that mean a player will not appear", () => {
-    for (const designation of ["OUT", "IR", "PUP", "NFI", "SUSPENDED", "INACTIVE"]) {
-      expect(isIrEligible(designation)).toBe(true);
-    }
+  /*
+    The provider's own wording, not ours.
+
+    This used to iterate the seven short codes the implementation contained and
+    assert they were accepted — the constant checked against itself, which
+    passes for any constant including a wrong one. That is how "Injured
+    Reserve" went unnoticed: it is the second most common value in the column
+    and matched nothing. Every string below is one this project has observed in
+    the field, recorded with its counts in docs/TANK01.md.
+  */
+  it("accepts the designations the provider actually publishes", () => {
+    expect(isIrEligible("Injured Reserve")).toBe(true);
+    expect(isIrEligible("Out")).toBe(true);
+    expect(isIrEligible("Doubtful")).toBe(true);
+  });
+
+  it("admits a designation nobody here has seen", () => {
+    /*
+      The property the inversion buys, and the reason to keep it.
+
+      An allow-list is correct only while its enumeration is complete, and this
+      vocabulary belongs to another company. Refusing an unfamiliar designation
+      strands a player who is genuinely hurt, with no bound; admitting one costs
+      a manager an IR slot he chose to spend, capped at `irSlots`.
+
+      This fails the moment somebody re-tightens it into an allow-list, which is
+      the whole job of the test.
+    */
+    expect(isIrEligible("Reserve/COVID-19")).toBe(true);
+    expect(isIrEligible("Physically Unable To Perform")).toBe(true);
   });
 
   it("treats a healthy player as ineligible however the absence is spelt", () => {
@@ -34,6 +60,40 @@ describe("isIrEligible", () => {
   it("normalises case and whitespace, because the column is provider text", () => {
     expect(isIrEligible(" out ")).toBe(true);
     expect(isIrEligible("Questionable")).toBe(false);
+    expect(isIrEligible("  questionable  ")).toBe(false);
+  });
+
+  it("refuses the one designation that means he may still play", () => {
+    // 240 of the 383 designated players carried this on 2026-08-27 — the
+    // largest group in the column by some way, and the one the IR slot is not
+    // for. A questionable player usually plays.
+    expect(isIrEligible("Questionable")).toBe(false);
+  });
+});
+
+describe("an injury getting worse never costs the slot", () => {
+  /*
+    Issue 251, at the arithmetic rather than the predicate.
+
+    The check is continuous, so a designation is re-read every time the roster
+    is counted. "Out" was accepted and "Injured Reserve" was not, which meant a
+    player who got *more* injured — the ordinary progression, and precisely the
+    population an IR slot exists for — silently stopped being exempt. His
+    manager was then told the roster was full, had waiver claims refused on that
+    basis, and saw him labelled as no longer out.
+  */
+  it("keeps the exemption when Out becomes Injured Reserve", () => {
+    const before = irExemptCount([entry("hurt", true, "Out")], 2);
+    const after = irExemptCount([entry("hurt", true, "Injured Reserve")], 2);
+
+    expect(before).toBe(1);
+    expect(after).toBe(1);
+  });
+
+  it("still counts a player who recovers", () => {
+    // The exemption is conditional in both directions: it is not a one-way
+    // ratchet, and a fit player on the list counts against the roster again.
+    expect(irExemptCount([entry("fit", true, "Questionable")], 2)).toBe(0);
   });
 });
 

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -35,38 +35,58 @@
  */
 
 /**
- * Designations that mean a player is genuinely unavailable.
+ * Designations that mean a player may still take the field.
  *
- * The same set the autofill treats as unavailable, restated here rather than
- * imported from `@rostr/db` — this package must not depend on that one, and the
- * two are the same list for the same reason rather than by coincidence. If they
- * drift, the symptom is a player the autofill benches but IR refuses to hold.
+ * **A deny-list, and the inversion is the point.** This was an allow-list of
+ * seven short codes — OUT, IR, INACTIVE, SUSPENDED, DOUBTFUL, PUP, NFI — and
+ * the column it matches against holds the provider's wording verbatim. Tank01
+ * writes `"Injured Reserve"`, which is in none of them, so the players the
+ * feature exists for were the ones it refused. Issue 251.
  *
- * `DOUBTFUL` is included, and is the debatable one. It is kept because the whole
- * set answers "will not appear this week", and a manager should not have to
- * re-litigate a designation the provider already made.
+ * An allow-list is correct only if the enumeration is complete, and nobody can
+ * complete this one: it is another company's vocabulary and it can change
+ * mid-season. A deny-list is correct if no unlisted designation means "may
+ * still play", which is a far smaller claim — and `docs/TANK01.md` records the
+ * evidence for it: of 383 designated players on 2026-08-27, the field held
+ * exactly four values, and `"Questionable"` was the only one of them meaning a
+ * player might appear.
+ *
+ * **The failure directions are not symmetric, which is what licenses this.**
+ * Refusing wrongly strands a player who is genuinely on injured reserve, with
+ * no bound and no recourse. Admitting wrongly lets a manager spend an IR slot
+ * on somebody who might play — and {@link capped} holds the exemption to
+ * `roster.irSlots` however many are stashed, while `onIr` means he stashed the
+ * player deliberately. So the cost is bounded by a number in the signed rules
+ * and paid by the manager who chose it. That is the same trade `DOUBTFUL` has
+ * always carried here, described two paragraphs down.
+ *
+ * `syncInjuries` warns on any designation not yet recorded in `docs/TANK01.md`,
+ * so a new value arrives in the logs rather than silently changing a rule.
  */
-export const IR_ELIGIBLE_DESIGNATIONS = new Set([
-  "OUT",
-  "IR",
-  "INACTIVE",
-  "SUSPENDED",
-  "DOUBTFUL",
-  "PUP",
-  "NFI",
-]);
+export const MAY_STILL_PLAY = new Set(["QUESTIONABLE"]);
 
 /**
  * Whether this designation permits a player to occupy an IR slot.
  *
  * **Decided by the owner, 2026-08-23: "whenever a player is on IR they need to
  * be actually injured."** So this is asked continuously rather than only at the
- * moment somebody is placed there.
+ * moment somebody is placed there — which is also why a designation that gets
+ * *worse* must never cost a manager the slot. Before issue 251 it did: a player
+ * stashed as `"Out"` who progressed to `"Injured Reserve"` stopped being exempt,
+ * had his waiver claims refused for a full roster, and was labelled as no longer
+ * out. One predicate, five faces.
+ *
+ * `DOUBTFUL` remains eligible, and is the debatable one. It is kept because the
+ * question is "will he appear this week", and a manager should not have to
+ * re-litigate a designation the provider already made.
  *
  * A null or empty designation is a healthy player. Note this reads the
  * designation column, which `CLAUDE.md` records as *shown and never enforced* —
  * that rule exists so a designation arriving on a Sunday cannot invalidate a
  * lineup that was legal when it was set, and nothing here touches a lineup.
+ * **Do not reuse this predicate for the autofill.** It reads as the same
+ * question and is not: that path writes starting slots from a cron with nobody
+ * watching, and is exactly what the invariant forbids.
  * See {@link irExemptCount} for how the continuous check avoids doing anything
  * destructive when a player recovers.
  */
@@ -74,9 +94,8 @@ export function isIrEligible(designation: string | null | undefined): boolean {
   if (designation === null || designation === undefined) return false;
   const normalised = designation.trim().toUpperCase();
   if (normalised === "") return false;
-  return IR_ELIGIBLE_DESIGNATIONS.has(normalised);
+  return !MAY_STILL_PLAY.has(normalised);
 }
-
 export interface IrRosterEntry {
   readonly playerId: string;
   readonly onIr: boolean;

--- a/packages/db/src/injuries.ts
+++ b/packages/db/src/injuries.ts
@@ -1,6 +1,51 @@
-import type { StatsProvider } from "@rostr/stats";
+import type { ProviderInjury, StatsProvider } from "@rostr/stats";
 import type { SqlClient } from "./client.js";
 
+/**
+ * Designations recorded in `docs/TANK01.md`, with counts and a capture date.
+ *
+ * Not a rule — `isIrEligible` is a deny-list and admits anything not in its own
+ * small set, deliberately. This is the evidence register: a value absent here
+ * is one nobody has written down, and the warning below is how the next one
+ * gets noticed.
+ */
+const RECORDED_DESIGNATIONS = new Set(["QUESTIONABLE", "INJURED RESERVE", "OUT", "DOUBTFUL"]);
+
+/**
+ * Report designations this project has not seen before.
+ *
+ * The vocabulary decides a rule and belongs to somebody else. It was guessed
+ * once — seven short codes against a column holding `"Injured Reserve"` — and the
+ * guess refused the players injured reserve exists for, silently, for as long
+ * as it took an agent to read the code. Issue 251.
+ *
+ * So the deny-list is deliberately permissive and this is the other half: an
+ * unfamiliar designation is admitted, and said out loud. Aggregated by distinct
+ * value rather than per player, because a new word on 200 rosters is one fact.
+ *
+ * Mirrors `mapGameStatus`'s warning in the Tank01 adapter, for the same reason:
+ * an operator gets told, rather than a wrong answer being written every hour
+ * without comment.
+ */
+function reportUnrecordedDesignations(injuries: readonly ProviderInjury[]): void {
+  const unrecorded = new Map<string, number>();
+  for (const injury of injuries) {
+    const value = injury.designation.trim();
+    if (value === "") continue;
+    if (RECORDED_DESIGNATIONS.has(value.toUpperCase())) continue;
+    unrecorded.set(value, (unrecorded.get(value) ?? 0) + 1);
+  }
+
+  for (const [value, count] of unrecorded) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[injuries] unrecorded injury designation ${JSON.stringify(value)} on ${count} ` +
+        `player(s). It is being treated as injured, which is this rule's safe ` +
+        `direction. Record it verbatim in docs/TANK01.md, and add it to ` +
+        `MAY_STILL_PLAY in packages/core if it means the player may still appear.`,
+    );
+  }
+}
 /**
  * Keep injury designations current between player syncs.
  *
@@ -95,6 +140,7 @@ export async function syncInjuries(
   if (injuries.length === 0) {
     return { designated: 0, cleared: 0, providerReturned: 0 };
   }
+  reportUnrecordedDesignations(injuries);
 
   const designated = await db.query<{ external_ref: string }>(
     `UPDATE players AS p

--- a/packages/stats/src/cli.ts
+++ b/packages/stats/src/cli.ts
@@ -86,6 +86,35 @@ async function probe(): Promise<void> {
     console.log(`  Sample: ${JSON.stringify(firstPlayer).slice(0, 300)}`);
   }
 
+  /*
+    Every distinct injury designation, counted.
+
+    The same response, not a second call: this endpoint is what `listInjuries`
+    reads, so the histogram costs nothing beyond the request already made.
+
+    It exists because the vocabulary decides a rule. `isIrEligible` matches this
+    field to answer whether a player may be stashed on injured reserve, and the
+    column holds the provider's wording verbatim — nothing normalises it. The
+    set was guessed once and the guess was wrong, so it is measured here rather
+    than remembered, and the result belongs in docs/TANK01.md with the date.
+  */
+  console.log("\nInjury designations");
+  const designations = new Map<string, number>();
+  let designated = 0;
+  for (const player of players) {
+    const injury = player["injury"];
+    if (typeof injury !== "object" || injury === null) continue;
+    const raw = (injury as Record<string, unknown>)["designation"];
+    if (typeof raw !== "string" || raw.trim() === "") continue;
+    designated++;
+    designations.set(raw, (designations.get(raw) ?? 0) + 1);
+  }
+  console.log(`  ${designated} of ${players.length} carry one.`);
+  for (const [value, count] of [...designations].sort((a, b) => b[1] - a[1])) {
+    // Quoted, so trailing spaces and casing are visible rather than inferred.
+    console.log(`  ${JSON.stringify(value).padEnd(34)} ${count}`);
+  }
+
   // The important one: confirm the stat field names in stat-map.ts are real.
   //
   // Sampling one player is not enough — categories only appear when a player has


### PR DESCRIPTION
Closes #251.

`isIrEligible` matched `injury_designation` against seven short codes — `OUT`, `IR`, `INACTIVE`, `SUSPENDED`, `DOUBTFUL`, `PUP`, `NFI` — and the column holds Tank01's wording **verbatim**. Tank01 writes `"Injured Reserve"`. It matched nothing.

## Measured, not assumed

The issue asked that the vocabulary be enumerated rather than hand-extended from guesses. Done — `pnpm stats:probe`, 2026-08-27, one call to an endpoint the probe already hits:

| `injury.designation` | players |
| --- | --- |
| `"Questionable"` | 240 |
| `"Injured Reserve"` | **101** |
| `"Out"` | 40 |
| `"Doubtful"` | 2 |

**383 of 3,870 players carry one, and those four are the only values in the field.** Recorded in `docs/TANK01.md` in the house format, with the caveat that this is one snapshot the day after the NFL cutdown deadline — an unusually rich sample, not a season-typical distribution.

Three things the capture settled that argument could not:

- **No practice-report wording exists in this field.** `"Did Not Participate In Practice"` was the string that would have embarrassed a deny-list — a fully fit player admitted to IR. It is not there.
- **`"Questionable"` is the only value meaning "may still play"**, so the deny set is one word, evidenced rather than guessed.
- **`injuryBadge` contains guesses too.** It maps `"physically unable to perform"` and `"suspension"`; neither appears — in late August, when PUP and suspensions are most likely. The display layer was treated as the oracle during triage; it is not one.

## The manager never saw a refusal

The `NOT_INJURED` message is nearly unreachable. `LineupEditor.tsx` hides the "To IR" button for a player the server would reject, and the bench row's only injury marker read `players.status` — **a column nothing in this repo has ever written**, so it tested `"ACTIVE"` against a set of out designations and rendered nothing.

No badge, no button. Nothing to notice and nothing to report, which is why a defect affecting the second-largest designated population survived.

## The worse half is downstream

The check is *continuous*, so the entry gate was not the only victim. A player stashed as `"Out"` whose designation progressed to `"Injured Reserve"` — the ordinary direction of an injury, and exactly the population an IR slot is for — silently stopped being exempt. His manager was told **"This roster is full"**, had waiver claims refused on that basis, and saw him labelled **"no longer out — counts against your roster"**.

The app reported a worsening injury as a recovery. One predicate, five faces: the hidden button, the refusal, the roster count, the waiver resolver, and the banner. Inverting the predicate repairs all five — `waivers.ts` needs no edit at all, which is worth stating because review will look for one.

## Inverted rather than extended

Extending the list leaves the same defect with a longer list, and the repo had already made that mistake twice — the rule layer guessed `NFI`/`INACTIVE`, the display layer guessed `PUP`/`SUSPENSION`, and neither set contains the other.

So `MAY_STILL_PLAY` holds the designations meaning a player might appear, and everything else is eligible. **Correctness now requires only that no unlisted designation means "may still play"** — a far smaller claim than completeness, and one the capture supports.

**On "fail-open on a signed rule"**, which is the first objection to expect: the exemption is capped at `roster.irSlots` by `capped()` on all three entry points, and requires `onIr` — meaning the manager deliberately stashed the player. Verified there is no path where a wrong designation exempts someone nobody stashed, including the `processWaivers` hypothetical, which takes its exempt set from `on_ir && isIrEligible` and can only shrink it. So the worst case is bounded by a number in the signed rules and paid by the manager who chose to spend it — the same trade `DOUBTFUL` has always carried here.

`syncInjuries` now warns on any designation not yet in `docs/TANK01.md`, so the next new value arrives in the logs rather than silently in a rule.

## Deliberately not touched

`packages/db/src/lineups.ts`'s `OUT_STATUSES` reads the same dead column and looks like the same bug. **It is a different rule.** It feeds the autofill's `unavailable` flag, which writes starting slots from a cron with nobody watching. `CLAUDE.md` records that the designation is *shown and never enforced*, precisely so one arriving on a Sunday cannot invalidate a lineup that was legal when it was set — and `isIrEligible` is licensed to read it only because *"nothing here touches a lineup."* Repointing that flag would. Filed separately, along with the related defect that an abandoned team's autofill will start a player who has been on IR for weeks, since `onIr` is only ever set by a manager pressing a button.

## Verified

`pnpm test` **2262 passed**, `pnpm test:web` 281 passed, typecheck, lint and format clean. The new tests were run against the old allow-list to confirm they fail: three do.

The old test iterated the constant's own contents back at it — a set checking itself, which passes for any set including a wrong one. Its only provider-verbatim string was `"Questionable"`, appearing as a *negative* assertion excluded by the same mechanism that wrongly excluded `"Injured Reserve"`. That is how this shipped green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
