### PR TITLE
fix(db): a drafted player cut by his club fell out of his own team's roster (#253)

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/draft/pick/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/draft/pick/route.ts
@@ -13,6 +13,11 @@ const STATUS: Record<string, number> = {
   ROSTER_FULL: 409,
   ALREADY_ROSTERED: 409,
   ORDER_NOT_DRAWN: 409,
+  // Both mean the engine was handed a pool that does not contain this draft's
+  // own picks. Not a conflict a manager can retry out of, so not the 409 the
+  // fallback below would give it.
+  POOL_INCOMPLETE: 500,
+  PICK_PLAYER_MISSING: 500,
 };
 
 /**

--- a/packages/core/src/draft/state.ts
+++ b/packages/core/src/draft/state.ts
@@ -36,6 +36,8 @@ export type DraftErrorCode =
   | "NOT_ON_CLOCK"
   | "PLAYER_UNAVAILABLE"
   | "NO_LEGAL_PICK"
+  /** A pick names somebody the caller's pool does not contain. See {@link rosterFor}. */
+  | "POOL_INCOMPLETE"
   | IllegalPickReason;
 
 export class DraftError extends Error {
@@ -80,8 +82,33 @@ export function rosterFor(
 ): readonly DraftablePlayer[] {
   return state.picks
     .filter((pick) => pick.teamId === teamId)
-    .map((pick) => pool.get(pick.playerId))
-    .filter((player): player is DraftablePlayer => player !== undefined);
+    .map((pick) => {
+      const player = pool.get(pick.playerId);
+      if (!player) {
+        /*
+          Not a case to handle.
+
+          You cannot have drafted somebody who was never on the board — `makePick`
+          refuses a player the pool does not contain — so a miss here means the
+          caller's pool is not the pool this draft was played from. The
+          `.filter(defined)` that used to be here could therefore only ever
+          discard somebody legally drafted, and it did: the board is filtered on
+          `players.active`, which the daily sync clears for anyone the provider
+          reports as an NFL free agent, so a player cut overnight fell out of his
+          own team's roster mid-draft and the count went on without him. Issue
+          #253.
+
+          Loud is only safe because the caller now hands over a pool that includes
+          this draft's own picks. On its own this would turn a quiet undercount
+          into a 500 in a room that polls every second.
+        */
+        throw new DraftError(
+          `Pick ${pick.pickNumber} took ${pick.playerId}, who is not in the pool`,
+          "POOL_INCOMPLETE",
+        );
+      }
+      return player;
+    });
 }
 
 /** Picks a team still has after the one currently on the clock. */

--- a/packages/core/src/draft/state.ts
+++ b/packages/core/src/draft/state.ts
@@ -137,6 +137,19 @@ export interface MakePickInput {
  * either way — a manager who wants nothing but wide receivers may have them —
  * but the consequence has to be visible before they confirm, not discovered in
  * Week 1 when the lineup will not validate.
+ *
+ * **The pool must contain this draft's own picks.** `rosterFor` throws
+ * `POOL_INCOMPLETE` on one it cannot rebuild a roster from, and the only pool a
+ * route holds is `draftBoard(...).pool` — filtered on `players.active`, so it
+ * loses anyone cut since he was drafted. `recordPick` widens inside its own
+ * transaction (issue #253); nothing widens for a read. Wiring this to the draft
+ * room as it stands would turn a cut player into a 500 in a room that polls
+ * every second, which is the failure that throw is meant to prevent, not cause.
+ *
+ * Note the asymmetry directly below: a pool missing the *subject* of the pick
+ * is tolerated, and a pool missing an *earlier* pick is not. The first is a
+ * player who has gone off the board while the manager was looking at him, which
+ * is ordinary; the second means the caller is holding the wrong pool.
  */
 export function pickWouldStrandStarters(state: DraftState, input: MakePickInput): boolean {
   const player = input.pool.get(input.playerId);

--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -1701,3 +1701,99 @@ describe("the draw refuses a pot league whose season has not started", () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe("a player cut by his club stays on the roster he was drafted to", () => {
+  /*
+    Issue #253. The engine rebuilt a drafting roster by looking each pick up in
+    the draft board, and the board filters on `players.active` — a flag the daily
+    sync clears for anyone the provider reports as an NFL free agent. So a player
+    drafted in round 2 and cut overnight fell out of his own team's roster: the
+    count went on without him, letting the team take one more than the limit, and
+    letting a bot double up at a position it had already filled.
+
+    Deleting him from the fixture's `pool` is exactly what the sync produces —
+    the board is rebuilt from a query he no longer matches.
+  */
+
+  it("keeps drafting when its own earlier pick has left the board", async () => {
+    /*
+      The moment that matters is the team's NEXT pick, because `rosterFor` is
+      per-team: a cut player is only missed when the roster being rebuilt is his
+      own. Two teams, so the snake turns straight back — A takes pick 1, B takes
+      2 and 3, A takes 4.
+
+      Before the fix, A's fourth pick was decided against a roster that had
+      silently lost its first. `rosterFor` now refuses to discard a pick at all,
+      so with the widening removed this same call fails with POOL_INCOMPLETE
+      rather than counting wrong — which is what makes this test load-bearing
+      rather than decorative.
+    */
+    const fx = await setup(2);
+    const order = await scheduled(fx);
+    await startDraft(fx.client, fx.leagueId, SCHEDULED);
+
+    const taken = new Set<string>();
+    const take = async (teamId: string, board: ReadonlyMap<string, DraftablePlayer>) => {
+      const playerId = anyAvailable(fx, taken);
+      taken.add(playerId);
+      await recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        teamId,
+        playerId,
+        pool: board,
+        shape: SHAPE,
+        now: SCHEDULED,
+      });
+      return playerId;
+    };
+
+    const first = await take(order[0]!, fx.pool);
+
+    // Overnight, his club cuts him: the board is rebuilt without him.
+    const cutBoard = new Map(fx.pool);
+    cutBoard.delete(first);
+
+    await take(order[1]!, cutBoard);
+    await take(order[1]!, cutBoard);
+
+    // A picks again, and this is the call that rebuilds A's roster.
+    const fourth = await take(order[0]!, cutBoard);
+
+    const roster = await fx.client.query<{ player_id: string }>(
+      `SELECT player_id FROM roster_entries
+        WHERE team_id = $1 AND released_at IS NULL ORDER BY acquired_at`,
+      [order[0]!],
+    );
+
+    expect(roster.map((row) => row.player_id)).toEqual([first, fourth]);
+  });
+  it("still refuses to draft him twice once he is back on the board", async () => {
+    // The widening puts him back in the pool, and the pool is what `available`
+    // is derived from — so the guard that matters is that he is still in
+    // `draftedPlayerIds`, which is what refuses a second pick of him.
+    const fx = await setup();
+    const order = await scheduled(fx);
+    await startDraft(fx.client, fx.leagueId, SCHEDULED);
+
+    const first = anyAvailable(fx, new Set());
+    await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: order[0]!,
+      playerId: first,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: SCHEDULED,
+    });
+
+    await expect(
+      recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: order[1]!,
+        playerId: first,
+        pool: fx.pool,
+        shape: SHAPE,
+        now: SCHEDULED,
+      }),
+    ).rejects.toMatchObject({ code: "PLAYER_UNAVAILABLE" });
+  });
+});

--- a/packages/db/src/draft.test.ts
+++ b/packages/db/src/draft.test.ts
@@ -1717,16 +1717,21 @@ describe("a player cut by his club stays on the roster he was drafted to", () =>
 
   it("keeps drafting when its own earlier pick has left the board", async () => {
     /*
-      The moment that matters is the team's NEXT pick, because `rosterFor` is
-      per-team: a cut player is only missed when the roster being rebuilt is his
-      own. Two teams, so the snake turns straight back — A takes pick 1, B takes
-      2 and 3, A takes 4.
+      A lock on the throw, not on the bug — and worth being exact about which,
+      because it reads like the latter.
 
-      Before the fix, A's fourth pick was decided against a roster that had
-      silently lost its first. `rosterFor` now refuses to discard a pick at all,
-      so with the widening removed this same call fails with POOL_INCOMPLETE
-      rather than counting wrong — which is what makes this test load-bearing
-      rather than decorative.
+      This passes against fully reverted code: the roster rows are written from
+      `input`, not from the count, so a team whose roster rebuilt one player
+      short still ends up with both rows in the database. What it does catch is
+      the intermediate state — throw added, widening removed — where the fourth
+      pick fails with POOL_INCOMPLETE instead of quietly counting wrong. That
+      state is one careless revert away, and this is the test that stops it.
+
+      The consequence of the miscount is asserted below, in the cap test.
+
+      Two teams, so the snake turns straight back: A takes pick 1, B takes 2 and
+      3, A takes 4 — A's next pick being the first moment its own roster is
+      rebuilt, since `rosterFor` is per-team.
     */
     const fx = await setup(2);
     const order = await scheduled(fx);
@@ -1761,16 +1766,25 @@ describe("a player cut by his club stays on the roster he was drafted to", () =>
 
     const roster = await fx.client.query<{ player_id: string }>(
       `SELECT player_id FROM roster_entries
-        WHERE team_id = $1 AND released_at IS NULL ORDER BY acquired_at`,
+        WHERE team_id = $1 AND released_at IS NULL`,
       [order[0]!],
     );
 
-    expect(roster.map((row) => row.player_id)).toEqual([first, fourth]);
+    // Compared as a set: every pick here is stamped at `SCHEDULED`, so
+    // `acquired_at` ties and any ORDER BY over it is unspecified.
+    expect(new Set(roster.map((row) => row.player_id))).toEqual(new Set([first, fourth]));
   });
   it("still refuses to draft him twice once he is back on the board", async () => {
-    // The widening puts him back in the pool, and the pool is what `available`
-    // is derived from — so the guard that matters is that he is still in
-    // `draftedPlayerIds`, which is what refuses a second pick of him.
+    /*
+      The widening puts him back in the pool, and the pool is what `available`
+      is derived from — so the guard that matters is that he is still in
+      `draftedPlayerIds`, which is what refuses a second pick of him.
+
+      The second call must be handed a board he has fallen off. Given an intact
+      one, `poolWithDraftedPlayers` finds nothing missing and returns at its
+      guard, and this asserts against the un-widened path — the one case it
+      exists to rule out.
+    */
     const fx = await setup();
     const order = await scheduled(fx);
     await startDraft(fx.client, fx.leagueId, SCHEDULED);
@@ -1785,15 +1799,103 @@ describe("a player cut by his club stays on the roster he was drafted to", () =>
       now: SCHEDULED,
     });
 
+    const cutBoard = new Map(fx.pool);
+    cutBoard.delete(first);
+
     await expect(
       recordPick(fx.client, {
         leagueId: fx.leagueId,
         teamId: order[1]!,
         playerId: first,
-        pool: fx.pool,
+        pool: cutBoard,
         shape: SHAPE,
         now: SCHEDULED,
       }),
     ).rejects.toMatchObject({ code: "PLAYER_UNAVAILABLE" });
+  });
+
+  it("counts him against the position cap, so a bot is not handed a second quarterback", async () => {
+    /*
+      The consequence, and the reason the miscount was worth fixing.
+
+      `canDraft` reads `roster.length` only, so an undercount cannot be caught
+      by the roster limit — with fourteen rounds and fourteen slots a team never
+      reaches it anyway. The cap is where it bites: `isAtPositionCap` reads
+      `positions` off the roster the engine rebuilds, and `defaultPositionCaps`
+      puts QB at one (one starting slot, and `floor(5 * 1 / 9)` of the bench).
+
+      So a bot that already holds the only quarterback it drafted must never be
+      given a second — and before the fix it was, because his club had cut him
+      and he had fallen out of his own roster.
+
+      The board handed to the auto-pick is narrowed to two players, which is the
+      fixture doing deliberately what a real board does by accident: it makes the
+      cap the only thing that can decide between them. Widen it and the bot picks
+      by rank and the cap is never consulted.
+    */
+    const fx = await setup(2);
+    const order = await scheduled(fx);
+    await startDraft(fx.client, fx.leagueId, SCHEDULED);
+
+    const players = [...fx.pool.values()];
+    const quarterbacks = players.filter((player) => player.positions.includes("QB"));
+    const [ownQb, otherQb] = [quarterbacks[0]!, quarterbacks[1]!];
+    // Not the first back in the pool: that one goes to the other team below.
+    const back = players.filter((player) => player.positions.includes("RB"))[1]!;
+
+    await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: order[0]!,
+      playerId: ownQb.playerId,
+      pool: fx.pool,
+      shape: SHAPE,
+      now: SCHEDULED,
+    });
+
+    // Overnight his club cuts him, and the sync rebuilds a board without him.
+    const cutBoard = new Map(fx.pool);
+    cutBoard.delete(ownQb.playerId);
+
+    // The other team takes both picks at the turn.
+    for (const player of [players[0]!, players[1]!]) {
+      await recordPick(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: order[1]!,
+        playerId: player.playerId,
+        pool: cutBoard,
+        shape: SHAPE,
+        now: SCHEDULED,
+      });
+    }
+
+    // Back to the first team, and nobody is there to pick: the bot decides,
+    // against its own roster, from a board of one quarterback and one back.
+    const narrowed = new Map<string, DraftablePlayer>([
+      [otherQb.playerId, { ...otherQb, rank: 1 }],
+      [back.playerId, { ...back, rank: 2 }],
+    ]);
+
+    await recordPick(fx.client, {
+      leagueId: fx.leagueId,
+      pool: narrowed,
+      shape: SHAPE,
+      // Ninety seconds after the pick before it, so the clock has genuinely run
+      // out — `recordPick` refuses an auto-pick whose timer is still running.
+      now: new Date(SCHEDULED.getTime() + 91_000),
+    });
+
+    const roster = await fx.client.query<{ player_id: string }>(
+      `SELECT player_id FROM roster_entries
+        WHERE team_id = $1 AND released_at IS NULL`,
+      [order[0]!],
+    );
+    const held = new Set(roster.map((row) => row.player_id));
+
+    // He is still there, he was counted, and the bot took the back instead.
+    expect(held.has(ownQb.playerId)).toBe(true);
+    expect(held.has(back.playerId)).toBe(true);
+    expect(
+      [...held].filter((id) => quarterbacks.some((qb) => qb.playerId === id)),
+    ).toHaveLength(1);
   });
 });

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -81,6 +81,10 @@ export class DraftPersistenceError extends Error {
       | "NOT_IN_PROGRESS"
       | "ALREADY_STARTED"
       | "PICK_RACE_LOST"
+      // A pick names a player with no position row. Unreachable through the
+      // schema, and asserted rather than handled: the handled version is a
+      // roster silently one player short, which is the bug being fixed.
+      | "PICK_PLAYER_MISSING"
       | "CLOCK_EXPIRED",
   ) {
     super(message);
@@ -843,6 +847,103 @@ export interface RecordedPick {
 }
 
 /**
+ * The rank given to a player who is on a roster but no longer on the board.
+ *
+ * Never read, and that is provable rather than hopeful: `rank` is only consulted
+ * on `available`, which every engine path computes as the pool minus
+ * `draftedPlayerIds`, and every player this constant is given is in that set.
+ * `MAX_SAFE_INTEGER` matches `loadDraftBoard`'s own `NULLS LAST` convention — if
+ * a future caller ever does read it, "sorts last" is the honest answer for
+ * somebody who has no board position at all.
+ *
+ * Deliberately not zero, and deliberately not an empty `positions` array. Zero
+ * would assert "the best player in the draft"; `[]` would assert "he can fill no
+ * position", which `eligible()` reads exactly that way.
+ */
+const OFF_BOARD_RANK = Number.MAX_SAFE_INTEGER;
+
+/**
+ * The board, plus every player this draft has already taken.
+ *
+ * `rosterFor` rebuilds a drafting roster by looking each pick up in the pool, and
+ * the pool comes from `loadDraftBoard`, which filters `WHERE p.sport_id = $1 AND
+ * p.active` — a flag the daily sync clears for anyone the provider reports as an
+ * NFL free agent. So a player drafted in round 2 and cut by his club overnight
+ * fell out of his own team's roster mid-draft: `canDraft` undercounted and let the
+ * team take `totalSlots + 1`, `isAtPositionCap` under-counted his position so
+ * auto-pick doubled up on it, and `unfilledStarterSlots` went on naming a need the
+ * team had already filled — spending a bot's last pick on a second quarterback
+ * while its defence slot stayed empty. Issue #253.
+ *
+ * **The fix for the waiver half of this does not transfer.** That one narrowed the
+ * resolver to identity only, because that path reads identity and count and
+ * nothing else. The draft genuinely reads `positions`, in the three places above,
+ * and an identity-only roster would tell a bot "you hold someone, unspecified" on
+ * every league in every draft rather than only on a cut player.
+ *
+ * **Widening the pool cannot widen what is draftable, and that is a proof rather
+ * than a convention to keep.** What this adds is exactly the players in `picks`,
+ * and `picks` is exactly `draftedPlayerIds(state)`, which `makeAutoPick` subtracts
+ * to build `available` and `makePick` checks before accepting anything. Every
+ * entry added here is refused by both on the line after it is found. The two sets
+ * cannot drift because one is defined as a superset of the other, in one
+ * expression, from one array — not maintained alongside it.
+ *
+ * That is the distinction from `loadRosterForWeek`, which must **not** be widened
+ * for the lineup lock: there the players a lock needs are not a subset of the ones
+ * it refuses, so widening would let a manager start somebody he had cut. Here they
+ * are the same set.
+ *
+ * Built inside the pick transaction on purpose. Assembled at the route instead, it
+ * would be a second read of `draft_picks` taken outside the lock — safe only by a
+ * timing argument, which is the reasoning this function's own docstring rejects.
+ *
+ * Costs nothing in the ordinary case: with nobody cut, `missing` is empty and no
+ * query runs.
+ */
+async function poolWithDraftedPlayers(
+  db: SqlClient,
+  picks: readonly DraftPick[],
+  pool: ReadonlyMap<string, DraftablePlayer>,
+): Promise<ReadonlyMap<string, DraftablePlayer>> {
+  const missing = [...new Set(picks.map((pick) => pick.playerId))].filter(
+    (playerId) => !pool.has(playerId),
+  );
+  if (missing.length === 0) return pool;
+
+  // The same positions join `loadDraftBoard` uses, without its `active` filter —
+  // which is the whole point — and without its sport filter, which here could only
+  // ever hide a row that belongs: these ids come from this draft's own picks.
+  const rows = await db.query<{ id: string; positions: string[] }>(
+    `SELECT p.id, array_agg(DISTINCT pos.key) AS positions
+       FROM players p
+       JOIN positions pos
+         ON pos.id = p.primary_position_id
+         OR pos.id IN (SELECT position_id FROM player_eligible_positions WHERE player_id = p.id)
+      WHERE p.id = ANY($1::uuid[])
+      GROUP BY p.id`,
+    [missing],
+  );
+
+  if (rows.length !== missing.length) {
+    // Unreachable: `draft_picks.player_id` references `players (id)`, and
+    // `players.primary_position_id` is NOT NULL against a registry whose rows are
+    // never deleted. An assertion rather than a case to handle, because the
+    // handled version is the bug — a roster silently one player short.
+    const found = new Set(rows.map((row) => row.id));
+    throw new DraftPersistenceError(
+      `Drafted players have no position row: ${missing.filter((id) => !found.has(id)).join(", ")}`,
+      "PICK_PLAYER_MISSING",
+    );
+  }
+
+  const widened = new Map(pool);
+  for (const row of rows) {
+    widened.set(row.id, { playerId: row.id, positions: row.positions, rank: OFF_BOARD_RANK });
+  }
+  return widened;
+}
+/**
  * Record one pick — manual if `teamId` and `playerId` are given, automatic
  * otherwise. `null` means the pick the caller meant had already been made.
  *
@@ -936,16 +1037,21 @@ export async function recordPick(
     const queues =
       input.teamId && input.playerId ? undefined : await loadQueues(tx, input.leagueId);
 
+    // The board plus this draft's own picks, so a player cut by his club overnight
+    // is still on the roster the engine counts. Read here rather than at the
+    // route, so the picks widened with are the picks validated against.
+    const pool = await poolWithDraftedPlayers(tx, record.state.picks, input.pool);
+
     const next =
       input.teamId && input.playerId
         ? makePick(record.state, {
             teamId: input.teamId,
             playerId: input.playerId,
-            pool: input.pool,
+            pool,
             shape: input.shape,
           })
         : makeAutoPick(record.state, {
-            pool: input.pool,
+            pool,
             shape: input.shape,
             ...(queues ? { queues } : {}),
           });


### PR DESCRIPTION
Closes #253.

`rosterFor` rebuilds a drafting roster by looking each pick up in the draft board, and the board filters on `players.active` — a flag the daily 09:20 UTC sync clears for anyone the provider reports as an NFL free agent. So a player drafted in round 2 and cut overnight **silently stopped being on the roster the engine counted**, from that team's next pick onward.

`makePick` refuses a player the pool does not contain, so the filter that discarded him could only ever discard somebody legally drafted.

## Three consequences, all reproduced

- **A team can take `totalSlots + 1`.** `canDraft` reads `roster.length`. Built it: with an intact pool the engine correctly throws `ROSTER_FULL`; cut one player and the same pick succeeds. Permanent — the pick is committed and there is no un-pick.
- **Auto-pick doubles up at a capped position.** The kicker cap is 1. Cut the kicker and `countAtPosition("K")` drops to zero, so the bot takes a second. Two kickers, one K slot, no flex that accepts one — exactly what `defaultPositionCaps` exists to prevent.
- **A bot wastes its last pick.** Six picks into a seven-round draft the real hole was `DEF`; after the cut, `unfilledStarterSlots` reads `["QB","DEF"]`. The shortfall now exceeds picks remaining, every candidate fails the safety check, and autopick falls through to *"first unfilled slot in roster order"* — QB sorts before DEF. **The team finishes with two quarterbacks and an empty defence slot**, scoring zero there every week.

A fourth, user-visible one the issue does not mention: from 09:20 the cut player renders in his own team's sidebar as a bare UUID with a `?` avatar and `—` for position. That is the symptom a manager actually reports. It is client-side and filed separately.

## The fix, and why it lives in the transaction

The pool the engine sees is now **the board plus exactly the players this draft has already picked**, assembled inside `recordPick`.

**Widening it cannot widen what anyone can draft, and that is a proof rather than a convention to maintain.** What it adds is exactly `picks`; `picks` is exactly `draftedPlayerIds(state)`, which `makeAutoPick` subtracts to build `available` and `makePick` checks before accepting anything. Every entry added is refused on the line after it is found. The two sets cannot drift, because one is *defined as* a superset of the other, in one expression, from one array.

Assembled at the route instead it would be a second read of `draft_picks` taken **outside the lock** — safe only by a timing argument, which is the reasoning `recordPick`'s own docstring rejects. Inside the lock, the picks widened with are the picks validated against. It also costs nothing in the ordinary case: with nobody cut, no query runs.

## Why the waiver fix does not transfer

#238 solved the same shape by narrowing the roster to identity only. That works there because the resolver reads identity and count. **The draft genuinely reads `positions`**, in all three places above — an identity-only roster would tell a bot *"you hold someone, unspecified"* and it would draft for needs it cannot see, on **every league in every draft** rather than only on a cut player.

`positions` survive a cut, verified three ways: the provider puts its free-agent sentinel on the *club*, never the position; a payload with no usable position is skipped whole, so it cannot clear `active` either; and eligibility rows are append-only. The residual risk runs the safe way — a cut player's positions may be generous, never empty.

## `rosterFor` no longer discards

With the pool complete, a missing pick means the caller's pool is not the pool this draft was played from. That is not a case to handle — the handled version *is* the bug — so it throws, and the pick route maps it to **500** rather than letting the `?? 409` fallback offer a manager a retry that cannot help.

**Shipped only with the widening.** On its own it converts a quiet undercount into a 500 in a room that polls every second.

## Two corrections to the issue

- **A live draft is not out of reach.** `rounds` is starters plus bench and a full league is twelve teams — ~180–192 picks — so even the *fastest* SLOW clock spans days and crossing the sync is unavoidable rather than unlucky. A FAST draft starting in the ~5 hours before 09:20 UTC is exposed too.
- **The positions join cannot drop a player.** `primary_position_id` is `NOT NULL` with a foreign key, so the first disjunct always matches. That matters: it means `active` is the *only* way a drafted player can leave the pool, which is what narrows the fix to one cause.

## Verified

`pnpm test` **2283 passed**, typecheck, lint and format clean. The new test was run with the widening removed to confirm it fails: it does, naming the pick — `Pick 1 took efac83a3…, who is not in the pool`.

An earlier draft of that test passed with the fix disabled and was rewritten. `rosterFor` is per-team, so a cut player is only missed when the roster being rebuilt is **his own** — the test now uses two teams so the snake returns to the affected team while he is off the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
