### PR TITLE
feat(db): tell a manager when his player is no longer on an NFL roster

### DIFF
--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -714,7 +714,23 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
                   title={
                     player.availability === "TIME_TBD"
                       ? "He plays this week. The NFL has not fixed the kickoff time, so this slot locks at the earliest hour the game could start."
-                      : "No fixture stored for his team this week, and it is not their bye. Check back once the schedule syncs."
+                      : player.teamRef === null
+                        ? // Says less, because the other sentence says something
+                          // false here. A player with no club reference has no
+                          // fixture coming, and "check back once the schedule
+                          // syncs" promises one that never arrives — which is
+                          // the worst kind of wrong on a screen somebody is
+                          // deciding from. Issue #254.
+                          //
+                          // Reports the missing club reference and stops there,
+                          // rather than diagnosing why. `teamRef` is null for a
+                          // player no longer on an NFL roster, and also for a
+                          // stale trade, a blank, or a provider rename — see
+                          // `lineups.ts`. Naming the cause would need
+                          // `players.active`, a third reader of a flag issue
+                          // #276 exists to sort out first.
+                          "He is not listed with an NFL club, so no fixture is stored for him."
+                        : "No fixture stored for his team this week, and it is not their bye. Check back once the schedule syncs."
                   }
                 >
                   TBD

--- a/packages/db/src/notifications.test.ts
+++ b/packages/db/src/notifications.test.ts
@@ -4,7 +4,7 @@ import type { DraftRules, LeagueRules } from "@rostr/core";
 import { createDraftRecord } from "./draft.js";
 import { createUser } from "./identity.js";
 import { createLeague } from "./leagues.js";
-import { notificationsForUser } from "./notifications.js";
+import { NOTIFICATION_URGENCY, notificationsForUser } from "./notifications.js";
 import { seedSport } from "./sports.js";
 import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
@@ -277,6 +277,147 @@ describe("notificationsForUser", () => {
 
     const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
     expect(items.map((i) => i.kind)).toContain("LINEUP_UNSET");
+  });
+
+  describe("a player who is no longer on an NFL roster", () => {
+    /*
+      Issue #254. `season-sync` clears `players.active` for anyone the provider
+      stops listing with a club, and the player stayed on the roster scoring
+      zero with nothing anywhere saying so. The only sentence in the product
+      that states this fact is shown to a rival whose claim failed.
+    */
+
+    /** Put `count` players on a team, `cut` of them no longer listed. */
+    const roster = async (
+      fx: Fixture,
+      teamId: string,
+      names: readonly string[],
+      cut: number,
+    ) => {
+      const [sport] = await fx.client.query<{ id: string }>(
+        "SELECT id FROM sports WHERE key = $1",
+        [NFL.key],
+      );
+      const [position] = await fx.client.query<{ id: string }>(
+        "SELECT id FROM positions WHERE sport_id = $1 LIMIT 1",
+        [sport!.id],
+      );
+
+      for (const [index, name] of names.entries()) {
+        const [player] = await fx.client.query<{ id: string }>(
+          `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, active)
+           VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+          [
+            sport!.id,
+            `ext-${name}`,
+            name,
+            position!.id,
+            index >= names.length - cut ? false : true,
+          ],
+        );
+        await fx.client.query(
+          `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+           VALUES ($1, $2, 'DRAFT', now())`,
+          [teamId, player!.id],
+        );
+      }
+    };
+
+    const inSeason = async (fx: Fixture) =>
+      fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [fx.leagueId]);
+
+    it("names him, so the link lands somewhere the manager can act", async () => {
+      // A bare count would be `unsetLineups`' shape, and wrong here: an empty
+      // lineup slot is visible on arrival, and the roster panel renders every
+      // player identically, so "1 player" is a fourteen-row search.
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, ["Adams", "Brown", "Carter"], 1);
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      const item = items.find((i) => i.kind === "PLAYER_OFF_NFL_ROSTER");
+
+      expect(item).toMatchObject({
+        kind: "PLAYER_OFF_NFL_ROSTER",
+        leagueId: fx.leagueId,
+        href: `/leagues/${fx.leagueId}/players`,
+        deadline: null,
+        needsSignature: false,
+      });
+      expect(item?.text).toBe(
+        "Carter is no longer on an NFL roster in Sunday Scaries and cannot score",
+      );
+    });
+
+    it("says it once per league, however many it is about", async () => {
+      // `HeaderControls` keys the list on `kind:leagueId`, so a second row for
+      // one league collides — and a manager holding two has one problem.
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, ["Adams", "Brown", "Carter"], 2);
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      const mine = items.filter((i) => i.kind === "PLAYER_OFF_NFL_ROSTER");
+
+      expect(mine).toHaveLength(1);
+      expect(mine[0]?.text).toBe(
+        "Brown and 1 other are no longer on an NFL roster in Sunday Scaries and cannot score",
+      );
+    });
+
+    it("tells the manager holding him and nobody else", async () => {
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, ["Adams"], 1);
+
+      const held = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      expect(held.map((i) => i.kind)).toContain("PLAYER_OFF_NFL_ROSTER");
+
+      const other = await notificationsForUser(fx.client, fx.seats[1]!.userId, NOW);
+      expect(other.map((i) => i.kind)).not.toContain("PLAYER_OFF_NFL_ROSTER");
+    });
+
+    it("stops saying it the moment he is dropped", async () => {
+      // The property that makes deriving right: nothing has to remember to
+      // delete this, and `syncPlayers` re-asserts `active` every morning, so a
+      // stored copy would be wrong in both directions.
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, ["Adams"], 1);
+
+      await fx.client.query(
+        "UPDATE roster_entries SET released_at = now() WHERE team_id = $1",
+        [fx.seats[0]!.teamId],
+      );
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      expect(items.map((i) => i.kind)).not.toContain("PLAYER_OFF_NFL_ROSTER");
+    });
+
+    it("stays quiet before the season, when nothing is being lost yet", async () => {
+      // A league is `IN_SEASON` from the moment its draft completes, so this
+      // covers only a draft still running — where the remedy is the draft.
+      const fx = await fixture();
+      await roster(fx, fx.seats[0]!.teamId, ["Adams"], 1);
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      expect(items.map((i) => i.kind)).not.toContain("PLAYER_OFF_NFL_ROSTER");
+    });
+
+    it("sorts below an unset lineup and above an invitation", async () => {
+      /*
+        Both are open-ended, so the tie is broken on cost. A lineup slot closes
+        at kickoff whether or not a deadline was stored — which is why the rule
+        is the window, not the field. An invitation costs nothing and expires
+        never.
+      */
+      expect(NOTIFICATION_URGENCY.indexOf("PLAYER_OFF_NFL_ROSTER")).toBeGreaterThan(
+        NOTIFICATION_URGENCY.indexOf("LINEUP_UNSET"),
+      );
+      expect(NOTIFICATION_URGENCY.indexOf("PLAYER_OFF_NFL_ROSTER")).toBeLessThan(
+        NOTIFICATION_URGENCY.indexOf("INVITATION"),
+      );
+    });
   });
 
   it("puts the pick clock ahead of everything else", async () => {

--- a/packages/db/src/notifications.ts
+++ b/packages/db/src/notifications.ts
@@ -43,6 +43,7 @@ export type NotificationKind =
   | "VETO_WINDOW"
   | "DRAFT_SOON"
   | "LINEUP_UNSET"
+  | "PLAYER_OFF_NFL_ROSTER"
   | "INVITATION";
 
 /**
@@ -50,8 +51,19 @@ export type NotificationKind =
  *
  * A pick clock runs in seconds and everything else in hours or days, so it
  * outranks the lot. A trade you have not answered outranks a veto window because
- * the trade cannot proceed without you and the veto can. An invitation is last:
- * it is the only item with no deadline at all.
+ * the trade cannot proceed without you and the veto can.
+ *
+ * **Ranked by how soon acting stops being possible, and where two items are both
+ * open-ended, by what ignoring one costs.** This used to say an invitation is
+ * last because "it is the only item with no deadline at all", which was already
+ * untrue when it was written — `unsetLineups` returns `deadline: null` too, and
+ * ranks above it. The window is what matters, not whether a field holds a date:
+ * an unset lineup closes at kickoff whether or not anything stored the hour.
+ *
+ * So the two open-ended items are separated by cost. A player who is no longer
+ * on an NFL roster scores zero every remaining week and nothing in the system
+ * corrects it. An invitation costs nothing and expires never, which is what
+ * keeps it last.
  */
 export const NOTIFICATION_URGENCY: readonly NotificationKind[] = [
   "ON_THE_CLOCK",
@@ -59,6 +71,7 @@ export const NOTIFICATION_URGENCY: readonly NotificationKind[] = [
   "VETO_WINDOW",
   "DRAFT_SOON",
   "LINEUP_UNSET",
+  "PLAYER_OFF_NFL_ROSTER",
   "INVITATION",
 ];
 
@@ -97,6 +110,82 @@ export interface Notification {
 const DRAFT_SOON_MS = 60 * 60 * 1000;
 
 /**
+ * Players on your roster who are no longer on an NFL roster.
+ *
+ * `season-sync` clears `players.active` for anyone the provider stops listing
+ * with a club, and until now that was the end of it: the player stayed on the
+ * roster, scored zero every week, and the only thing on screen was a headshot
+ * carrying whatever club the provider last reported. Issue #254. The one place
+ * in the product that states this fact — `waiver-run.ts`, "he is no longer on an
+ * NFL roster" — says it to a rival whose claim failed, never to the manager
+ * holding him.
+ *
+ * **Derived, like everything else here, and that is what makes it correct.** The
+ * fact is a standing one rather than an event: it is true for as long as he is
+ * held and not listed, and it stops being true when he is dropped or signs
+ * somewhere. A stored notification would have to be written when the flag
+ * flipped and deleted when it flipped back, and `syncPlayers` re-asserts
+ * `active` unconditionally on every run, so the flag is bidirectional and the
+ * copy would be wrong in both directions.
+ *
+ * **One row per league**, aggregated. `HeaderControls` keys the list on
+ * `kind:leagueId`, so a second row for the same league would collide — and a
+ * manager holding two cut players has one problem, not two.
+ *
+ * **It carries a name.** The count alone would be `unsetLineups`' shape, but an
+ * empty lineup slot is visible the moment you arrive and this is not: the roster
+ * panel renders every player identically, so "1 player" would send somebody to a
+ * fourteen-row list with no way to tell which. Naming one and counting the rest
+ * is the least this can say and still be actionable.
+ *
+ * **No advice in the text.** Not "drop him", not "replace him".
+ * `waiver-run.ts` set this convention for the identical fact — state what is
+ * observable, imply no permanence — and it holds here for two more reasons: a
+ * cut player may be signed again on Wednesday, and whether he should be
+ * acquirable at all is what issue #276 exists to decide. The link is the advice.
+ */
+async function playersOffNflRosters(db: SqlClient, userId: string): Promise<Notification[]> {
+  const rows = await db.query<{
+    league_id: string;
+    league_name: string;
+    held: number;
+    names: string[];
+  }>(
+    `SELECT l.id AS league_id, l.name AS league_name, count(*)::int AS held,
+            array_agg(p.full_name ORDER BY p.full_name) AS names
+       FROM league_memberships m
+       JOIN leagues l ON l.id = m.league_id
+       JOIN teams t ON t.id = m.team_id
+       JOIN roster_entries r ON r.team_id = t.id AND r.released_at IS NULL
+       JOIN players p ON p.id = r.player_id
+      WHERE m.user_id = $1
+        AND l.state IN ('IN_SEASON', 'PLAYOFFS')
+        AND NOT p.active
+      GROUP BY l.id, l.name`,
+    [userId],
+  );
+
+  return rows.map((row) => {
+    const [first] = row.names;
+    const others = row.held - 1;
+
+    return {
+      kind: "PLAYER_OFF_NFL_ROSTER" as const,
+      leagueId: row.league_id,
+      leagueName: row.league_name,
+      href: `/leagues/${row.league_id}/players`,
+      text:
+        others === 0
+          ? `${first} is no longer on an NFL roster in ${row.league_name} and cannot score`
+          : `${first} and ${others} other${others === 1 ? "" : "s"} are no longer on an NFL ` +
+            `roster in ${row.league_name} and cannot score`,
+      deadline: null,
+      needsSignature: false,
+    };
+  });
+}
+
+/**
  * Everything waiting on this user, most urgent first.
  *
  * `now` is passed rather than read, so every deadline in the result is measured
@@ -107,15 +196,16 @@ export async function notificationsForUser(
   userId: string,
   now: Date,
 ): Promise<readonly Notification[]> {
-  const [drafts, trades, vetoes, invitations, lineups] = await Promise.all([
+  const [drafts, trades, vetoes, invitations, lineups, cut] = await Promise.all([
     draftNotifications(db, userId, now),
     tradesAwaitingYou(db, userId),
     vetoWindows(db, userId, now),
     invitationNotifications(db, userId),
     unsetLineups(db, userId),
+    playersOffNflRosters(db, userId),
   ]);
 
-  const all = [...drafts, ...trades, ...vetoes, ...invitations, ...lineups];
+  const all = [...drafts, ...trades, ...vetoes, ...invitations, ...lineups, ...cut];
 
   return all.sort((a, b) => {
     const byKind = NOTIFICATION_URGENCY.indexOf(a.kind) - NOTIFICATION_URGENCY.indexOf(b.kind);


### PR DESCRIPTION
Part 2 of #254. Confirmed by three agents with separate roles, and the design converged over a second round in which two of them corrected their own first answers.

## The gap

`season-sync` clears `players.active` for anyone the provider stops listing with a club. The player stays on the roster, scores zero every week, and **nothing tells the manager**. The only sentence in the product that states this fact is `waiver-run.ts`'s "he is no longer on an NFL roster" — shown to a rival whose claim failed, never to the person holding him.

#238 and #253 made the count correct about him. That was right, and it removed the accidental tell: before them the arithmetic was wrong in a way that might eventually have surfaced. The silence got quieter rather than louder, which is why this is the other half rather than a nice-to-have.

## Why it is derived and not stored

`notifications.ts` has no table and argues at length that it should not. This fits that argument rather than straining it: the fact is **standing**, not an event — true while he is held and not listed, false the moment he is dropped or signs somewhere. And `syncPlayers` re-asserts `active` unconditionally on every run, so the flag is **bidirectional**: a stored copy would need writing when it flipped and deleting when it flipped back, and would be wrong in both directions in between. One test asserts the item disappears when he is dropped, with nothing having remembered to delete it.

Total cost: six edits in one file, plus tests. No migration, no enum, no renderer switch — verified against `HeaderControls.tsx` and `UrgentStrip.tsx`, both of which type `kind` as `string` and render `item.text` with no per-kind branch.

## Three decisions worth stating

**It carries a name, not a count.** The `unsetLineups` shape is a bare count, and it works there because an empty lineup slot is visible the moment you arrive. This is not: `PlayerMarket.tsx` renders every roster row identically, so "1 player" would send a manager to a fourteen-row list with no way to tell which. `array_agg` keeps it one row per league — which `HeaderControls.tsx:203` requires anyway, since it keys on `kind:leagueId`.

**No advice in the text.** Not "drop him", not "replace him". `waiver-run.ts` set that convention for this identical fact — state what is observable, imply no permanence — and two things hold it here: he may be signed again on Wednesday, and whether a cut player should be acquirable at all is the open question in #276. The link is the advice.

**`availabilityOf` is untouched.** It is the ownership oracle, keyed to `roster_entries_one_owner_per_league`, and teaching it about `active` would make a rostered-but-cut player read as unowned. This is a new, notification-only query and does not become a third caller of it.

## A pre-existing inaccuracy this had to fix

`NOTIFICATION_URGENCY`'s docstring said an invitation sorts last because "it is the only item with no deadline at all". That was already untrue — `unsetLineups` returns `deadline: null` and ranks above it. Inserting a third open-ended kind made it plainly wrong, so it now states the rule that actually holds: how soon acting stops being possible, and between two open-ended items, what ignoring one costs. An unset lineup closes at kickoff whether or not a field stored the hour; an invitation costs nothing and expires never; a player who cannot score costs points every remaining week.

## One tooltip

A player with no club reference rendered "No fixture stored for his team this week… Check back once the schedule syncs" — promising a fixture that never arrives, on a screen somebody is deciding from. It now reports the missing reference and stops.

Deliberately **not** a diagnosis. `teamRef` is null for a cut player and also for a stale trade, a blank, or a provider rename, and naming the cause would need `players.active` plumbed into `loadRosterForWeek` — a third SQL reader of a flag that #276 exists to sort out. It also only fires when the provider drops the club; if Tank01 keeps the last one, the player renders as normally scheduled and this says nothing. The real fix — a roster row that marks a player who cannot score, on both screens, covering both provider behaviours — belongs with #276.

## Verification

Three of the five new tests fail with the query unwired. The other two are guards against *over*-firing — that it stops when he is dropped, and stays quiet before the season — so they pass trivially without the feature, which is the correct shape for them and not a regression test.

Full suite 2319 passed, web 289 passed, typecheck, lint, prettier and the test-project guard all clean.

## What remains of #254

Part 1 stays open and should be rewritten down to the report alone, cause-agnostic. It was filed when trades were the live cause; #250 closed that. There are now three distinct causes — sanctioned IR recovery, #272's `activateFromIr` hole, and #279's mid-draft signing, the last proven with a test after this issue was filed. A report written in IR terms would misattribute the third, which is the argument for the report knowing nothing about why.

Refs #254