### PR TITLE
fix: nothing ingested weekly projections, so week 1 lineups were a lottery

### DIFF
--- a/apps/web/src/lib/jobs/season-sync.ts
+++ b/apps/web/src/lib/jobs/season-sync.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NFL } from "@rostr/core";
 import {
+  currentWeek,
   recordCronRun,
   seasonsInPlay,
   syncByeWeeks,
@@ -95,7 +96,18 @@ export async function runSeasonSyncJob(
     /** Fixtures the provider has not given a kickoff time. See the loop below. */
     undatedGames?: number;
     ranked?: number;
+    /** Season-aggregate projection rows, for the draft board. */
     projections?: number;
+    /** Weekly projection rows, which the autofill ranks on. */
+    weeklyProjections?: number;
+    /**
+     * Which weeks those were pulled for.
+     *
+     * Named rather than counted, because "42 rows" cannot tell an operator that
+     * the job has been writing week 0 and nothing else — which is what it did
+     * from the day it shipped until issue #287.
+     */
+    projectionWeeks?: readonly number[];
     error?: string;
     /**
      * Weeks whose schedule sync threw, named rather than counted.
@@ -176,6 +188,48 @@ export async function runSeasonSyncJob(
       const rankings = await syncRankings(client, provider, NFL.key, season);
       const projections = await syncProjections(client, provider, NFL.key, season);
 
+      /*
+        And the week itself, which nothing ever asked for.
+
+        `syncProjections` defaults its week to the season aggregate, and the call
+        above takes that default — so week 0 was the only row this system ever
+        wrote. `loadProjectedPoints` asks for the real week, so it came back
+        empty every week of every season, and a league whose signed rules say
+        `WEEKLY_PROJECTION` silently ranked on season averages instead. Issue
+        #287. The asymmetry was visible three lines up: `syncGames` loops the
+        weeks, this did not.
+
+        Two weeks, not eighteen. A projection for week 12 published in August is
+        not a projection, and eighteen provider calls a day for seventeen answers
+        nobody reads is the kind of cost `listSeasonProjections` exists to avoid.
+        The current week is what the autofill is ranking on now; the next one is so
+        that a week has projections before its own Thursday rather than after it.
+
+        Failures here are collected like the per-week game failures above rather
+        than thrown: a provider that has not published week N+1 yet is the
+        ordinary case in the hours after a week ends, not a fault.
+      */
+      const projectionWeeks: number[] = [];
+      const playing = await currentWeek(client, NFL.key, season, now);
+      for (const week of [playing ?? 1, (playing ?? 0) + 1]) {
+        if (week >= 1 && week <= NFL.seasonWeeks && !projectionWeeks.includes(week)) {
+          projectionWeeks.push(week);
+        }
+      }
+
+      let weeklyProjections = 0;
+      for (const week of projectionWeeks) {
+        try {
+          const result = await syncProjections(client, provider, NFL.key, season, week);
+          weeklyProjections += result.inserted + result.updated;
+        } catch (error) {
+          weekFailures.push({
+            week,
+            reason: `projections: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        }
+      }
+
       runs.push({
         season,
         players: players.inserted + players.updated,
@@ -185,6 +239,8 @@ export async function runSeasonSyncJob(
         weekFailures,
         ranked: rankings.inserted,
         projections: projections.inserted,
+        weeklyProjections,
+        projectionWeeks,
       });
     } catch (error) {
       // One season's failure must not stop another's, and a partial season is

--- a/packages/db/src/lineups.test.ts
+++ b/packages/db/src/lineups.test.ts
@@ -28,6 +28,7 @@ import {
   loadWeekLineups,
   loadWeekStats,
   PRIMARY_PROJECTION_SOURCE,
+  SEASON_AGGREGATE_WEEK,
   PRIMARY_STAT_SOURCE,
   setLineup,
 } from "./lineups.js";
@@ -2060,5 +2061,133 @@ describe("the autofill ranks an injured player behind a healthy one — #269", (
     // A sort key, not an exclusion: he is still a candidate.
     expect(candidate.unavailable).toBe(true);
     expect(candidate.playerId).toBe(fx.player("sun-qb"));
+  });
+});
+
+describe("the autofill ranks on something real in week 1 — #287", () => {
+  /*
+    No production caller ever passed a week to `syncProjections`, so only the
+    season aggregate was written and `loadProjectedPoints` — which asks for the
+    real week — came back empty every week of every season. A league whose
+    signed rules say `WEEKLY_PROJECTION` silently ranked on season averages.
+
+    In week 1 that was worse than a downgrade. `loadAverages` returns all-null
+    for `week <= 1` — correctly, there is no prior week to average — so with no
+    projections either, every candidate ranked `null` and `compare` fell
+    through to its last tie-break, which compares player ids. Those are
+    `gen_random_uuid()`. Launch weekend was a lottery, and because the autofill
+    never revisits a slot it filled, the lottery result stood for the week.
+  */
+
+  const project = async (
+    fx: Fixture,
+    week: number,
+    values: readonly [string, number][],
+  ): Promise<void> => {
+    const [key] = await fx.client.query<{ id: string }>(
+      `SELECT k.id FROM stat_keys k
+         JOIN sports s ON s.id = k.sport_id
+        WHERE s.key = $1 AND k.key = 'rec_yd'`,
+      [NFL.key],
+    );
+
+    for (const [handle, value] of values) {
+      await fx.client.query(
+        `INSERT INTO player_projections (player_id, season, week, stat_key_id, source, value)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (player_id, season, week, stat_key_id, source)
+         DO UPDATE SET value = EXCLUDED.value`,
+        [fx.player(handle), SEASON, week, key!.id, PRIMARY_PROJECTION_SOURCE, value],
+      );
+    }
+  };
+
+  it("uses the week's projections when the week has them", async () => {
+    const fx = await setup();
+    // wr-c is the worse receiver by season average; the week says otherwise.
+    await project(fx, WEEK, [
+      ["wr-a", 10],
+      ["wr-c", 900],
+    ]);
+
+    const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
+
+    expect(projected.get(fx.player("wr-c"))).toBeGreaterThan(projected.get(fx.player("wr-a"))!);
+  });
+
+  it("falls back to the season projection when the week has none", async () => {
+    /*
+      The safety net, and the case that was permanently live before #287: the
+      ingest only ever wrote week 0, so this is what every real week hit.
+    */
+    const fx = await setup();
+    await project(fx, SEASON_AGGREGATE_WEEK, [
+      ["wr-a", 10],
+      ["wr-c", 900],
+    ]);
+
+    const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
+
+    expect(projected.size).toBeGreaterThan(0);
+    expect(projected.get(fx.player("wr-c"))).toBeGreaterThan(projected.get(fx.player("wr-a"))!);
+  });
+
+  it("never mixes the two, because a season total dwarfs a week's", async () => {
+    /*
+      All or nothing, deliberately. A map holding one player's weekly number
+      beside another's season total would rank everybody with a weekly row
+      below everybody without one — not a fallback, a corruption. So a week
+      with any projections at all uses only those.
+    */
+    const fx = await setup();
+    await project(fx, SEASON_AGGREGATE_WEEK, [["wr-a", 900]]);
+    await project(fx, WEEK, [["wr-c", 10]]);
+
+    const projected = await loadProjectedPoints(fx.client, SEASON, WEEK, fx.rules);
+
+    // Only the player the week names. The season row is not consulted at all.
+    expect(projected.has(fx.player("wr-c"))).toBe(true);
+    expect(projected.has(fx.player("wr-a"))).toBe(false);
+  });
+
+  it("gives week 1 a real ranking instead of a uuid ordering", async () => {
+    /*
+      The launch-weekend case. `loadAverages` is all-null at week 1 by design,
+      so before this the whole ranking was `playerId.localeCompare`.
+
+      Asserted by running the fill twice against two different projections and
+      requiring it to follow them. Under uuid ordering the answer cannot change,
+      because the ids do not.
+    */
+    const first = await setup();
+    await project(first, SEASON_AGGREGATE_WEEK, [
+      ["wr-a", 900],
+      ["wr-b", 10],
+      ["wr-c", 10],
+    ]);
+    await autoFillLineup(first.client, first.leagueId, first.teamId, WEEK, BEFORE_ANYTHING);
+
+    const second = await setup();
+    await project(second, SEASON_AGGREGATE_WEEK, [
+      ["wr-a", 10],
+      ["wr-b", 900],
+      ["wr-c", 10],
+    ]);
+    await autoFillLineup(second.client, second.leagueId, second.teamId, WEEK, BEFORE_ANYTHING);
+
+    const startedWr = async (fx: Fixture) => {
+      const rows = await fx.client.query<{ player_id: string }>(
+        `SELECT l.player_id FROM lineups l
+           JOIN slot_types st ON st.id = l.slot_type_id
+          WHERE l.team_id = $1 AND l.week = $2 AND st.key = 'WR'
+            AND l.player_id IS NOT NULL`,
+        [fx.teamId, WEEK],
+      );
+      return rows.map((row) => row.player_id);
+    };
+
+    // Each run starts the receiver its own projections favour.
+    expect(await startedWr(first)).toContain(first.player("wr-a"));
+    expect(await startedWr(second)).toContain(second.player("wr-b"));
   });
 });

--- a/packages/db/src/lineups.ts
+++ b/packages/db/src/lineups.ts
@@ -109,6 +109,23 @@ export const PRIMARY_STAT_SOURCE = "tank01";
  */
 export const PRIMARY_PROJECTION_SOURCE = "tank01";
 
+/**
+ * Week 0 is the season aggregate.
+ *
+ * The draft board asks "who is worth picking for the year"; the autofill asks
+ * "who scores most this Sunday". Same table, same shape, different question —
+ * and a sentinel rather than a nullable column, because Postgres treats NULLs
+ * as distinct and the primary key would then permit two season projections from
+ * one source for the same player.
+ *
+ * Declared here rather than in `sync.ts` because both files need it and
+ * `sync.ts` already imports `PRIMARY_PROJECTION_SOURCE` from this one. Putting
+ * it there and reading it here would close an import cycle around a
+ * module-level constant, which is a temporal-dead-zone hazard settled by
+ * whichever file the bundler happens to load first.
+ */
+export const SEASON_AGGREGATE_WEEK = 0;
+
 export class LineupError extends Error {
   constructor(
     message: string,
@@ -895,6 +912,26 @@ export async function loadAverages(
  *
  * A player with no projection is simply absent from the map, and the autolineup
  * falls back to his season average for that player alone.
+ *
+ * **Falls back to the season projection when the week has none at all**, and the
+ * all-or-nothing part is the whole of it. A season total is a much larger number
+ * than a week's, so a map holding both would rank every player who happened to
+ * have a weekly row below every player who did not — which is not a fallback, it
+ * is a corruption. Either the week has projections and they are used, or it has
+ * none and the season totals rank everybody consistently.
+ *
+ * That case is not hypothetical and was not rare. Issue #287: no production
+ * caller ever passed a week to `syncProjections`, so only the season aggregate
+ * was ever written and this query returned nothing, every week, all season. A
+ * league whose signed rules say `WEEKLY_PROJECTION` silently ranked on season
+ * averages instead — and in week 1, where {@link loadAverages} has no prior week
+ * to average either, every candidate ranked `null` and the autolineup fell
+ * through to its last tie-break, which compares player UUIDs. Launch weekend
+ * would have been decided by `gen_random_uuid()`.
+ *
+ * The ingest is fixed too, so this is the safety net rather than the mechanism.
+ * It still earns its place: it covers the week before a provider publishes, and
+ * any week whose pull failed.
  */
 export async function loadProjectedPoints(
   db: SqlClient,
@@ -903,13 +940,24 @@ export async function loadProjectedPoints(
   rules: LeagueRules,
   source: string = PRIMARY_PROJECTION_SOURCE,
 ): Promise<ReadonlyMap<string, number>> {
-  const rows = await db.query<{ player_id: string; key: string; value: number }>(
+  const weekly = await db.query<{ player_id: string; key: string; value: number }>(
     `SELECT p.player_id, k.key, p.value
        FROM player_projections p
        JOIN stat_keys k ON k.id = p.stat_key_id
       WHERE p.season = $1 AND p.week = $2 AND p.source = $3`,
     [season, week, source],
   );
+
+  const rows =
+    weekly.length > 0 || week === SEASON_AGGREGATE_WEEK
+      ? weekly
+      : await db.query<{ player_id: string; key: string; value: number }>(
+          `SELECT p.player_id, k.key, p.value
+             FROM player_projections p
+             JOIN stat_keys k ON k.id = p.stat_key_id
+            WHERE p.season = $1 AND p.week = $2 AND p.source = $3`,
+          [season, SEASON_AGGREGATE_WEEK, source],
+        );
 
   const byPlayer = new Map<string, StatLine[]>();
   for (const row of rows) {

--- a/packages/db/src/sync.ts
+++ b/packages/db/src/sync.ts
@@ -12,7 +12,7 @@
 
 import type { ProviderGame, StatsProvider } from "@rostr/stats";
 import type { SqlClient } from "./client.js";
-import { PRIMARY_PROJECTION_SOURCE } from "./lineups.js";
+import { PRIMARY_PROJECTION_SOURCE, SEASON_AGGREGATE_WEEK } from "./lineups.js";
 import { loadSportIds } from "./sports.js";
 
 export interface SyncResult {
@@ -397,17 +397,6 @@ export interface ProjectionCapableProvider {
   listSeasonProjections(season: number): Promise<readonly ProviderProjectionRow[]>;
   listWeekProjections(season: number, week: number): Promise<readonly ProviderProjectionRow[]>;
 }
-
-/**
- * Week 0 is the season aggregate.
- *
- * The draft board asks "who is worth picking for the year"; the autofill asks
- * "who scores most this Sunday". Same table, same shape, different question —
- * and a sentinel rather than a nullable column, because Postgres treats NULLs
- * as distinct and the primary key would then permit two season projections from
- * one source for the same player.
- */
-export const SEASON_AGGREGATE_WEEK = 0;
 
 /**
  * Pull projections.


### PR DESCRIPTION
Closes #287. Found while assessing #266 — and it is considerably more urgent than the issue it was found under, with twelve days to kickoff.

## The bug

`syncProjections` defaults its week to the season aggregate, and **both production callers take that default**:

- `apps/web/src/lib/jobs/season-sync.ts:177`
- `packages/db/src/cli.ts:195`

So week 0 is the only row this system has ever written. `loadProjectedPoints` asks for the **real** week, and came back empty every week of every season.

The asymmetry was visible three lines from the bug: `syncGames` loops the weeks; `syncProjections` was called once with no week at all.

## Two consequences

**A signed rule that does nothing.** Leagues default to `autofill: "WEEKLY_PROJECTION"`, frozen into the rule set members sign. With projections always absent, `rankingValue` falls through to `averageMilliPoints` and every league silently ranks on season averages. Fourth instance of this shape after `irSlots`, `botsAllowed` and `players.status`.

**Week 1 was decided by random UUID.** `loadAverages` short-circuits to all-null for `week <= 1` — correct on its own terms, there is no prior week to average. Combined with empty projections, **every candidate ranks `null`**, and `compare` falls through to its final tie-break:

```js
return a.playerId.localeCompare(b.playerId);   // gen_random_uuid()
```

And because `autoFillLineup` treats a slot it filled as decided — `keep` promotes it to `locked`, and locked slots never consult the pool again — that random lineup would have stood for the whole week. On launch weekend.

## The fix, in two halves

**Ingest the week.** `season-sync` now pulls the current week and the next one. Two weeks, not eighteen — a projection for week 12 published in August is not a projection, and seventeen answers nobody reads is exactly the cost `listSeasonProjections` exists to avoid. The current week is what the autofill ranks on now; the next is so a week has projections *before* its own Thursday rather than after it. Failures are collected like the per-week schedule failures beside them, because a provider that has not published next week yet is the ordinary case rather than a fault.

**Fall back to the season aggregate** when a week has none — and the **all-or-nothing** part is the whole of it. A season total dwarfs a week's, so a map holding both would rank every player who happened to have a weekly row below every player who did not. That is not a fallback, it is a corruption. Either the week has projections and they are used, or it has none and season totals rank everybody consistently. There is a test asserting the two are never mixed.

The fallback is the safety net rather than the mechanism, and it still earns its place: it covers the week before a provider publishes, and any week whose pull failed.

## An import cycle avoided rather than shipped

`SEASON_AGGREGATE_WEEK` moves from `sync.ts` to `lineups.ts`. Both need it, and `sync.ts` already imports `PRIMARY_PROJECTION_SOURCE` from `lineups.ts` — so leaving it where it was and reading it from here would have closed a cycle around a module-level constant, which is a temporal dead-zone settled by whichever file the bundler loads first. Same hazard the `league-state.ts` split avoided earlier this week.

## Reporting

The run report names the **weeks** it pulled, not just a row count. "42 rows" cannot tell an operator that the job has been writing week 0 and nothing else — which is precisely what it did from the day it shipped.

## Verification

Two of the four new tests fail with the fallback disabled, including the week-1 case: it runs the fill twice against opposite projections and requires the lineup to follow them. Under UUID ordering the answer cannot change, because the ids do not.

Full suite 2362 passed, web 288 passed, typecheck, lint, prettier and the test-project guard clean.

## Context

Found while three agents assessed #266 (the autofill runs too late to include Thursday-night players). That issue is **deferred past Sep 9** — it is a scheduling change to `currentWeek`, which has three documented rounds of scar tissue, and every failure mode it can introduce is silent.

The same investigation also turned up **#288**: an abandoned team gets a near-empty lineup in playoff week 15, because playoff fixtures do not exist until the regular season finalises — 168 hours after week 14's last kickoff. That is a larger defect than #266 and should be what decides its priority.