### PR TITLE
feat: a roster over the limit is frozen, and nobody is picked for it

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -21,6 +21,8 @@ import {
   loadRosterForWeek,
   loadTbdKickoffs,
   loadWeekStats,
+  overageFor,
+  overLimitNotice,
   setAutofillEnabled,
   setLineup,
 } from "@rostr/db";
@@ -35,6 +37,10 @@ const STATUS: Record<string, number> = {
   // somebody else wrote the slot between validation and the write, so the client
   // re-reads and submits again. 409 rather than 422: the request was well formed.
   LINEUP_MOVED: 409,
+  // The roster holds more players than the limit, so the lineup is frozen until
+  // somebody is released. A conflict with the team's state rather than anything
+  // wrong with the lineup submitted, so 409 and not 422.
+  ROSTER_OVER_LIMIT: 409,
   SLOT_TYPE_UNKNOWN: 500,
   // A league whose games are not ingested cannot enforce a kickoff lock, so it
   // refuses rather than accepting a lineup it could not police.
@@ -117,6 +123,11 @@ export async function GET(
     const averages = await loadAverages(client, playerIds, context.season, week, context.rules);
 
     const autofillEnabled = await getAutofillEnabled(client, context.myTeamId);
+
+    // Same function the write path refuses with. See the response below.
+    const editingNotice = overLimitNotice(
+      await overageFor(client, context.myTeamId, context.rules),
+    );
 
     const now = Math.floor(Date.now() / 1000);
 
@@ -214,6 +225,18 @@ export async function GET(
       week,
       /** From the frozen rules, so the screen cannot invent an allowance. */
       irSlots: context.rules.roster.irSlots,
+      /*
+        Whether this team may edit at all, and the sentence if not.
+
+        Composed here from the same function `setLineup` throws with, so the
+        screen and the server cannot disagree about it — and it is the only way
+        that sentence gets a test, because `apps/web` cannot render a component
+        in one.
+      */
+      editing: {
+        open: editingNotice === null,
+        notice: editingNotice,
+      },
       autofill: {
         enabled: autofillEnabled ?? true,
         /**

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -69,6 +69,13 @@ interface RosterPlayer {
 
 interface LineupResponse {
   week: number;
+  /**
+   * Whether this team may edit its lineup, and why not when it may not.
+   *
+   * Composed by the server from the same function the write refuses with, so
+   * the screen cannot offer something the server will turn down.
+   */
+  editing: { open: boolean; notice: string | null };
   autofill: {
     enabled: boolean;
     mode: "WEEKLY_PROJECTION" | "SEASON_AVERAGE";
@@ -449,6 +456,15 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
         </div>
       )}
 
+      {data.editing.notice !== null && (
+        // Said once, above everything, because it explains why every control
+        // below is inert. The sentence comes from the server so it cannot drift
+        // from the rule that produced it.
+        <p className="rounded border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200/80">
+          {data.editing.notice}
+        </p>
+      )}
+
       {(saveError || problems.length > 0) && (
         <div className="space-y-1 rounded border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
           {saveError && <p>{saveError}</p>}
@@ -554,7 +570,7 @@ export function LineupEditor({ leagueId, week }: { leagueId: string; week: numbe
               <div className="min-w-0 flex-1">
                 <select
                   value={slot.playerId ?? ""}
-                  disabled={slot.locked || saving}
+                  disabled={slot.locked || saving || !data.editing.open}
                   onChange={(e) => assign(slot, e.target.value || null)}
                   className="w-full rounded border border-nocturne-neutral-800 bg-transparent px-2 py-1.5 text-sm disabled:opacity-50"
                 >

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -495,8 +495,29 @@ legal — accepting a trade you have room for, then signing somebody — would p
 together, and the trade would be the thing that broke.
 
 **The one exception is injured reserve, and § 2 describes it.** A stashed player who
-recovers stops being exempt and can leave you over the limit. He is never forced off, and
-until you resolve it you cannot acquire anyone. Nothing else may ever put a team over.
+recovers stops being exempt, and that can leave you over the limit two ways. Directly: you
+were at the limit with him stashed, his designation clears, and you hold one more than you
+may. Or through a trade you had room for — you accepted with room to spare, a stashed player
+recovered while the league had its say, and the trade landed you over anyway. Neither is
+refused, because neither is anything anybody did. **Nothing else may ever put a team over.**
+
+**While you are over, the league stops acting for you.** You cannot sign anyone and a waiver
+claim will not be awarded to you. Your lineup is frozen as it stands — nothing is cleared,
+nothing is benched, and you cannot change it either. **And the autofill will not pick anyone
+for you**, so a slot you left empty stays empty and scores nothing, exactly as if you had
+turned it off. That is the whole of it. There is no fine, no forfeit, and nothing is taken
+away from you.
+
+It does keep your lineup honest while you are over: a player you release is taken out of it,
+because leaving him there would go on scoring him for you after he had gone.
+
+**Releasing a player ends it, and releasing is never refused for being over.** It is the way
+out, so it stays open — and so does a trade that leaves you at the limit or below, because a
+trade that sheds is you resolving this rather than continuing it. Dropping the recovered
+player works and is usually the right move; dropping someone still genuinely stashed does
+not, because he was never counting against you in the first place. You are told how far over
+you are and by how many, and the moment you are back at the limit everything opens again on
+its own. Nobody has to approve it.
 
 ---
 
@@ -653,7 +674,8 @@ and no forfeiture. A manager who stops setting lineups is not defrauding anyone,
 rule people would only discover by losing money to it is the wrong rule to have.
 
 Instead, **a slot you leave empty gets filled for you**, and it is on by default. The fill
-runs through the week and always before your week is scored. It never starts a player whose
+runs through the week and always before your week is scored — unless your roster is over the
+limit, and § 6 says what happens then. It never starts a player whose
 own game has kicked off, so a slot you leave empty past a player's lock will not be filled
 with him — the same rule that stops you starting him yourself.
 
@@ -691,6 +713,14 @@ Which of the two a league uses is frozen at creation, like every other rule.
 > **decision** standing in for the manager's own start/sit call, and nobody asks two
 > providers to agree on one of those. The projection used is recorded with the lineup, so
 > the decision is checkable after the fact.
+
+**It does not pick anyone while your roster is over the limit.** § 6 sets that out, and this
+is the half of it that costs something: with nobody being picked for you, an empty slot is
+just an empty slot and it scores nothing. Two things follow, and both are deliberate. A
+lineup you had already set stands and scores exactly as it would have — nobody is punished
+for work already done. And a lineup you were leaving to the autofill will not be rescued,
+which is the real weight of the rule. You are told the moment it applies, on the hub and on
+your lineup screen, and releasing one player turns it back on.
 
 **You can turn it off.** It is a per-team setting, not a league rule, so it is yours alone
 and changeable whenever you like. Off means an empty slot stays empty and scores nothing —

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -281,6 +281,7 @@ export {
   countedRosterSize,
   projectedRosterSize,
   reservedByTrades,
+  rosterOverage,
   irExemptCount,
   irExemptOnRoster,
   MAY_STILL_PLAY,
@@ -288,5 +289,6 @@ export {
   refuseIrPlacement,
   type CommittedTrade,
   type IrPlacementRefusal,
+  type RosterOverage,
   type IrRosterEntry,
 } from "./season/injured-reserve.js";

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -216,6 +216,72 @@ export function projectedRosterSize(input: {
   return countedRosterSize(staying, input.irSlots) + input.arriving;
 }
 
+/** A team's standing against its roster limit, right now. */
+export interface RosterOverage {
+  /** Past the limit, and therefore restricted. */
+  readonly over: boolean;
+  /** Players counting against the limit, genuinely stashed ones already subtracted. */
+  readonly counted: number;
+  /** The limit itself, carried so no caller has to fetch the shape to say "15 of 14". */
+  readonly limit: number;
+  /**
+   * How many must go before the team is legal again. Zero when it already is.
+   *
+   * Carried rather than left to the caller to subtract. Four surfaces say this
+   * number out loud — the notification, the lineup refusal, the market screen
+   * and the roster panel — and one subtraction written in four places is how
+   * four sentences come to disagree about one roster.
+   */
+  readonly mustRelease: number;
+}
+
+/**
+ * How far past the roster limit a team is, and what it takes to get back.
+ *
+ * **Counted size, never row count.** A team at the limit holding two genuinely
+ * stashed players has sixteen rows and is perfectly legal — that is what the
+ * allowance in RULES.md §2 *is*. So this goes through {@link countedRosterSize},
+ * which subtracts the exemption and caps it at `irSlots`. A check written
+ * against `roster.length` reports an overage that does not exist and locks a
+ * manager out of a lineup he was entitled to set.
+ *
+ * **Strictly over, not full.** `counted === limit` is a team with no room to
+ * add, and every acquisition path already refuses that on its own with `>=`.
+ * This asks the different question — is the state itself illegal — and only
+ * `>` answers it. Conflating the two would put every full roster in the league
+ * under a lineup lock, which is most of them for most of the season, and which
+ * is a rule nobody signed.
+ *
+ * **No trade reservation, deliberately.** {@link reservedByTrades} holds room
+ * against an acquisition that has not happened; a team at the limit with an
+ * accepted give-one-get-two has done nothing wrong and may still see that trade
+ * vetoed. The two must never be summed: that one gates *acquiring*, this one
+ * gates *being*.
+ *
+ * **The designation has to be read live by the caller.** This state is reachable
+ * in exactly one way — a designation clears on the hourly cron and the counted
+ * size rises with no row written and nobody having acted. A cached designation
+ * cannot see that, which would make this silent for the only case it exists for.
+ *
+ * `mustRelease` is not always one: the exemption is capped, so two stashed
+ * players recovering in the same pass move a team two past the limit at once.
+ */
+export function rosterOverage(input: {
+  /** Every unreleased row the team holds now, designations read live. */
+  readonly roster: readonly IrRosterEntry[];
+  /** Starters plus bench. IR is already excluded from it. */
+  readonly totalSlots: number;
+  readonly irSlots: number;
+}): RosterOverage {
+  const counted = countedRosterSize(input.roster, input.irSlots);
+  const mustRelease = Math.max(0, counted - input.totalSlots);
+
+  // `over` is returned rather than left for callers to re-derive, for the reason
+  // `mustRelease` is: the requirement is that the surfaces cannot disagree, and
+  // that only holds if none of them works it out again.
+  return { over: mustRelease > 0, counted, limit: input.totalSlots, mustRelease };
+}
+
 /** One accepted trade, from the point of view of one of its two teams. */
 export interface CommittedTrade {
   /** How many players this team is due to receive. Each one will count. */

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -87,6 +87,8 @@ export {
   type RosterMove,
 } from "./waivers.js";
 
+export { overageFor, overLimitNotice, heldForCapacity } from "./roster-capacity.js";
+
 export {
   getAutofillEnabled,
   loadAverages,

--- a/packages/db/src/injured-reserve.ts
+++ b/packages/db/src/injured-reserve.ts
@@ -9,6 +9,7 @@ import type { IrPlacementRefusal } from "@rostr/core";
 import { getLeagueRules } from "./leagues.js";
 import type { SqlClient } from "./client.js";
 import { withTransaction } from "./transaction.js";
+import { heldForCapacity } from "./roster-capacity.js";
 import { committedTradeMoves } from "./trades.js";
 
 /**
@@ -157,30 +158,6 @@ export async function moveToIr(
 }
 
 /**
- * The roster, for a capacity question, locked.
- *
- * A sibling of `heldRoster` rather than a reuse of it: that one joins `games`
- * for a kickoff time, which needs a season and a week, and activation
- * deliberately has no kickoff rule — the route does not even send a week for it.
- *
- * `FOR UPDATE OF r` for the same reason `heldRoster` gives: lock the roster
- * rows, never the shared `players` rows.
- */
-async function heldForCapacity(
-  tx: SqlClient,
-  teamId: string,
-): Promise<{ player_id: string; on_ir: boolean; designation: string | null }[]> {
-  return tx.query<{ player_id: string; on_ir: boolean; designation: string | null }>(
-    `SELECT r.player_id, r.on_ir, p.injury_designation AS designation
-       FROM roster_entries r
-       JOIN players p ON p.id = r.player_id
-      WHERE r.team_id = $1 AND r.released_at IS NULL
-      FOR UPDATE OF r`,
-    [teamId],
-  );
-}
-
-/**
  * Bring a player back.
  *
  * **A recovered player is never refused**, and that is the important
@@ -242,12 +219,7 @@ export async function activateFromIr(
       compute the same room, and the two `UPDATE`s touch different rows so
       nothing conflicts. Textbook write skew, and `FOR UPDATE` is what stops it.
     */
-    const held = await heldForCapacity(tx, input.teamId);
-    const roster = held.map((row) => ({
-      playerId: row.player_id,
-      onIr: row.on_ir,
-      injuryDesignation: row.designation,
-    }));
+    const roster = await heldForCapacity(tx, input.teamId, { lock: true });
 
     if (!roster.some((entry) => entry.playerId === input.playerId && entry.onIr)) {
       throw new IrError("That player is not on injured reserve.", "NOT_ON_IR");

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildNflPprRules, indexScoringRules, NFL, NFL_PPR_SCORING } from "@rostr/core";
+import {
+  buildNflPprRules,
+  buildRosterShape,
+  indexScoringRules,
+  NFL,
+  NFL_PPR_ROSTER,
+  NFL_PPR_SCORING,
+} from "@rostr/core";
 import { resolveWeek } from "@rostr/core";
 import type { DraftRules, LeagueRules, LineupAssignment } from "@rostr/core";
 import type { SqlClient } from "./client.js";
@@ -1720,5 +1727,213 @@ describe("the autofill will not take a slot the manager still holds", () => {
     });
 
     expect(await flexAfter(fx)).toBe(fx.players.get("rb-c"));
+  });
+});
+
+describe("a roster over the limit is frozen, and nobody is picked for it", () => {
+  /*
+    A team can only get here one way, and it is not something the manager did:
+    a player stashed on injured reserve recovers, the exemption is read live,
+    and the counted size rises with no row written and nobody having acted.
+
+    While over, the league stops acting for them — the lineup is frozen and the
+    autofill picks nobody. It still *tidies*, and that half is not a courtesy:
+    the autofill is the only thing that takes a released player out of a stored
+    lineup, this manager is required to release somebody, and a released player
+    left standing in a slot goes on scoring for the team that cut him while
+    being addable by everyone else.
+
+    ESPN behaves the same way in both halves — it never fills a slot for you,
+    and it never leaves a player you dropped in your lineup.
+  */
+
+  const SHAPE = buildRosterShape(NFL_PPR_ROSTER, NFL);
+
+  /** Top the team up to `rows` unreleased players, all fit and all playing Sunday. */
+  const fillTo = async (fx: Fixture, rows: number): Promise<void> => {
+    const [sport] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM sports WHERE key = $1",
+      [NFL.key],
+    );
+    const [rb] = await fx.client.query<{ id: string }>(
+      "SELECT id FROM positions WHERE sport_id = $1 AND key = 'RB'",
+      [sport!.id],
+    );
+    const [held] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM roster_entries WHERE team_id = $1 AND released_at IS NULL",
+      [fx.teamId],
+    );
+
+    for (let i = held!.n; i < rows; i++) {
+      const handle = `filler-${i}`;
+      const [player] = await fx.client.query<{ id: string }>(
+        `INSERT INTO players (sport_id, external_ref, full_name, primary_position_id, team_ref)
+         VALUES ($1, $2, $3, $4, 'CIN') RETURNING id`,
+        [sport!.id, handle, handle, rb!.id],
+      );
+      await fx.client.query(
+        "INSERT INTO roster_entries (team_id, player_id, acquired_via) VALUES ($1, $2, 'DRAFT')",
+        [fx.teamId, player!.id],
+      );
+    }
+  };
+
+  it("refuses a lineup change while over, and allows one at exactly the limit", async () => {
+    /*
+      The boundary, and the reason it is a test of its own. Every acquisition
+      check in the repo asks `counted >= totalSlots` — correct for "may I add
+      one more". This rule asks whether the state is illegal, which is only
+      `>`. Writing `>=` here would freeze the lineup of every full roster in
+      the league, which is most of them for most of the season.
+    */
+    const fx = await setup();
+    await fillTo(fx, SHAPE.totalSlots);
+
+    const legal = await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb")! }],
+      now: BEFORE_ANYTHING,
+    });
+    expect(legal).toBeDefined();
+
+    // One more, and the same edit is refused.
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).rejects.toMatchObject({ code: "ROSTER_OVER_LIMIT" });
+
+    // And says both numbers, because "your roster is full" is the sentence
+    // that sends a manager to do the thing that was just refused.
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("thu-qb")! }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).rejects.toThrow(/15 players and the limit is 14/);
+  });
+
+  it("lets the manager edit again the moment somebody is released", async () => {
+    // Nothing else has to be cleared, and nobody has to approve it.
+    const fx = await setup();
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    await fx.client.query(
+      `UPDATE roster_entries SET released_at = now()
+        WHERE team_id = $1 AND player_id = $2`,
+      [fx.teamId, fx.players.get("bye-te")],
+    );
+
+    await expect(
+      setLineup(fx.client, {
+        leagueId: fx.leagueId,
+        teamId: fx.teamId,
+        week: WEEK,
+        assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb")! }],
+        now: BEFORE_ANYTHING,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("still writes a lineup, so the league's week can be scored", async () => {
+    /*
+      The regression this must never cause. `resolveWeek` throws on a team with
+      no lineup at all — scoring one as zero would silently hand its opponent a
+      free win — so a team that were simply skipped here would take its whole
+      league's week down with it, and in a pot league block settlement. Eleven
+      innocent managers would pay for one over-full roster.
+    */
+    const fx = await setup();
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    const outcome = await ensureLineups(fx.client, fx.leagueId, WEEK, BEFORE_ANYTHING);
+
+    expect(outcome.teamsOverLimit).toEqual([fx.teamId]);
+
+    const [rows] = await fx.client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM lineups WHERE team_id = $1 AND week = $2",
+      [fx.teamId, WEEK],
+    );
+    expect(rows!.n).toBe(SHAPE.starters.length);
+
+    // Every slot empty: it was tidied, not filled.
+    const [filled] = await fx.client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM lineups
+        WHERE team_id = $1 AND week = $2 AND player_id IS NOT NULL`,
+      [fx.teamId, WEEK],
+    );
+    expect(filled!.n).toBe(0);
+  });
+
+  it("still fills the other teams in the same league", async () => {
+    // Per team, not per league. The other manager did nothing.
+    const fx = await setup();
+    await fillTo(fx, SHAPE.totalSlots + 1);
+
+    await ensureLineups(fx.client, fx.leagueId, WEEK, BEFORE_ANYTHING);
+
+    const [filled] = await fx.client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM lineups
+        WHERE team_id = $1 AND week = $2 AND player_id IS NOT NULL`,
+      [fx.otherTeamId, WEEK],
+    );
+    expect(filled!.n).toBeGreaterThan(0);
+  });
+
+  it("takes a released player out of the lineup even though it picks nobody", async () => {
+    /*
+      The half that is not a courtesy, and the reason "the autofill does not run"
+      is the wrong way to build this.
+
+      A manager over the limit is required to release somebody, and a starter is
+      the obvious choice. If the lineup were left untouched he would keep
+      scoring for the team that cut him — and be addable by everybody else at
+      the same time, so one player would score for two teams in one week.
+    */
+    const fx = await setup();
+
+    // A lineup set while the roster was still legal.
+    await setLineup(fx.client, {
+      leagueId: fx.leagueId,
+      teamId: fx.teamId,
+      week: WEEK,
+      assignments: [{ slotType: "QB", slotIndex: 0, playerId: fx.players.get("sun-qb")! }],
+      now: BEFORE_ANYTHING,
+    });
+
+    // Two over, so releasing one still leaves them over — otherwise the
+    // ordinary autofill takes over and fills the slot, which is a different
+    // test.
+    await fillTo(fx, SHAPE.totalSlots + 2);
+
+    // Still over, the manager releases the quarterback they had started.
+    await fx.client.query(
+      `UPDATE roster_entries SET released_at = now()
+        WHERE team_id = $1 AND player_id = $2`,
+      [fx.teamId, fx.players.get("sun-qb")],
+    );
+
+    await ensureLineups(fx.client, fx.leagueId, WEEK, BEFORE_ANYTHING);
+
+    const [qb] = await fx.client.query<{ player_id: string | null }>(
+      `SELECT l.player_id FROM lineups l
+         JOIN slot_types st ON st.id = l.slot_type_id
+        WHERE l.team_id = $1 AND l.week = $2 AND st.key = 'QB' AND l.slot_index = 0`,
+      [fx.teamId, WEEK],
+    );
+
+    // Gone, and not replaced.
+    expect(qb?.player_id).toBeNull();
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -52,6 +52,7 @@ import type {
 } from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { getLeagueRules } from "./leagues.js";
+import { overageFor, overLimitNotice } from "./roster-capacity.js";
 import { withTransaction } from "./transaction.js";
 
 /**
@@ -131,7 +132,16 @@ export class LineupError extends Error {
        * this one means nothing is wrong except the timing. The client re-reads
        * and submits again.
        */
-      | "LINEUP_MOVED",
+      | "LINEUP_MOVED"
+      /**
+       * This team holds more players than the limit, so its lineup is frozen.
+       *
+       * Not `INVALID_LINEUP`: nothing about the submitted lineup is wrong, and
+       * the fix is on a different screen. Not `LINEUP_MOVED` either — that one
+       * says "try again", and re-reading changes nothing here until somebody is
+       * released.
+       */
+      | "ROSTER_OVER_LIMIT",
     readonly problems: readonly LineupProblem[] = [],
   ) {
     super(message);
@@ -566,6 +576,21 @@ export async function setLineup(
   );
   if (!team) throw new LineupError("Team is not in this league", "TEAM_NOT_IN_LEAGUE");
 
+  /*
+    Frozen while the roster is over the limit.
+
+    Before the schedule check below, deliberately: a team over the limit in a
+    league whose schedule has not loaded should be told the thing it can act on,
+    not handed the operator's problem.
+
+    Read outside the transaction like every other precondition here. The window
+    is a manager racing his own drop, and it resolves in his favour the moment
+    he retries.
+  */
+  const overage = await overageFor(db, input.teamId, stored.rules);
+  const notice = overLimitNotice(overage);
+  if (notice) throw new LineupError(notice, "ROSTER_OVER_LIMIT");
+
   const season = stored.rules.seasonYear;
 
   // Fail closed. Without the schedule there are no kickoff times, so no lock can
@@ -969,6 +994,23 @@ export async function autoFillLineup(
   teamId: string,
   week: number,
   now: number,
+  options?: {
+    /**
+     * Tidy the lineup but pick nobody. Defaults to filling.
+     *
+     * For a team over the roster limit. The autofill does two jobs — it takes
+     * players the team no longer owns *out* of the lineup, and it puts players
+     * *into* empty slots — and only the second is a courtesy. Withholding the
+     * first would be a scoring bug rather than a penalty: the manager over the
+     * limit is required to release somebody, releasing a starter is the obvious
+     * move, and a released player left standing in a slot goes on scoring for
+     * the team that cut him while being addable by everybody else.
+     *
+     * ESPN behaves the same way in both halves: it never fills a slot for you,
+     * and it never leaves a player you dropped in your lineup.
+     */
+    readonly fillEmptySlots?: boolean;
+  },
 ): Promise<readonly LineupAssignment[]> {
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) throw new LineupError("League has no rules", "LEAGUE_NOT_FOUND");
@@ -1069,9 +1111,23 @@ export async function autoFillLineup(
       keep.set(slot, assignment);
     }
 
+    /*
+      An empty candidate pool is how "tidy but pick nobody" is expressed, and it
+      is not a trick. `autolineupChoices` copies every locked or kept slot
+      through untouched and only consults the pool for the ones still open, so an
+      empty pool leaves exactly the slots the manager set — minus anyone who has
+      left the roster — and materialises the rest as empty.
+
+      Materialising them matters as much as the tidying: `resolveWeek` throws on
+      a team with no lineup at all, on the grounds that scoring it as zero would
+      silently hand its opponent a free win. A team that is simply skipped here
+      would take its whole league's week down with it.
+    */
+    const fillable = options?.fillEmptySlots === false ? [] : candidates;
+
     const filled = autolineup({
       shape: buildRosterShape(stored.rules.roster, NFL),
-      roster: candidates,
+      roster: fillable,
       mode,
       locked: [...keep.values()],
       // The same clock the lock check above already used. A player whose game
@@ -1190,7 +1246,21 @@ export async function ensureLineups(
   leagueId: string,
   week: number,
   now: number,
-): Promise<{ teamsFilled: number; teamsOptedOut: number }> {
+): Promise<{
+  teamsFilled: number;
+  teamsOptedOut: number;
+  /**
+   * Teams whose roster is over the limit, so nobody was picked for them.
+   *
+   * Ids rather than a count, because a number in a cron body cannot be acted
+   * on and the whole point is that an operator can name the team without
+   * opening a database session.
+   */
+  teamsOverLimit: readonly string[];
+}> {
+  const stored = await getLeagueRules(db, leagueId);
+  if (!stored) throw new LineupError("League has no rules", "LEAGUE_NOT_FOUND");
+
   const teams = await db.query<{ id: string; autofill_enabled: boolean; is_bot: boolean }>(
     "SELECT id, autofill_enabled, is_bot FROM teams WHERE league_id = $1 ORDER BY slot",
     [leagueId],
@@ -1198,8 +1268,30 @@ export async function ensureLineups(
 
   let teamsFilled = 0;
   let teamsOptedOut = 0;
+  const teamsOverLimit: string[] = [];
 
   for (const team of teams) {
+    /*
+      Over the limit: tidied, never filled.
+
+      Not a `continue`. A team skipped here gets no lineup rows at all, and
+      `resolveWeek` throws on a team with none — so one manager's over-full
+      roster would stop the whole league's week from scoring, and in a pot
+      league block its settlement. The punishment would land on everybody
+      except the person who caused it.
+
+      Tidied rather than left alone because the autofill is the only thing that
+      takes a released player out of a stored lineup. This manager is required
+      to release somebody; leaving the lineup untouched would let the player
+      they cut go on scoring for them, while being addable by anyone else.
+    */
+    const overage = await overageFor(db, team.id, stored.rules);
+    if (overage.over) {
+      await autoFillLineup(db, leagueId, team.id, week, now, { fillEmptySlots: false });
+      teamsOverLimit.push(team.id);
+      continue;
+    }
+
     // A bot has no manager to forget, so the switch is not theirs to hold.
     if (team.is_bot || team.autofill_enabled) {
       await autoFillLineup(db, leagueId, team.id, week, now);
@@ -1215,7 +1307,7 @@ export async function ensureLineups(
     teamsOptedOut++;
   }
 
-  return { teamsFilled, teamsOptedOut };
+  return { teamsFilled, teamsOptedOut, teamsOverLimit };
 }
 
 /**

--- a/packages/db/src/notifications.test.ts
+++ b/packages/db/src/notifications.test.ts
@@ -420,6 +420,115 @@ describe("notificationsForUser", () => {
     });
   });
 
+  describe("a roster over the limit", () => {
+    /*
+      The one state a manager reaches without acting: a stashed player recovers
+      on the injuries cron, the exemption is read live, and the counted size
+      rises with nothing written and nobody having done anything.
+
+      This item is the safety valve on the rule. The rest of the restriction is
+      discovered the moment the manager tries something; the autofill is not —
+      it is a thing that silently does not happen, on a Sunday. §8 says a rule
+      people would only discover by losing money to it is the wrong rule to
+      have, and without this that is what it would be.
+    */
+
+    /** Give the team `rows` players, `stashed` of them on IR with a designation. */
+    const roster = async (
+      fx: Fixture,
+      teamId: string,
+      rows: number,
+      stashed: { designation: string | null } | null,
+    ) => {
+      const [sport] = await fx.client.query<{ id: string }>(
+        "SELECT id FROM sports WHERE key = $1",
+        [NFL.key],
+      );
+      const [position] = await fx.client.query<{ id: string }>(
+        "SELECT id FROM positions WHERE sport_id = $1 LIMIT 1",
+        [sport!.id],
+      );
+
+      for (let i = 0; i < rows; i++) {
+        const onIr = stashed !== null && i === 0;
+        const handle = `over-${teamId.slice(0, 6)}-${i}`;
+        const [player] = await fx.client.query<{ id: string }>(
+          `INSERT INTO players
+             (sport_id, external_ref, full_name, primary_position_id, injury_designation)
+           VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+          [sport!.id, handle, handle, position!.id, onIr ? stashed.designation : null],
+        );
+        await fx.client.query(
+          `INSERT INTO roster_entries (team_id, player_id, acquired_via, acquired_at, on_ir)
+           VALUES ($1, $2, 'DRAFT', now(), $3)`,
+          [teamId, player!.id, onIr],
+        );
+      }
+    };
+
+    const inSeason = async (fx: Fixture) =>
+      fx.client.query("UPDATE leagues SET state = 'IN_SEASON' WHERE id = $1", [fx.leagueId]);
+
+    it("stays quiet while a genuinely stashed player keeps the team legal", async () => {
+      // Fifteen rows, one genuinely out: counted fourteen, exactly at the limit
+      // and perfectly legal. This is the case a check on row count gets wrong.
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, 15, { designation: "OUT" });
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      expect(items.map((i) => i.kind)).not.toContain("ROSTER_OVER_LIMIT");
+    });
+
+    it("speaks the moment he recovers, with both numbers and the way out", async () => {
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, 15, { designation: "OUT" });
+
+      // The injuries cron clears it. Nothing else changes.
+      await fx.client.query("UPDATE players SET injury_designation = NULL WHERE id = ANY($1)", [
+        (
+          await fx.client.query<{ player_id: string }>(
+            "SELECT player_id FROM roster_entries WHERE team_id = $1 AND on_ir",
+            [fx.seats[0]!.teamId],
+          )
+        ).map((row) => row.player_id),
+      ]);
+
+      const items = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      const item = items.find((i) => i.kind === "ROSTER_OVER_LIMIT");
+
+      expect(item).toMatchObject({
+        kind: "ROSTER_OVER_LIMIT",
+        leagueId: fx.leagueId,
+        href: `/leagues/${fx.leagueId}/players`,
+        deadline: null,
+      });
+      expect(item?.text).toContain("holds 15 players and the limit is 14");
+      expect(item?.text).toContain("release one player");
+      // Says what it costs, because that half is otherwise invisible.
+      expect(item?.text).toContain("autofill will not pick anyone");
+    });
+
+    it("tells the manager holding the roster and nobody else", async () => {
+      const fx = await fixture();
+      await inSeason(fx);
+      await roster(fx, fx.seats[0]!.teamId, 15, null);
+
+      const held = await notificationsForUser(fx.client, fx.seats[0]!.userId, NOW);
+      expect(held.map((i) => i.kind)).toContain("ROSTER_OVER_LIMIT");
+
+      const other = await notificationsForUser(fx.client, fx.seats[1]!.userId, NOW);
+      expect(other.map((i) => i.kind)).not.toContain("ROSTER_OVER_LIMIT");
+    });
+
+    it("outranks an unset lineup, because it costs more and closes no later", async () => {
+      expect(NOTIFICATION_URGENCY.indexOf("ROSTER_OVER_LIMIT")).toBeLessThan(
+        NOTIFICATION_URGENCY.indexOf("LINEUP_UNSET"),
+      );
+    });
+  });
+
   it("puts the pick clock ahead of everything else", async () => {
     // The strip shows one item, so the order decides what a manager sees. A
     // 90-second clock outranks anything measured in hours.

--- a/packages/db/src/notifications.ts
+++ b/packages/db/src/notifications.ts
@@ -29,7 +29,8 @@
  */
 
 import type { SqlClient } from "./client.js";
-import { pickPosition } from "@rostr/core";
+import { buildRosterShape, NFL, pickPosition, rosterOverage } from "@rostr/core";
+import type { IrRosterEntry, LeagueRules } from "@rostr/core";
 
 /**
  * What kind of thing is waiting.
@@ -42,6 +43,7 @@ export type NotificationKind =
   | "TRADE_AWAITING_YOU"
   | "VETO_WINDOW"
   | "DRAFT_SOON"
+  | "ROSTER_OVER_LIMIT"
   | "LINEUP_UNSET"
   | "PLAYER_OFF_NFL_ROSTER"
   | "INVITATION";
@@ -70,6 +72,11 @@ export const NOTIFICATION_URGENCY: readonly NotificationKind[] = [
   "TRADE_AWAITING_YOU",
   "VETO_WINDOW",
   "DRAFT_SOON",
+  // Above an unset lineup because it costs strictly more and closes at least as
+  // soon: an unset lineup costs the empty slots and only when autofill is off,
+  // while this costs the lineup *and* the autofill *and* every acquisition, and
+  // the window shuts at the same kickoff.
+  "ROSTER_OVER_LIMIT",
   "LINEUP_UNSET",
   "PLAYER_OFF_NFL_ROSTER",
   "INVITATION",
@@ -186,6 +193,100 @@ async function playersOffNflRosters(db: SqlClient, userId: string): Promise<Noti
 }
 
 /**
+ * Leagues where this manager's roster is over the limit.
+ *
+ * The one state a manager can be in without having done anything: a player
+ * stashed on injured reserve recovers, the exemption is read live, and the
+ * counted size rises on the hourly cron's schedule rather than theirs. Nothing
+ * is forced off the roster — but until they release somebody the league stops
+ * acting for them, and the autofill in particular stops picking anyone.
+ *
+ * **Which is why this has to reach them.** The rest of the restriction is
+ * discovered the moment they try to do something. The autofill is not: it is a
+ * thing that silently does not happen, on a Sunday, to a manager who may not
+ * open the app. `RULES.md` §8 says a rule people would only discover by losing
+ * money to it is the wrong rule to have, and without this notification that is
+ * exactly what this would be.
+ *
+ * Rules live in a frozen JSON document rather than in columns, and the
+ * exemption depends on `isIrEligible` — another company's vocabulary, which
+ * changes — so this returns a row per rostered player and does the arithmetic
+ * in TypeScript through the same helper every other capacity check uses.
+ * Re-expressing that deny-list in SQL would be a second copy of a moving rule.
+ * It is the first non-aggregate query in this file; at a dozen or so rows per
+ * league that is within the budget the module documents.
+ */
+async function rostersOverLimit(db: SqlClient, userId: string): Promise<Notification[]> {
+  const rows = await db.query<{
+    league_id: string;
+    league_name: string;
+    canonical: string;
+    player_id: string;
+    on_ir: boolean;
+    designation: string | null;
+  }>(
+    `SELECT l.id AS league_id, l.name AS league_name, lr.canonical,
+            r.player_id, r.on_ir, p.injury_designation AS designation
+       FROM league_memberships m
+       JOIN leagues l ON l.id = m.league_id
+       JOIN league_rules lr ON lr.league_id = l.id
+       JOIN teams t ON t.id = m.team_id
+       JOIN roster_entries r ON r.team_id = t.id AND r.released_at IS NULL
+       JOIN players p ON p.id = r.player_id
+      WHERE m.user_id = $1
+        AND l.state IN ('IN_SEASON', 'PLAYOFFS')`,
+    [userId],
+  );
+
+  const byLeague = new Map<
+    string,
+    { name: string; canonical: string; roster: IrRosterEntry[] }
+  >();
+  for (const row of rows) {
+    const found = byLeague.get(row.league_id) ?? {
+      name: row.league_name,
+      canonical: row.canonical,
+      roster: [],
+    };
+    found.roster.push({
+      playerId: row.player_id,
+      onIr: row.on_ir,
+      injuryDesignation: row.designation,
+    });
+    byLeague.set(row.league_id, found);
+  }
+
+  const items: Notification[] = [];
+  for (const [leagueId, league] of byLeague) {
+    const rules = JSON.parse(league.canonical) as LeagueRules;
+    const shape = buildRosterShape(rules.roster, NFL);
+    const overage = rosterOverage({
+      roster: league.roster,
+      totalSlots: shape.totalSlots,
+      irSlots: shape.irSlots,
+    });
+    if (!overage.over) continue;
+
+    const players = overage.mustRelease === 1 ? "one player" : `${overage.mustRelease} players`;
+
+    items.push({
+      kind: "ROSTER_OVER_LIMIT",
+      leagueId,
+      leagueName: league.name,
+      href: `/leagues/${leagueId}/players`,
+      text:
+        `Your roster in ${league.name} holds ${overage.counted} players and the limit is ` +
+        `${overage.limit} — release ${players}. Until then your lineup is frozen and the ` +
+        `autofill will not pick anyone for you.`,
+      deadline: null,
+      needsSignature: false,
+    });
+  }
+
+  return items;
+}
+
+/**
  * Everything waiting on this user, most urgent first.
  *
  * `now` is passed rather than read, so every deadline in the result is measured
@@ -196,16 +297,25 @@ export async function notificationsForUser(
   userId: string,
   now: Date,
 ): Promise<readonly Notification[]> {
-  const [drafts, trades, vetoes, invitations, lineups, cut] = await Promise.all([
+  const [drafts, trades, vetoes, invitations, lineups, cut, overLimit] = await Promise.all([
     draftNotifications(db, userId, now),
     tradesAwaitingYou(db, userId),
     vetoWindows(db, userId, now),
     invitationNotifications(db, userId),
     unsetLineups(db, userId),
     playersOffNflRosters(db, userId),
+    rostersOverLimit(db, userId),
   ]);
 
-  const all = [...drafts, ...trades, ...vetoes, ...invitations, ...lineups, ...cut];
+  const all = [
+    ...drafts,
+    ...trades,
+    ...vetoes,
+    ...invitations,
+    ...lineups,
+    ...cut,
+    ...overLimit,
+  ];
 
   return all.sort((a, b) => {
     const byKind = NOTIFICATION_URGENCY.indexOf(a.kind) - NOTIFICATION_URGENCY.indexOf(b.kind);

--- a/packages/db/src/roster-capacity.ts
+++ b/packages/db/src/roster-capacity.ts
@@ -1,0 +1,107 @@
+import { buildRosterShape, NFL, rosterOverage } from "@rostr/core";
+import type { LeagueRules, RosterOverage } from "@rostr/core";
+import type { SqlClient } from "./client.js";
+
+/**
+ * Whether a team is over its roster limit, and what that costs it.
+ *
+ * A team can only get here one way, and it is not something the manager did: a
+ * player stashed on injured reserve recovers, the exemption is read live, and
+ * the counted size rises with no row written and nobody having acted. That can
+ * happen directly, or by letting a trade the team legitimately had room for
+ * land them over after a recovery during the veto window.
+ *
+ * The state is allowed — nothing is forced off a roster on a provider's say-so,
+ * which is the rule the whole injured-reserve design is built on. What happens
+ * instead is that the league stops acting on the manager's behalf until they
+ * resolve it: they cannot sign anyone, cannot be awarded a claim, cannot change
+ * their lineup, and the autofill will not pick players for them.
+ *
+ * **A leaf module on purpose.** `notifications.ts` needs this and imports almost
+ * nothing; `lineups.ts` needs it too, and `lineups.ts → trades.ts → week.ts →
+ * lineups.ts` is a cycle waiting for anyone who reaches for the trade helpers
+ * from here. Taking already-loaded rules as an argument rather than fetching
+ * them keeps this file importing only `@rostr/core` and the client type, which
+ * makes the cycle unconstructible rather than merely absent.
+ */
+
+/** Every unreleased row a team holds, with the designation read live. */
+export async function heldForCapacity(
+  db: SqlClient,
+  teamId: string,
+  options?: { readonly lock?: boolean },
+): Promise<{ playerId: string; onIr: boolean; injuryDesignation: string | null }[]> {
+  /*
+    `FOR UPDATE OF r` when the caller is about to write, and never on the joined
+    `players` rows — the designation is read here and never written, and locking
+    a shared player row would serialise every team in the league behind one
+    manager's move.
+  */
+  const rows = await db.query<{
+    player_id: string;
+    on_ir: boolean;
+    designation: string | null;
+  }>(
+    `SELECT r.player_id, r.on_ir, p.injury_designation AS designation
+       FROM roster_entries r
+       JOIN players p ON p.id = r.player_id
+      WHERE r.team_id = $1 AND r.released_at IS NULL
+      ${options?.lock ? "FOR UPDATE OF r" : ""}`,
+    [teamId],
+  );
+
+  return rows.map((row) => ({
+    playerId: row.player_id,
+    onIr: row.on_ir,
+    injuryDesignation: row.designation,
+  }));
+}
+
+/** How far past its limit this team is. */
+export async function overageFor(
+  db: SqlClient,
+  teamId: string,
+  rules: LeagueRules,
+  options?: { readonly lock?: boolean },
+): Promise<RosterOverage> {
+  const shape = buildRosterShape(rules.roster, NFL);
+  const roster = await heldForCapacity(db, teamId, options);
+
+  return rosterOverage({
+    roster,
+    totalSlots: shape.totalSlots,
+    irSlots: shape.irSlots,
+  });
+}
+
+/**
+ * What a manager over the limit is told, or `null` when they are not over.
+ *
+ * Pure, and separated from the query for the reason `marketClosedReason` is:
+ * `apps/web` cannot render a component in a test, so a sentence composed inside
+ * one is verified only by being run in production. This is the half that gets a
+ * test, and the same function composes the refusal the server throws and the
+ * notice the screen renders — so the two cannot say different things.
+ *
+ * It names no player. Any active player resolves this, so there is nothing to
+ * go and find, and the obvious name to print would be the recovered player —
+ * who is usually the right man to release, but not always, and the product
+ * should not appear to be asking for him specifically.
+ *
+ * It does give advice, where the cut-player notification deliberately does not.
+ * That convention holds for a fact whose remedy is a judgement call. Here the
+ * remedy is the only exit, and the product has just taken two other controls
+ * away — withholding the one instruction that works is the defect issue #273
+ * describes, not a principle.
+ */
+export function overLimitNotice(overage: RosterOverage): string | null {
+  if (!overage.over) return null;
+
+  const players = overage.mustRelease === 1 ? "one player" : `${overage.mustRelease} players`;
+
+  return (
+    `Your roster holds ${overage.counted} players and the limit is ${overage.limit} — ` +
+    `release ${players}. Until then you cannot change your lineup, the autofill will not ` +
+    `pick anyone for you, and you cannot add anybody.`
+  );
+}

--- a/packages/db/src/week.ts
+++ b/packages/db/src/week.ts
@@ -242,6 +242,15 @@ export interface ResolveWeekOutcome {
    */
   readonly finalizedWithUnfinishedGames?: string;
   /**
+   * Teams whose roster was over the limit, so the autofill picked nobody.
+   *
+   * Present only when it happened, like the field above. Ids rather than a
+   * count: an operator reading a cron body needs to be able to name the team
+   * without opening a database session, and "one team was not filled" is a
+   * number nobody can act on.
+   */
+  readonly teamsOverLimit?: readonly string[];
+  /**
    * How many matchups this run declined to write because they were already
    * final, when it wrote at least one other.
    *
@@ -292,7 +301,7 @@ export async function resolveLeagueWeek(
     throw new WeekError(`Week ${week} is already final`, "ALREADY_FINAL");
   }
 
-  await ensureLineups(db, leagueId, week, Math.floor(now.getTime() / 1000));
+  const filled = await ensureLineups(db, leagueId, week, Math.floor(now.getTime() / 1000));
 
   const lineups = await loadWeekLineups(db, leagueId, week);
   const stats = await loadWeekStats(db, stored.rules.sportKey, stored.rules.seasonYear, week);
@@ -376,6 +385,7 @@ export async function resolveLeagueWeek(
     finalized,
     ...(decision.hold === null ? {} : { holdReason: decision.hold }),
     ...(decision.fallback ? { finalizedWithUnfinishedGames: decision.fallback } : {}),
+    ...(filled.teamsOverLimit.length > 0 ? { teamsOverLimit: filled.teamsOverLimit } : {}),
     ...(alreadyFinal > 0 ? { matchupsAlreadyFinal: alreadyFinal } : {}),
     results,
   };


### PR DESCRIPTION
Closes #273, and settles the consequence half of #283. Designed by three agents — one wrote the rule, one the enforcement, one tried to break it. The breaker found a scoring-integrity hole in the version originally asked for, and the design changed because of it.

## The rule

A team can end up over its roster limit **only** because a player on injured reserve recovered — directly, or because a trade it legitimately had room for landed over after a recovery during the veto window. Nothing else can put a team over; every other door now refuses.

That state stays allowed. Nothing is forced off a roster on a provider's say-so. What changes is that **the league stops acting for you** until you resolve it: lineup frozen, autofill picks nobody, adds and waiver awards refused (already true). Releasing one player ends it, and releasing is never refused for being over.

## What ESPN does, since that was the question

- **ESPN never fills a slot for you.** There is no autofill; an empty slot scores zero. "Quick Lineup" is a button the manager presses.
- **ESPN never leaves a player you dropped in your lineup.** You cannot drop a player once his game starts, and before that dropping removes him. The only case where a dropped player still scores is a slot already locked — which this repo already replicates exactly.

This change is both of those.

## The hole in "the autofill does not run"

The autofill does two jobs: it **picks** players for empty slots, and it **takes players you no longer own out of your lineup**. `lineups.ts:1068` is the only line in the codebase that does the second.

Withholding it is not a penalty, it is a scoring bug:

1. Over the limit, the lineup is frozen, so **dropping is the only action allowed**.
2. Frozen also means you cannot move a player out of a starting slot first.
3. So you cut a starter — and nothing removes him from your lineup.
4. `scoreTeamLineup` looks up stats by player id with **no ownership check**. He scores for the team that cut him.
5. He is a free agent, so somebody else adds and starts him. **One player, two teams, one week.**

So: **tidied, never filled.** `autolineup` already expresses it exactly — an empty candidate pool copies every kept slot through and materialises the rest as empty. There is a test asserting the released player is gone *and* not replaced.

## The edge that would have taken down whole leagues

`resolveWeek` **throws** on a team with no lineup at all — deliberately, because *"scoring it as zero would silently hand its opponent a free win"* — and `ensureLineups` is what makes that precondition true.

The obvious implementation of "don't autofill them" is `continue`. That writes no lineup rows, so `resolveWeek` throws, so **nobody in the league is scored** and in a pot league settlement is blocked. Eleven innocent managers would pay for one over-full roster.

Two agents found this independently without seeing each other's work. The regression test fails against the skip:

```
× still writes a lineup, so the league's week can be scored
  → expected +0 to be 9
```

## Strictly over, never merely full

Every acquisition check in the repo asks `counted >= totalSlots` — right for "may I add one more". This asks whether the state is *illegal*, which is only `>`. Writing `>=` would freeze the lineup of every full roster in the league, which is most of them for most of the season. Its own boundary test.

It also uses **counted** size, not row count: a team at the limit with two genuinely stashed players holds sixteen rows and is perfectly legal — that is what the IR allowance *is*.

## Why the notification is not decoration

`RULES.md` §8: *"a rule people would only discover by losing money to it is the wrong rule to have."*

Every other part of this restriction is discovered on the next click. The autofill is a thing that **silently does not happen**, on a Sunday, to a manager who may not open the app — and the recovery lands on a cron's schedule, not theirs. The notification is what keeps this rule on the right side of that sentence, so it carries both numbers, the action, and what it currently costs.

The cron's outcome carries the **team ids**, not a count, so an operator asking why a team scored nothing does not need a database session.

## Also

- `RULES.md` §6 and §8 amended. Members sign that document and it promised the fill "always" runs. **Worth reading before merge.**
- `heldForCapacity` — which #284 added privately to `injured-reserve.ts` two hours ago — is now shared from the new leaf module, rather than left as the second copy of a capacity query. That drift is the exact failure that caused this week's #271 regression.
- The new module is a leaf (`@rostr/core` + the client type only) because `notifications.ts` needs it and `lineups.ts → trades.ts → week.ts → lineups.ts` is a cycle waiting for anyone who reaches for trade helpers from it.

## Verification

Three of five lineup tests and three of four notification tests fail with enforcement disabled; the rest guard against over-refusing and correctly pass either way. Both traps above are caught by tests, not by argument.

Full suite 2347 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.

## Not in this PR

The 35-hour window in which a manager cannot comply — `dropPlayer`'s kickoff refusal is week-scoped and the week does not turn until Tuesday 00:00 ET, so from Sunday kickoff every drop refuses. It is much less harmful now that the lineup is still tidied and nothing is silently withheld, but it is real and it deserves its own issue.