### PR TITLE
fix(db): trades were open during the draft, and after the season

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/trades/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/trades/route.ts
@@ -7,6 +7,7 @@ import {
   listTrades,
   lockedByTrade,
   proposeTrade,
+  tradeClosedReason,
   TradeError,
   transactionWeek,
   vetoTrade,
@@ -33,6 +34,9 @@ const STATUS: Record<string, number> = {
   PLAYER_IN_ANOTHER_TRADE: 409,
   ALREADY_VETOED: 409,
   ROSTER_WOULD_OVERFLOW: 409,
+  // The league is not playing. A conflict with its state, like the 409s above,
+  // and it shares its name with the waiver code for the same rule.
+  LEAGUE_NOT_IN_SEASON: 409,
   TRADES_DISABLED: 400,
   PAST_DEADLINE: 400,
   SAME_TEAM: 400,
@@ -106,6 +110,21 @@ export async function GET(
       deadlineWeek: context.rules.trades.deadlineWeek,
       vetoWindowHours: context.rules.trades.vetoWindowHours,
       tradingClosed: await tradingClosed(now, context.rules),
+      /*
+        Whether the league is playing at all, and the sentence if not.
+
+        Separate from `tradingClosed`, which is the *deadline* — a different
+        question with a different answer, and collapsing them would tell a
+        manager in August that the trade deadline has passed.
+
+        Composed here from the same function that refuses the write, so the
+        screen and the server cannot disagree about what is on offer. It is also
+        the only way the sentence gets a test.
+      */
+      trading: {
+        open: tradeClosedReason(context.state) === null,
+        notice: tradeClosedReason(context.state),
+      },
       teams: teams.map((team) => ({
         teamId: team.id,
         name: team.name,

--- a/apps/web/src/components/TradeBlock.tsx
+++ b/apps/web/src/components/TradeBlock.tsx
@@ -62,6 +62,14 @@ interface TradesResponse {
    * January, permanently.
    */
   tradingClosed: boolean;
+  /**
+   * Whether the league is playing at all, and why not when it is not.
+   *
+   * Separate from `tradingClosed`, which is the deadline. Both can shut trading
+   * and they say different things — "the deadline has passed" is wrong and
+   * confusing in August, when the real answer is that the draft is still on.
+   */
+  trading: { open: boolean; notice: string | null };
   teams: TradeTeam[];
   trades: Trade[];
 }
@@ -181,7 +189,16 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
         </p>
       )}
 
-      {data.enabled && pastDeadline && (
+      {data.trading.notice !== null && (
+        // Above the deadline banner, because it is the more basic fact: a league
+        // that is not playing has not reached its deadline, and saying both
+        // would be saying one wrong thing.
+        <p className="rounded border border-nocturne-neutral-800 bg-nocturne-neutral-950 px-4 py-3 text-sm text-nocturne-neutral-400">
+          {data.trading.notice}
+        </p>
+      )}
+
+      {data.enabled && data.trading.open && pastDeadline && (
         <p className="rounded border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200/80">
           The trade deadline is the end of week {data.deadlineWeek}, and an accepted trade waits{" "}
           {data.vetoWindowHours} hours before it executes — so anything proposed now would land
@@ -192,7 +209,7 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
       {/* --------------------------------------------------------------- */}
       {/* Building an offer                                                */}
       {/* --------------------------------------------------------------- */}
-      {data.enabled && !pastDeadline && mine && (
+      {data.enabled && data.trading.open && !pastDeadline && mine && (
         <section className="space-y-4">
           <h2 className="text-sm font-medium text-nocturne-neutral-400">Propose a trade</h2>
 
@@ -305,18 +322,27 @@ export function TradeBlock({ leagueId }: { leagueId: string }) {
                 <div className="flex flex-wrap gap-2">
                   {trade.state === "PROPOSED" && trade.receiverTeamId === data.myTeamId && (
                     <>
-                      <button
-                        onClick={() =>
-                          void act(
-                            { action: "ACCEPT", tradeId: trade.tradeId },
-                            `Accepted. It executes in ${data.vetoWindowHours} hours unless the league blocks it.`,
-                          )
-                        }
-                        disabled={busy}
-                        className="rounded border border-nocturne-accent px-3 py-1 text-xs font-medium text-black disabled:opacity-30"
-                      >
-                        Accept
-                      </button>
+                      {/*
+                        Accept goes when the league is not playing; Decline stays.
+                        That asymmetry is the point: a stale offer left from a
+                        draft has to be dismissable, or it sits here with no
+                        legal action available to anybody. The notice above says
+                        why Accept is missing.
+                      */}
+                      {data.trading.open && (
+                        <button
+                          onClick={() =>
+                            void act(
+                              { action: "ACCEPT", tradeId: trade.tradeId },
+                              `Accepted. It executes in ${data.vetoWindowHours} hours unless the league blocks it.`,
+                            )
+                          }
+                          disabled={busy}
+                          className="rounded border border-nocturne-accent px-3 py-1 text-xs font-medium text-black disabled:opacity-30"
+                        >
+                          Accept
+                        </button>
+                      )}
                       <button
                         onClick={() =>
                           void act({ action: "DECLINE", tradeId: trade.tradeId }, "Declined.")

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -471,6 +471,13 @@ accept a trade and cut the player they promised, and execution would find a hole
 roster spot used to be. This is the database half of "both NFTs move to the escrow PDA",
 and it holds whether or not the league has a pot.
 
+**Trading opens when the draft finishes.** Until the last pick is in, nobody owns a
+settled roster — the draft is still deciding who owns what, and it counts a team by the
+picks it has made rather than by the players it holds. A trade agreed before then would be
+invisible to it: the team receiving players would still be dealt every one of its picks and
+finish over the limit, and the team sending them would finish under it, with a starting
+slot it no longer has a pick left to fill. Trading closes again when the season is over.
+
 **A trade may change the shape of a roster, never its size past the limit.** A two-for-one
 is a normal trade and no proposal is refused for being uneven — only one where a side gives
 nothing, because a gift is how an eliminated team hands its roster to a friend without

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -307,6 +307,7 @@ export {
   lockedByTrade,
   proposeTrade,
   resolveDueTrades,
+  tradeClosedReason,
   TradeError,
   vetoTrade,
   withdrawTrade,

--- a/packages/db/src/league-state.ts
+++ b/packages/db/src/league-state.ts
@@ -1,0 +1,34 @@
+/**
+ * When a league is playing, and therefore when its rosters may move.
+ *
+ * One fact, in one place, because two files enforce it and they must not be
+ * able to disagree. `waivers.ts` refuses free-agent adds, drops and claims
+ * outside these states (issue #279); `trades.ts` refuses proposals and
+ * acceptances. If those two ever answered differently, a manager could reach
+ * the same roster through the door that had not been told.
+ *
+ * It lives in its own module rather than in either of them because `waivers.ts`
+ * already imports from `trades.ts`, so the reverse import would close a cycle —
+ * and a module-level `Set` inside a cycle is a temporal-dead-zone hazard that
+ * depends on which file the bundler loads first. This module imports nothing.
+ *
+ * **The SQL predicates are deliberately not derived from this.** A query cannot
+ * import a `Set`, and the two selection queries do not even ask the same
+ * question: `leaguesDueForWaivers` names the states it wants, while
+ * `leaguesWithDueTrades` names the two it must avoid. See that function for why
+ * the difference is not an oversight.
+ */
+const TRANSACTING_STATES = new Set(["IN_SEASON", "PLAYOFFS"]);
+
+/**
+ * Whether this league is playing.
+ *
+ * `state` is a `string` rather than a union because nothing in this repo has
+ * ever given `leagues.state` one — every boundary that carries it types it as
+ * `string`, unlike `TradeState` or `CronJobState`, which are declared unions.
+ * Narrowing it is worth doing and is worth doing everywhere at once, which is a
+ * larger change than the one this file arrived with.
+ */
+export function isTransacting(state: string): boolean {
+  return TRANSACTING_STATES.has(state);
+}

--- a/packages/db/src/trades.test.ts
+++ b/packages/db/src/trades.test.ts
@@ -22,6 +22,7 @@ import {
   lockedByTrade,
   proposeTrade,
   resolveDueTrades,
+  tradeClosedReason,
   TradeError,
   vetoTrade,
   withdrawTrade,
@@ -2074,5 +2075,172 @@ describe("a trade may never leave a team over the roster limit", () => {
     await expect(
       acceptTrade(fx.client, second.tradeId, fx.teams[1]!, MONDAY),
     ).rejects.toMatchObject({ code: "ROSTER_WOULD_OVERFLOW" });
+  });
+});
+
+describe("trading is shut unless the league is playing", () => {
+  /*
+    Nothing in `trades.ts` read `leagues.state` at any of its nine entry points,
+    so a trade could be proposed, accepted and executed in the middle of a
+    draft. The draft counts a team's roster from its own picks and never reads
+    `roster_entries`, so the swap is invisible to it: the receiving team is
+    still dealt every one of its picks and finishes over the limit, and the
+    sending team finishes under it with a starting slot it can no longer fill.
+
+    The deadline did not catch it, which is why nothing did. `transactionWeek`
+    asks `games` by sport and season — a table with no league column at all — so
+    a league drafting in August is told its execution week is 1 exactly as a
+    league in play is, and `1 > 11` is false.
+
+    Milder than the same hole on the free-agent side: a traded player was
+    drafted, so he stays in the drafted set and no auto-pick reaches for him.
+    Worse in what it costs: a signing added one player, a trade moves any
+    number, and the capacity check at acceptance approves it because two rounds
+    into a draft a team genuinely does have room.
+  */
+
+  const inState = async (fx: Fixture, state: string) =>
+    fx.client.query("UPDATE leagues SET state = $2 WHERE id = $1", [fx.leagueId, state]);
+
+  it("refuses a proposal during the draft, and says when trading opens", async () => {
+    const fx = await setup();
+    await inState(fx, "DRAFTING");
+
+    await expect(
+      proposeTrade(fx.client, {
+        leagueId: fx.leagueId,
+        proposerTeamId: fx.teams[0]!,
+        proposerGives: [fx.players.get("p1")!],
+        receiverTeamId: fx.teams[1]!,
+        receiverGives: [fx.players.get("p2")!],
+        now: MONDAY,
+      }),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_IN_SEASON" });
+
+    await expect(
+      proposeTrade(fx.client, {
+        leagueId: fx.leagueId,
+        proposerTeamId: fx.teams[0]!,
+        proposerGives: [fx.players.get("p1")!],
+        receiverTeamId: fx.teams[1]!,
+        receiverGives: [fx.players.get("p2")!],
+        now: MONDAY,
+      }),
+    ).rejects.toThrow(/last pick is in/);
+  });
+
+  it("refuses an acceptance during the draft, which is the gate that matters", async () => {
+    // Acceptance is where the assets freeze and where capacity is checked, and
+    // it is the last moment nothing has moved. A refusal leaves the trade
+    // PROPOSED, which both exits can still clear.
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await inState(fx, "DRAFTING");
+
+    await expect(acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY)).rejects.toMatchObject({
+      code: "LEAGUE_NOT_IN_SEASON",
+    });
+  });
+
+  it("still lets the receiver decline one, or nothing could ever clear it", async () => {
+    /*
+      The asymmetry, pinned so a later tidy-up cannot remove it "for symmetry".
+
+      Once accepting is refused, a stale offer left over from a draft would be
+      permanently undismissable if declining were refused too — it would sit on
+      the screen and in the notification strip with no legal action available to
+      anybody.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await inState(fx, "DRAFTING");
+
+    await expect(
+      declineTrade(fx.client, tradeId, fx.teams[1]!, MONDAY),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still lets the proposer withdraw one", async () => {
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await inState(fx, "DRAFTING");
+
+    await expect(
+      withdrawTrade(fx.client, tradeId, fx.teams[0]!, MONDAY),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still lets the league veto an accepted one", async () => {
+    /*
+      The most important of the three. If a trade is somehow accepted in a
+      league that is not playing — which is exactly the state this rule leaves
+      behind when it ships — the veto is the league's only lever against it.
+      Refusing the vote would freeze the trade and disarm the one control that
+      could stop it.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await inState(fx, "DRAFTING");
+
+    await expect(vetoTrade(fx.client, tradeId, fx.teams[2]!, MONDAY)).resolves.toBeDefined();
+  });
+
+  it("holds an accepted trade back while the league drafts, rather than executing it", async () => {
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await inState(fx, "DRAFTING");
+
+    expect(await leaguesWithDueTrades(fx.client, AFTER_WINDOW)).toEqual([]);
+
+    // And it lands on its own once the draft finishes — the league reaches
+    // IN_SEASON in the same transaction as the final pick, so the wait is the
+    // rest of the draft and no longer.
+    await inState(fx, "IN_SEASON");
+    expect(await leaguesWithDueTrades(fx.client, AFTER_WINDOW)).toEqual([fx.leagueId]);
+  });
+
+  it("still selects a league whose season is over, so its stale trades expire", async () => {
+    /*
+      Why this filter is negative where the waiver one is positive.
+
+      Naming the playing states here would strand every overdue trade in a
+      finished league: nothing would select it again, the trade would stay
+      ACCEPTED for good, and both sides' players would stay frozen. Selected,
+      it resolves itself — `transactionWeek` answers null once the season's
+      games are behind us, `pastTradeDeadline` treats that as past every
+      deadline, and the trade expires with the rosters untouched.
+    */
+    const fx = await setup();
+    const tradeId = await propose(fx);
+    await acceptTrade(fx.client, tradeId, fx.teams[1]!, MONDAY);
+    await inState(fx, "SETTLED");
+
+    expect(await leaguesWithDueTrades(fx.client, AFTER_WINDOW)).toEqual([fx.leagueId]);
+  });
+
+  it("gives the screen the same sentence the refusal carries", async () => {
+    const fx = await setup();
+    await inState(fx, "DRAFTING");
+
+    const notice = tradeClosedReason("DRAFTING");
+    expect(notice).not.toBeNull();
+
+    await expect(
+      proposeTrade(fx.client, {
+        leagueId: fx.leagueId,
+        proposerTeamId: fx.teams[0]!,
+        proposerGives: [fx.players.get("p1")!],
+        receiverTeamId: fx.teams[1]!,
+        receiverGives: [fx.players.get("p2")!],
+        now: MONDAY,
+      }),
+    ).rejects.toThrow(notice!);
+
+    expect(tradeClosedReason("IN_SEASON")).toBeNull();
+    expect(tradeClosedReason("PLAYOFFS")).toBeNull();
+    expect(tradeClosedReason("FORMING")).toMatch(/has not drafted yet/);
+    expect(tradeClosedReason("SETTLED")).toMatch(/season is over/);
   });
 });

--- a/packages/db/src/trades.ts
+++ b/packages/db/src/trades.ts
@@ -37,6 +37,7 @@ import {
   vetoesRequired,
 } from "@rostr/core";
 import type { CommittedTrade, LeagueRules } from "@rostr/core";
+import { isTransacting } from "./league-state.js";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { withTransaction } from "./transaction.js";
@@ -96,6 +97,18 @@ export class TradeError extends Error {
       | "VETOED_WHILE_EXECUTING"
       | "ALREADY_VETOED"
       | "ROSTER_WOULD_OVERFLOW"
+      /**
+       * The league is not playing, so there is nothing settled to trade.
+       *
+       * Not `WRONG_STATE`, which is about the *trade's* state. This union has
+       * split a code off that one twice already for the same reason — the
+       * member is not confused about the trade, and telling them about it sends
+       * them looking for a fault that is not there.
+       *
+       * Deliberately the same name as `WaiverError`'s code for the same rule,
+       * so somebody grepping the string finds both halves of it.
+       */
+      | "LEAGUE_NOT_IN_SEASON"
       | "ASSET_GONE",
   ) {
     super(message);
@@ -406,6 +419,26 @@ export async function proposeTrade(
   const stored = await getLeagueRules(db, input.leagueId);
   if (!stored) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
 
+  /*
+    The league question first, because it is true or false before any player is
+    named — and answering the player question first sends a manager to a button
+    that will refuse them anyway.
+
+    Read from the column rather than from `stored`, deliberately. State is not
+    in the frozen document and must not look as though it is: it changes, which
+    is the whole reason anything reads it.
+
+    No lock. A proposal landing in the instant a draft ends is harmless — it
+    simply becomes a legal proposal — so there is nothing here for a lock to
+    protect.
+  */
+  const [league] = await db.query<{ state: string }>(
+    "SELECT state FROM leagues WHERE id = $1",
+    [input.leagueId],
+  );
+  if (!league) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
+  refuseUnlessTrading(league.state);
+
   // Derived here, never taken from the caller. This used to be a `week` field on
   // the input, supplied by the route — so the rule depended on a number computed
   // outside the package that enforces it, and the route computed it wrongly.
@@ -593,6 +626,76 @@ async function projectedSizeFor(
 }
 
 /**
+ * Why trading is shut, or `null` when it is open.
+ *
+ * Nothing in this file has ever read `leagues.state` — not at any of its nine
+ * entry points — so a trade could be proposed, accepted and executed in the
+ * middle of a draft. The draft engine counts a team's roster from
+ * `state.picks` and never reads `roster_entries`, so a mid-draft swap is
+ * invisible to it: the receiving team is still dealt every one of its picks and
+ * finishes over the limit, and the sending team finishes under it with a
+ * starting slot it can no longer fill.
+ *
+ * It is worse than the same hole on the free-agent side (#279), for three
+ * reasons. A signing added one player; a trade moves any number. The capacity
+ * check at acceptance *approves* it, because two rounds into a draft a team
+ * genuinely does have room for twelve more. And it takes two managers to agree,
+ * which is the shape collusion has — while the league's only defence is a veto
+ * cast on a trade whose real effect nobody can see yet.
+ *
+ * The deadline does not catch it, which is why nothing did: `transactionWeek`
+ * asks `games` by sport and season, and that table has no league column at all,
+ * so a league drafting in August is told the execution week is 1 exactly as a
+ * league in play is. `1 > 11` is false, and the trade goes through.
+ *
+ * Exported so the screen refuses from the same function the server does.
+ */
+export function tradeClosedReason(state: string): string | null {
+  if (isTransacting(state)) return null;
+
+  if (state === "DRAFTING") {
+    return (
+      "Your draft is still running — every roster in this league is still being filled, " +
+      "so there is nothing settled to trade yet. Trading opens when the last pick is in."
+    );
+  }
+
+  if (state === "FORMING") {
+    return (
+      "This league has not drafted yet. Nobody owns a player until the draft runs, " +
+      "and trading opens when it finishes."
+    );
+  }
+
+  return "This league's season is over, so its rosters are final.";
+}
+
+/**
+ * The same rule, as a refusal.
+ *
+ * **Proposing and accepting only.** Declining, withdrawing and vetoing are not
+ * gated, and that asymmetry is load-bearing rather than an omission:
+ *
+ * - Decline and withdraw only ever cancel. Once accepting is refused, a stale
+ *   offer left over from a draft would be permanently undismissable if
+ *   declining were refused too — it would sit on the screen and in the
+ *   notification strip with no legal action available to anybody.
+ * - A veto is the league's only lever against a trade that is already accepted,
+ *   which is exactly the state this rule leaves behind when it ships. Refusing
+ *   the vote would freeze the trade and disarm the one control that could stop
+ *   it, which is strictly worse than letting it be cast.
+ *
+ * `resolveTrade` is not gated either, and must not be: a throw there leaves the
+ * trade accepted and retried hourly with both sides' players frozen, which is
+ * the failure its own capacity comment already warns about. The executor is
+ * held back at selection instead — see `leaguesWithDueTrades`.
+ */
+function refuseUnlessTrading(state: string): void {
+  const reason = tradeClosedReason(state);
+  if (reason) throw new TradeError(reason, "LEAGUE_NOT_IN_SEASON");
+}
+
+/**
  * Accept a trade, opening the veto window.
  *
  * This is the moment the players freeze. Nothing moves yet — rosters swap only
@@ -622,6 +725,27 @@ export async function acceptTrade(
   );
 
   return withTransaction(db, async (tx) => {
+    /*
+      The league state, locked, and this is the gate that matters.
+
+      Acceptance is the moment the assets freeze and the moment capacity is
+      checked, and it is the last point at which nothing has moved. Refusing
+      here leaves the trade `PROPOSED`, which both exits can still clear.
+
+      `FOR SHARE` for the reason `addFreeAgent` gives: `recordPick` sets
+      `IN_SEASON` in the transaction that commits the final pick, so this either
+      reads `DRAFTING` and refuses, or reads `IN_SEASON` after the last pick has
+      landed. There is no window between them — which is what makes the capacity
+      check below trustworthy again, since it now runs against a finished roster
+      or not at all.
+    */
+    const [league] = await tx.query<{ state: string }>(
+      "SELECT state FROM leagues WHERE id = $1 FOR SHARE",
+      [trade.leagueId],
+    );
+    if (!league) throw new TradeError("League has no rules", "LEAGUE_NOT_FOUND");
+    refuseUnlessTrading(league.state);
+
     // Re-validate every asset now, not only at propose time. Accepting is the
     // moment the trade freezes for execution, and the proposal's checks are
     // stale: since then a player could have been dropped, or committed to a
@@ -1353,11 +1477,42 @@ export async function leaguesWithDueTrades(
   db: SqlClient,
   now: Date,
 ): Promise<readonly string[]> {
-  const rows = await db.query<{ league_id: string }>(
-    `SELECT DISTINCT league_id FROM trades
-      WHERE state = 'ACCEPTED' AND veto_deadline IS NOT NULL AND veto_deadline <= $1`,
+  /*
+    Held back for the two states in which a roster is still being filled by
+    something that cannot see this table.
+
+    **Negative, where `leaguesDueForWaivers` is positive, and the difference is
+    deliberate.** Naming `IN_SEASON` and `PLAYOFFS` here would strand every
+    overdue trade in a league that has finished: nothing would ever select it
+    again, the trade would stay `ACCEPTED` for good, and both sides' players
+    would stay frozen in a league that is over. Today those leagues resolve
+    themselves correctly — once the season's games are behind us
+    `transactionWeek` answers `null`, `pastTradeDeadline` treats that as past
+    every deadline, and `resolveTrade` writes `EXPIRED` with the rosters
+    untouched. That is the outcome `RULES.md` §6 names, and it is reached
+    without anybody adding a branch for it.
+
+    So this filter says what is actually true: the draft is the thing the
+    executor cannot see. Everything after it is a league whose rosters are
+    settled, and the deadline path already decides correctly for all of them.
+
+    **Not vacuous, unlike its sibling.** A pending waiver claim can only exist
+    for a league that was playing when it was filed, so that filter never
+    excludes anything. This one does: an accepted trade in a drafting league is
+    exactly what it holds back. After the gate on `acceptTrade` no new one can
+    arise, so what it catches is any row already accepted when this shipped —
+    and those execute on their own once the draft ends.
+  */
+  const rows = await db.query<{ id: string }>(
+    `SELECT DISTINCT l.id
+       FROM leagues l
+       JOIN trades t ON t.league_id = l.id
+                    AND t.state = 'ACCEPTED'
+                    AND t.veto_deadline IS NOT NULL
+                    AND t.veto_deadline <= $1
+      WHERE l.state NOT IN ('FORMING', 'DRAFTING')`,
     [now.toISOString()],
   );
 
-  return rows.map((row) => row.league_id);
+  return rows.map((row) => row.id);
 }

--- a/packages/db/src/waivers.ts
+++ b/packages/db/src/waivers.ts
@@ -54,6 +54,7 @@ import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
 import { isUniqueViolation } from "./pg-errors.js";
 import { loadDraftBoard } from "./sync.js";
+import { isTransacting } from "./league-state.js";
 import { committedTradeMoves, lockedByTrade } from "./trades.js";
 import { withTransaction } from "./transaction.js";
 import { transactionWeek } from "./week.js";
@@ -381,9 +382,6 @@ async function lockRosterRow(
  * `acceptTrade` that committed before it. Under REPEATABLE READ it would read
  * the transaction's original snapshot and silently revert to the bug.
  */
-/** The states in which a manager may move players. Nothing else is a market. */
-const TRANSACTING_STATES = new Set(["IN_SEASON", "PLAYOFFS"]);
-
 /** Which half of the market is being asked for, because they refuse differently. */
 export type RosterMove = "ACQUIRE" | "RELEASE";
 
@@ -425,7 +423,7 @@ export type RosterMove = "ACQUIRE" | "RELEASE";
  * acquisition, and the commissioner holds the control that resumes it.
  */
 export function marketClosedReason(state: string, move: RosterMove): string | null {
-  if (TRANSACTING_STATES.has(state)) return null;
+  if (isTransacting(state)) return null;
 
   if (state === "DRAFTING") {
     return move === "ACQUIRE"


### PR DESCRIPTION
The last live instance of the hole #281 closed for free agents and waivers. Three agents: one audited every trade path, one designed, one attacked. They disagreed on the decision that mattered, and resolving that disagreement is most of this PR.

## Proven, not inferred

```
✓ the deadline check does not refuse in August
✓ proposes, accepts, is selected by the cron, and EXECUTES — mid-draft
✓ and a SETTLED league is still selected by the cron
```

The mid-draft case asserts the league is still `DRAFTING` at resolution, that `resolveDueTrades` returns `EXECUTED`, and that both `roster_entries` rows actually swapped teams.

**The deadline is why nothing caught it.** `transactionWeek` asks `games` by sport and season — and that table has no `league_id` column at all, so there is no per-league schedule to be pre-season *from*. A league drafting in August is told its execution week is 1, exactly as a league in play is, and `1 > 11` is false.

## Severity: a miscount, not a wedge — and I want to be exact about that

I inherited #279's framing and it does not apply. A traded player was *drafted*, so he stays in `draftedPlayerIds` and no auto-pick reaches for him. #279's free agent was in `roster_entries` and **not** in `state.picks`; a traded player is in both. A trade is ownership-conserving where a signing was ownership-creating. No collision, no 500 loop, no dead league.

Worse in three other ways, though:

- **Unbounded.** A signing added one player. A trade moves any number — and `acceptTrade`'s capacity check *approves* it, because two rounds into a draft a team genuinely has room for twelve more.
- **Collusion-shaped**, and the league's only defence is a veto cast on a trade whose real effect is invisible at voting time.
- **Every slow draft outlasts the default 48-hour veto window** — 8 days at the fastest slow setting, months at 24h per pick. No unusual configuration required.

Plus the same stranded-starter harm #279 gated `dropPlayer` for: trade your only quarterback away and auto-pick still believes that slot is filled. Except a cut is self-inflicted, and a trade is something a counterparty can solicit.

## The disagreement, and why the filter is negative

The design agent said filter negatively (`NOT IN ('FORMING','DRAFTING')`); the breaker said positively (`IN ('IN_SEASON','PLAYOFFS')`), matching the waiver sibling — and then, in the same report, identified the `SETTLED` case as *"a landmine you would be arming"*. Its own recommendation arms it.

The negative filter is right, and the reason is mechanical. A finished league that is still selected resolves itself correctly today: `transactionWeek` answers `null` once the season's games are behind us, `pastTradeDeadline` treats `null` as past every deadline, and `resolveTrade` writes `EXPIRED` with rosters untouched and assets released — the outcome `RULES.md` §6 already names, reached with no new branch. Filter positively and that league is never selected again: the trade stays `ACCEPTED` for good, with both sides' players frozen in a league that is over.

So the filter names the two states where a roster is still being filled by something that cannot see this table, rather than naming the states that are fine.

**And unlike its sibling it is not vacuous.** A pending waiver claim can only exist for a league that was playing when it was filed, so that filter never excludes anything. This one does — an accepted trade in a drafting league is exactly what it holds back. After the gate no new one can arise, so what it catches is any row already accepted when this ships, and those execute on their own once the draft ends.

## What is deliberately not gated

**Decline, withdraw and veto.** Once accepting is refused, a stale offer left from a draft would be permanently undismissable if declining were refused too — it would sit on the screen and in the notification strip with no legal action available to anybody. And a veto is the league's only lever against a trade that is *already* accepted, which is precisely the state this rule leaves behind when it ships; refusing the vote would freeze the trade and disarm the one control that could stop it.

There is a test for each, so a later tidy-up cannot delete the asymmetry for symmetry's sake.

**`resolveTrade`.** A throw there leaves the trade accepted and retried hourly with both sides frozen — the failure its own capacity comment already warns about. It is held back at selection instead.

## Why not make the draft's capacity check read `roster_entries`

That is the honest-looking fix and it is the one #279 already paid to rule out. The snake gives every team exactly `rounds` picks and no way to skip one, so a team that received a net-positive trade would hit `totalSlots` before its picks ran out — then `canDraft` refuses every candidate, `autoPick` returns `null`, and `makeAutoPick` throws `NO_LEGAL_PICK` deterministically on every remaining tick. It converts today's miscount into tomorrow's dead league.

There is also nothing to defend: `trade_assets.player_id` references `players`, so there is no pick trading and no schema that could express one. The feature was never designed to run before kickoff.

## Verification

Four of eight new tests fail with the gate and filter disabled; the other four pin what must *not* be gated, so they correctly pass either way.

**Zero existing tests broke** — the breaker predicted this by simulating the gate with a load-time transform before I wrote a line, and it was right: #281 had already put `IN_SEASON` into every trade fixture.

Full suite 2334 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.

## Not in this PR

`resolveTrade` still does not re-check capacity at execution, so a trade accepted legally can still overflow a roster if a stashed player recovers during the veto window. That is a real hole and an old one — it predates this change and is not created by it — but the deferral here widens the window slightly. It needs its own change, because the answer is a third non-throwing terminal branch and a decision about whether expiring a legal trade is acceptable. Filing separately.