### PR TITLE
fix(db): pnpm db:sync pulls the weekly projections the cron pulls

### DIFF
--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -20,6 +20,7 @@ import { listCronRuns } from "./cron-runs.js";
 import { loadMigrations, migrate } from "./migrate.js";
 import { createPostgresClient } from "./postgres.js";
 import { seedSport } from "./sports.js";
+import { currentWeek } from "./week.js";
 import {
   loadDraftBoard,
   syncByeWeeks,
@@ -196,6 +197,42 @@ async function main(): Promise<void> {
         console.log(
           `projections +${projections.inserted} stat lines, ` +
             `${projections.skipped} players unmatched`,
+        );
+
+        /*
+          And the weeks, which is what the autofill actually ranks on.
+
+          The call above takes `syncProjections`' default week, which is the
+          season aggregate — the draft board's number. Issue #287: for the whole
+          life of this system that was the only week ever written, so
+          `loadProjectedPoints` came back empty every week, and in week 1 — where
+          there is no prior week to average either — the autofill fell through to
+          comparing player uuids.
+
+          The cron gained this and this command did not, which is the drift the
+          job's own docstring warns about: "It is tempting to have the cron do a
+          narrower job than the operator command. That is how the two drift, and
+          then 'run the sync' means one thing to a person and another to the
+          scheduler." It drifted the other way round for an hour. An operator who
+          sets a database up by hand and drafts the same day would have got the
+          uuid lottery back.
+
+          Same two weeks the cron pulls, and the same reason: a projection for
+          week 12 published in August is not a projection.
+        */
+        const playing = await currentWeek(client, NFL.key, season, new Date());
+        const projectionWeeks = [...new Set([playing ?? 1, (playing ?? 0) + 1])].filter(
+          (week) => week >= 1 && week <= REGULAR_SEASON_WEEKS,
+        );
+
+        let weekly = 0;
+        for (const week of projectionWeeks) {
+          const result = await syncProjections(client, provider, NFL.key, season, week);
+          weekly += result.inserted + result.updated;
+        }
+        console.log(
+          `weekly     +${weekly} projected stat lines for week${projectionWeeks.length > 1 ? "s" : ""} ` +
+            `${projectionWeeks.join(" and ")}`,
         );
 
         if (projections.unmatched.length > 0) {


### PR DESCRIPTION
A regression from #287, merged an hour earlier. Found by an agent tracing writers while assessing #116.

## What broke

#287 taught `season-sync` (the cron) to pull the current week's projections and the next one's. `pnpm db:sync` — the command an operator runs to set a database up — still called `syncProjections` with no week, so it wrote only the season aggregate.

The job's docstring says exactly why that matters, and it sits four lines from where the change landed:

> It is tempting to have the cron do a narrower job than the operator command — only the schedule, say. **That is how the two drift**, and then "run the sync" means one thing to a person and another to the scheduler.

It drifted the other way round from the one that comment anticipates: the cron ended up doing *more* than the operator command.

## Why it matters on the launch path

Seed a database with `pnpm db:sync`, create a league, draft the same day — and the autofill is back to #287's behaviour, because no weekly projections exist. In week 1 that means ranking by random UUID, since `loadAverages` has no prior week to average either. The next 09:20 UTC cron run would heal it, but only after the lineups had been decided and frozen, since the autofill never revisits a slot it filled.

That is precisely the setup path a deployer follows eleven days before kickoff.

## The fix

The same two weeks, the same bound. `REGULAR_SEASON_WEEKS` is `NFL.seasonWeeks`, which is the constant the cron bounds on — checked, so this does not re-create the drift in a third place.

Verified in chunks rather than one run: core 557, stats/escrow/pinning 580, db 937, web 288 — 2362 passing, reconciling with the full suite's total. (A single full-suite run crashed workers with "Worker exited unexpectedly" under memory pressure from a long session; the chunked runs are clean and the totals match.)