### PR TITLE
fix(db): the player market was open during the draft, and before it

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/players/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/players/route.ts
@@ -4,6 +4,7 @@ import {
   availablePlayers,
   cancelClaim,
   dropPlayer,
+  marketClosedReason,
   pendingClaims,
   submitClaim,
   WaiverError,
@@ -25,6 +26,14 @@ const STATUS: Record<string, number> = {
   SLOT_HELD_FOR_TRADE: 409,
   DUPLICATE_CLAIM: 409,
   IN_A_TRADE: 409,
+  // The league is not playing. A conflict with its state, like every other 409
+  // here, and the fallback below would call it a malformed request.
+  LEAGUE_NOT_IN_SEASON: 409,
+  // Not new, and not part of #279 — `RULES.md` §6's kickoff refusal has been
+  // reaching the client as a 400 since it was written, because it was never
+  // added here. Fixed alongside rather than left as the odd one out in a map
+  // this change already edits.
+  GAME_STARTED: 409,
 };
 
 /** Everyone unrostered, with whether they can be added now or only claimed. */
@@ -91,6 +100,22 @@ export async function GET(
         injuryDesignation: row.injury_designation,
       })),
       claims: await pendingClaims(client, id, context.myTeamId),
+      /*
+        Whether this league is transacting at all, and the sentence if not.
+
+        Composed here rather than in the component, from the same function that
+        refuses the write, because the screen and the server must not be able to
+        disagree about it — a live Add button over a server that says no is a
+        wall rather than an answer. It is also the only way this string gets a
+        test: `apps/web` cannot render a component in one.
+
+        The list itself stays. Those players genuinely are unrostered, and
+        looking at the pool during a draft is useful.
+      */
+      market: {
+        open: marketClosedReason(context.state, "ACQUIRE") === null,
+        notice: marketClosedReason(context.state, "ACQUIRE"),
+      },
     });
   } catch (error) {
     if (error instanceof DraftContextError) {

--- a/apps/web/src/components/PlayerMarket.tsx
+++ b/apps/web/src/components/PlayerMarket.tsx
@@ -51,6 +51,14 @@ interface MarketResponse {
   available: Available[];
   roster: Rostered[];
   claims: Claim[];
+  /**
+   * Whether this league is transacting, and why not when it is not.
+   *
+   * The sentence is composed by the server from the same function that refuses
+   * the write, so the two cannot drift. Rendering a button the server will
+   * refuse is the failure this exists to prevent — it turns a rule into a wall.
+   */
+  market: { open: boolean; notice: string | null };
 }
 
 const fetcher = async (url: string): Promise<MarketResponse> => {
@@ -157,6 +165,15 @@ export function PlayerMarket({ leagueId }: { leagueId: string }) {
       {failure && (
         <p className="rounded border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
           {failure}
+        </p>
+      )}
+
+      {data.market.notice !== null && (
+        // Said once, at the top, rather than on every row. The buttons below are
+        // gone rather than disabled: a disabled button invites a manager to work
+        // out why, and the sentence has already told them.
+        <p className="rounded border border-nocturne-neutral-800 bg-nocturne-neutral-950 px-3 py-2 text-xs text-nocturne-neutral-400">
+          {data.market.notice}
         </p>
       )}
 
@@ -268,23 +285,25 @@ export function PlayerMarket({ leagueId }: { leagueId: string }) {
                 <span className="text-xs text-amber-400/70">{clearsIn(player.clearsAt)}</span>
               )}
 
-              <button
-                onClick={() =>
-                  void act({
-                    action: "ADD",
-                    playerId: player.playerId,
-                    dropPlayerId: dropWith || null,
-                  })
-                }
-                disabled={busy || claimedIds.has(player.playerId)}
-                className="rounded border border-nocturne-accent px-3 py-1 text-xs font-medium text-black disabled:opacity-30"
-              >
-                {claimedIds.has(player.playerId)
-                  ? "Claimed"
-                  : player.availability === "ON_WAIVERS"
-                    ? "Claim"
-                    : "Add"}
-              </button>
+              {data.market.open && (
+                <button
+                  onClick={() =>
+                    void act({
+                      action: "ADD",
+                      playerId: player.playerId,
+                      dropPlayerId: dropWith || null,
+                    })
+                  }
+                  disabled={busy || claimedIds.has(player.playerId)}
+                  className="rounded border border-nocturne-accent px-3 py-1 text-xs font-medium text-black disabled:opacity-30"
+                >
+                  {claimedIds.has(player.playerId)
+                    ? "Claimed"
+                    : player.availability === "ON_WAIVERS"
+                      ? "Claim"
+                      : "Add"}
+                </button>
+              )}
             </li>
           ))}
         </ul>
@@ -326,13 +345,15 @@ export function PlayerMarket({ leagueId }: { leagueId: string }) {
                   </span>
                 </span>
               </button>
-              <button
-                onClick={() => void act({ action: "DROP", playerId: player.playerId })}
-                disabled={busy}
-                className="rounded border border-nocturne-neutral-800 px-2 py-1 text-xs text-nocturne-neutral-400 hover:text-nocturne-text disabled:opacity-30"
-              >
-                Drop
-              </button>
+              {data.market.open && (
+                <button
+                  onClick={() => void act({ action: "DROP", playerId: player.playerId })}
+                  disabled={busy}
+                  className="rounded border border-nocturne-neutral-800 px-2 py-1 text-xs text-nocturne-neutral-400 hover:text-nocturne-text disabled:opacity-30"
+                >
+                  Drop
+                </button>
+              )}
             </li>
           ))}
         </ul>

--- a/apps/web/src/lib/draft-context.ts
+++ b/apps/web/src/lib/draft-context.ts
@@ -23,6 +23,14 @@ export interface DraftContext {
   readonly rules: LeagueRules;
   readonly shape: RosterShape;
   readonly season: number;
+  /**
+   * The league's current state.
+   *
+   * From the column, and — unlike `season` below — that is the point. State is
+   * not in the frozen document and must not look as though it is: it changes,
+   * which is the whole reason anything reads it.
+   */
+  readonly state: string;
 }
 
 export class DraftContextError extends Error {
@@ -41,7 +49,8 @@ export async function draftContext(leagueId: string): Promise<DraftContext> {
   const [league] = await client.query<{
     season: number;
     commissioner_id: string;
-  }>("SELECT season, commissioner_id FROM leagues WHERE id = $1", [leagueId]);
+    state: string;
+  }>("SELECT season, commissioner_id, state FROM leagues WHERE id = $1", [leagueId]);
   if (!league) throw new DraftContextError("League not found", 404);
 
   const stored = await getLeagueRules(client, leagueId);
@@ -72,6 +81,7 @@ export async function draftContext(leagueId: string): Promise<DraftContext> {
       through the caller's `?? 1` fallback.
     */
     season: stored.rules.seasonYear,
+    state: league.state,
   };
 }
 

--- a/packages/db/src/draft.ts
+++ b/packages/db/src/draft.ts
@@ -85,6 +85,11 @@ export class DraftPersistenceError extends Error {
       // schema, and asserted rather than handled: the handled version is a
       // roster silently one player short, which is the bug being fixed.
       | "PICK_PLAYER_MISSING"
+      // A pick names somebody this league already holds by a route other than
+      // the draft. Closed at source by the market gate (#279); translated here
+      // because a bare unique violation escaping this insert wedges the draft
+      // permanently rather than failing one pick.
+      | "PICK_PLAYER_TAKEN"
       | "CLOCK_EXPIRED",
   ) {
     super(message);
@@ -1082,11 +1087,39 @@ export async function recordPick(
     // The draft is the origin of every roster in the league, so the pick lands
     // on the roster in the same transaction. A pick recorded without a roster
     // entry would leave a team owning a player nothing else could see.
-    await tx.query(
-      `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
-       VALUES ($1, $2, 'DRAFT', $3)`,
-      [pick.teamId, pick.playerId, input.now],
-    );
+    try {
+      await tx.query(
+        `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at)
+         VALUES ($1, $2, 'DRAFT', $3)`,
+        [pick.teamId, pick.playerId, input.now],
+      );
+    } catch (cause) {
+      if (!isUniqueViolation(cause)) throw cause;
+
+      /*
+        Somebody in this league already holds him, by a route that did not go
+        through the draft.
+
+        This was a bare insert, and the raw 23505 from
+        `roster_entries_one_owner_per_league` escaped as itself — which the draft
+        `GET` route rethrows, so the room 500s once a second for as long as the
+        condition holds. And it holds: `makeAutoPick` draws from the pool minus
+        this draft's own picks, a player acquired outside the draft is in
+        neither set, and the choice is deterministic, so every tick reaches for
+        the same player forever. Issue #279 measured it — a draft that never
+        advances and a league that never reaches `IN_SEASON`.
+
+        The gate on `addFreeAgent` closes the only production path that could
+        put a non-drafted player into this league's rosters, so this should now
+        be unreachable. It is translated rather than left bare because
+        "unreachable" is a claim about today's writers, and the cost of being
+        wrong about it is a dead league rather than a failed request.
+      */
+      throw new DraftPersistenceError(
+        `Pick ${pick.pickNumber} took ${pick.playerId}, who is already held in this league`,
+        "PICK_PLAYER_TAKEN",
+      );
+    }
 
     // A drafted player is off everyone's queue. Leaving them would make the next
     // auto-pick reach for someone already gone.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -83,6 +83,8 @@ export {
   type AddInput,
   type Availability,
   type WaiverRunOutcome,
+  marketClosedReason,
+  type RosterMove,
 } from "./waivers.js";
 
 export {

--- a/packages/db/src/injured-reserve.test.ts
+++ b/packages/db/src/injured-reserve.test.ts
@@ -44,6 +44,20 @@ async function setup(): Promise<Fixture> {
     rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
   });
 
+  /*
+    In season, because that is where these tests live.
+
+    `createLeague` leaves a league `FORMING`, and since #279 a roster move is
+    refused outside `IN_SEASON`/`PLAYOFFS` — the draft is how a roster is filled
+    before then. Every fixture here describes a league that has drafted and is
+    playing; without this line they describe one that cannot transact at all,
+    which is a different subject from the one being tested.
+
+    Set directly rather than driven through `startDraft` and a full pick
+    sequence, which would make every waiver test a draft test.
+  */
+  await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
   const { teamId } = await addTestTeam(db, league.id, "The Stashers");
 
   const [sport] = await db.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [

--- a/packages/db/src/trades.race.test.ts
+++ b/packages/db/src/trades.race.test.ts
@@ -122,6 +122,20 @@ async function setup(): Promise<Fixture> {
     rules,
   });
 
+  /*
+    In season, because that is where these tests live.
+
+    `createLeague` leaves a league `FORMING`, and since #279 a roster move is
+    refused outside `IN_SEASON`/`PLAYOFFS` — the draft is how a roster is filled
+    before then. Every fixture here describes a league that has drafted and is
+    playing; without this line they describe one that cannot transact at all,
+    which is a different subject from the one being tested.
+
+    Set directly rather than driven through `startDraft` and a full pick
+    sequence, which would make every waiver test a draft test.
+  */
+  await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
   const teams: string[] = [];
   for (let i = 0; i < 4; i++) {
     teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -118,6 +118,20 @@ async function setup(overrides?: Partial<LeagueRules>): Promise<Fixture> {
     rules,
   });
 
+  /*
+    In season, because that is where these tests live.
+
+    `createLeague` leaves a league `FORMING`, and since #279 a roster move is
+    refused outside `IN_SEASON`/`PLAYOFFS` — the draft is how a roster is filled
+    before then. Every fixture here describes a league that has drafted and is
+    playing; without this line they describe one that cannot transact at all,
+    which is a different subject from the one being tested.
+
+    Set directly rather than driven through `startDraft` and a full pick
+    sequence, which would make every waiver test a draft test.
+  */
+  await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
   const teams: string[] = [];
   for (let i = 0; i < 6; i++) {
     teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);
@@ -225,6 +239,9 @@ async function setupWithSecondLeague(): Promise<TwoLeagueFixture> {
     commissionerId: other.id,
     rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
   });
+  await fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [
+    otherLeague.id,
+  ]);
 
   const otherTeams: string[] = [];
   for (let i = 0; i < 2; i++) {

--- a/packages/db/src/waiver-run.test.ts
+++ b/packages/db/src/waiver-run.test.ts
@@ -48,6 +48,20 @@ async function setup(): Promise<Fixture> {
     rules: buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules,
   });
 
+  /*
+    In season, because that is where these tests live.
+
+    `createLeague` leaves a league `FORMING`, and since #279 a roster move is
+    refused outside `IN_SEASON`/`PLAYOFFS` — the draft is how a roster is filled
+    before then. Every fixture here describes a league that has drafted and is
+    playing; without this line they describe one that cannot transact at all,
+    which is a different subject from the one being tested.
+
+    Set directly rather than driven through `startDraft` and a full pick
+    sequence, which would make every waiver test a draft test.
+  */
+  await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
+
   const teams: string[] = [];
   for (let i = 0; i < 2; i++) {
     teams.push((await addTestTeam(db, league.id, `Team ${i + 1}`)).teamId);

--- a/packages/db/src/waivers.test.ts
+++ b/packages/db/src/waivers.test.ts
@@ -19,6 +19,7 @@ import {
   pendingClaims,
   processWaivers,
   seedWaiverPriority,
+  marketClosedReason,
   submitClaim,
 } from "./waivers.js";
 
@@ -78,6 +79,20 @@ async function setup(): Promise<Fixture> {
     commissionerId: commissioner.id,
     rules,
   });
+
+  /*
+    In season, because that is where these tests live.
+
+    `createLeague` leaves a league `FORMING`, and since #279 a roster move is
+    refused outside `IN_SEASON`/`PLAYOFFS` — the draft is how a roster is filled
+    before then. Every fixture here describes a league that has drafted and is
+    playing; without this line they describe one that cannot transact at all,
+    which is a different subject from the one being tested.
+
+    Set directly rather than driven through `startDraft` and a full pick
+    sequence, which would make every waiver test a draft test.
+  */
+  await db.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [league.id]);
 
   const teams: string[] = [];
   for (let i = 0; i < 4; i++) {
@@ -1703,10 +1718,8 @@ describe("choosing which leagues are due — #131", () => {
       addPlayerId: fx.players.get("held")!,
       now: MONDAY,
     });
-    // The selection query only considers leagues actually playing.
-    await fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [
-      fx.leagueId,
-    ]);
+    // Already in season — `setup` puts it there, because since #279 nothing
+    // here could transact otherwise. This used to set it.
   }
 
   it("still returns the healthy leagues when one cannot be checked", async () => {
@@ -1840,5 +1853,175 @@ describe("choosing which leagues are due — #131", () => {
 
     // And due the moment it arrives.
     expect((await leaguesDueForWaivers(fx.client, runsAt)).due).toEqual([fx.leagueId]);
+  });
+});
+
+describe("the market is shut unless the league is playing", () => {
+  /*
+    Issue #279. Nothing gated a roster move on the league's state, so a manager
+    could sign free agents during their own draft — the draft counts its own
+    picks and never reads `roster_entries`, this file counts `roster_entries`
+    and never reads the draft, and a team finished a completed draft holding
+    `totalSlots + 1`.
+
+    The miscount was the mild half. `makeAutoPick` draws from the pool minus
+    this draft's own picks; a signing is in neither set, so the bot reaches for
+    somebody already owned, the roster insert violates
+    `roster_entries_one_owner_per_league`, and it does so identically on every
+    tick — a draft that never advances and a room that 500s once a second.
+  */
+
+  const WHEN = new Date(MONDAY.getTime() + 2 * DAY);
+
+  const closed = async (fx: Fixture, state: string) =>
+    fx.client.query("UPDATE leagues SET state = $2 WHERE id = $1", [fx.leagueId, state]);
+
+  /** Drop somebody first, so there is a claimable player. Needs an open market. */
+  const waived = async (fx: Fixture): Promise<string> => {
+    await dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, MONDAY);
+    return fx.players.get("held")!;
+  };
+
+  it("refuses a signing during the draft, and says where players come from", async () => {
+    const fx = await setup();
+    await closed(fx, "DRAFTING");
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fx.players.get("target")!,
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_IN_SEASON" });
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fx.players.get("target")!,
+        now: MONDAY,
+      }),
+    ).rejects.toThrow(/drafting them/);
+  });
+
+  it("refuses one before the draft too, which is the worse case", async () => {
+    // Reachable from the state every league sits in by default — and a league
+    // that signs anyone pre-draft cannot make pick 1, because the first
+    // auto-pick is the one that collides.
+    const fx = await setup();
+    await closed(fx, "FORMING");
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fx.players.get("target")!,
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_IN_SEASON" });
+  });
+
+  it("refuses a release during the draft, because auto-pick cannot see it", async () => {
+    /*
+      Not symmetry. `makeAutoPick` reads the roster it is filling from
+      `state.picks`, so a manager who drafts a quarterback and cuts him three
+      rounds later leaves the bot believing that slot is filled:
+      `wouldStrandStarters` never reserves a pick for one, and the team ends the
+      draft with no quarterback and no way to have gotten one.
+    */
+    const fx = await setup();
+    await closed(fx, "DRAFTING");
+
+    await expect(
+      dropPlayer(fx.client, fx.leagueId, fx.teams[0]!, fx.players.get("held")!, MONDAY),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_IN_SEASON" });
+  });
+
+  it("refuses a claim during the draft, which would otherwise detonate later", async () => {
+    // `everyoneIsOnWaivers` is a pure weekly clock with no season awareness, so
+    // a pre-season Tuesday reads as a waiver period. Those claims sat PENDING
+    // through the draft — `leaguesDueForWaivers` skips `DRAFTING` — and went
+    // live in the first hour after the final pick.
+    const fx = await setup();
+    const wanted = await waived(fx);
+    await closed(fx, "DRAFTING");
+
+    await expect(
+      submitClaim(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[1]!,
+        addPlayerId: wanted,
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_IN_SEASON" });
+  });
+
+  it("keeps the run itself ungated, so a cycle cannot wedge", async () => {
+    /*
+      The failure this must not reproduce: `0038`'s CHECK refused inside the
+      run's single transaction, so it rolled back the whole league's cycle
+      rather than one claim, the claims stayed PENDING, and the hourly cron
+      re-selected the league and failed identically — forever.
+
+      A claim filed in season must still resolve after the league enters the
+      playoffs, which is the one forward transition that can happen underneath
+      a pending claim.
+    */
+    const fx = await setup();
+    const wanted = await waived(fx);
+    await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[1]!,
+      addPlayerId: wanted,
+      now: MONDAY,
+    });
+
+    await closed(fx, "PLAYOFFS");
+
+    const outcome = await processWaivers(fx.client, fx.leagueId, WHEN);
+    expect(outcome.awarded).toBe(1);
+    expect(await pendingClaims(fx.client, fx.leagueId, fx.teams[1]!)).toHaveLength(0);
+  });
+
+  it("lets a manager withdraw a claim whatever the state, because that is the exit", async () => {
+    // Gating the escape hatch is how a recoverable state becomes a permanent
+    // one. It writes nothing any capacity rule reads.
+    const fx = await setup();
+    const wanted = await waived(fx);
+    const { claimId } = await submitClaim(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teams[1]!,
+      addPlayerId: wanted,
+      now: MONDAY,
+    });
+
+    await closed(fx, "DRAFTING");
+    await expect(
+      cancelClaim(fx.client, fx.leagueId, fx.teams[1]!, claimId),
+    ).resolves.toBeUndefined();
+    expect(await pendingClaims(fx.client, fx.leagueId, fx.teams[1]!)).toHaveLength(0);
+  });
+
+  it("gives the screen the same sentence the refusal carries", async () => {
+    // The two must not be able to disagree: one decides what the screen offers
+    // and the other decides what the server accepts.
+    const fx = await setup();
+    await closed(fx, "DRAFTING");
+
+    const notice = marketClosedReason("DRAFTING", "ACQUIRE");
+    expect(notice).not.toBeNull();
+
+    await expect(
+      addFreeAgent(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teams[0]!,
+        addPlayerId: fx.players.get("target")!,
+        now: MONDAY,
+      }),
+    ).rejects.toThrow(notice!);
+
+    expect(marketClosedReason("IN_SEASON", "ACQUIRE")).toBeNull();
+    expect(marketClosedReason("PLAYOFFS", "RELEASE")).toBeNull();
   });
 });

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -73,7 +73,9 @@ export class WaiverError extends Error {
       | "SLOT_HELD_FOR_TRADE"
       | "DUPLICATE_CLAIM"
       | "IN_A_TRADE"
-      | "GAME_STARTED",
+      | "GAME_STARTED"
+      /** The league is not playing, so nobody is moving players. */
+      | "LEAGUE_NOT_IN_SEASON",
   ) {
     super(message);
     this.name = "WaiverError";
@@ -379,6 +381,89 @@ async function lockRosterRow(
  * `acceptTrade` that committed before it. Under REPEATABLE READ it would read
  * the transaction's original snapshot and silently revert to the bug.
  */
+/** The states in which a manager may move players. Nothing else is a market. */
+const TRANSACTING_STATES = new Set(["IN_SEASON", "PLAYOFFS"]);
+
+/** Which half of the market is being asked for, because they refuse differently. */
+export type RosterMove = "ACQUIRE" | "RELEASE";
+
+/**
+ * Why the market is shut, or `null` when it is open.
+ *
+ * Issue #279. Nothing anywhere gated a roster move on the league's state, so a
+ * manager could sign free agents during their own draft — or before it. The
+ * draft's capacity guard counts its own picks and never reads
+ * `roster_entries`; this file counts `roster_entries` and never reads the
+ * draft. Neither could see the other, and a team ended a completed draft
+ * holding `totalSlots + 1`.
+ *
+ * The miscount was not the worst of it. `makeAutoPick` draws from the pool
+ * minus this draft's own picks, and a free-agent signing is in neither set, so
+ * the bot reaches for a player somebody already owns, the `roster_entries`
+ * insert violates `roster_entries_one_owner_per_league`, and it does so
+ * deterministically on every tick — a permanently wedged draft whose room 500s
+ * once a second. Signing before the draft is worse still: the first pick is the
+ * one that collides, and the league never makes a pick at all.
+ *
+ * **Both halves, and releasing is not merely for symmetry.** Auto-pick reads
+ * the roster it is filling from `state.picks` too, so a manager who drafts a
+ * quarterback and cuts him three rounds later leaves the bot believing that
+ * slot is filled: `wouldStrandStarters` never reserves a pick for one, and the
+ * team finishes with no quarterback and no way to have gotten one. That is the
+ * exact harm auto-pick exists to prevent.
+ *
+ * **Exported, because the screen has to say the same thing the server does.**
+ * `availablePlayers` carries that rule already — the two must not be able to
+ * disagree, because one decides what the screen offers and the other decides
+ * what the server accepts. A manager who is shown a live Add button and then
+ * refused has met a wall rather than an explanation.
+ *
+ * Note a paused draft holds `DRAFTING` — `pauseDraft` writes `drafts.status`
+ * and nothing ever writes league state backwards — so a long pause closes the
+ * market for its duration. That is not a trap: picks are the only way to
+ * acquire anyone at that point, so a paused draft has already stopped
+ * acquisition, and the commissioner holds the control that resumes it.
+ */
+export function marketClosedReason(state: string, move: RosterMove): string | null {
+  if (TRANSACTING_STATES.has(state)) return null;
+
+  if (state === "DRAFTING") {
+    return move === "ACQUIRE"
+      ? "Your draft is still running — you get players by drafting them. Free agency opens when the last pick is in."
+      : "Your draft is still running — it counts every pick you have made, so nobody can be released until the last pick is in.";
+  }
+
+  if (state === "FORMING") {
+    return "This league has not drafted yet. Rosters are filled by the draft, and free agency opens when it finishes.";
+  }
+
+  return "This league's season is over, so its rosters are final.";
+}
+
+/**
+ * The same rule, as a refusal.
+ *
+ * **Member-initiated paths only.** `processWaivers` also writes roster rows and
+ * must never refuse on state: its whole league runs in one transaction, so a
+ * throw rolls back the cycle rather than one claim, the claims stay `PENDING`,
+ * and the hourly cron re-selects the league and fails identically — forever.
+ * That is not hypothetical; migration `0038`'s CHECK did exactly it. The run is
+ * gated where it is safe to gate, at selection, by `leaguesDueForWaivers`.
+ *
+ * It needs no gate anyway. A `PENDING` claim can only exist for a league that
+ * was transacting when it was filed, state only ever moves forward, and no
+ * forward transition leaves `IN_SEASON` or `PLAYOFFS` — so the refusal is
+ * unreachable there by construction and would be pure downside.
+ *
+ * `cancelClaim` is ungated for the same family of reasons: it is the manager's
+ * own exit, it writes nothing any capacity rule reads, and closing an escape
+ * hatch is how a recoverable state becomes a permanent one.
+ */
+function refuseUnlessTransacting(state: string, move: RosterMove): void {
+  const reason = marketClosedReason(state, move);
+  if (reason) throw new WaiverError(reason, "LEAGUE_NOT_IN_SEASON");
+}
+
 async function refuseIfFrozen(
   tx: SqlClient,
   leagueId: string,
@@ -450,6 +535,21 @@ export async function dropPlayer(
   if (!stored) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
 
   return withTransaction(db, async (tx) => {
+    // First, and `FOR SHARE` rather than a bare read.
+    //
+    // The lock is not needed for correctness of this check — state only moves
+    // forward, so a stale read can only be an earlier state, which is only ever
+    // more restrictive. It costs nothing in a statement that has to run anyway,
+    // and it closes something else: this was the one member path that could
+    // land in the middle of a `processWaivers` run, which is precisely what the
+    // matching lock in `addFreeAgent` exists to prevent.
+    const [league] = await tx.query<{ state: string }>(
+      "SELECT state FROM leagues WHERE id = $1 FOR SHARE",
+      [leagueId],
+    );
+    if (!league) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
+    refuseUnlessTransacting(league.state, "RELEASE");
+
     const entry = await lockRosterRow(tx, leagueId, teamId, playerId);
     if (!entry) throw new WaiverError("That player is not on this roster", "NOT_ON_ROSTER");
 
@@ -548,7 +648,18 @@ export async function addFreeAgent(db: SqlClient, input: AddInput): Promise<void
     // lock exists.
     //
     // Adds racing *each other* are arbitrated below, by the index, not by a lock.
-    await tx.query("SELECT id FROM leagues WHERE id = $1 FOR SHARE", [input.leagueId]);
+    // The same lock, one column wider. Reading the state here rather than
+    // before the transaction is what makes it trustworthy: `recordPick` sets
+    // `IN_SEASON` in the transaction that commits the final pick, and `FOR
+    // SHARE` conflicts with that write — so this either reads `DRAFTING` and
+    // refuses, or reads `IN_SEASON` after the last pick has landed. There is no
+    // window between them.
+    const [league] = await tx.query<{ state: string }>(
+      "SELECT state FROM leagues WHERE id = $1 FOR SHARE",
+      [input.leagueId],
+    );
+    if (!league) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
+    refuseUnlessTransacting(league.state, "ACQUIRE");
 
     // Inside the transaction, not before it. Read on `db` and written on `tx`,
     // this answered a question about a moment that had already passed by the time
@@ -769,6 +880,38 @@ export async function submitClaim(
   db: SqlClient,
   input: AddInput,
 ): Promise<{ claimId: string }> {
+  /*
+    The league questions first, because they are true or false before any player
+    is named — and answering the player question first sends a manager to a
+    button that will refuse them anyway.
+
+    This is also the read that used to sit three checks lower, fetching
+    `waiver_priority` only to test whether the row existed. Widened rather than
+    duplicated: it now carries the state as well, joins the team on, and costs
+    the same one round trip. `waiver_priority` is legitimately nullable, so
+    presence is tested on `t.id`, exactly as the old `if (!priority)` did.
+
+    One behaviour change worth naming: a caller naming a team in another league
+    now gets `TEAM_NOT_IN_LEAGUE` where it used to get whatever
+    `availabilityOf` said about the player.
+  */
+  const [league] = await db.query<{
+    state: string;
+    team_id: string | null;
+    waiver_priority: number | null;
+  }>(
+    `SELECT l.state, t.id AS team_id, t.waiver_priority
+       FROM leagues l
+       LEFT JOIN teams t ON t.id = $2 AND t.league_id = l.id
+      WHERE l.id = $1`,
+    [input.leagueId, input.teamId],
+  );
+  if (!league) throw new WaiverError("League has no rules", "LEAGUE_NOT_FOUND");
+  if (league.team_id === null) {
+    throw new WaiverError("Team is not in this league", "TEAM_NOT_IN_LEAGUE");
+  }
+  refuseUnlessTransacting(league.state, "ACQUIRE");
+
   const availability = await availabilityOf(db, input.leagueId, input.addPlayerId, input.now);
   if (availability === "ROSTERED") {
     throw new WaiverError("Somebody already has that player", "PLAYER_TAKEN");
@@ -787,12 +930,6 @@ export async function submitClaim(
   );
   if (existing) throw new WaiverError("You already claimed that player", "DUPLICATE_CLAIM");
 
-  const [priority] = await db.query<{ waiver_priority: number | null }>(
-    "SELECT waiver_priority FROM teams WHERE id = $1 AND league_id = $2",
-    [input.teamId, input.leagueId],
-  );
-  if (!priority) throw new WaiverError("Team is not in this league", "TEAM_NOT_IN_LEAGUE");
-
   const [row] = await db.query<{ id: string }>(
     `INSERT INTO waiver_claims
        (league_id, team_id, add_player_id, drop_player_id, priority_at_claim)
@@ -803,7 +940,7 @@ export async function submitClaim(
       input.teamId,
       input.addPlayerId,
       input.dropPlayerId ?? null,
-      priority.waiver_priority,
+      league.waiver_priority,
     ],
   );
 


### PR DESCRIPTION
Closes #279. Confirmed by a test I wrote before the agents ran, then designed and attacked by three agents with separate roles. Two of their results changed the fix.

## The bug, and the worse bug behind it

Nothing gated a roster move on the league's state. The draft's capacity guard counts its own picks and never reads `roster_entries`; `addFreeAgent` counts `roster_entries` and never reads the draft. A manager signs a free agent mid-draft, the draft still deals them every one of their `rounds` picks, and they finish holding `totalSlots + 1`.

That is the mild half. `makeAutoPick` draws from the pool minus this draft's own picks, and a player acquired outside the draft is in neither set — so the bot reaches for somebody the league already holds and the roster insert violates `roster_entries_one_owner_per_league`. The choice is deterministic, so it happens identically on every tick:

```
PROBE first throw: 23505 | duplicate key value violates unique constraint "roster_entries_one_owner_per_league"
PROBE draft status: IN_PROGRESS picks: 1
PROBE second throw: 23505 | ...
PROBE draft status after retry: IN_PROGRESS picks: 1
```

The draft never advances, the league never reaches `IN_SEASON`, and the draft `GET` route rethrows anything that is not a `DraftContextError` — so **every open draft room 500s, once a second, permanently**. That route's own docstring calls this "the worst possible moment for the room to go blank".

Signing *before* the draft is worse still. The first pick is the one that collides:

```
PROBE pre-draft signings held: 5  state: FORMING
PROBE after draft — picks: 0  draft: IN_PROGRESS  err: 23505
```

**Zero picks.** A league that signs anyone pre-draft cannot make pick 1 — reachable from `FORMING`, which is the state every league starts in.

## Why a gate rather than fixing the count

The obvious alternative is to make the draft's capacity guard read `roster_entries`. It is the honest invariant and it is what #238 taught. It is also worse, and this was measured rather than argued: a team at 13 picks plus one signing is at `totalSlots` when its 14th pick arrives, so `canDraft` returns `ROSTER_FULL` for every candidate, `autoPick` returns `null`, and `makeAutoPick` throws `NO_LEGAL_PICK` — which nothing catches.

```
PROBE autoPick with a roster at totalSlots: null
```

It converts a silent miscount into a permanently stalled draft. The gate is also correct in the domain sense: during a draft, the draft *is* the acquisition mechanism.

## Releasing is gated too, and not for symmetry

I proposed gating `dropPlayer` for consistency and asked the design agent to justify it separately. It found a correctness argument instead: `makeAutoPick` reads the roster it is filling from `state.picks`, so a manager who drafts a quarterback and cuts him three rounds later leaves the bot believing that slot is filled. `wouldStrandStarters` never reserves a pick for a quarterback, and the team finishes the draft without one and with no way to have gotten one — the exact harm auto-pick exists to prevent.

## What is deliberately *not* gated

`processWaivers` and `cancelClaim`.

A throw inside the waiver run rolls back the league's entire cycle rather than one claim, leaves every claim `PENDING`, and re-fails on the next hourly tick — forever. That is not hypothetical: `waivers.ts` documents migration `0038`'s CHECK doing exactly it. The run needs no gate anyway — a pending claim can only exist for a league that was transacting, state only moves forward, and no forward transition leaves the transacting set, so the refusal would be unreachable by construction and pure downside. It is gated where it is safe to gate, at selection, by `leaguesDueForWaivers`.

`cancelClaim` is the manager's own exit. Closing an escape hatch is how a recoverable state becomes a permanent one.

There is a test for each of those, and they are the two that pass with the gate disabled — correctly, because they guard against *over*-gating rather than under-gating.

## The screen changes in the same commit

`availablePlayers` and `availabilityOf` carry an explicit rule that the screen and the server must not be able to disagree, because one decides what is offered and the other decides what is accepted. Shipping the refusal alone would leave a live Add button over a server that says no — a wall instead of an explanation. The notice is composed by the server from the same function that refuses the write, which is also the only way that string gets a test.

The list itself stays. Those players genuinely are unrostered, and scouting the pool during a draft is useful.

## Two riders, both called out rather than smuggled

- **`GAME_STARTED` maps to 409.** Not part of this bug — RULES.md §6's kickoff refusal has been reaching clients as a **400** since it was written, because it was never added to that map. I edited that map earlier tonight to add `SLOT_HELD_FOR_TRADE` and did not notice its sibling.
- **The bare 23505 on the draft's roster insert is translated.** The gate closes the only production path that could cause it; it is translated anyway because "unreachable" is a claim about today's writers and the cost of being wrong is a dead league rather than a failed request.

## The test cost, measured

Every fixture in five files described a league that had never drafted, so **68 tests asserted behaviour the rules do not allow**. They now say they are in season. One of them — `cancelClaim` called with three arguments — was passing vacuously: the claim id bound as the league id, so the UPDATE matched nothing and resolved `undefined`. Typecheck caught that; vitest could not, and would not have.

Five of the seven new tests fail with the gate disabled.

Full suite 2326 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.

## Not fixed here

`leaguesWithDueTrades` has no state filter either, so the hourly cron executes accepted trades mid-draft — the same hole with N players instead of one, and invisible on every screen. Recorded on #279; it needs its own change because the trade path has a different recovery story.