### PR TITLE
fix(db): activating an injured player could put a roster over the limit

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/ir/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/ir/route.ts
@@ -25,6 +25,11 @@ const STATUS: Record<string, number> = {
   NOT_INJURED: 409,
   IR_FULL: 409,
   GAME_STARTED: 409,
+  // Bringing him back would breach the roster limit, or a trade is holding the
+  // room. Same family as the three above, and without these the fallback below
+  // would report a state conflict as a malformed request.
+  ROSTER_WOULD_OVERFLOW: 409,
+  SLOT_HELD_FOR_TRADE: 409,
 };
 
 function fail(error: unknown): NextResponse {

--- a/packages/db/src/injured-reserve.test.ts
+++ b/packages/db/src/injured-reserve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildNflPprRules, NFL } from "@rostr/core";
+import { buildNflPprRules, buildRosterShape, NFL } from "@rostr/core";
 import type { DraftRules, LeagueRules } from "@rostr/core";
 import { createLeague } from "./leagues.js";
 import { createUser } from "./identity.js";
@@ -356,5 +356,183 @@ describe("the check constraint", () => {
 describe("IrError", () => {
   it("carries a code a route can map to a status", () => {
     expect(new IrError("nope", "NOT_INJURED").code).toBe("NOT_INJURED");
+  });
+});
+
+describe("activation may not push a roster past the limit — #272", () => {
+  /*
+    `activateFromIr` was an unconditional flag flip. A team at the limit could
+    bring back a player who was still genuinely hurt and sit at `totalSlots + 1`
+    — a second route past the line #250 drew, and the one the function's own
+    docstring was accidentally defending.
+
+    That argument is sound for a *recovered* player: he already counts,
+    activation costs nothing, and refusing would trap the roster in an illegal
+    state. It never covered a player who is still out, where activation is +1
+    and leaving him stashed is legal and stable.
+
+    The fixture is why this was reachable at all — every test in this file ran
+    on a four-player roster against fourteen slots, ten short of the boundary
+    the rule lives on.
+  */
+
+  const SHAPE = buildRosterShape(
+    (buildNflPprRules({ seasonYear: 2026, draft: DRAFT }) as LeagueRules).roster,
+    NFL,
+  );
+
+  /** Top the team up to `rows` unreleased players, all fit. */
+  const fillTo = async (fx: Fixture, rows: number): Promise<void> => {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [rb] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [held] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [fx.teamId],
+    );
+
+    for (let i = held!.n; i < rows; i++) {
+      const handle = `filler-${i}`;
+      const [player] = await fx.client.query<{ id: string }>(
+        `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+         VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+        [sport!.id, handle, handle, rb!.id],
+      );
+      await fx.client.query(
+        "INSERT INTO roster_entries (team_id, player_id, acquired_via) VALUES ($1, $2, 'DRAFT')",
+        [fx.teamId, player!.id],
+      );
+    }
+  };
+
+  /** Counted size, worked out here rather than imported, so the test agrees independently. */
+  const countedFor = async (fx: Fixture): Promise<number> => {
+    const rows = await fx.client.query<{ on_ir: boolean; designation: string | null }>(
+      `SELECT r.on_ir, p.injury_designation AS designation
+         FROM roster_entries r JOIN players p ON p.id = r.player_id
+        WHERE r.team_id = $1 AND r.released_at IS NULL`,
+      [fx.teamId],
+    );
+    const genuine = rows.filter((row) => row.on_ir && row.designation === "OUT").length;
+    return rows.length - Math.min(genuine, SHAPE.irSlots);
+  };
+
+  const stash = async (fx: Fixture, handle: string) =>
+    moveToIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get(handle)!,
+      week: 2,
+      now: NOW,
+    });
+
+  const activate = async (fx: Fixture, handle: string) =>
+    activateFromIr(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      playerId: fx.players.get(handle)!,
+    });
+
+  it("refuses to bring back a player who is still out, when the roster is full", async () => {
+    const fx = await setup();
+    await stash(fx, "hurt");
+    // One stashed and exempt, fourteen counting: exactly at the limit.
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots);
+
+    await expect(activate(fx, "hurt")).rejects.toMatchObject({
+      code: "ROSTER_WOULD_OVERFLOW",
+    });
+
+    // Says the number, and says the stash is not a problem to be solved.
+    await expect(activate(fx, "hurt")).rejects.toThrow(/15 players and the limit is 14/);
+    await expect(activate(fx, "hurt")).rejects.toThrow(/as long as he needs it/);
+
+    // And he is still on injured reserve, which is the legal state he was in.
+    const [row] = await fx.client.query<{ on_ir: boolean }>(
+      "SELECT on_ir FROM roster_entries WHERE team_id = $1 AND player_id = $2",
+      [fx.teamId, fx.players.get("hurt")],
+    );
+    expect(row?.on_ir).toBe(true);
+  });
+
+  it("still brings back a recovered player from a roster already over the limit", async () => {
+    /*
+      The escape route, and the reason the predicate asks what the move costs
+      rather than whether the player is exempt. This team is over the limit
+      because his designation cleared — refusing here would trap it in the
+      illegal state instead of letting the manager resolve it.
+    */
+    const fx = await setup();
+    await stash(fx, "hurt");
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    await fx.client.query("UPDATE players SET injury_designation = NULL WHERE id = $1", [
+      fx.players.get("hurt"),
+    ]);
+
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots + 1);
+    await expect(activate(fx, "hurt")).resolves.toBeDefined();
+  });
+
+  it("allows it when the roster has room", async () => {
+    const fx = await setup();
+    await stash(fx, "hurt");
+    await fillTo(fx, SHAPE.totalSlots);
+
+    // Thirteen counting, one exempt: bringing him back lands exactly on the
+    // limit, which is legal.
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots - 1);
+    await expect(activate(fx, "hurt")).resolves.toBeDefined();
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots);
+  });
+
+  it("allows the one that costs nothing when more are hurt than there are slots", async () => {
+    /*
+      The case a predicate keyed on "is this player exempt" gets wrong, and the
+      reason this one is keyed on the delta instead.
+
+      `irExemptCount` caps exemptions at `irSlots` **by count, not identity** —
+      three stashed players against two slots means two exemptions and no way
+      to say which two. So the first activation costs nothing: one of the three
+      was already counting. Only the second one raises the count.
+
+      A predicate asking `onIr && isIrEligible` answers yes for all three and
+      refuses all three, every one wrongly.
+    */
+    const fx = await setup();
+    await stash(fx, "hurt");
+    await stash(fx, "alsohurt");
+
+    // A third stash needs a slot to free first, which is how a real roster
+    // reaches this state: a designation lifts, the slot frees, it comes back.
+    await fx.client.query(
+      "UPDATE players SET injury_designation = 'QUESTIONABLE' WHERE id = $1",
+      [fx.players.get("hurt")],
+    );
+    await stash(fx, "third");
+    await fx.client.query("UPDATE players SET injury_designation = 'OUT' WHERE id = $1", [
+      fx.players.get("hurt"),
+    ]);
+
+    await fillTo(fx, SHAPE.totalSlots + 2);
+
+    // Three stashed, two slots: fourteen counting, at the limit.
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots);
+
+    // Free — one of the three was already counting.
+    await expect(activate(fx, "hurt")).resolves.toBeDefined();
+    expect(await countedFor(fx)).toBe(SHAPE.totalSlots);
+
+    // This one genuinely costs a slot.
+    await expect(activate(fx, "alsohurt")).rejects.toMatchObject({
+      code: "ROSTER_WOULD_OVERFLOW",
+    });
   });
 });

--- a/packages/db/src/injured-reserve.ts
+++ b/packages/db/src/injured-reserve.ts
@@ -1,8 +1,15 @@
-import { buildRosterShape, NFL, refuseIrPlacement } from "@rostr/core";
+import {
+  buildRosterShape,
+  countedRosterSize,
+  NFL,
+  refuseIrPlacement,
+  reservedByTrades,
+} from "@rostr/core";
 import type { IrPlacementRefusal } from "@rostr/core";
 import { getLeagueRules } from "./leagues.js";
 import type { SqlClient } from "./client.js";
 import { withTransaction } from "./transaction.js";
+import { committedTradeMoves } from "./trades.js";
 
 /**
  * Moving a player on and off injured reserve.
@@ -20,7 +27,26 @@ import { withTransaction } from "./transaction.js";
 export class IrError extends Error {
   constructor(
     message: string,
-    readonly code: IrPlacementRefusal | "LEAGUE_NOT_FOUND" | "NOT_ON_IR" | "GAME_STARTED",
+    readonly code:
+      | IrPlacementRefusal
+      | "LEAGUE_NOT_FOUND"
+      | "NOT_ON_IR"
+      | "GAME_STARTED"
+      /**
+       * Bringing him back would put the roster over the limit.
+       *
+       * Named as `acceptTrade` names the same fact, and deliberately not
+       * `ROSTER_FULL`: that code's sentence is "drop someone first", which is
+       * the instruction issue #273 documents as misleading in exactly this
+       * corner — dropping the injured man frees an IR slot, not a roster slot.
+       *
+       * Not added to `IrPlacementRefusal`. That union is the vocabulary
+       * `refuseIrPlacement` speaks about *placing* a player, and it would owe a
+       * `REFUSALS` message for a refusal it can never produce.
+       */
+      | "ROSTER_WOULD_OVERFLOW"
+      /** A slot is being held for a trade this team accepted. */
+      | "SLOT_HELD_FOR_TRADE",
   ) {
     super(message);
     this.name = "IrError";
@@ -131,17 +157,70 @@ export async function moveToIr(
 }
 
 /**
+ * The roster, for a capacity question, locked.
+ *
+ * A sibling of `heldRoster` rather than a reuse of it: that one joins `games`
+ * for a kickoff time, which needs a season and a week, and activation
+ * deliberately has no kickoff rule — the route does not even send a week for it.
+ *
+ * `FOR UPDATE OF r` for the same reason `heldRoster` gives: lock the roster
+ * rows, never the shared `players` rows.
+ */
+async function heldForCapacity(
+  tx: SqlClient,
+  teamId: string,
+): Promise<{ player_id: string; on_ir: boolean; designation: string | null }[]> {
+  return tx.query<{ player_id: string; on_ir: boolean; designation: string | null }>(
+    `SELECT r.player_id, r.on_ir, p.injury_designation AS designation
+       FROM roster_entries r
+       JOIN players p ON p.id = r.player_id
+      WHERE r.team_id = $1 AND r.released_at IS NULL
+      FOR UPDATE OF r`,
+    [teamId],
+  );
+}
+
+/**
  * Bring a player back.
  *
- * **Never refused for capacity**, and that is the important asymmetry. A team
- * whose stashed player recovered is already over the counted limit — the
- * exemption evaporated the moment his designation cleared — so refusing to
- * activate him would trap the roster in the illegal state rather than let the
- * manager resolve it. Activation is the fix, not the offence.
+ * **A recovered player is never refused**, and that is the important
+ * asymmetry. A team whose stashed player recovered is already over the counted
+ * limit — the exemption evaporated the moment his designation cleared — so
+ * refusing to activate him would trap the roster in the illegal state rather
+ * than let the manager resolve it. Activation is the fix, not the offence.
  *
- * Nor does it check the kickoff. Coming off IR only ever *adds* to what counts
- * against the limit, so it cannot be used to dodge anything mid-game, and the
- * lineup lock still decides whether he can actually be started.
+ * **A player who is still genuinely hurt is a different case, and this used to
+ * treat them alike.** He is not counting, activation is `+1`, and nothing is
+ * trapped by refusing: leaving him on injured reserve is a legal, stable state
+ * that costs the team nothing. So a team at the limit could bring him back and
+ * sit at `totalSlots + 1` — a second route past the line #250 drew, and the
+ * one the docstring above was accidentally defending. Issue #272.
+ *
+ * ## The question this asks, and the one it refuses to ask
+ *
+ * Not "is this player exempt". That has no answer. `irExemptCount` caps
+ * exemptions at `irSlots` **by count, not by identity**, so a team holding
+ * three genuinely-injured players with two slots has two exemptions and no way
+ * to say which two — and any tie-break invented here (insertion order, id,
+ * acquisition date) would be a rule that exists nowhere else in the product.
+ *
+ * The well-formed question is what the move *costs*: recompute the counted size
+ * with this player's flag flipped and compare. The algebra is
+ * `capped(g, s) - capped(g - 1, s)`, which is **1 when `g <= s` and 0 when
+ * `g > s`** — so the third stashed player of three, with two slots, activates
+ * for free, because one of the three was already counting. A predicate keyed on
+ * `onIr && isIrEligible` refuses all three of them, every one wrongly.
+ *
+ * ## Why this cannot trap anybody
+ *
+ * It refuses only when the move *raises* the count and lands over the limit,
+ * which means the roster it refuses from is `after - 1 <= totalSlots` —
+ * legal. A refusal therefore never leaves a manager in an illegal state, which
+ * is what separates it from the case the docstring above rightly protects.
+ *
+ * Still no kickoff check. Coming off IR only ever adds to what counts, so it
+ * cannot be used to dodge anything mid-game, and the lineup lock still decides
+ * whether he can actually be started.
  */
 export async function activateFromIr(
   db: SqlClient,
@@ -151,16 +230,83 @@ export async function activateFromIr(
     readonly playerId: string;
   },
 ): Promise<{ playerId: string }> {
-  const rows = await db.query<{ player_id: string }>(
-    `UPDATE roster_entries SET on_ir = false
-      WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL AND on_ir
-      RETURNING player_id`,
-    [input.teamId, input.playerId],
-  );
+  const stored = await getLeagueRules(db, input.leagueId);
+  if (!stored) throw new IrError("League has no rules", "LEAGUE_NOT_FOUND");
+  const shape = buildRosterShape(stored.rules.roster, NFL);
 
-  if (rows.length === 0) {
-    throw new IrError("That player is not on injured reserve.", "NOT_ON_IR");
-  }
+  return withTransaction(db, async (tx) => {
+    /*
+      Locked, because this reads every row of the roster and then writes one of
+      them. Two managers cannot do this at once, but one manager with two tabs
+      can: both reads see a roster where only their own flip is pending, both
+      compute the same room, and the two `UPDATE`s touch different rows so
+      nothing conflicts. Textbook write skew, and `FOR UPDATE` is what stops it.
+    */
+    const held = await heldForCapacity(tx, input.teamId);
+    const roster = held.map((row) => ({
+      playerId: row.player_id,
+      onIr: row.on_ir,
+      injuryDesignation: row.designation,
+    }));
 
-  return { playerId: input.playerId };
+    if (!roster.some((entry) => entry.playerId === input.playerId && entry.onIr)) {
+      throw new IrError("That player is not on injured reserve.", "NOT_ON_IR");
+    }
+
+    // The same roster with this one move made. Rows are unchanged — activation
+    // releases nobody — so only the exemption count can move.
+    const activated = roster.map((entry) =>
+      entry.playerId === input.playerId ? { ...entry, onIr: false } : entry,
+    );
+
+    const before = countedRosterSize(roster, shape.irSlots);
+    const after = countedRosterSize(activated, shape.irSlots);
+
+    /*
+      Room already spoken for by accepted trades, counted against the roster
+      this move would leave behind.
+
+      Computed on `activated` rather than on `roster`: a stashed player who is
+      also on his way out in a trade frees no roster slot while he is exempt,
+      but does once he is not, and measuring before the flip would count him
+      twice and refuse a move that fits.
+
+      Cheap to skip when the move is free — `after > before` is checked first,
+      so the recovered player never reaches this query at all.
+    */
+    if (after > before) {
+      const moves = await committedTradeMoves(tx, input.leagueId);
+      const reserved = reservedByTrades(
+        activated,
+        moves.get(input.teamId) ?? [],
+        shape.irSlots,
+      );
+
+      if (after + reserved > shape.totalSlots) {
+        // Which count crossed the line decides what he is told, the same way
+        // `addFreeAgent` decides it. "Drop someone" is the wrong instruction
+        // when the room exists and a trade is holding it.
+        const spokenFor = after <= shape.totalSlots;
+        throw new IrError(
+          spokenFor
+            ? "A roster spot is being held for a trade you accepted, so there is no room to " +
+                "bring him back until that trade executes or is vetoed. He is still listed out, " +
+                "so injured reserve holds his place until then."
+            : `Bringing him back would leave you holding ${after} players and the limit is ` +
+                `${shape.totalSlots}. He is still listed out, so injured reserve is his for as ` +
+                `long as he needs it — release one of your active players first if you want him ` +
+                `back now.`,
+          spokenFor ? "SLOT_HELD_FOR_TRADE" : "ROSTER_WOULD_OVERFLOW",
+        );
+      }
+    }
+
+    await tx.query(
+      `UPDATE roster_entries SET on_ir = false
+        WHERE team_id = $1 AND player_id = $2 AND released_at IS NULL AND on_ir`,
+      [input.teamId, input.playerId],
+    );
+
+    return { playerId: input.playerId };
+  });
 }


### PR DESCRIPTION
Closes #272. Three agents: one designed the predicate, one attacked it, one traced what the manager actually experiences. **The fix the issue proposed is wrong, and this PR proves it by running it.**

## The hole

`activateFromIr` was an unconditional flag flip with no capacity check. A team at the limit could bring back a still genuinely injured player and sit at `totalSlots + 1`.

The docstring argued it must never refuse. That argument is sound for a **recovered** player — he already counts, activation costs nothing, and refusing would trap the roster in an illegal state. It was never true for a player who is still out, where activation is `+1` and leaving him stashed is legal and stable. The docstring was defending a case that was not this one.

## Why the issue's predicate is wrong

#272 proposes: refuse when `onIr && isIrEligible(designation)` and the team is at the limit.

**"Is this player exempt" has no answer.** `irExemptCount` caps exemptions at `irSlots` **by count, not by identity**. Three injured players against two slots means two exemptions and no way to say which two — and any tie-break invented here (insertion order, id, acquisition date) would be a rule existing nowhere else in the product.

Measured, at the limit with three stashed and two slots:

```
before { rows: 16, counted: 14 }   after { rows: 16, counted: 14 }   <- +0
```

The first activation **costs nothing** — one of the three was already counting. The issue's predicate refuses it, and refuses all three.

I verified this rather than reasoning about it: installing the naive predicate in place of the delta one fails the capping test.

## The predicate that is right

Ask what the move costs, not who is exempt. Recompute the counted size with this player's flag flipped:

```
after > before  &&  after + reserved > totalSlots
```

The algebra is `capped(g,s) − capped(g−1,s)`, which is **1 when `g ≤ s` and 0 when `g > s`** — so it permits the free activation and refuses the one that genuinely costs a slot.

**It cannot trap anybody, and that is a proof rather than an argument.** It refuses only when the move raises the count *and* lands over the limit, so the roster it refuses from is `after − 1 ≤ totalSlots` — legal. A refusal can never leave a manager in an illegal state. The recovered player is `after === before` and is never refused at any roster size, which is the escape route the docstring exists to protect.

## The traps the breaker found, and where they land

It measured two: activation is not kickoff-gated but `dropPlayer` is, and `dropPlayer` is league-state-gated (from #281) while activation is not. On a Sunday with every game kicked off, or in a finished league, the refusal stands and the remedy is closed.

Both were measured against the **naive** predicate, in a state where the roster was already legal at `g > s`. Under the delta form they do not arise: that state is `+0` and is permitted. And where the delta form does refuse, the manager's roster is legal and their player keeps his IR place — being unable to make a move is not a trap when the state you remain in is the legal one.

## The fixture had to grow, and that is the finding I would not have made alone

Every test in `injured-reserve.test.ts` ran on a **four-player roster against fourteen slots** — ten short of the boundary this rule lives on. The full suite was unanimous across the change in both directions: it could not have caught the hole, and could not have caught a bad fix. A green run there was evidence of nothing.

The fixture now reaches the limit. Two of the four new tests fail without the predicate; the other two guard against over-refusing (the recovered player over the limit, and a roster with room) and correctly pass either way.

## Also

- Counts room already held by accepted trades, so a still-out player cannot be activated into a slot a trade is reserving — the same rule `addFreeAgent` and `acceptTrade` use. Skipped when the move is free, so it can never reach the escape route.
- `FOR UPDATE` on the roster read. This reads every row and writes one of them; one manager with two tabs is enough for write skew, since both reads see only their own flip pending and the two updates touch different rows.
- The refusal names the number and says injured reserve is his "for as long as he needs it" — because #272's whole argument is that nothing is trapped, and a sentence that does not say so reads as a wall. It deliberately avoids `ROSTER_FULL`, whose "drop someone first" is the instruction #273 documents as misleading here.
- Both new codes map to 409; without them the route's fallback would report a state conflict as a malformed request.

Full suite 2338 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.