### PR TITLE
fix: the autofill ranks an injured player behind a healthy one

### DIFF
--- a/apps/web/src/app/api/leagues/[id]/lineup/route.ts
+++ b/apps/web/src/app/api/leagues/[id]/lineup/route.ts
@@ -300,10 +300,10 @@ export async function GET(
         playerId: player.playerId,
         name: player.fullName,
         positions: player.positions,
-        status: player.status,
-        // Shown, never enforced. The lock is `locked` above, computed from
-        // kickoff; a designation arriving on the Sunday must not be able to
-        // invalidate a lineup that was legal when it was set.
+        // Shown, never enforced *here*. The lock is `locked` above, computed
+        // from kickoff; a designation arriving on the Sunday must not be able to
+        // invalidate a lineup that was legal when it was set. The autofill may
+        // now rank on it, and only that — see `DECISIONS.md` and issue #269.
         imageUrl: player.imageUrl,
         teamRef: player.teamRef,
         injuryDesignation: player.injuryDesignation,

--- a/apps/web/src/components/LineupEditor.tsx
+++ b/apps/web/src/components/LineupEditor.tsx
@@ -36,7 +36,6 @@ interface RosterPlayer {
   playerId: string;
   name: string;
   positions: string[];
-  status: string;
   kickoffAt: number | null;
   /**
    * How settled this player's week is. `BYE` is a rest week and he cannot

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -738,3 +738,79 @@ one is a different product.
 frozen rule set and **enforced nowhere** — a guarantee members signed that did nothing.
 One field also cannot disagree with itself the way "allowed" and "how many" can.
 schemaVersion 2 -> 3.
+
+## The autofill may read an injury designation, and only to rank an empty slot
+
+Decided 2026-08-28 by the owner: **"do as ESPN does."**
+
+The injury designation is refreshed wholesale on every sync with no revision
+history and no source column, and is therefore **shown and never enforced**:
+nothing scoring, locking, drafting or settling may read it, and a designation
+arriving on the Sunday must not be able to invalidate a lineup that was legal
+when it was set.
+
+That rule is unchanged. This adds one exception, and its boundary is the whole
+of it.
+
+**`autoFillLineup` may read the designation, to order candidates for a slot the
+manager left empty.** Nothing else may. It is a **sort key and never an
+exclusion**: a slot with nobody else still gets filled, exactly as it is for a
+player on a bye.
+
+Three things make this narrower than it looks.
+
+**An empty slot is not a lineup that was legal when it was set** — nothing was
+set. The harm that rule names is a designation overturning a manager's own
+choice, and there is no choice here to overturn. A slot the manager fills
+himself is untouched, as § 8 already says.
+
+**§ 8 has always promised this.** _"A player with a game this week who is not
+ruled out comes first, because a player on a bye or officially out cannot score
+at all."_ Members signed that. The code tested `players.status`, a column
+nothing in this repo has ever written — 271 inserts and 59 updates across the
+whole of its history, none of them naming it — so the comparison was `"ACTIVE"`
+against out-codes and never matched once. This makes a signed rule true rather
+than adding a rule, which is the third time that shape has turned up after
+`irSlots` and `botsAllowed`.
+
+**It is what the products managers know actually do.** ESPN's Quick Lineup
+"will fill the holes in your lineup and take players with 'O' designations
+out"; its Lineup Protection substitutes for a starter marked Out or IL and is
+explicitly not an optimiser; Yahoo's Start Active Players swaps a starter only
+when "bench player is healthy and starting player is injured". None of them
+demotes a questionable player, and none refuses to field somebody rather than
+leave a slot empty.
+
+**The vocabulary is the autofill's own and is not shared with `isIrEligible`.**
+That predicate is a deny-list, treating anything unfamiliar as injured, because
+stranding a genuinely injured player is the worse failure there and its cost is
+bounded by a number in the signed rules. Here the asymmetry reverses: an
+unfamiliar designation ranks **normally**, because benching a healthy starter
+every week in a lineup nobody is watching is unbounded and silent.
+`QUESTIONABLE` — 240 of the 383 designated players in `docs/TANK01.md`'s
+2026-08-27 capture — is **not** demoted. A questionable player usually plays.
+
+**Never an exclusion, and that is not timidity.** `defaultPositionCaps` puts
+QB, K and DEF at one apiece, so a roster the autopicker built holds exactly one
+of each. Refusing to field a designated kicker would empty that slot for the
+week with nothing on the roster able to fill it — manufacturing the permanent
+hole the autopicker's own stranding guard exists to prevent.
+
+**Rejected: reading the absence of a projection instead.** `player_projections`
+carries a source, but it is upserted in place with no revision history, its
+rows are never deleted, and the provider covers roughly 620 of 3,870 players.
+"Nobody projects him" means the provider does not cover him. It is a worse
+input than the designation on every axis this rule cares about, and it is
+silent in exactly the Sunday case.
+
+**Owed, and not yet paid.** The projections precedent below was granted on a
+condition — _"store the projection used, with its source, and the decision is as
+reproducible as anything else in the system"_ — and nothing records either the
+projection or this designation. Issue #267 is that debt. This exception is
+taken on the narrower ground that a demotion cannot overturn a manager's
+choice, but the recording is still owed and both inputs should land together.
+
+**Not decided here: whether an injured-reserve designation should exclude a
+player outright.** That would change § 8's "Who is eligible", which is frozen
+text existing leagues have signed, and it is what issue #270 would need. Left
+open deliberately.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -285,6 +285,8 @@ export {
   irExemptCount,
   irExemptOnRoster,
   MAY_STILL_PLAY,
+  UNLIKELY_TO_PLAY,
+  unlikelyToPlay,
   isIrEligible,
   refuseIrPlacement,
   type CommittedTrade,

--- a/packages/core/src/season/injured-reserve.test.ts
+++ b/packages/core/src/season/injured-reserve.test.ts
@@ -3,6 +3,7 @@ import {
   countedRosterSize,
   irExemptCount,
   isIrEligible,
+  unlikelyToPlay,
   refuseIrPlacement,
 } from "./injured-reserve.js";
 import type { IrRosterEntry } from "./injured-reserve.js";
@@ -180,5 +181,78 @@ describe("refuseIrPlacement", () => {
     expect(refuseIrPlacement({ roster: [injured], playerId: "hurt", irSlots: 0 })).toBe(
       "IR_FULL",
     );
+  });
+});
+
+describe("unlikelyToPlay", () => {
+  /*
+    The autofill's own vocabulary, deliberately not `isIrEligible`'s.
+
+    They sound like one question and are two: "is he shelved for a while"
+    against "will he appear on Sunday". `DOUBTFUL` is where they part — he may
+    occupy an IR slot, and he is ranked behind a healthy player here.
+  */
+
+  it("demotes the three designations that mean he will not appear", () => {
+    expect(unlikelyToPlay("Out")).toBe(true);
+    expect(unlikelyToPlay("Doubtful")).toBe(true);
+    expect(unlikelyToPlay("Injured Reserve")).toBe(true);
+  });
+
+  it("leaves a questionable player alone, which is most of them", () => {
+    /*
+      240 of the 383 designated players in `docs/TANK01.md`'s capture — five of
+      every eight — and the one value the provider uses to mean he may still
+      play. Demoting it would bench a questionable starter behind a healthy
+      bench body every week, in the lineup nobody is watching.
+
+      No major product does it: ESPN's Quick Lineup acts on "O" alone, and
+      Yahoo's Start Active Players swaps a starter only for a healthy one.
+    */
+    expect(unlikelyToPlay("Questionable")).toBe(false);
+  });
+
+  it("treats an unfamiliar designation as fit, which is the opposite of the IR rule", () => {
+    /*
+      The inversion, and it is the whole reason this is a separate set.
+
+      `isIrEligible` is a deny-list: an unknown word means injured, because
+      refusing a genuinely hurt player an IR slot strands him with no recourse.
+      Here the unbounded failure runs the other way — demoting a healthy man
+      benches him every week with nobody watching — so an unknown word ranks
+      normally.
+
+      It also means the vocabulary being incomplete cannot hurt anyone.
+      `docs/TANK01.md` lists "Physically Unable To Perform" and "Suspension" as
+      never yet observed; if either arrives, this treats him as fit and
+      `syncInjuries` puts the new word in the logs.
+    */
+    expect(unlikelyToPlay("Physically Unable To Perform")).toBe(false);
+    expect(unlikelyToPlay("Suspension")).toBe(false);
+    expect(isIrEligible("Physically Unable To Perform")).toBe(true);
+  });
+
+  it("reads a healthy player as fit", () => {
+    expect(unlikelyToPlay(null)).toBe(false);
+    expect(unlikelyToPlay(undefined)).toBe(false);
+    expect(unlikelyToPlay("")).toBe(false);
+    expect(unlikelyToPlay("   ")).toBe(false);
+  });
+
+  it("matches the provider's wording however it is cased or padded", () => {
+    // The column holds Tank01's wording verbatim, which is title case with a
+    // space — the shape the old seven short codes could never match.
+    expect(unlikelyToPlay("  injured reserve  ")).toBe(true);
+    expect(unlikelyToPlay("OUT")).toBe(true);
+  });
+
+  it("parts from the IR rule on exactly one value", () => {
+    // Doubtful may take an IR slot and is still ranked behind a healthy body.
+    expect(isIrEligible("Doubtful")).toBe(true);
+    expect(unlikelyToPlay("Doubtful")).toBe(true);
+
+    // Questionable is the mirror: never IR-eligible, never demoted.
+    expect(isIrEligible("Questionable")).toBe(false);
+    expect(unlikelyToPlay("Questionable")).toBe(false);
   });
 });

--- a/packages/core/src/season/injured-reserve.ts
+++ b/packages/core/src/season/injured-reserve.ts
@@ -66,6 +66,66 @@
 export const MAY_STILL_PLAY = new Set(["QUESTIONABLE"]);
 
 /**
+ * Designations that mean a player will probably not take the field this week.
+ *
+ * **An allow-list, and the inversion from {@link MAY_STILL_PLAY} is deliberate
+ * rather than an inconsistency.** That one is a deny-list because refusing an IR
+ * placement wrongly strands a genuinely injured player with no recourse, while
+ * admitting one wrongly costs a manager a slot he chose to spend, bounded by
+ * `roster.irSlots`. Here the asymmetry runs the other way: this decides who the
+ * autofill starts, in a lineup nobody is watching, and demoting a healthy man
+ * wrongly benches him every week with no bound and nobody to notice. So an
+ * unfamiliar designation ranks **normally**, which is the safe direction on this
+ * path and the dangerous one on the other.
+ *
+ * That is also why this is a separate set rather than a reuse. The two answer
+ * questions that sound identical and are not — "is he shelved for a while"
+ * against "will he appear on Sunday" — and `DOUBTFUL` is where they part:
+ * eligible for an IR slot, and demoted here.
+ *
+ * `QUESTIONABLE` is deliberately absent. It is 240 of the 383 designated
+ * players in `docs/TANK01.md`'s capture — five of every eight — and it is the
+ * one value the provider uses to mean a player may still play. Demoting it
+ * would bench a questionable starter behind a healthy bench body every week,
+ * which no major product does: ESPN's Quick Lineup acts on "O" alone, and
+ * Yahoo's Start Active Players swaps a starter only for a healthy alternative.
+ *
+ * `syncInjuries` warns on any designation not yet recorded in `docs/TANK01.md`,
+ * so a new value arrives in the logs rather than silently changing a ranking.
+ */
+export const UNLIKELY_TO_PLAY = new Set(["OUT", "DOUBTFUL", "INJURED RESERVE"]);
+
+/**
+ * Whether the autofill should rank this player behind healthy ones.
+ *
+ * `RULES.md` §8 has promised this since it was written — *"a player with a game
+ * this week who is not ruled out comes first, because a player on a bye or
+ * officially out cannot score at all"* — and nothing delivered it. The code that
+ * was meant to tested `players.status`, a column no writer in this repo has ever
+ * set, so the comparison was `"ACTIVE"` against a set of out-codes and never
+ * matched. Members signed a rule that did nothing. Issue #269, and the third
+ * time this repo has found that shape after `irSlots` and `botsAllowed`.
+ *
+ * **A ranking, never an exclusion, and that distinction is load-bearing.**
+ * `defaultPositionCaps` puts QB, K and DEF at one apiece, so a roster built by
+ * the autopicker holds exactly one of each — and excluding a designated kicker
+ * would empty the kicker slot for the week with nothing on the roster able to
+ * fill it. Demoted, he is still started when there is nobody else, which is
+ * both what the products do and what an empty slot deserves.
+ *
+ * Reads the injury designation, which `CLAUDE.md` records as *shown and never
+ * enforced*. See `DECISIONS.md` for the exception that permits it: the harm that
+ * rule names is a designation overturning a lineup the manager set, and a slot
+ * he left empty is not one. It may rank an empty slot and may do nothing else.
+ */
+export function unlikelyToPlay(designation: string | null | undefined): boolean {
+  if (designation === null || designation === undefined) return false;
+  const normalised = designation.trim().toUpperCase();
+  if (normalised === "") return false;
+  return UNLIKELY_TO_PLAY.has(normalised);
+}
+
+/**
  * Whether this designation permits a player to occupy an IR slot.
  *
  * **Decided by the owner, 2026-08-23: "whenever a player is on IR they need to

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -17,6 +17,7 @@ import { addTestTeam, createTestDatabase } from "./testing.js";
 import type { PGliteClient } from "./testing.js";
 import {
   autoFillLineup,
+  autolineupCandidate,
   ensureLineups,
   loadAverages,
   LineupError,
@@ -1935,5 +1936,129 @@ describe("a roster over the limit is frozen, and nobody is picked for it", () =>
 
     // Gone, and not replaced.
     expect(qb?.player_id).toBeNull();
+  });
+});
+
+describe("the autofill ranks an injured player behind a healthy one — #269", () => {
+  /*
+    `RULES.md` §8 has promised this to every member who signed: "a player with a
+    game this week who is not ruled out comes first, because a player on a bye or
+    officially out cannot score at all."
+
+    It has never once happened. The check tested `players.status` against a set
+    of short codes, and nothing in this repo has ever written that column — so
+    the comparison was "ACTIVE" against out-codes and never matched. A signed
+    rule that did nothing, which is the third time this repo has found that
+    shape after `irSlots` and `botsAllowed`.
+
+    Ranked down, never excluded: QB, K and DEF cap at one apiece, so refusing to
+    field a designated kicker would empty that slot for the week with nothing on
+    the roster able to fill it.
+
+    **The two that assert the flag are the regression tests.** This fixture
+    gives its players random ids and `compare` breaks ties on ascending id, so
+    with nobody demoted two equally-ranked quarterbacks are a coin toss. A
+    demotion settles that — it is the first term of the comparison, ahead of
+    points entirely — so the end-to-end cases below are deterministic *with* the
+    rule and decide by chance without it. The cases that read `unavailable`
+    directly fail on a revert every time, which is what holds this rule down.
+  */
+
+  const designate = async (fx: Fixture, handle: string, designation: string | null) =>
+    fx.client.query("UPDATE players SET injury_designation = $2 WHERE id = $1", [
+      fx.player(handle),
+      designation,
+    ]);
+
+  const startedAt = async (fx: Fixture, slot: string, index = 0) => {
+    const [row] = await fx.client.query<{ player_id: string | null }>(
+      `SELECT l.player_id FROM lineups l
+         JOIN slot_types st ON st.id = l.slot_type_id
+        WHERE l.team_id = $1 AND l.week = $2 AND st.key = $3 AND l.slot_index = $4`,
+      [fx.teamId, WEEK, slot, index],
+    );
+    return row?.player_id ?? null;
+  };
+
+  it("passes over a player who is ruled out, whoever else is available", async () => {
+    // Deterministic in the direction that matters: the demoted man loses to
+    // anyone not demoted, regardless of how the tie between the others falls.
+    const fx = await setup();
+    await designate(fx, "sun-qb", "Out");
+
+    await autoFillLineup(fx.client, fx.leagueId, fx.teamId, WEEK, BEFORE_ANYTHING);
+
+    // The fixture holds exactly two quarterbacks, so a demotion decides it
+    // outright rather than leaving a tie to a random id.
+    expect(await startedAt(fx, "QB")).toBe(fx.player("thu-qb"));
+  });
+
+  it("passes over one on injured reserve, which is issue #270's player", async () => {
+    const fx = await setup();
+    await designate(fx, "sun-qb", "Injured Reserve");
+
+    await autoFillLineup(fx.client, fx.leagueId, fx.teamId, WEEK, BEFORE_ANYTHING);
+
+    expect(await startedAt(fx, "QB")).toBe(fx.player("thu-qb"));
+  });
+
+  it("still starts him when there is nobody else, because an empty slot scores nothing", async () => {
+    /*
+      The half that stops this stranding a roster. `defaultPositionCaps` puts K
+      and DEF at one apiece, so a designated kicker is the only kicker — and a
+      rule that refused to field him would leave that slot empty every week with
+      no possible remedy.
+
+      ESPN and Yahoo both work this way: they substitute when a healthy
+      alternative exists, and neither leaves a slot empty rather than field
+      somebody injured.
+    */
+    const fx = await setup();
+    await designate(fx, "k-a", "Injured Reserve");
+
+    await autoFillLineup(fx.client, fx.leagueId, fx.teamId, WEEK, BEFORE_ANYTHING);
+
+    expect(await startedAt(fx, "K")).toBe(fx.player("k-a"));
+  });
+
+  it("does not demote a questionable player, or one nobody has recorded", async () => {
+    /*
+      Asserted on the flag rather than on who wins, because two undemoted players
+      tie and the tie breaks on a random id.
+
+      Questionable is five of every eight designated players and the one value
+      meaning he may still play. An unrecorded designation ranks normally too,
+      which is the opposite of the IR rule's polarity and is what makes an
+      incomplete vocabulary harmless here.
+    */
+    const fx = await setup();
+    await designate(fx, "sun-qb", "Questionable");
+    await designate(fx, "thu-qb", "Physically Unable To Perform");
+
+    const roster = await loadRosterForWeek(fx.client, fx.teamId, SEASON, WEEK);
+
+    for (const handle of ["sun-qb", "thu-qb"]) {
+      const player = roster.get(fx.player(handle))!;
+      const candidate = autolineupCandidate(player, {
+        averageMilliPoints: null,
+        projectedMilliPoints: null,
+      });
+      expect(candidate.unavailable).toBe(false);
+    }
+  });
+
+  it("marks one who is ruled out unavailable, without excluding him", async () => {
+    const fx = await setup();
+    await designate(fx, "sun-qb", "Doubtful");
+
+    const roster = await loadRosterForWeek(fx.client, fx.teamId, SEASON, WEEK);
+    const candidate = autolineupCandidate(roster.get(fx.player("sun-qb"))!, {
+      averageMilliPoints: null,
+      projectedMilliPoints: null,
+    });
+
+    // A sort key, not an exclusion: he is still a candidate.
+    expect(candidate.unavailable).toBe(true);
+    expect(candidate.playerId).toBe(fx.player("sun-qb"));
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -39,6 +39,7 @@ import {
   scorePlayer,
   seasonAverage,
   startingSlots,
+  unlikelyToPlay,
   validateLineup,
 } from "@rostr/core";
 import type {
@@ -369,7 +370,6 @@ async function weekFirstKickoff(
  */
 export type RosterPlayer = LineupPlayer & {
   readonly fullName: string;
-  readonly status: string;
   /** Provider-published headshot, or a crest for a team unit. Null renders as initials. */
   readonly imageUrl: string | null;
   /** The club, not the fantasy team — "PHI". */
@@ -417,7 +417,6 @@ export async function loadRosterForWeek(
   const rows = await db.query<{
     player_id: string;
     full_name: string;
-    status: string;
     positions: string[];
     kickoff_at: string | null;
     team_scheduled: boolean;
@@ -430,7 +429,6 @@ export async function loadRosterForWeek(
   }>(
     `SELECT p.id AS player_id,
             p.full_name,
-            p.status,
             -- Display only. A roster row shows a face, a club, and whether the
             -- man is hurt; none of the three is read by a lock, by
             -- validateLineup, or by anything that scores.
@@ -462,7 +460,7 @@ export async function loadRosterForWeek(
         AND g.week = $3
         AND (g.home_team_ref = p.team_ref OR g.away_team_ref = p.team_ref)
       WHERE r.team_id = $1 AND r.released_at IS NULL
-      GROUP BY p.id, p.full_name, p.status, g.kickoff_at, p.team_ref, p.sport_id, r.on_ir,
+      GROUP BY p.id, p.full_name, g.kickoff_at, p.team_ref, p.sport_id, r.on_ir,
                g.home_team_ref, g.away_team_ref,
                p.image_url, p.injury_designation`,
     [teamId, season, week],
@@ -479,7 +477,6 @@ export async function loadRosterForWeek(
       {
         playerId: row.player_id,
         fullName: row.full_name,
-        status: row.status,
         positions: row.positions,
         imageUrl: row.image_url,
         teamRef: row.team_ref,
@@ -928,9 +925,6 @@ export async function loadProjectedPoints(
   );
 }
 
-/** Injury designations that mean a player will not appear. */
-const OUT_STATUSES = new Set(["OUT", "IR", "INACTIVE", "SUSPENDED", "DOUBTFUL", "PUP", "NFI"]);
-
 /**
  * One roster row, as the autofill sees it.
  *
@@ -946,7 +940,7 @@ export function autolineupCandidate(
     readonly playerId: string;
     readonly positions: readonly string[];
     readonly kickoffAt: number | null;
-    readonly status: string;
+    readonly injuryDesignation: string | null;
   },
   ranking: {
     readonly averageMilliPoints: number | null;
@@ -959,9 +953,20 @@ export function autolineupCandidate(
     kickoffAt: player.kickoffAt,
     averageMilliPoints: ranking.averageMilliPoints,
     projectedMilliPoints: ranking.projectedMilliPoints,
-    // A bye and an injury designation both mean "will not appear". Neither is a
-    // hard exclusion — a team with nobody else still has to field someone.
-    unavailable: player.kickoffAt === null || OUT_STATUSES.has(player.status.toUpperCase()),
+    /*
+      A bye and a designation that means he will not appear are the same fact to
+      a ranking: no points either way. Neither is a hard exclusion — a team with
+      nobody else still has to field somebody, and `defaultPositionCaps` puts
+      QB, K and DEF at one apiece, so excluding would empty those slots outright.
+
+      This used to test `players.status` against a set of short codes. Nothing in
+      this repo has ever written that column — 271 inserts and 59 updates across
+      the whole of its history, none of them naming it — so the comparison was
+      `"ACTIVE"` against out-codes and never matched once. `RULES.md` §8 has
+      promised this behaviour to every member who signed, and it did nothing.
+      Issue #269.
+    */
+    unavailable: player.kickoffAt === null || unlikelyToPlay(player.injuryDesignation),
   };
 }
 


### PR DESCRIPTION
Closes #269. Three agents: one proved the dead code, one researched what ESPN, Sleeper and Yahoo actually do, one hunted for harm. **This is not a new rule — it is a signed rule that has never worked.**

## The promise, and the code that never kept it

`RULES.md` §8, frozen and signed by every member:

> "a player with a game this week who **is not ruled out** comes first, because a player on a bye or **officially out** cannot score at all."

The code meant to deliver it:

```js
OUT_STATUSES.has(player.status.toUpperCase())
```

`players.status` is `NOT NULL DEFAULT 'ACTIVE'` and **nothing in this repo has ever written it.** That was verified against the entire git object database — 2,224 blobs — finding **271 `INSERT INTO players`** and **59 `UPDATE players`** across all history, none of which names the column. So the comparison was `"ACTIVE"` against a set of out-codes and never matched once. `unavailable` meant "on a bye" and nothing else.

Third time this repo has found that shape, after `irSlots` and `botsAllowed`.

## What ESPN and Yahoo actually do

- **ESPN Quick Lineup** — *"will fill the holes in your lineup and take players with **'O' designations** out."*
- **ESPN Lineup Protection** — substitutes for a starter marked **Out or IL**, and is explicitly *"NOT a lineup optimizer."*
- **Yahoo Start Active Players** — swaps a starter only when *"bench player is healthy and starting player is injured."*

None of the three demotes **Questionable**. None refuses to field somebody rather than leave a slot empty. This change is both of those.

## Questionable is untouched, and that is the important half

240 of the 383 designated players in `docs/TANK01.md`'s live capture — **five of every eight** — and the one value the provider uses to mean he may still play. The tempting one-liner (`injuryDesignation !== null`) misfires on all of them, in the direction that costs points, because `unavailable` is the **first** term of `compare`, ahead of the ranking entirely. A measured example: benching one questionable WR1 cascades through three slots and costs 16 points.

## A ranking, never an exclusion

`defaultPositionCaps` puts **QB, K and DEF at one apiece**, so a roster the autopicker built holds exactly one of each. Excluding a designated kicker would empty that slot for the week with nothing on the roster able to fill it — manufacturing the permanent hole the autopicker's own stranding guard exists to prevent. Measured: **one** designated kicker is enough.

Demoted, he is still started when there is nobody else. That is what an empty slot deserves and what both products do.

## Why a separate vocabulary rather than reusing `isIrEligible`

They sound like one question and are two — *"is he shelved for a while"* against *"will he appear on Sunday"* — and `DOUBTFUL` is exactly where they part: eligible for an IR slot, demoted here.

The polarities are opposite, deliberately. `MAY_STILL_PLAY` is a **deny**-list (unfamiliar means injured) because stranding a genuinely injured player is the worse failure there, bounded by a number in the signed rules. `UNLIKELY_TO_PLAY` is an **allow**-list (unfamiliar ranks normally) because benching a healthy starter every week in a lineup nobody watches is unbounded and silent.

That also settles the "wait for more data" objection: the two designations `TANK01.md` records as never yet observed rank as **fit**, so an incomplete vocabulary cannot hurt anyone.

And the sharing trap is real but stated backwards in the issue — since #251 it is a deny-list, so the dangerous edit is a **removal** from `MAY_STILL_PLAY`, not an addition. That would silently make questionable players IR-stashable and roster-limit-exempt across **five** call sites.

## Verification

The two cases that read `unavailable` directly fail on a revert every time. The end-to-end cases are deterministic with the rule and decide by coin-flip without it — the fixture gives players random ids and ties break on ascending id — and the test says so rather than pretending otherwise.

Full suite 2358 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.

## Also

- The dead `players.status` comes out of `RosterPlayer`, the query, the route payload and the client type. It was declared in the browser and read by nothing.
- `DECISIONS.md` records the exception: the autofill may read a designation, **only** to rank a slot the manager left empty, never to exclude. It also records the debt — #267's recording of what the autofill used is still owed, and this is taken on the narrower ground that a demotion cannot overturn a choice nobody made.

## Not in this PR

**#270** — the abandoned team starting a man on IR for weeks. This helps (he now sorts last) but does not close it: once #265 removes everyone whose game has started, the demoted player can be the last body standing and gets started anyway. Closing it properly needs exclusion, which is the kicker problem above. Left open deliberately.