### PR TITLE
fix(db): a trade could leave a team holding more players than the limit (#250)

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/players/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/players/route.ts
@@ -19,6 +19,10 @@ const STATUS: Record<string, number> = {
   NOT_A_FREE_AGENT: 409,
   NOT_ON_WAIVERS: 409,
   ROSTER_FULL: 409,
+  // Its sibling: the roster has room and a trade has spoken for it. A conflict
+  // with the league's state, not a malformed request, and the fallback below
+  // would call it 400.
+  SLOT_HELD_FOR_TRADE: 409,
   DUPLICATE_CLAIM: 409,
   IN_A_TRADE: 409,
 };

--- a/apps/web/src/lib/waiver-run.ts
+++ b/apps/web/src/lib/waiver-run.ts
@@ -45,6 +45,17 @@ export function whyClaimFailed(reason: string | null): string {
       // lines above this sentence, so the old wording denied, on one line, the
       // fact rendered on the line before it.
       return "your roster was still full, even after any drop the claim named";
+    case "SLOT_HELD_FOR_TRADE":
+      // The empty slot is real and the claim still lost, which without this
+      // sentence is the panel's least explicable outcome: `default:` says only
+      // "this claim did not succeed" beside a roster the manager can see has
+      // room. Says which trade nothing — the panel has no trade to name — but
+      // says the shape of it, so they know to look at the trade and not at
+      // their roster.
+      return (
+        "a roster spot was being held for a trade you had accepted, so the run " +
+        "could not award him"
+      );
     case "DROP_ON_IR":
       // The mistake this fix makes likely. Once claims start being awarded,
       // "drop the injured one" is the natural way to make room — and it is the

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -471,9 +471,25 @@ accept a trade and cut the player they promised, and execution would find a hole
 roster spot used to be. This is the database half of "both NFTs move to the escrow PDA",
 and it holds whether or not the league has a pot.
 
-**Rosters may change size.** A two-for-one is a normal trade; roster limits are a lineup
-concern. Only a trade where one side gives nothing is refused, because a gift is how an
-eliminated team hands its roster to a friend without anyone calling it a trade.
+**A trade may change the shape of a roster, never its size past the limit.** A two-for-one
+is a normal trade and no proposal is refused for being uneven — only one where a side gives
+nothing, because a gift is how an eliminated team hands its roster to a friend without
+anyone calling it a trade.
+
+**But a roster may never hold more than the limit.** If accepting would leave you over, the
+trade cannot be accepted until you have made room, and it says how many players you need to
+release. The same is true for the team that proposed it: a trade neither side can hold is
+not one anybody can accept.
+
+Room is held from the moment you accept, not from the moment the trade executes. Between
+those is the veto window, and during it nothing may be added into the space the trade is
+coming into — not a free agent, not a waiver claim. Otherwise two moves that are each
+legal — accepting a trade you have room for, then signing somebody — would put you over
+together, and the trade would be the thing that broke.
+
+**The one exception is injured reserve, and § 2 describes it.** A stashed player who
+recovers stops being exempt and can leave you over the limit. He is never forced off, and
+until you resolve it you cannot acquire anyone. Nothing else may ever put a team over.
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -280,11 +280,13 @@ export {
 export {
   countedRosterSize,
   projectedRosterSize,
+  reservedByTrades,
   irExemptCount,
   irExemptOnRoster,
   MAY_STILL_PLAY,
   isIrEligible,
   refuseIrPlacement,
+  type CommittedTrade,
   type IrPlacementRefusal,
   type IrRosterEntry,
 } from "./season/injured-reserve.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -279,6 +279,7 @@ export {
 
 export {
   countedRosterSize,
+  projectedRosterSize,
   irExemptCount,
   irExemptOnRoster,
   MAY_STILL_PLAY,

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -174,6 +174,48 @@ export function countedRosterSize(roster: readonly IrRosterEntry[], irSlots: num
   return roster.length - irExemptCount(roster, irSlots);
 }
 
+/**
+ * How many players a team will count as holding once its accepted trades land.
+ *
+ * A trade's rows do not move when it is accepted — they move when it executes,
+ * up to the end of the veto window. So a team can accept a trade it has room
+ * for, sign a free agent in the meantime, and be over the limit by the time the
+ * trade lands. Neither acquisition is illegal alone; only the pair is, and
+ * nothing looking at one of them can see the other.
+ *
+ * This is what lets the room be held. An accepted trade reserves the space it
+ * needs from the moment it is accepted, so the intervening add is refused
+ * instead of the trade dying later for something nobody did wrong.
+ *
+ * **Incoming players always count.** A trade never carries the IR flag across —
+ * a player arrives on the receiving roster active, whatever he was on the
+ * sending one — so there is no exemption arithmetic on the inbound side.
+ *
+ * **Outgoing exempt players free nothing.** They were not being counted, so
+ * their departure returns no space. That asymmetry is why counted size does not
+ * conserve across a trade the way row count does, and it is why a one-for-one
+ * of two stashed players can put **both** teams over at once.
+ */
+export function projectedRosterSize(input: {
+  /** Every unreleased row the team holds now. */
+  readonly roster: readonly IrRosterEntry[];
+  /** Players accepted trades have committed this team to give up. */
+  readonly leaving: ReadonlySet<string>;
+  /** How many players accepted trades have committed this team to receive. */
+  readonly arriving: number;
+  readonly irSlots: number;
+}): number {
+  /*
+    Recomputed against the roster the departures leave behind, never against a
+    cached count, for the reason `irExemptOnRoster` gives two functions up: a
+    stashed player who is sent away frees an IR slot rather than a roster slot,
+    and a stashed player who recovers while the trade is pending starts counting
+    where he did not before.
+  */
+  const staying = input.roster.filter((entry) => !input.leaving.has(entry.playerId));
+  return countedRosterSize(staying, input.irSlots) + input.arriving;
+}
+
 export type IrPlacementRefusal =
   /** The player is healthy, or carries a designation that does not qualify. */
   | "NOT_INJURED"

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -216,6 +216,60 @@ export function projectedRosterSize(input: {
   return countedRosterSize(staying, input.irSlots) + input.arriving;
 }
 
+/** One accepted trade, from the point of view of one of its two teams. */
+export interface CommittedTrade {
+  /** How many players this team is due to receive. Each one will count. */
+  readonly arriving: number;
+  /** The players this team is due to give up. */
+  readonly leaving: ReadonlySet<string>;
+}
+
+/**
+ * How much room this team's accepted trades have already spoken for.
+ *
+ * **Worst case per trade, never netted across them.** Every trade that would
+ * raise this team's count is assumed to land; every trade that would relieve it
+ * is assumed not to. That is not pessimism for its own sake — acceptance is not
+ * execution, and a trade can still be vetoed or expire, so relief that has not
+ * happened cannot be spent. A trade whose departures outnumber its arrivals
+ * reserves nothing; it does not hand back space it has not yet freed.
+ *
+ * Netting is the mistake this exists to prevent, and it has two shapes:
+ *
+ * - **Netting a departure against today's roster.** Those players are still on
+ *   it. Subtracting them makes a full team look like it has room, and the add
+ *   that follows puts it over the limit *now* — permanently, if the trade is
+ *   then vetoed. There is no state in which that team is asked to drop anyone.
+ * - **Netting one trade against another.** A team holding a give-two-get-one
+ *   and a give-one-get-two nets to zero and reserves nothing. Veto the first,
+ *   execute the second, and it is over by one. Summing `max(0, …)` per trade
+ *   holds a slot for the second regardless of what happens to the first.
+ *
+ * Zero when a team has no accepted trades, which is the ordinary case.
+ */
+export function reservedByTrades(
+  roster: readonly IrRosterEntry[],
+  trades: readonly CommittedTrade[],
+  irSlots: number,
+): number {
+  const now = countedRosterSize(roster, irSlots);
+
+  return trades.reduce((total, trade) => {
+    /*
+      Per trade against the *current* roster, so the IR arithmetic is the one
+      `projectedRosterSize` documents: an outgoing stashed player frees an IR
+      slot rather than a roster slot, and frees nothing here either.
+    */
+    const after = projectedRosterSize({
+      roster,
+      leaving: trade.leaving,
+      arriving: trade.arriving,
+      irSlots,
+    });
+    return total + Math.max(0, after - now);
+  }, 0);
+}
+
 export type IrPlacementRefusal =
   /** The player is healthy, or carries a designation that does not qualify. */
   | "NOT_INJURED"

--- a/packages/core/src/waivers/claims.ts
+++ b/packages/core/src/waivers/claims.ts
@@ -58,6 +58,8 @@ export type ClaimFailure =
   | "ALREADY_ROSTERED"
   | "DROP_NOT_ON_ROSTER"
   | "DROP_ON_IR"
+  /** The team's remaining room is committed to a trade it has already accepted. */
+  | "SLOT_HELD_FOR_TRADE"
   | "PLAYER_UNAVAILABLE";
 
 export interface ClaimOutcome {
@@ -91,6 +93,20 @@ export interface ResolveInput {
   readonly rosters: ReadonlyMap<string, readonly RosterMember[]>;
   readonly pool: ReadonlyMap<string, DraftablePlayer>;
   readonly shape: RosterShape;
+  /**
+   * Slots each team has already committed to an accepted trade, net.
+   *
+   * A trade's rows do not move until it executes, so between acceptance and
+   * execution a team's roster understates what it is about to hold. Without this
+   * a claim awarded on Wednesday morning and a trade executing Wednesday night
+   * are each legal and together put the team over the limit — and the run cannot
+   * refuse by throwing, so the trade would be the thing that broke.
+   *
+   * Net of departures: a trade sending two and receiving one commits −1, which
+   * frees room rather than holding it. Computed by the caller, which is the only
+   * layer that can see both the accepted trades and the live IR designations.
+   */
+  readonly reserved?: ReadonlyMap<string, number>;
   /*
     Players stashed on injured reserve who currently qualify for it — the flag
     **and** a live eligible designation, decided by the caller.
@@ -119,7 +135,7 @@ export interface ResolveInput {
  * exactly.
  */
 export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
-  const { claims, priority, rosters, pool, shape, irExempt } = input;
+  const { claims, priority, rosters, pool, shape, irExempt, reserved } = input;
 
   const rank = new Map(priority.map((teamId, index) => [teamId, index]));
 
@@ -243,6 +259,21 @@ export function resolveWaiverClaims(input: ResolveInput): WaiverResolution {
       afterDrop.length - exempt >= shape.totalSlots
     ) {
       outcomes.push({ ...base, awarded: false, reason: "DROP_ON_IR" });
+      continue;
+    }
+
+    /*
+      Room held for a trade this team already accepted.
+
+      Checked here rather than folded into `exempt`, because `exempt` means
+      "how many of this array do not count" and these players are not in the
+      array at all — they are arriving later. Passing it through that parameter
+      would be arithmetically equivalent and would make the next reader wrong
+      about what the number means.
+    */
+    const held = reserved?.get(claim.teamId) ?? 0;
+    if (held > 0 && afterDrop.length - exempt + held >= shape.totalSlots) {
+      outcomes.push({ ...base, awarded: false, reason: "SLOT_HELD_FOR_TRADE" });
       continue;
     }
 

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -1759,6 +1759,41 @@ describe("a trade may never leave a team over the roster limit", () => {
     }
   };
 
+  const rosterIds = async (fx: Fixture, teamId: string): Promise<readonly string[]> => {
+    const rows = await fx.client.query<{ player_id: string }>(
+      `SELECT player_id FROM roster_entries
+        WHERE team_id = $1 AND released_at IS NULL ORDER BY player_id`,
+      [teamId],
+    );
+    return rows.map((row) => row.player_id);
+  };
+
+  const rowsHeldBy = async (fx: Fixture, teamId: string): Promise<number> => {
+    const [row] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [teamId],
+    );
+    return row!.n;
+  };
+
+  /** A free agent nobody holds, for the add tests below. */
+  const freeAgent = async (fx: Fixture, handle: string): Promise<string> => {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [position] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [player] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+      [sport!.id, handle, handle, position!.id],
+    );
+    return player!.id;
+  };
+
   const countedFor = async (fx: Fixture, teamId: string): Promise<number> => {
     const rows = await fx.client.query<{ on_ir: boolean; designation: string | null }>(
       `SELECT r.on_ir, p.injury_designation AS designation
@@ -1922,5 +1957,105 @@ describe("a trade may never leave a team over the roster limit", () => {
     // And the trade the room was held for still lands, at exactly the limit.
     await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
     expect(await countedFor(fx, fx.teams[1]!)).toBe(shape.totalSlots);
+  });
+
+  it("does not credit a departure that has not happened, so a full team still cannot add", async () => {
+    /*
+      The direction the sibling test above does not cover, and the one that
+      matters most: the team gives away *more* than it receives.
+
+      Holding the room for an accepted trade means projecting forward, and the
+      obvious projection subtracts the players the trade will take away. Those
+      players are still on the roster. Subtract them and a team at exactly the
+      limit reads as having room, the add is waved through, and it holds one
+      more than `totalSlots` from that moment — not when the trade lands, now.
+
+      Then veto the trade and the rows never move at all. There is no state
+      afterwards in which anybody is asked to drop, so the team simply stays
+      over. "A team can never have over the amount of players" is the owner's
+      rule and this is the path that breaks it.
+    */
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    await fillTo(fx, fx.teams[1]!, shape.totalSlots);
+
+    // Two out, one in: a trade this team has room for either way.
+    const gives = (await rosterIds(fx, fx.teams[1]!)).slice(0, 2);
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [fx.players.get("p1")!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [...gives],
+      now: MONDAY,
+    });
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const agent = await freeAgent(fx, "surplus-agent");
+
+    // Full is full. Not `SLOT_HELD_FOR_TRADE`: there is no spare slot being
+    // held, the roster is at the limit today, and dropping somebody is exactly
+    // what would let this through — which is what `ROSTER_FULL` tells them and
+    // the other code does not.
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[1]!,
+        addPlayerId: agent,
+        now: new Date("2026-10-14T12:00:00Z"),
+      }),
+    ).rejects.toMatchObject({ code: "ROSTER_FULL" });
+
+    expect(await rowsHeldBy(fx, fx.teams[1]!)).toBe(shape.totalSlots);
+  });
+
+  it("does not let one accepted trade pay for another, since only one may land", async () => {
+    /*
+      Two accepted trades are not one bigger trade. Each is all-or-nothing, and
+      either can be vetoed independently, so a projection that merges them
+      assumes an outcome nobody has agreed to.
+
+      Here the first trade sends two away for one, and the second brings two in
+      for one. Merged, they cancel: three out, three in, and the second is
+      accepted. Veto the first — an ordinary thing for a league to do — and the
+      second executes against a roster that never shrank, one over the limit,
+      with both trades having passed every check that was made.
+
+      Counting the worst case per trade refuses the second at acceptance, which
+      is the recoverable moment: nothing has moved, and the team can accept it
+      again once the first has landed.
+    */
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    await fillTo(fx, fx.teams[0]!, 5);
+    await fillTo(fx, fx.teams[1]!, shape.totalSlots);
+
+    const held = await rosterIds(fx, fx.teams[1]!);
+    const mine = await rosterIds(fx, fx.teams[0]!);
+
+    // Two out, one in. Accepted, and correctly so.
+    const first = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [mine[0]!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [held[0]!, held[1]!],
+      now: MONDAY,
+    });
+    await acceptTrade(fx.client, first.tradeId, fx.teams[1]!, MONDAY);
+
+    // One out, two in — against a roster still holding all fourteen.
+    const second = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [mine[1]!, mine[2]!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [held[2]!],
+      now: MONDAY,
+    });
+
+    await expect(
+      acceptTrade(fx.client, second.tradeId, fx.teams[1]!, MONDAY),
+    ).rejects.toMatchObject({ code: "ROSTER_WOULD_OVERFLOW" });
   });
 });

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildNflPprRules, NFL } from "@rostr/core";
+import { buildNflPprRules, buildRosterShape, countedRosterSize, NFL } from "@rostr/core";
 import type { DraftRules, LeagueRules } from "@rostr/core";
 import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
@@ -1380,8 +1380,11 @@ describe("resolution", () => {
 
   it("executes an uneven trade", async () => {
     // Two for one. Team 1 starts with two players and ends with one; team 2
-    // starts with one and ends with two. Rosters changing size is legal — a
-    // roster limit is a lineup concern, not a trade one.
+    // starts with one and ends with two.
+    //
+    // An uneven trade is legal — no proposal is refused for its shape. What is
+    // refused is one that would leave a team holding more than `totalSlots`,
+    // and this fixture is far below it, so the shape is all this exercises.
     const fx = await setup();
     const { tradeId } = await proposeTrade(fx.client, {
       leagueId: fx.leagueId,
@@ -1705,5 +1708,219 @@ describe("a veto cast while the trade is being resolved — #134", () => {
       tradeId,
     ]);
     expect(rows).toHaveLength(1);
+  });
+});
+
+describe("a trade may never leave a team over the roster limit", () => {
+  /*
+    Issue #250. Trades applied no capacity check at all, so a two-for-one put a
+    team over `totalSlots` and nothing refused, reported or repaired it.
+
+    Two things about this are easy to get wrong, and both are exercised below.
+
+    **The check is on counted size, not row count.** Rows conserve across a
+    trade — one side's loss is the other's gain — but counted size does not,
+    because an outgoing player stashed on IR was never being counted while every
+    incoming player is. So a plain one-for-one can raise *both* teams.
+
+    **It has to hold at execution, not acceptance.** The rows move when the veto
+    window closes, so a team can accept with room, acquire somebody meanwhile,
+    and land over. Neither move is illegal alone. The room is held from
+    acceptance instead, so the later acquisition is what gets refused.
+  */
+
+  /** Top a team up to `count` rows, beyond whatever `setup` gave it. */
+  const fillTo = async (fx: Fixture, teamId: string, count: number): Promise<void> => {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [position] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [held] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [teamId],
+    );
+
+    for (let i = held!.n; i < count; i++) {
+      const handle = `filler-${teamId.slice(0, 8)}-${i}`;
+      const [player] = await fx.client.query<{ id: string }>(
+        `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+         VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+        [sport!.id, handle, handle, position!.id],
+      );
+      await fx.client.query(
+        `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+         VALUES ($1, $2, 'DRAFT', $3)`,
+        [teamId, player!.id, new Date(MONDAY.getTime() - 30 * 24 * HOUR)],
+      );
+    }
+  };
+
+  const countedFor = async (fx: Fixture, teamId: string): Promise<number> => {
+    const rows = await fx.client.query<{ on_ir: boolean; designation: string | null }>(
+      `SELECT r.on_ir, p.injury_designation AS designation
+         FROM roster_entries r JOIN players p ON p.id = r.player_id
+        WHERE r.team_id = $1 AND r.released_at IS NULL`,
+      [teamId],
+    );
+    return countedRosterSize(
+      rows.map((row, index) => ({
+        playerId: String(index),
+        onIr: row.on_ir,
+        injuryDesignation: row.designation,
+      })),
+      buildRosterShape(fx.rules.roster, NFL).irSlots,
+    );
+  };
+
+  it("refuses an acceptance that would put the accepting team over", async () => {
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    await fillTo(fx, fx.teams[1]!, shape.totalSlots);
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [fx.players.get("p1")!, fx.players.get("spare")!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [fx.players.get("p2")!],
+      now: MONDAY,
+    });
+
+    // Says how many, because "full" without a number is not actionable.
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "ROSTER_WOULD_OVERFLOW",
+    });
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toThrow(
+      /release 1 more/,
+    );
+  });
+
+  it("accepts once the receiving team has made room", async () => {
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    await fillTo(fx, fx.teams[1]!, shape.totalSlots - 1);
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [fx.players.get("p1")!, fx.players.get("spare")!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [fx.players.get("p2")!],
+      now: MONDAY,
+    });
+
+    const accepted = await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    expect(accepted.state).toBe("ACCEPTED");
+
+    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    expect(await countedFor(fx, fx.teams[1]!)).toBe(shape.totalSlots);
+  });
+
+  it("refuses a one-for-one that would put BOTH teams over", async () => {
+    /*
+      The case a row-count check passes silently, and the reason this one is
+      written against counted size.
+
+      Each team sits at the limit with one player stashed on IR, so each holds
+      one more row than it counts. They swap those two stashed players: no row
+      moves on net, and both teams rise by one counted, because an arriving
+      player never carries the IR flag across.
+    */
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+
+    const stashed: string[] = [];
+    for (const teamId of [fx.teams[0]!, fx.teams[1]!]) {
+      await fillTo(fx, teamId, shape.totalSlots + 1);
+
+      const [row] = await fx.client.query<{ player_id: string }>(
+        `SELECT player_id FROM roster_entries
+          WHERE team_id = $1 AND released_at IS NULL ORDER BY player_id LIMIT 1`,
+        [teamId],
+      );
+      await fx.client.query(
+        "UPDATE players SET injury_designation = 'Injured Reserve' WHERE id = $1",
+        [row!.player_id],
+      );
+      await fx.client.query(
+        "UPDATE roster_entries SET on_ir = true WHERE team_id = $1 AND player_id = $2",
+        [teamId, row!.player_id],
+      );
+      stashed.push(row!.player_id);
+    }
+
+    expect(await countedFor(fx, fx.teams[0]!)).toBe(shape.totalSlots);
+    expect(await countedFor(fx, fx.teams[1]!)).toBe(shape.totalSlots);
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      proposerGives: [stashed[0]!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [stashed[1]!],
+      now: MONDAY,
+    });
+
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "ROSTER_WOULD_OVERFLOW",
+    });
+  });
+
+  it("holds the room, so an add inside the veto window is refused", async () => {
+    /*
+      The half acceptance alone cannot cover. The team accepts with exactly
+      enough room, then tries to sign a free agent before the trade executes.
+      Both moves are legal alone; only the pair is not, and the add is the one
+      nobody has committed to yet.
+    */
+    const fx = await setup();
+    const shape = buildRosterShape(fx.rules.roster, NFL);
+    await fillTo(fx, fx.teams[1]!, shape.totalSlots - 1);
+
+    const { tradeId } = await proposeTrade(fx.client, {
+      leagueId: fx.leagueId,
+      proposerTeamId: fx.teams[0]!,
+      // Two for one: the receiving team nets one player, so one slot is held.
+      // A one-for-one would hold nothing, because it is net zero — and an add
+      // during its window is legitimately fine.
+      proposerGives: [fx.players.get("p1")!, fx.players.get("spare")!],
+      receiverTeamId: fx.teams[1]!,
+      receiverGives: [fx.players.get("p2")!],
+      now: MONDAY,
+    });
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [position] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [agent] = await fx.client.query<{ id: string }>(
+      `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+       VALUES ($1, 'free-agent', 'Free Agent', $2, 'CIN') RETURNING id`,
+      [sport!.id, position!.id],
+    );
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[1]!,
+        addPlayerId: agent!.id,
+        // Wednesday midday: no game in progress, so the kickoff guard is not
+        // what refuses this. The sibling freeze tests use the same instant.
+        now: new Date("2026-10-14T12:00:00Z"),
+      }),
+    ).rejects.toMatchObject({ code: "SLOT_HELD_FOR_TRADE" });
+
+    // And the trade the room was held for still lands, at exactly the limit.
+    await resolveDueTrades(fx.client, fx.leagueId, AFTER_WINDOW);
+    expect(await countedFor(fx, fx.teams[1]!)).toBe(shape.totalSlots);
   });
 });

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -25,8 +25,11 @@
  */
 
 import {
+  buildRosterShape,
   isVetoed,
+  NFL,
   pastTradeDeadline,
+  projectedRosterSize,
   tradeBlockedBecause,
   vetoWindowEndsAt,
   vetoWindowHasClosed,
@@ -281,6 +284,70 @@ export async function lockedByTrade(
   return new Set(rows.map((row) => row.player_id));
 }
 
+/** What each team's accepted trades have committed it to receive and to give up. */
+export interface CommittedTradeMoves {
+  /** How many players are due to arrive. Each one will count: see below. */
+  readonly arriving: number;
+  /** Players due to leave. */
+  readonly leaving: ReadonlySet<string>;
+}
+
+/**
+ * The roster moves every accepted trade in this league is committed to make.
+ *
+ * Derived from `trades.state = 'ACCEPTED'`, not stored. A second table would be a
+ * copy free to disagree with the original, which is the argument
+ * `notifications.ts` makes for deriving rather than recording.
+ *
+ * This exists because a trade's rows do not move until it executes. Between
+ * acceptance and execution a team can legally acquire somebody, and the pair —
+ * legal add plus legal trade — lands them over the roster limit with nothing
+ * having looked at both. Counting the committed moves against a team from the
+ * moment it accepts holds the room, so the add is refused rather than the trade
+ * failing later for a reason neither side caused.
+ *
+ * Same query as {@link lockedByTrade}, one column wider: that one asks which
+ * players are frozen, this one asks which way they are going.
+ */
+export async function committedTradeMoves(
+  db: SqlClient,
+  leagueId: string,
+): Promise<ReadonlyMap<string, CommittedTradeMoves>> {
+  const rows = await db.query<{
+    proposer_team_id: string;
+    receiver_team_id: string;
+    from_team_id: string;
+    player_id: string;
+  }>(
+    `SELECT t.proposer_team_id, t.receiver_team_id, a.from_team_id, a.player_id
+       FROM trade_assets a
+       JOIN trades t ON t.id = a.trade_id
+      WHERE t.league_id = $1 AND t.state = 'ACCEPTED'`,
+    [leagueId],
+  );
+
+  const moves = new Map<string, { arriving: number; leaving: Set<string> }>();
+  const forTeam = (teamId: string) => {
+    const found = moves.get(teamId);
+    if (found) return found;
+    const fresh = { arriving: 0, leaving: new Set<string>() };
+    moves.set(teamId, fresh);
+    return fresh;
+  };
+
+  for (const row of rows) {
+    // The same derivation `resolveTrade` uses: an asset goes to whichever side
+    // of the trade did not send it.
+    const toTeamId =
+      row.from_team_id === row.proposer_team_id ? row.receiver_team_id : row.proposer_team_id;
+
+    forTeam(row.from_team_id).leaving.add(row.player_id);
+    forTeam(toTeamId).arriving += 1;
+  }
+
+  return moves;
+}
+
 // ---------------------------------------------------------------------------
 // Proposing
 // ---------------------------------------------------------------------------
@@ -464,6 +531,46 @@ function explain(code: string, rules: LeagueRules): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * What a team will count as holding once this trade and its siblings land.
+ *
+ * Reads the designation live, like every other capacity check in the repo, so a
+ * player who recovers while a trade is pending starts counting from that moment.
+ */
+async function projectedSizeFor(
+  tx: SqlClient,
+  teamId: string,
+  irSlots: number,
+  moves: ReadonlyMap<string, CommittedTradeMoves>,
+  extra: { readonly arriving: number; readonly leaving: ReadonlySet<string> },
+): Promise<number> {
+  const held = await tx.query<{
+    player_id: string;
+    on_ir: boolean;
+    designation: string | null;
+  }>(
+    `SELECT r.player_id, r.on_ir, p.injury_designation AS designation
+       FROM roster_entries r
+       JOIN players p ON p.id = r.player_id
+      WHERE r.team_id = $1 AND r.released_at IS NULL`,
+    [teamId],
+  );
+
+  const committed = moves.get(teamId);
+  const leaving = new Set([...(committed?.leaving ?? []), ...extra.leaving]);
+
+  return projectedRosterSize({
+    roster: held.map((row) => ({
+      playerId: row.player_id,
+      onIr: row.on_ir,
+      injuryDesignation: row.designation,
+    })),
+    leaving,
+    arriving: (committed?.arriving ?? 0) + extra.arriving,
+    irSlots,
+  });
+}
+
+/**
  * Accept a trade, opening the veto window.
  *
  * This is the moment the players freeze. Nothing moves yet — rosters swap only
@@ -545,6 +652,56 @@ export async function acceptTrade(
         throw new TradeError(
           `${asset.player_id} is already committed to an accepted trade`,
           "PLAYER_IN_ANOTHER_TRADE",
+        );
+      }
+    }
+
+    /*
+      Capacity, for BOTH teams, and on counted size rather than row count.
+
+      Rows conserve across a trade; counted size does not. An outgoing player
+      who was stashed on IR was not being counted, so his departure frees
+      nothing — while every incoming player counts, because a trade never
+      carries the IR flag across. So a plain one-for-one of two stashed players
+      takes two teams that were each exactly at the limit to one over, each.
+      There is no 'side receiving more' to scope this to.
+
+      Checked here rather than at execution because a throw there is unrecoverable
+      in the wrong way: `resolveDueTrades` writes a terminal state for one error
+      only, so an over-capacity failure would leave the trade ACCEPTED and retried
+      hourly, freezing the counterparty's players indefinitely for a roster
+      problem that is not theirs.
+
+      And checked against what the accepted trades of this league have already
+      committed each team to, not merely what they hold now — otherwise a team
+      accepts with room, signs a free agent inside the veto window, and lands
+      over the limit when the trade executes. Both acquisitions are legal; only
+      the pair is not.
+    */
+    const shape = buildRosterShape(stored.rules.roster, NFL);
+    const moves = await committedTradeMoves(tx, trade.leagueId);
+
+    for (const teamId of [trade.receiverTeamId, trade.proposerTeamId]) {
+      const gives = new Set(
+        assets.filter((a) => a.from_team_id === teamId).map((a) => a.player_id),
+      );
+      const gets = assets.filter((a) => a.from_team_id !== teamId).length;
+
+      const projected = await projectedSizeFor(tx, teamId, shape.irSlots, moves, {
+        arriving: gets,
+        leaving: gives,
+      });
+
+      if (projected > shape.totalSlots) {
+        const over = projected - shape.totalSlots;
+        const mine = teamId === actingTeamId;
+        throw new TradeError(
+          mine
+            ? `Accepting this leaves you holding ${projected} players and the limit is ` +
+                `${shape.totalSlots} — release ${over} more first.`
+            : `The other team no longer has room for what you are sending back, so this ` +
+                `trade cannot be accepted.`,
+          "ROSTER_WOULD_OVERFLOW",
         );
       }
     }

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -30,12 +30,13 @@ import {
   NFL,
   pastTradeDeadline,
   projectedRosterSize,
+  reservedByTrades,
   tradeBlockedBecause,
   vetoWindowEndsAt,
   vetoWindowHasClosed,
   vetoesRequired,
 } from "@rostr/core";
-import type { LeagueRules } from "@rostr/core";
+import type { CommittedTrade, LeagueRules } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { withTransaction } from "./transaction.js";
@@ -284,13 +285,17 @@ export async function lockedByTrade(
   return new Set(rows.map((row) => row.player_id));
 }
 
-/** What each team's accepted trades have committed it to receive and to give up. */
-export interface CommittedTradeMoves {
-  /** How many players are due to arrive. Each one will count: see below. */
-  readonly arriving: number;
-  /** Players due to leave. */
-  readonly leaving: ReadonlySet<string>;
-}
+/**
+ * Every accepted trade a team is party to, **one entry each**.
+ *
+ * Kept apart rather than merged into a single arriving/leaving pair, because
+ * merging them loses the fact that a trade is all-or-nothing: two trades that
+ * cancel out on paper reserve nothing once merged, and the team ends up over
+ * the limit when one is vetoed and the other executes. `reservedByTrades`
+ * takes the worst case across them, which it can only do if it can still see
+ * where one trade ends and the next begins.
+ */
+export type CommittedTradeMoves = readonly CommittedTrade[];
 
 /**
  * The roster moves every accepted trade in this league is committed to make.
@@ -314,24 +319,31 @@ export async function committedTradeMoves(
   leagueId: string,
 ): Promise<ReadonlyMap<string, CommittedTradeMoves>> {
   const rows = await db.query<{
+    trade_id: string;
     proposer_team_id: string;
     receiver_team_id: string;
     from_team_id: string;
     player_id: string;
   }>(
-    `SELECT t.proposer_team_id, t.receiver_team_id, a.from_team_id, a.player_id
+    `SELECT t.id AS trade_id, t.proposer_team_id, t.receiver_team_id,
+            a.from_team_id, a.player_id
        FROM trade_assets a
        JOIN trades t ON t.id = a.trade_id
       WHERE t.league_id = $1 AND t.state = 'ACCEPTED'`,
     [leagueId],
   );
 
-  const moves = new Map<string, { arriving: number; leaving: Set<string> }>();
-  const forTeam = (teamId: string) => {
-    const found = moves.get(teamId);
+  const moves = new Map<string, Map<string, { arriving: number; leaving: Set<string> }>>();
+  const forTeam = (teamId: string, tradeId: string) => {
+    let byTrade = moves.get(teamId);
+    if (!byTrade) {
+      byTrade = new Map();
+      moves.set(teamId, byTrade);
+    }
+    const found = byTrade.get(tradeId);
     if (found) return found;
     const fresh = { arriving: 0, leaving: new Set<string>() };
-    moves.set(teamId, fresh);
+    byTrade.set(tradeId, fresh);
     return fresh;
   };
 
@@ -341,11 +353,11 @@ export async function committedTradeMoves(
     const toTeamId =
       row.from_team_id === row.proposer_team_id ? row.receiver_team_id : row.proposer_team_id;
 
-    forTeam(row.from_team_id).leaving.add(row.player_id);
-    forTeam(toTeamId).arriving += 1;
+    forTeam(row.from_team_id, row.trade_id).leaving.add(row.player_id);
+    forTeam(toTeamId, row.trade_id).arriving += 1;
   }
 
-  return moves;
+  return new Map([...moves].map(([teamId, byTrade]) => [teamId, [...byTrade.values()]]));
 }
 
 // ---------------------------------------------------------------------------
@@ -555,19 +567,29 @@ async function projectedSizeFor(
     [teamId],
   );
 
-  const committed = moves.get(teamId);
-  const leaving = new Set([...(committed?.leaving ?? []), ...extra.leaving]);
+  const roster = held.map((row) => ({
+    playerId: row.player_id,
+    onIr: row.on_ir,
+    injuryDesignation: row.designation,
+  }));
 
-  return projectedRosterSize({
-    roster: held.map((row) => ({
-      playerId: row.player_id,
-      onIr: row.on_ir,
-      injuryDesignation: row.designation,
-    })),
-    leaving,
-    arriving: (committed?.arriving ?? 0) + extra.arriving,
-    irSlots,
-  });
+  /*
+    Two different questions, and they must not be answered the same way.
+
+    The trade being accepted is *atomic*: its departures and its arrivals move
+    in one transaction, so its departures do free room for its own arrivals. A
+    two-for-one is permitted, which is the owner's rule.
+
+    Every other accepted trade is *conditional*. Its rows have not moved and may
+    never move, so it can only take room, never give it back. Merging the two
+    sets — which is what this used to do — credits a departure that has not
+    happened against an arrival that might, and lets both a veto and a second
+    trade put the team over.
+  */
+  return (
+    projectedRosterSize({ roster, leaving: extra.leaving, arriving: extra.arriving, irSlots }) +
+    reservedByTrades(roster, moves.get(teamId) ?? [], irSlots)
+  );
 }
 
 /**

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -39,7 +39,7 @@ import {
   availabilityAt,
   everyoneIsOnWaivers,
   buildRosterShape,
-  countedRosterSize,
+  projectedRosterSize,
   isIrEligible,
   dropDestination,
   initialWaiverPriority,
@@ -53,7 +53,7 @@ import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { isUniqueViolation } from "./pg-errors.js";
 import { loadDraftBoard } from "./sync.js";
-import { lockedByTrade } from "./trades.js";
+import { committedTradeMoves, lockedByTrade } from "./trades.js";
 import { withTransaction } from "./transaction.js";
 import { transactionWeek } from "./week.js";
 
@@ -68,6 +68,8 @@ export class WaiverError extends Error {
       | "NOT_A_FREE_AGENT"
       | "NOT_ON_WAIVERS"
       | "ROSTER_FULL"
+      /** A slot is being held for a trade this team accepted but that has not executed. */
+      | "SLOT_HELD_FOR_TRADE"
       | "DUPLICATE_CLAIM"
       | "IN_A_TRADE"
       | "GAME_STARTED",
@@ -617,16 +619,44 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
       [input.teamId],
     );
     const shape = buildRosterShape(stored.rules.roster, NFL);
-    const counted = countedRosterSize(
-      held.map((row) => ({
+
+    /*
+      Counted against what accepted trades have already committed this team to,
+      not only what it holds right now.
+
+      A trade's rows do not move until it executes, so without this a manager
+      accepts a trade they have room for, signs a free agent inside the veto
+      window, and the trade lands them over the limit. Neither move is illegal
+      alone. Holding the room from acceptance means this add is refused instead —
+      which is the recoverable half of the pair, because the trade is a decision
+      two managers already made and this is one nobody has made yet.
+    */
+    const moves = await committedTradeMoves(tx, input.leagueId);
+    const committed = moves.get(input.teamId);
+    const projected = projectedRosterSize({
+      roster: held.map((row) => ({
         playerId: row.player_id,
         onIr: row.on_ir,
         injuryDesignation: row.designation,
       })),
-      shape.irSlots,
-    );
-    if (counted >= shape.totalSlots) {
-      throw new WaiverError("This roster is full — drop someone first", "ROSTER_FULL");
+      leaving: committed?.leaving ?? new Set<string>(),
+      arriving: committed?.arriving ?? 0,
+      irSlots: shape.irSlots,
+    });
+
+    if (projected >= shape.totalSlots) {
+      // Named apart from a plain full roster, because the manager is looking at
+      // an empty slot. `whyClaimFailed` says a full roster stayed full "even
+      // after any drop the claim named", which would be untrue here and would
+      // send them dropping players that will not help.
+      const held = committed !== undefined && committed.arriving > 0;
+      throw new WaiverError(
+        held
+          ? "A roster spot is being held for a trade you accepted, so there is no room " +
+              "for this add until that trade executes or is vetoed"
+          : "This roster is full — drop someone first",
+        held ? "SLOT_HELD_FOR_TRADE" : "ROSTER_FULL",
+      );
     }
 
     // The arbitration, and the only part of it that holds under concurrency.
@@ -1036,6 +1066,29 @@ export async function processWaivers(
     const dropIsFrozen = (row: { drop_player_id: string | null }): boolean =>
       row.drop_player_id !== null && frozen.has(row.drop_player_id);
 
+    /*
+      Room already committed to accepted trades, per team and net of departures.
+
+      `frozen` above stops a claim *dropping* a player a trade is waiting on.
+      This stops a claim *filling* a slot a trade is waiting to arrive into —
+      the same hazard from the other direction, and the one that would otherwise
+      make the trade fail for something the trade did not do.
+
+      Departures are netted off using the same live designations everything else
+      here reads: a player leaving who was stashed on IR was not counting, so his
+      going frees nothing and must not be credited as though it did.
+    */
+    const moves = await committedTradeMoves(tx, leagueId);
+    const reserved = new Map<string, number>();
+    for (const [teamId, move] of moves) {
+      const roster = rosters.get(teamId) ?? [];
+      const countedLeaving = roster.filter(
+        (member) => move.leaving.has(member.playerId) && !irExempt.has(member.playerId),
+      ).length;
+      const net = move.arriving - countedLeaving;
+      if (net > 0) reserved.set(teamId, net);
+    }
+
     const resolution = resolveWaiverClaims({
       claims: claims
         .filter(
@@ -1058,6 +1111,7 @@ export async function processWaivers(
       rosters,
       pool,
       shape,
+      reserved,
       irExempt,
     });
 

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -39,7 +39,8 @@ import {
   availabilityAt,
   everyoneIsOnWaivers,
   buildRosterShape,
-  projectedRosterSize,
+  countedRosterSize,
+  reservedByTrades,
   isIrEligible,
   dropDestination,
   initialWaiverPriority,
@@ -48,7 +49,7 @@ import {
   resolveWaiverClaims,
   waiverClearsAt,
 } from "@rostr/core";
-import type { RosterMember, DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
+import type { IrRosterEntry, DraftablePlayer, LeagueRules, WaiverClaim } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { isUniqueViolation } from "./pg-errors.js";
@@ -632,30 +633,51 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
       two managers already made and this is one nobody has made yet.
     */
     const moves = await committedTradeMoves(tx, input.leagueId);
-    const committed = moves.get(input.teamId);
-    const projected = projectedRosterSize({
-      roster: held.map((row) => ({
-        playerId: row.player_id,
-        onIr: row.on_ir,
-        injuryDesignation: row.designation,
-      })),
-      leaving: committed?.leaving ?? new Set<string>(),
-      arriving: committed?.arriving ?? 0,
-      irSlots: shape.irSlots,
-    });
+    const roster = held.map((row) => ({
+      playerId: row.player_id,
+      onIr: row.on_ir,
+      injuryDesignation: row.designation,
+    }));
 
-    if (projected >= shape.totalSlots) {
-      // Named apart from a plain full roster, because the manager is looking at
-      // an empty slot. `whyClaimFailed` says a full roster stayed full "even
-      // after any drop the claim named", which would be untrue here and would
-      // send them dropping players that will not help.
-      const held = committed !== undefined && committed.arriving > 0;
+    /*
+      Present tense first, then what has been promised away.
+
+      `counting` is what this team holds *now*. Nothing an accepted trade has
+      committed to may reduce it: those players are still on the roster, and the
+      trade can still be vetoed, in which case they stay. Subtracting them here
+      is how a full team was waved through into holding one more than the limit
+      — with no state afterwards that asks anyone to drop.
+
+      `reservedByTrades` then adds back only what the trades can *take*, worst
+      case and per trade.
+    */
+    const counting = countedRosterSize(roster, shape.irSlots);
+    const reserved = reservedByTrades(roster, moves.get(input.teamId) ?? [], shape.irSlots);
+
+    if (counting + reserved >= shape.totalSlots) {
+      /*
+        Which of the two refused it decides what the manager is told, and telling
+        them the wrong one sends them to the wrong screen.
+
+        A full roster is `ROSTER_FULL`: drop someone and the add works. It is
+        only `SLOT_HELD_FOR_TRADE` when there is room today and a trade has
+        spoken for it — the case where the manager is looking at an empty slot,
+        and where `whyClaimFailed`'s "still full even after any drop the claim
+        named" would be untrue.
+
+        Keyed on which count crossed the line, not on whether a trade exists.
+        Every accepted trade has an arriving side — `proposeTrade` refuses
+        `NOTHING_OFFERED` — so "this team is in a trade" would relabel every
+        genuinely full roster and tell managers that dropping will not help, when
+        it is the only thing that will.
+      */
+      const spokenFor = counting < shape.totalSlots;
       throw new WaiverError(
-        held
+        spokenFor
           ? "A roster spot is being held for a trade you accepted, so there is no room " +
               "for this add until that trade executes or is vetoed"
           : "This roster is full — drop someone first",
-        held ? "SLOT_HELD_FOR_TRADE" : "ROSTER_FULL",
+        spokenFor ? "SLOT_HELD_FOR_TRADE" : "ROSTER_FULL",
       );
     }
 
@@ -947,7 +969,18 @@ export async function processWaivers(
       [leagueId],
     );
 
-    const rosters = new Map<string, RosterMember[]>(priority.map((teamId) => [teamId, []]));
+    /*
+      `IrRosterEntry`, not `RosterMember`: the query already selects `on_ir` and
+      the designation, and the trade reservation below has to ask the same
+      question about a departing player that every other capacity check asks —
+      was he counting? Deriving that from a separate set would be a second
+      answer free to disagree with the first, and the capping (`irSlots` bounds
+      how many may be exempt) is exactly where two answers drift apart.
+
+      Still assignable where `RosterMember` is wanted, so the resolver's
+      identity-and-count contract is unchanged.
+    */
+    const rosters = new Map<string, IrRosterEntry[]>(priority.map((teamId) => [teamId, []]));
 
     /*
       Ownership comes from `rosterRows` and from nothing else.
@@ -975,7 +1008,11 @@ export async function processWaivers(
     */
     const irExempt = new Set<string>();
     for (const row of rosterRows) {
-      rosters.get(row.team_id)?.push({ playerId: row.player_id });
+      rosters.get(row.team_id)?.push({
+        playerId: row.player_id,
+        onIr: row.on_ir,
+        injuryDesignation: row.designation,
+      });
       if (row.on_ir && isIrEligible(row.designation)) irExempt.add(row.player_id);
     }
 
@@ -1074,19 +1111,21 @@ export async function processWaivers(
       the same hazard from the other direction, and the one that would otherwise
       make the trade fail for something the trade did not do.
 
-      Departures are netted off using the same live designations everything else
-      here reads: a player leaving who was stashed on IR was not counting, so his
-      going frees nothing and must not be credited as though it did.
+      Worst case per trade, and never netted across them. A departure that has
+      not happened frees nothing — the trade can still be vetoed — and two
+      trades that cancel out on paper still reserve a slot for whichever of them
+      would raise the count, because only one of them may land.
+
+      The IR arithmetic comes with it: a player leaving who was stashed on IR was
+      not counting, so his going returns no room and is not credited as though it
+      did.
     */
     const moves = await committedTradeMoves(tx, leagueId);
     const reserved = new Map<string, number>();
-    for (const [teamId, move] of moves) {
-      const roster = rosters.get(teamId) ?? [];
-      const countedLeaving = roster.filter(
-        (member) => move.leaving.has(member.playerId) && !irExempt.has(member.playerId),
-      ).length;
-      const net = move.arriving - countedLeaving;
-      if (net > 0) reserved.set(teamId, net);
+    for (const [teamId, trades] of moves) {
+      const held = rosters.get(teamId) ?? [];
+      const room = reservedByTrades(held, trades, shape.irSlots);
+      if (room > 0) reserved.set(teamId, room);
     }
 
     const resolution = resolveWaiverClaims({


### PR DESCRIPTION
Closes #250.

`proposeTrade`, `acceptTrade` and `resolveTrade` applied **no capacity check of any kind**. Verified end to end on a real fixture: a two-for-one leaves the receiving team with **15 active roster rows against a limit of 14**, and no constraint, trigger or index anywhere in the schema fires. Trades stack — a second one takes them to 16.

The rule now enforced, per the owner's decision:

> A roster may never hold more than the limit. Nothing may put a team over — not a trade, not a waiver award, not a free agent. The one exception is a player on injured reserve recovering: he stops being exempt, he is never forced off, and until it is resolved the team may acquire nobody.

## Counted size, not row count — and both teams

The tempting check is on the side receiving more players. **It is wrong, and silently.**

Rows conserve across a trade. Counted size does not: an outgoing player stashed on IR was never being counted, so his departure frees nothing, while every incoming player counts because a trade deliberately never carries the IR flag across.

So a plain **one-for-one of two stashed players** takes two teams that were each exactly at the limit to one over — *each*. Executed:

```
before:  A { rows: 15, onIrRows: 1, counted: 14 }
         B { rows: 15, onIrRows: 1, counted: 14 }
after:   A { rows: 15, onIrRows: 0, counted: 15 }
         B { rows: 15, onIrRows: 0, counted: 15 }
```

There is no "side receiving more" in that trade at all. There is a test.

## Held from acceptance, not checked at execution

A trade's rows do not move when it is accepted — they move up to 48 hours later, when the veto window closes. So a team can accept a trade it has room for, sign a free agent or win a waiver claim in the meantime, and be over when the trade lands. **Neither acquisition is illegal alone; only the pair is, and nothing looking at one could see the other.** Both routes were reproduced before the fix.

Re-checking at execution would be worse than the bug. `resolveDueTrades` writes a terminal state for exactly one error — the one establishing a trade can *never* execute — so an over-capacity failure would leave the trade `ACCEPTED` and retried hourly, **freezing the counterparty's players indefinitely** over a roster problem that is not theirs. And killing it outright contradicts `RULES.md`: *a trade the league does not veto stands.*

So the room is reserved from acceptance, derived from `trades.state = 'ACCEPTED'` rather than stored, and the **intervening acquisition** is what gets refused — the recoverable half of the pair. The trade is a decision two managers already made; the add is one nobody has made yet.

`addFreeAgent` and the waiver resolver report this as `SLOT_HELD_FOR_TRADE` rather than reusing `ROSTER_FULL`, whose copy says the roster stayed full *"even after any drop the claim named"* — untrue, and actively misleading, to a manager looking at an empty slot they are holding.

## `RULES.md` said the opposite

The replaced paragraph:

> **Rosters may change size.** A two-for-one is a normal trade; roster limits are a lineup concern.

That is in the document members sign. And `ROSTER_WOULD_OVERFLOW` **already existed** on the error union and was already mapped to 409 — thrown nowhere. `git log -S` puts it in the *same commit* that wrote that sentence. The refusal was scaffolded and then documented away; this wires it.

## Verified

`pnpm test` **2285 passed**, typecheck, lint and format clean. The three new tests were run against the code with each guard disabled to confirm they fail: they do.

Every capacity check consumes `countedRosterSize` / the new `projectedRosterSize`, so "how many players may a team hold" keeps one answer rather than acquiring a fourth.

## Deliberately not here

- **Atomic drop-as-part-of-accepting.** The refusal names how many to release and the manager drops on the market screen they already have. Making it one action needs a `release.ts` extraction to break a module cycle plus a trade-UI player picker — a separate change, and this one holds the invariant without it.
- **`activateFromIr` has no capacity check**, so a team at the limit can activate a *still-injured* stashed player and sit over. A second unsanctioned route past the same line. Filed.
- **A team over the cap by IR recovery must drop twice, using standalone drops** — add-with-drop and waiver-with-drop both refuse, and `ROSTER_FULL` is the only explanation. A dead end on the one over-cap path the rules permit. Filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
