### PR TITLE
Design drop 9: mobile complete, responsive landing

### DIFF
--- a/docs/design/PULL_REQUEST_DROP9.md
+++ b/docs/design/PULL_REQUEST_DROP9.md
@@ -1,0 +1,64 @@
+# Design drop 9 — mobile completed, landing made responsive, stale copy retired
+
+Not for immediate merge — review pass pending.
+
+## What changed
+
+### screens/Rostr Mobile.dc.html — 17 frames become 34
+Every shipped route and every bottom-nav tab now has a 390px design, plus the edge
+states. New frames, in file order:
+
+- 18 Leagues — the drop-8 hub stacked for a phone (your leagues → invitations → public;
+  no join button in any list, every card leads to the rules)
+- 19 Player detail — status decides the pinned action; a claim names its drop on the button
+- 20 Full standings — twelve rows, three columns, PF on the second line, the cut line drawn
+- 21 Matchup — slot against slot, the second line explains any missing number
+- 22 Sign in — email code first, wallet second (a wallet signs only money and consent)
+- 23 Finish setting up — the username gate, stated as what it unblocks
+- 24 Draft board tab — one round at a time as twelve rows, pager at the thumb;
+  strict position-identity tags (need-colouring stays on the Draft tab)
+- 25 Pre-draft queue — 44px arrows, no drag; autopick fallback stated
+- 26 Notifications — the desktop dropdown as a page; needs-you first with the
+  do-nothing consequence
+- 27 Account menu — bottom sheet carrying Sign out and the Finish-setting-up branch
+  (the two affordances STATUS.md warns a header rebuild deletes)
+- 28 League home, pre-draft — countdown, seat meter, the one useful action
+- 29 Draft room, connection lost — server clock keeps running; queue covers you
+- 30 Claim lost — who won on what priority, and what did not change
+- 31 Trade composer — tap-to-toggle from both rosters; 48h veto stated before send
+- 32 Team tab — bench + IR; Drop refuses with GAME_STARTED after kickoff
+- 33 Draft complete — section-glow end state, pinned action is the Week 1 lineup
+- 34 Dead invite link — names which of the three death reasons applied, offers
+  public leagues / create instead of a wall
+
+### screens/Rostr Landing.dc.html — phone breakpoint added
+The design had no rules below 980px; at 390px the nav, hero draft board (min ~470px),
+rules table and the two-column close band all overflowed, which is the clipped dark
+band on the right. Added a max-width:640px pass: nav compacts (tagline + How-it-works
+hidden), hero/section paddings tighten, the board scrolls horizontally instead of
+clipping (mask dropped when scrolling), the rules table stacks its label cells, the
+close band and week split collapse to one column.
+**The shipped page.tsx needs the same treatment — this fixes the design, not the app.**
+
+### Stale copy corrected (per STATUS.md / ANSWERS.md)
+- Roster-as-NFT sentences removed: Mobile hero, Draft Room draft-complete,
+  Playoffs "Your roster, now", Trade Veto escrow caption. Replaced with the
+  no-commissioner claim the app actually ships.
+- Kickoff corrected to 9 September (Create League helper text, Draft Room).
+- Domain: rostr.gg → rostr.site everywhere (Mobile ×24, Invite and Join ×1).
+
+## Not touched
+- Rostr Screens.dc.html is still the drop-8 index (17 mobile frames, stale open
+  questions) — update separately or with the next drop.
+- Draft room state 6 still exists on desktop; ANSWERS.md says it can be deleted.
+
+## How to land this
+```
+git checkout -b design-drop-9
+cp -r handoff/docs/design/screens/* docs/design/screens/
+git add docs/design && git commit -m "Design drop 9: mobile complete (34 frames), responsive landing, retired copy removed"
+gh pr create --draft --title "Design drop 9" --body-file docs/design/PULL_REQUEST_DROP9.md
+```
+Open as a **draft PR** so it is not mergeable until you have been through it.
+Note: design-scoring.test.ts guards the Create League table — it was not changed here,
+only the kickoff date helper text, so it should stay green.

--- a/docs/design/PULL_REQUEST_DROP9.md
+++ b/docs/design/PULL_REQUEST_DROP9.md
@@ -5,8 +5,15 @@ Not for immediate merge — review pass pending.
 ## What changed
 
 ### screens/Rostr Mobile.dc.html — 17 frames become 34
-Every shipped route and every bottom-nav tab now has a 390px design, plus the edge
-states. New frames, in file order:
+Most shipped routes now have a 390px design, plus the edge states. Three do not:
+`/scoring`, `/invitations` (folded into frame 18 as a section) and `/ops/stats`.
+The bottom nav in these frames is `Home · Matchup · Team · Players · League`, which
+does not match the shipped nav (`LeagueChrome.tsx`): `League` is a fifth tab with no
+route, and `Trades` and `Standings` are shipped tabs missing from it — so frames 20,
+31 and 34 are unreachable from the design's own navigation. Reconcile before building.
+Routes are also written `/l/<slug>/…` throughout; shipped is `/leagues/[id]/…`.
+
+New frames, in file order:
 
 - 18 Leagues — the drop-8 hub stacked for a phone (your leagues → invitations → public;
   no join button in any list, every card leads to the rules)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -568,7 +568,7 @@ becomes consent, and the three outstanding managers happen to be the two teams t
 would hurt. The screen shows who has not signed and does not editorialise.
 
 **3 · Dissolving.** The copy is specific about what is lost — season stops, no champion,
-rosters keep their NFTs with the transfer restriction relaxed as at settlement, ten weeks of
+rosters stay exactly as they are, ten weeks of
 results stay on chain, and in a pot league every stake returns in full with no fee. The
 aside shows *your own* standing (3rd, inside the playoff cut) next to an irreversible
 decision, deliberately. Unanimity is what stops a losing half ending a season the winning

--- a/docs/design/screens/Rostr Amend and Dissolve.dc.html
+++ b/docs/design/screens/Rostr Amend and Dissolve.dc.html
@@ -335,7 +335,7 @@
           </div>
           <div style="display: grid; grid-template-columns: 140px minmax(0, 1fr); gap: 16px; align-items: baseline; padding: 12px 18px; border-bottom: 1px solid var(--color-neutral-900);">
             <span style="font-size: 12.5px; color: var(--color-neutral-500);">Your roster</span>
-            <span style="font-size: 13px; line-height: 1.55;">The fourteen NFTs stay in your wallet and their transfer restriction relaxes, the same as it would at settlement. They stop being a lineup and become just tokens.</span>
+            <span style="font-size: 13px; line-height: 1.55;">Your fourteen roster rows stay exactly as they are. They stop being a lineup and become just a record.</span>
           </div>
           <div style="display: grid; grid-template-columns: 140px minmax(0, 1fr); gap: 16px; align-items: baseline; padding: 12px 18px; border-bottom: 1px solid var(--color-neutral-900);">
             <span style="font-size: 12.5px; color: var(--color-neutral-500);">The record</span>

--- a/docs/design/screens/Rostr Create League.dc.html
+++ b/docs/design/screens/Rostr Create League.dc.html
@@ -87,7 +87,7 @@
             <div class="field">
               <label for="cl-date">Scheduled draft time</label>
               <input class="input" id="cl-date" value="Sat 22 Aug 2026 · 8:00 PM ET">
-              <span style="display: block; font-size: 11.5px; color: var(--color-neutral-600); margin-top: 6px;">Late August — drafts happen before the 10 September kickoff.</span>
+              <span style="display: block; font-size: 11.5px; color: var(--color-neutral-600); margin-top: 6px;">Late August — drafts happen before the 9 September kickoff.</span>
             </div>
             <div class="field">
               <label id="cl-mode">Pace</label>

--- a/docs/design/screens/Rostr Draft Room.dc.html
+++ b/docs/design/screens/Rostr Draft Room.dc.html
@@ -2079,7 +2079,7 @@
         <div>
           <div style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-300);">Draft complete</div>
           <h1 style="font-family: var(--font-heading); font-size: 34px; font-weight: 500; letter-spacing: -0.03em; line-height: 1.08; margin: 11px 0 0;">168 picks, 14 rounds, 2 hours 41 minutes.</h1>
-          <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-accent-200); margin: 13px 0 0; max-width: 520px; text-wrap: pretty;">Every player you drafted is now a Token-2022 NFT in your wallet. Week 1 kicks off Thu 10 Sep, and your first lineup is due before it.</p>
+          <p style="font-size: 14.5px; line-height: 1.6; color: var(--color-accent-200); margin: 13px 0 0; max-width: 520px; text-wrap: pretty;">Every pick is on your roster, and no commissioner can take one off it. Week 1 kicks off Wed 9 Sep, and your first lineup is due before it.</p>
           <div style="display: flex; gap: 12px; margin-top: 22px; flex-wrap: wrap;">
             <button type="button" class="btn btn-primary" style="font-size: 14px; padding: 10px 18px; min-height: 44px; border-color: var(--color-accent-300); color: var(--color-accent-100);">Set your Week 1 lineup</button>
             <button type="button" class="btn btn-ghost" style="font-size: 14px; padding: 10px 16px; min-height: 44px; color: var(--color-accent-200);">League home</button>

--- a/docs/design/screens/Rostr Draft Room.dc.html
+++ b/docs/design/screens/Rostr Draft Room.dc.html
@@ -1328,7 +1328,7 @@
       <div style="display: flex; flex-direction: column; gap: 9px; margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--color-neutral-900); font-size: 12.5px;">
         <div style="display: flex; justify-content: space-between; gap: 16px;"><span style="color: var(--color-neutral-500);">Signing against</span><span style="font-family: ui-monospace, monospace; color: var(--color-neutral-400);">rules 0x7f3a…c19d</span></div>
         <div style="display: flex; justify-content: space-between; gap: 16px;"><span style="color: var(--color-neutral-500);">Pick</span><span style="color: var(--color-neutral-400);">3.04 · overall 28</span></div>
-        <div style="display: flex; justify-content: space-between; gap: 16px;"><span style="color: var(--color-neutral-500);">Roster NFT mints to</span><span style="font-family: ui-monospace, monospace; color: var(--color-neutral-400);">7xKq…4vNb</span></div>
+        <div style="display: flex; justify-content: space-between; gap: 16px;"><span style="color: var(--color-neutral-500);">Roster recorded for</span><span style="font-family: ui-monospace, monospace; color: var(--color-neutral-400);">7xKq…4vNb</span></div>
       </div>
       <p style="font-size: 12.5px; line-height: 1.55; color: var(--color-neutral-500); margin: 16px 0 0;">Your wallet is asking you to sign. The pick is not recorded until it confirms — and the clock keeps running while you sign.</p>
       <div class="dialog-actions" style="display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px;">
@@ -1965,7 +1965,7 @@
         <div style="padding: 11px 18px; border-bottom: 1px solid var(--color-neutral-900); font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">What happened, in order</div>
         <div style="display: grid; grid-template-columns: 72px minmax(0, 1fr); gap: 16px; align-items: baseline; padding: 12px 18px; border-bottom: 1px solid var(--color-neutral-900);">
           <span style="font-family: ui-monospace, monospace; font-size: 11.5px; color: var(--color-neutral-500);">0:06</span>
-          <span style="font-size: 13.5px; line-height: 1.55;">You selected <span style="color: var(--color-neutral-200);">J. Kirchner, WR SEA</span> and approved the transaction in your wallet.</span>
+          <span style="font-size: 13.5px; line-height: 1.55;">You selected <span style="color: var(--color-neutral-200);">J. Kirchner, WR SEA</span> and nothing was signed &mdash; a pick is a database write.</span>
         </div>
         <div style="display: grid; grid-template-columns: 72px minmax(0, 1fr); gap: 16px; align-items: baseline; padding: 12px 18px; border-bottom: 1px solid var(--color-neutral-900);">
           <span style="font-family: ui-monospace, monospace; font-size: 11.5px; color: var(--color-neutral-500);">0:04</span>
@@ -2207,7 +2207,7 @@
           </div>
           <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 18px; font-size: 11.5px; color: var(--color-neutral-500);">
             <span>14 of 14 rostered &middot; IR does not count against the limit</span>
-            <span style="font-family: ui-monospace, monospace;">minted to 7xKq&hellip;4vNb</span>
+            <span style="font-family: ui-monospace, monospace;">recorded for 7xKq&hellip;4vNb</span>
           </div>
         </div>
       </div>

--- a/docs/design/screens/Rostr Invite and Join.dc.html
+++ b/docs/design/screens/Rostr Invite and Join.dc.html
@@ -62,7 +62,7 @@
             <span style="font-size: 11.5px; color: var(--color-neutral-600);">Private league — the link is the invitation</span>
           </div>
           <div style="display: flex; gap: 10px; margin-top: 12px;">
-            <input class="input" value="rostr.gg/join/0x7f3a…c19d" readonly="readonly" style="flex: 1 1 auto; min-width: 0; font-family: ui-monospace, monospace; font-size: 13px;">
+            <input class="input" value="rostr.site/join/0x7f3a…c19d" readonly="readonly" style="flex: 1 1 auto; min-width: 0; font-family: ui-monospace, monospace; font-size: 13px;">
             <button type="button" class="btn btn-primary" style="flex: 0 0 auto; font-size: 13.5px; padding: 9px 18px;">Copy link</button>
           </div>
           <div class="field" style="margin-top: 16px;">

--- a/docs/design/screens/Rostr Landing.dc.html
+++ b/docs/design/screens/Rostr Landing.dc.html
@@ -28,6 +28,21 @@
   @media (max-width: 980px) {
     .explore { grid-template-columns: minmax(0, 1fr) !important; gap: 28px !important; }
   }
+  @media (max-width: 640px) {
+    .nav-bar { padding: 12px 18px !important; }
+    .nav-links { gap: 10px !important; }
+    .nav-tagline, .nav-howto { display: none !important; }
+    .hero-pad { padding: 64px 20px 0 !important; }
+    .section-pad { padding: 56px 20px 72px !important; }
+    .board-scroll { overflow-x: auto !important; -webkit-mask-image: none !important; mask-image: none !important; }
+    .board-grid { min-width: 470px; }
+    .week-split, .close-grid, .playoff-grid { grid-template-columns: minmax(0, 1fr) !important; }
+    .close-grid { gap: 32px !important; }
+    .rules-table td { display: block; width: auto !important; }
+    .rules-table tr td:first-child { padding-bottom: 2px; border-bottom: 0; }
+    .close-section { padding: 56px 24px !important; margin: 40px 12px 0 !important; }
+    .footer-pad { padding: 32px 20px !important; }
+  }
   @keyframes rostrFade { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
 </style>
 </helmet>
@@ -43,13 +58,13 @@
     <button type="button" onClick="{{ replay }}" style="border: 1px solid var(--color-neutral-800); background: transparent; color: var(--color-neutral-400); font: inherit; text-transform: none; letter-spacing: 0; padding: 4px 10px; border-radius: 999px; cursor: pointer;" style-hover="border-color: var(--color-accent-700); color: var(--color-accent-300);">Replay throw</button>
   </div></sc-if>
 
-  <header class="nav" style="position: sticky; top: 0; z-index: 40; display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 14px 40px; background: rgba(22,24,38,0.86); backdrop-filter: blur(10px); border-bottom: 1px solid var(--color-neutral-900);">
+  <header class="nav nav-bar" style="position: sticky; top: 0; z-index: 40; display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 14px 40px; background: rgba(22,24,38,0.86); backdrop-filter: blur(10px); border-bottom: 1px solid var(--color-neutral-900);">
     <div style="display: flex; align-items: baseline; gap: 10px;">
       <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
-      <span style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
+      <span class="nav-tagline" style="font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-600);">fantasy football</span>
     </div>
-    <nav style="display: flex; align-items: center; gap: 22px; font-size: 13.5px; color: var(--color-neutral-400);">
-      <a href="#explore" style="color: inherit;" style-hover="color: var(--color-text);">How it works</a>
+    <nav class="nav-links" style="display: flex; align-items: center; gap: 22px; font-size: 13.5px; color: var(--color-neutral-400);">
+      <a href="#explore" class="nav-howto" style="color: inherit;" style-hover="color: var(--color-text);">How it works</a>
       <span style="display: flex; align-items: center; gap: 4px;">
         <a href="https://github.com/6figpsolseeker/rostr" aria-label="rostr on GitHub" style="display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: var(--radius-sm); color: var(--color-neutral-500);" style-hover="color: var(--color-text); background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
           <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.07-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A7.995 7.995 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
@@ -173,7 +188,7 @@
     </nav>
   </header>
 
-  <section data-screen-label="Hero" style="position: relative; padding: 104px 40px 0;">
+  <section data-screen-label="Hero" class="hero-pad" style="position: relative; padding: 104px 40px 0;">
     <div ref="{{ heroRef }}" style="position: relative; max-width: 1180px; margin: 0 auto; min-height: 400px;">
 
       <svg ref="{{ arcRef }}" width="100%" height="100%" preserveAspectRatio="none" style="position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none; z-index: 1;">
@@ -219,7 +234,7 @@
 
   <div style="height: 1px; max-width: 1180px; margin: 0 auto; background: linear-gradient(90deg, transparent, var(--color-neutral-800) 12%, var(--color-neutral-800) 88%, transparent);"></div>
 
-  <section data-screen-label="Explore" id="explore" style="padding: 76px 40px 96px;">
+  <section data-screen-label="Explore" id="explore" class="section-pad" style="padding: 76px 40px 96px;">
     <div style="max-width: 1180px; margin: 0 auto;">
 
       <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 32px; flex-wrap: wrap; margin-bottom: 40px;">
@@ -336,7 +351,7 @@
           <div>
             <h3 style="font-family: var(--font-heading); font-weight: 500; font-size: 30px; line-height: 1.14; letter-spacing: -0.026em; margin: 0;">The default league, in full.</h3>
             <p style="font-size: 15.5px; line-height: 1.62; color: var(--color-neutral-400); margin: 16px 0 0; max-width: 620px;">This is the whole rule set, not a summary of it. Full detail lives in <a href="https://github.com/6figpsolseeker/rostr/blob/main/docs/RULES.md">docs/RULES.md</a>.</p>
-            <table class="table" style="width: 100%; font-size: 14.5px; margin-top: 30px;">
+            <table class="table rules-table" style="width: 100%; font-size: 14.5px; margin-top: 30px;">
               <tbody>
                 <tr>
                   <td style="width: 156px; color: var(--color-neutral-500); vertical-align: top;">Scoring</td>
@@ -401,8 +416,8 @@
                   </span>
                 </div>
 
-                <div style="-webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 88px), transparent); mask-image: linear-gradient(90deg, #000 calc(100% - 88px), transparent);">
-                  <div style="display: grid; grid-template-columns: 24px repeat(3, minmax(120px, 1fr)); gap: 3px; align-items: stretch;">
+                <div class="board-scroll" style="-webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 88px), transparent); mask-image: linear-gradient(90deg, #000 calc(100% - 88px), transparent);">
+                  <div class="board-grid" style="display: grid; grid-template-columns: 24px repeat(3, minmax(120px, 1fr)); gap: 3px; align-items: stretch;">
                     <div></div>
                     <div style="padding: 0 8px 7px; border-bottom: 1px solid var(--color-neutral-900); min-width: 0;">
                       <span style="display: block; font-size: 11.5px; font-weight: 500; color: var(--color-neutral-400); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Pylon Co.</span>
@@ -531,7 +546,7 @@
             <h3 style="font-family: var(--font-heading); font-weight: 500; font-size: 30px; line-height: 1.14; letter-spacing: -0.026em; margin: 0;">The week you already know how to read.</h3>
             <p style="font-size: 15.5px; line-height: 1.62; color: var(--color-neutral-400); margin: 16px 0 0; max-width: 620px; text-wrap: pretty;">Matchups, projections, waiver order, a starting lineup that autofills if you miss kickoff. Nothing about the format is novel — the format is the part that works. What changes is who holds the rules.</p>
 
-            <div style="display: grid; grid-template-columns: minmax(0, 0.62fr) minmax(0, 1fr); gap: 36px; align-items: start; margin-top: 30px;">
+            <div class="week-split" style="display: grid; grid-template-columns: minmax(0, 0.62fr) minmax(0, 1fr); gap: 36px; align-items: start; margin-top: 30px;">
               <div style="display: flex; flex-direction: column; gap: 11px; font-size: 14.5px; color: var(--color-neutral-400);">
                 <div style="display: flex; gap: 12px;"><span style="color: var(--color-accent-500);">&mdash;</span><span>Head-to-head weekly matchups, Weeks 1&ndash;14</span></div>
                 <div style="display: flex; gap: 12px;"><span style="color: var(--color-accent-500);">&mdash;</span><span>Rolling waiver priority: win a claim, go to the back</span></div>
@@ -620,7 +635,7 @@
             <h3 style="font-family: var(--font-heading); font-weight: 500; font-size: 30px; line-height: 1.14; letter-spacing: -0.026em; margin: 0;">The bracket reseeds, and the contract does the rest.</h3>
             <p style="font-size: 15.5px; line-height: 1.62; color: var(--color-neutral-400); margin: 16px 0 0; max-width: 620px; text-wrap: pretty;">Six teams across Weeks 15 to 17. Every round reseeds &mdash; the best surviving seed always draws the worst &mdash; so the bracket cannot be drawn in advance. An upset changes who the top seed plays, not just who survives.</p>
 
-            <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin-top: 30px;">
+            <div class="playoff-grid" style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin-top: 30px;">
               <div class="card" style="padding: 16px; background: var(--color-surface);">
                 <div style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Week 15 &middot; quarterfinals</div>
                 <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 13px; font-size: 13px;">
@@ -699,8 +714,8 @@
     </div>
   </section>
 
-  <section data-screen-label="Close" id="start" style="margin: 40px 20px 0; border-radius: var(--radius-lg); background: radial-gradient(120% 140% at 12% 0%, var(--color-section-glow) 0%, var(--color-section) 46%, #1d2048 100%); padding: 84px 48px;">
-    <div style="max-width: 1180px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 0.72fr); gap: 56px; align-items: end;">
+  <section data-screen-label="Close" id="start" class="close-section" style="margin: 40px 20px 0; border-radius: var(--radius-lg); background: radial-gradient(120% 140% at 12% 0%, var(--color-section-glow) 0%, var(--color-section) 46%, #1d2048 100%); padding: 84px 48px;">
+    <div class="close-grid" style="max-width: 1180px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 0.72fr); gap: 56px; align-items: end;">
       <div>
         <h2 style="font-family: var(--font-heading); font-weight: 500; font-size: clamp(34px, 4.4vw, 54px); line-height: 1.06; letter-spacing: -0.03em; margin: 0; text-wrap: pretty;">A league can be joined, created, and drafted end to end today.</h2>
         <p style="font-size: 16.5px; line-height: 1.6; color: var(--color-accent-200); margin: 20px 0 0; max-width: 520px;">Nothing touches money yet. Bring eleven friends, or two &mdash; a single bot can square an odd field.</p>
@@ -716,7 +731,7 @@
     </div>
   </section>
 
-  <footer style="max-width: 1180px; margin: 0 auto; padding: 40px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; font-size: 13px; color: var(--color-neutral-600);">
+  <footer class="footer-pad" style="max-width: 1180px; margin: 0 auto; padding: 40px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; font-size: 13px; color: var(--color-neutral-600);">
     <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 600; color: var(--color-neutral-400);">rostr</span>
     <div style="display: flex; gap: 24px; flex-wrap: wrap;">
       <a href="https://github.com/6figpsolseeker/rostr">GitHub</a>

--- a/docs/design/screens/Rostr Mobile.dc.html
+++ b/docs/design/screens/Rostr Mobile.dc.html
@@ -1005,7 +1005,7 @@
 
               <div class="card" style="padding: 12px 14px; background: var(--color-surface);">
                 <div style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">Your roster, now</div>
-                <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-400); margin: 8px 0 0; text-wrap: pretty;">Fourteen tokens, still in your wallet. The transfer restriction relaxed at settlement.</p>
+                <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-400); margin: 8px 0 0; text-wrap: pretty;">Fourteen players, still yours to the last row. The season is settled, so nothing about this roster can change again.</p>
               </div>
             </div>
           </div>
@@ -2084,7 +2084,7 @@
         <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">30</span>
         <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Claim lost, and why</span>
       </div>
-      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Losing a claim costs nothing, and the screen proves it: who won, on what priority, and that your roster and your place in line did not move.</span>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Losing a claim costs nothing, and the screen proves it: who won, on what priority, and that your roster did not change.</span>
 
       <div data-screen-label="M &middot; Claim lost" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
@@ -2112,10 +2112,10 @@
               <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">What did not change</span>
               <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 9px; font-size: 12.5px; color: var(--color-neutral-400);">
                 <span>T. Kraft stays on your roster &mdash; the drop only fires on a win</span>
-                <span>Your priority stays 8 of 12 &mdash; only winning moves you back</span>
+                <span>Losing costs you nothing &mdash; only winning moves a team back</span>
               </div>
             </div>
-            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 14px 0 0; text-wrap: pretty;">Marchbanks is rostered now, so the claim cannot be refiled. He returns to the pool only if Cover Two drops him &mdash; then he waives for two days like anyone else.</p>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 14px 0 0; text-wrap: pretty;">Marchbanks is rostered now, so the claim cannot be refiled. He returns to the pool only if Cover Two drops him &mdash; then he waives for one day like anyone else.</p>
           </div>
           <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
             <button type="button" class="btn btn-ghost btn-block" style="min-height: 48px; font-size: 14.5px; color: var(--color-neutral-300);">Browse free agents</button>

--- a/docs/design/screens/Rostr Mobile.dc.html
+++ b/docs/design/screens/Rostr Mobile.dc.html
@@ -27,7 +27,7 @@
 
   <sc-if value="{{ showIntro }}" hint-placeholder-val="{{ true }}"><div style="max-width: 900px;">
     <h1 style="font-family: var(--font-heading); font-size: 26px; font-weight: 500; letter-spacing: -0.026em; margin: 0;">Mobile web · 390px</h1>
-    <p style="font-size: 14px; line-height: 1.6; color: var(--color-neutral-400); margin: 10px 0 0; text-wrap: pretty;">Seventeen screens at the narrowest common phone width, in a mobile browser. Not a reflow of the desktop layouts — the desktop two-column shell has no mobile equivalent, so navigation moves to a bottom bar within thumb reach, tables become stacked rows, and each screen commits to one primary action pinned above the bar. Every tap target is at least 44px.</p>
+    <p style="font-size: 14px; line-height: 1.6; color: var(--color-neutral-400); margin: 10px 0 0; text-wrap: pretty;">Thirty-four screens at the narrowest common phone width, in a mobile browser. Not a reflow of the desktop layouts — the desktop two-column shell has no mobile equivalent, so navigation moves to a bottom bar within thumb reach, tables become stacked rows, and each screen commits to one primary action pinned above the bar. Every tap target is at least 44px.</p>
   </div></sc-if>
 
   <div style="display: flex; gap: 26px; margin-top: 32px; align-items: start; flex-wrap: wrap;">
@@ -42,7 +42,7 @@
       <div data-screen-label="M · Landing" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
 
         <div style="height: 620px; overflow: hidden; position: relative;">
@@ -57,10 +57,10 @@
           </div>
 
           <div style="padding: 30px 18px 0;">
-            <span class="tag tag-outline" style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;">Pre-alpha · 2026 season</span>
+            <span class="tag tag-outline" style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;">Pre-alpha · 2026 season</span>
             <h2 style="font-family: var(--font-heading); font-size: 42px; font-weight: 500; line-height: 1.03; letter-spacing: -0.032em; margin: 16px 0 0;">Your roster<br>is yours.</h2>
             <div style="height: 1px; width: 100%; margin-top: 18px; background: linear-gradient(90deg, transparent, var(--color-accent) 22%, var(--color-accent) 78%, transparent);"></div>
-            <p style="font-size: 15px; line-height: 1.6; color: var(--color-neutral-400); margin: 18px 0 0; text-wrap: pretty;">Drafted players are held in your wallet, not on a platform's server. League rules are frozen at creation and hashed on-chain.</p>
+            <p style="font-size: 15px; line-height: 1.6; color: var(--color-neutral-400); margin: 18px 0 0; text-wrap: pretty;">No commissioner can edit your team, force a trade, or overrule a result. League rules are frozen at creation and hashed on-chain.</p>
             <div style="display: flex; flex-direction: column; gap: 10px; margin-top: 24px;">
               <button type="button" class="btn btn-primary btn-block" style="font-size: 15px; min-height: 48px;">Create a free league</button>
               <button type="button" class="btn btn-ghost btn-block" style="font-size: 15px; min-height: 48px; color: var(--color-neutral-300);">See how a season runs</button>
@@ -85,7 +85,7 @@
       <div data-screen-label="M · League home" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -187,7 +187,7 @@
       <div data-screen-label="M · Lineup" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/lineup</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/lineup</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -266,7 +266,7 @@
       <div data-screen-label="M · Draft room" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/draft</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/draft</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -349,7 +349,7 @@
       <div data-screen-label="M · Join" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/join/4kPq2m</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/join/4kPq2m</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -434,7 +434,7 @@
       <div data-screen-label="M · Signing" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/join/4kPq2m</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/join/4kPq2m</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column; position: relative;">
@@ -494,7 +494,7 @@
       <div data-screen-label="M &middot; Waivers" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/players</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/players</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -591,7 +591,7 @@
       <div data-screen-label="M &middot; Waiver run" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/waivers</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/waivers</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -667,7 +667,7 @@
       <div data-screen-label="M &middot; Trade received" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/trades/8f2c</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/trades/8f2c</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -757,7 +757,7 @@
       <div data-screen-label="M &middot; Veto vote" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/trades/3a9d</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/trades/3a9d</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -843,7 +843,7 @@
       <div data-screen-label="M &middot; Bracket" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/playoffs</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/playoffs</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -946,7 +946,7 @@
       <div data-screen-label="M &middot; Settled" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg/l/dropped-passes/playoffs</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes/playoffs</span>
         </div>
 
         <div style="height: 620px; display: flex; flex-direction: column;">
@@ -1028,7 +1028,7 @@
       <div data-screen-label="M &middot; Create league" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
         <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
           <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
@@ -1114,7 +1114,7 @@
       <div data-screen-label="M &middot; Freeze" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
         <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
           <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
@@ -1163,7 +1163,7 @@
       <div data-screen-label="M &middot; Invite" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
         <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
           <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
@@ -1177,7 +1177,7 @@
           <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
             <div class="card" style="padding: 13px 14px; background: color-mix(in srgb, var(--color-accent) 8%, transparent); border-color: var(--color-accent-800);">
               <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-accent-400);">Invite link</span>
-              <div style="font-family: ui-monospace, monospace; font-size: 12px; color: var(--color-neutral-300); margin-top: 7px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">rostr.gg/j/7k2p&hellip;q4mv</div>
+              <div style="font-family: ui-monospace, monospace; font-size: 12px; color: var(--color-neutral-300); margin-top: 7px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">rostr.site/j/7k2p&hellip;q4mv</div>
               <div style="display: flex; gap: 8px; margin-top: 11px;">
                 <button type="button" class="btn btn-primary" style="flex: 1; min-height: 44px; font-size: 13px;">Share</button>
                 <button type="button" class="btn btn-ghost" style="flex: 1; min-height: 44px; font-size: 13px; color: var(--color-accent-200);">Copy</button>
@@ -1234,7 +1234,7 @@
       <div data-screen-label="M &middot; Draft lobby" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
         <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
           <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
@@ -1280,7 +1280,7 @@
       <div data-screen-label="M &middot; Amend" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
         <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
-          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.gg</span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
         </div>
         <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
           <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
@@ -1340,6 +1340,985 @@
       </div>
     </div>
 
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">18</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Leagues</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The hub from drop 8, stacked: your leagues, then invitations, then public leagues. No join button in a list &mdash; every card leads to the rules.</span>
+
+      <div data-screen-label="M &middot; Leagues" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/leagues</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+            <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+            <div style="display: flex; align-items: center; gap: 6px;">
+              <button type="button" class="btn btn-ghost" aria-label="Notifications, 4 unread" style="position: relative; width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">
+                <svg width="17" height="17" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M221.8 175.94c-5.55-9.56-13.8-36.61-13.8-71.94a80 80 0 1 0-160 0c0 35.34-8.26 62.38-13.81 71.94A16 16 0 0 0 48 200h40.81a40 40 0 0 0 78.38 0H208a16 16 0 0 0 13.8-24.06ZM128 216a24 24 0 0 1-22.62-16h45.24A24 24 0 0 1 128 216Z"></path></svg>
+                <span style="position: absolute; top: 7px; right: 6px; display: inline-flex; align-items: center; justify-content: center; min-width: 15px; height: 15px; padding: 0 4px; border-radius: 999px; background: var(--color-accent); color: var(--color-bg); font-family: ui-monospace, monospace; font-size: 9.5px; font-weight: 600;">4</span>
+              </button>
+              <button type="button" class="btn btn-ghost" aria-label="Account" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center;">
+                <span style="display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 10px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+              </button>
+            </div>
+          </div>
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 16px; background: color-mix(in srgb, var(--color-accent) 14%, transparent); border-bottom: 1px solid var(--color-accent-800);">
+            <span style="font-size: 12.5px; color: var(--color-accent-100); min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">On the clock in <span style="font-weight: 500;">Sunday Scaries</span></span>
+            <span style="display: flex; align-items: center; gap: 10px; flex: 0 0 auto;">
+              <span style="font-family: ui-monospace, monospace; font-size: 12.5px; color: var(--color-accent-200); font-variant-numeric: tabular-nums;">1:12</span>
+              <a href="#" style="font-size: 12.5px; padding: 12px 0; margin: -12px 0;">Go</a>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 16px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Your leagues</span>
+            <a href="#" class="card" style="display: block; margin-top: 9px; padding: 13px 15px; background: var(--color-surface); border-left: 2px solid var(--color-accent); color: inherit;">
+              <span style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Sunday Scaries</span>
+                <span class="tag tag-accent" style="font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; flex: 0 0 auto;">Drafting</span>
+              </span>
+              <span style="display: block; margin-top: 6px; font-size: 12px; color: var(--color-accent-300);">You are on the clock &middot; pick 5.09 &middot; 1:12</span>
+            </a>
+            <a href="#" class="card" style="display: block; margin-top: 9px; padding: 13px 15px; background: var(--color-surface); border-left: 2px solid var(--color-neutral-800); color: inherit;">
+              <span style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Dynasty of Dropped Passes</span>
+                <span class="tag tag-neutral" style="font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; flex: 0 0 auto;">Week 3</span>
+              </span>
+              <span style="display: block; margin-top: 6px; font-size: 12px; color: var(--color-neutral-500);">2&ndash;0 &middot; 4th of 12 &middot; lineup not set, 1 slot empty</span>
+            </a>
+            <div style="display: flex; align-items: baseline; gap: 9px; margin-top: 20px;">
+              <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Invitations</span>
+              <span class="tag tag-accent" style="font-size: 9.5px; padding: 1px 6px;">1</span>
+            </div>
+            <div class="card" style="margin-top: 9px; padding: 13px 15px; background: var(--color-surface); border-color: var(--color-accent-800);">
+              <span style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Bye Week Blues</span>
+                <span style="font-size: 11.5px; color: var(--color-neutral-500); flex: 0 0 auto;">Private</span>
+              </span>
+              <span style="display: block; margin-top: 6px; font-size: 12px; color: var(--color-neutral-500);">9 of 12 seats &middot; drafts Sat 23 Aug, 8:00 PM &middot; Free</span>
+              <div style="display: flex; gap: 8px; margin-top: 11px;">
+                <a class="btn btn-primary" href="#" style="flex: 1; min-height: 44px; font-size: 13px; display: inline-flex; align-items: center; justify-content: center;">Read the rules</a>
+                <button type="button" class="btn btn-ghost" style="flex: 0 0 auto; min-height: 44px; padding: 0 14px; font-size: 13px; color: var(--color-neutral-400);">Decline</button>
+              </div>
+            </div>
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-top: 20px;">
+              <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Public leagues</span>
+              <span style="font-size: 11.5px; color: var(--color-neutral-500);">6 open</span>
+            </div>
+            <a href="#" class="card" style="display: block; margin-top: 9px; padding: 13px 15px; background: var(--color-surface); color: inherit;">
+              <span style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Open Field 12</span>
+                <span style="font-size: 11.5px; color: var(--color-neutral-400); flex: 0 0 auto;">Free</span>
+              </span>
+              <span style="display: block; margin-top: 6px; font-size: 12px; color: var(--color-accent-300);">11 of 12 &middot; nearly full &middot; drafts Fri 22 Aug, 19:00</span>
+            </a>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Create a league</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">19</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Player detail</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The screen both layouts were missing. Status decides the pinned action &mdash; on waivers it is a claim, and the drop it costs is stated on the button.</span>
+
+      <div data-screen-label="M &middot; Player detail" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="font-size: 14.5px;">Player</span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 18px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div style="display: flex; align-items: center; gap: 14px;">
+              <span style="display: inline-flex; align-items: center; justify-content: center; width: 52px; height: 52px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 14%, transparent); box-shadow: inset 0 0 0 1px var(--color-neutral-800); font-family: var(--font-heading); font-size: 15px; color: var(--color-accent-200);">DM</span>
+              <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+                <span style="font-family: var(--font-heading); font-size: 19px; font-weight: 500; letter-spacing: -0.02em;">D. Marchbanks</span>
+                <span style="font-size: 12px; color: var(--color-neutral-500);">WR &middot; DEN &middot; bye week 8</span>
+              </span>
+            </div>
+            <div style="display: flex; align-items: center; gap: 8px; margin-top: 13px;">
+              <span class="tag tag-accent" style="font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase;">On waivers</span>
+              <span style="font-size: 11.5px; color: var(--color-neutral-500);">Clears Wed 3:00 AM ET &middot; your priority 8 of 12</span>
+            </div>
+            <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 16px;">
+              <div class="card" style="padding: 11px 12px; background: var(--color-surface); text-align: center;">
+                <div style="font-family: var(--font-heading); font-size: 19px; font-variant-numeric: tabular-nums;">11.2</div>
+                <div style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-neutral-500); margin-top: 3px;">Avg</div>
+              </div>
+              <div class="card" style="padding: 11px 12px; background: var(--color-surface); text-align: center;">
+                <div style="font-family: var(--font-heading); font-size: 19px; font-variant-numeric: tabular-nums; color: var(--color-accent-200);">13.6</div>
+                <div style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-neutral-500); margin-top: 3px;">Proj wk 4</div>
+              </div>
+              <div class="card" style="padding: 11px 12px; background: var(--color-surface); text-align: center;">
+                <div style="font-family: var(--font-heading); font-size: 19px; font-variant-numeric: tabular-nums;">62%</div>
+                <div style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-neutral-500); margin-top: 3px;">Rostered</div>
+              </div>
+            </div>
+            <span style="display: block; margin-top: 18px; font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Game log</span>
+            <div class="card" style="margin-top: 9px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 40px minmax(0, 1fr) 46px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">Wk 3</span>
+                <span style="font-size: 13px; color: var(--color-neutral-400); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">at KC &middot; 6 rec, 91 yds, TD</span>
+                <span style="font-size: 13px; text-align: right; font-variant-numeric: tabular-nums;">18.1</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 40px minmax(0, 1fr) 46px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">Wk 2</span>
+                <span style="font-size: 13px; color: var(--color-neutral-400); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">vs LV &middot; 4 rec, 48 yds</span>
+                <span style="font-size: 13px; text-align: right; font-variant-numeric: tabular-nums;">8.8</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 40px minmax(0, 1fr) 46px; gap: 10px; align-items: center; padding: 11px 15px;">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">Wk 1</span>
+                <span style="font-size: 13px; color: var(--color-neutral-400); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">at SEA &middot; 3 rec, 67 yds</span>
+                <span style="font-size: 13px; text-align: right; font-variant-numeric: tabular-nums;">6.7</span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 14px 0 0; text-wrap: pretty;">A claim that wins drops the player named below at the Wednesday run. If your roster is full, naming a drop is required before the claim files.</p>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Claim &middot; drops T. Kraft</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">20</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Full standings</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">All twelve rows, three columns, the cut line where it falls. Points-for moves to the second line rather than earning a fourth column.</span>
+
+      <div data-screen-label="M &middot; Standings" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;">
+              <span style="font-size: 14.5px;">Standings</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">Through Week 3 &middot; top 6 make the bracket</span>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 12px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div class="card" style="padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">1</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Gridiron Heresy</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 341.2</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">3&ndash;0</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">2</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Pylon Co.</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 327.8</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">3&ndash;0</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 9%, transparent);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-accent-400);">3</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; color: var(--color-accent-200); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Route 66 <span style="color: var(--color-neutral-500);">&middot; you</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 318.4</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-accent-300); font-variant-numeric: tabular-nums;">2&ndash;1</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">4</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Tuesday Night Regrets</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 302.1</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">2&ndash;1</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">5</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Cover Two</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 298.7</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">2&ndash;1</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">6</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Audibles</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 287.5</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">1&ndash;2</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 9px; padding: 7px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="flex: 1; height: 1px; background: var(--color-accent-800);"></span>
+                <span style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-accent-400);">Playoff cut</span>
+                <span style="flex: 1; height: 1px; background: var(--color-accent-800);"></span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">7</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Play Action Only</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 281.0</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">1&ndash;2</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 24px minmax(0, 1fr) 48px; gap: 10px; align-items: center; padding: 11px 15px;">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">8</span>
+                <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Backfield Ballers</span><span style="font-size: 10.5px; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">PF 276.3</span></span>
+                <span style="font-size: 12.5px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">1&ndash;2</span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0;">Ties break on points-for. Standings recompute when a week finalises, never by hand.</p>
+          </div>
+          <nav style="display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--color-neutral-800); background: var(--color-surface);">
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Home</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Matchup</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Team</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Players</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-accent-300); box-shadow: inset 0 1px 0 var(--color-accent);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>League</a>
+          </nav>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">21</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Matchup</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Slot against slot, your side left. The second line under each name says why a number is missing &mdash; Final, in progress, or yet to kick off.</span>
+
+      <div data-screen-label="M &middot; Matchup" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;">
+              <span style="font-size: 14.5px;">Week 3 matchup</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">Sun 4:52 PM ET &middot; provisional</span>
+            </span>
+          </div>
+          <div style="display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); gap: 12px; align-items: center; padding: 16px; border-bottom: 1px solid var(--color-neutral-900);">
+            <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0;">
+              <span style="font-size: 12.5px; color: var(--color-accent-200); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Route 66</span>
+              <span style="font-family: var(--font-heading); font-size: 34px; color: var(--color-accent-200); font-variant-numeric: tabular-nums; letter-spacing: -0.02em;">86.2</span>
+              <span style="font-size: 11px; color: var(--color-neutral-500);">proj 118.4 &middot; 3 to play</span>
+            </span>
+            <span style="font-size: 11px; color: var(--color-neutral-600);">vs</span>
+            <span style="display: flex; flex-direction: column; gap: 3px; min-width: 0; text-align: right;">
+              <span style="font-size: 12.5px; color: var(--color-neutral-300); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Tuesday Night Regrets</span>
+              <span style="font-family: var(--font-heading); font-size: 34px; color: var(--color-neutral-400); font-variant-numeric: tabular-nums; letter-spacing: -0.02em;">71.9</span>
+              <span style="font-size: 11px; color: var(--color-neutral-500);">proj 104.8 &middot; 4 to play</span>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 12px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div class="card" style="padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 34px minmax(0, 1fr) 42px; gap: 8px; align-items: center; padding: 11px 13px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-size: 13px; font-variant-numeric: tabular-nums;">24.8</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">J. Whitcombe</span><span style="font-size: 10px; color: var(--color-neutral-600);">Final</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: center;">QB</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0; text-align: right;"><span style="font-size: 12px; color: var(--color-neutral-300); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">C. Vandersloot</span><span style="font-size: 10px; color: var(--color-neutral-600);">Q4 2:11</span></span>
+                <span style="font-size: 13px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">19.2</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 34px minmax(0, 1fr) 42px; gap: 8px; align-items: center; padding: 11px 13px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-size: 13px; font-variant-numeric: tabular-nums;">18.1</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">L. Marchetti</span><span style="font-size: 10px; color: var(--color-neutral-600);">Final</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: center;">RB</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0; text-align: right;"><span style="font-size: 12px; color: var(--color-neutral-300); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">R. Okafor</span><span style="font-size: 10px; color: var(--color-neutral-600);">Mon 8:15</span></span>
+                <span style="font-size: 13px; text-align: right; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">&mdash;</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 34px minmax(0, 1fr) 42px; gap: 8px; align-items: center; padding: 11px 13px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-size: 13px; font-variant-numeric: tabular-nums;">9.4</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">K. Osei-Bonsu</span><span style="font-size: 10px; color: var(--color-neutral-600);">Q3</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: center;">WR</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0; text-align: right;"><span style="font-size: 12px; color: var(--color-neutral-300); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">B. Whitfield</span><span style="font-size: 10px; color: var(--color-neutral-600);">Final</span></span>
+                <span style="font-size: 13px; text-align: right; color: var(--color-neutral-400); font-variant-numeric: tabular-nums;">11.6</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 34px minmax(0, 1fr) 42px; gap: 8px; align-items: center; padding: 11px 13px;">
+                <span style="font-size: 13px; font-variant-numeric: tabular-nums;">7.2</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">T. Kraft</span><span style="font-size: 10px; color: var(--color-neutral-600);">Final</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: center;">TE</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0; text-align: right;"><span style="font-size: 12px; color: var(--color-neutral-300); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">M. Delacroix</span><span style="font-size: 10px; color: var(--color-neutral-600);">Mon 8:15</span></span>
+                <span style="font-size: 13px; text-align: right; color: var(--color-neutral-600); font-variant-numeric: tabular-nums;">&mdash;</span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0;">Provisional &middot; finalises Tue 11:30 PM ET, 48 hours after the week&rsquo;s last game.</p>
+          </div>
+          <nav style="display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--color-neutral-800); background: var(--color-surface);">
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Home</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-accent-300); box-shadow: inset 0 1px 0 var(--color-accent);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Matchup</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Team</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Players</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>League</a>
+          </nav>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">22</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Sign in</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Email code first, wallet second &mdash; a wallet is only required when money or consent is signed, so it never gates the door.</span>
+
+      <div data-screen-label="M &middot; Sign in" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/signin</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="flex: 1; padding: 56px 24px 0;">
+            <span style="font-family: var(--font-heading); font-size: 21px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+            <h2 style="font-family: var(--font-heading); font-size: 26px; font-weight: 500; letter-spacing: -0.024em; line-height: 1.15; margin: 22px 0 0;">Sign in</h2>
+            <p style="font-size: 13.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 10px 0 0; text-wrap: pretty;">A code goes to your email. No password to remember, nothing to sign.</p>
+            <div class="field" style="margin-top: 24px;">
+              <label for="m-signin-email">Email</label>
+              <input class="input" id="m-signin-email" inputmode="email" placeholder="you@example.com" style="min-height: 48px; font-size: 15px;">
+            </div>
+            <button type="button" class="btn btn-primary btn-block" style="margin-top: 14px; min-height: 48px; font-size: 15px;">Send code</button>
+            <div style="display: flex; align-items: center; gap: 12px; margin: 26px 0;">
+              <span style="flex: 1; height: 1px; background: linear-gradient(90deg, transparent, var(--color-neutral-800));"></span>
+              <span style="font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-neutral-600);">or</span>
+              <span style="flex: 1; height: 1px; background: linear-gradient(90deg, var(--color-neutral-800), transparent);"></span>
+            </div>
+            <button type="button" class="btn btn-ghost btn-block" style="min-height: 48px; font-size: 14.5px; color: var(--color-neutral-300); display: inline-flex; align-items: center; justify-content: center; gap: 8px;">
+              <svg width="15" height="15" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M216 64H56a8 8 0 0 1 0-16h136a8 8 0 0 0 0-16H56a24 24 0 0 0-24 24v128a24 24 0 0 0 24 24h160a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16Zm-36 84a12 12 0 1 1 12-12 12 12 0 0 1-12 12Z"></path></svg>
+              Continue with wallet
+            </button>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 22px 0 0; text-wrap: pretty;">Either way you get the same account. A wallet signs only five things, all money or consent &mdash; never a pick, a lineup or a claim.</p>
+          </div>
+          <div style="padding: 14px 24px 18px;">
+            <span style="font-size: 11.5px; color: var(--color-neutral-600);">Open source, MIT &middot; no tracking</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">23</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Finish setting up</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">An account with no username cannot be invited, join or create &mdash; so this screen states what it unblocks rather than asking nicely.</span>
+
+      <div data-screen-label="M &middot; Finish setup" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/welcome</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="flex: 1; padding: 56px 24px 0;">
+            <span class="tag tag-outline" style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;">One step left</span>
+            <h2 style="font-family: var(--font-heading); font-size: 26px; font-weight: 500; letter-spacing: -0.024em; line-height: 1.15; margin: 16px 0 0;">Pick a username</h2>
+            <p style="font-size: 13.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 10px 0 0; text-wrap: pretty;">It is how leagues invite you. Until it exists, you cannot be invited to a league, join one, or create your own.</p>
+            <div class="field" style="margin-top: 24px;">
+              <label for="m-welcome-username">Username</label>
+              <input class="input" id="m-welcome-username" value="route66" style="min-height: 48px; font-size: 15px;">
+              <span style="display: block; font-size: 11.5px; color: var(--color-accent-300); margin-top: 6px;">Available</span>
+            </div>
+            <div class="card" style="margin-top: 20px; padding: 13px 14px; background: var(--color-surface);">
+              <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">This unblocks</span>
+              <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 9px; font-size: 12.5px; color: var(--color-neutral-400);">
+                <span>Being invited by name instead of by email</span>
+                <span>Joining a league, public or private</span>
+                <span>Creating one of your own</span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 18px 0 0;">You can change it later. Leagues you are already in keep your team name.</p>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Save and continue</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">24</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Draft board, the tab</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The place you go to look. Twelve columns become one round at a time &mdash; a round is twelve rows, and the pager is within thumb reach.</span>
+
+      <div data-screen-label="M &middot; Draft board" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+            <span style="font-size: 12px; color: var(--color-neutral-500);">Pick 5.09 &middot; Cover Two on the clock</span>
+            <span style="font-family: ui-monospace, monospace; font-size: 13px; color: var(--color-accent-200); font-variant-numeric: tabular-nums;">1:12</span>
+          </div>
+          <div style="display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="min-height: 44px; font-size: 12.5px; border-radius: 0; color: var(--color-neutral-500);">Draft</button>
+            <button type="button" class="btn btn-ghost" style="min-height: 44px; font-size: 12.5px; border-radius: 0; color: var(--color-accent-200); box-shadow: inset 0 -1px 0 var(--color-accent);">Board</button>
+            <button type="button" class="btn btn-ghost" style="min-height: 44px; font-size: 12.5px; border-radius: 0; color: var(--color-neutral-500);">Roster</button>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 14px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+              <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Round 5 &middot; in progress</span>
+              <span style="font-size: 11.5px; color: var(--color-neutral-600);">Snake &middot; order reverses each round</span>
+            </div>
+            <div class="card" style="margin-top: 9px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">5.06</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">A. St. Brown <span style="color: var(--color-neutral-600);">DET</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Pylon Co.</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: end;">WR</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">5.07</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">J. Gibbs <span style="color: var(--color-neutral-600);">DET</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Gridiron Heresy</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: end;">RB</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">5.08</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">T. McBride <span style="color: var(--color-neutral-600);">ARI</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Backfield Ballers &middot; bot</span></span>
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: end;">TE</span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 10%, transparent);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-accent-300);">5.09</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; color: var(--color-accent-200);">On the clock</span><span style="font-size: 10.5px; color: var(--color-neutral-500);">Cover Two &middot; 1:12 left</span></span>
+                <span></span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600);">5.10</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; color: var(--color-neutral-500);">&mdash;</span><span style="font-size: 10.5px; color: var(--color-neutral-600); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Route 66 &middot; you &middot; 2 picks away</span></span>
+                <span></span>
+              </div>
+              <div style="display: grid; grid-template-columns: 42px minmax(0, 1fr) 36px; gap: 10px; align-items: center; padding: 10px 14px;">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600);">5.11</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 12.5px; color: var(--color-neutral-500);">&mdash;</span><span style="font-size: 10.5px; color: var(--color-neutral-600); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Tuesday Night Regrets</span></span>
+                <span></span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0;">Tags are strict position identity. Need-colouring lives on the Draft tab, where it recomputes after each of your picks.</p>
+          </div>
+          <div style="display: flex; align-items: center; gap: 8px; padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-ghost" style="min-height: 48px; padding: 0 16px; font-size: 14px; color: var(--color-neutral-400);">&lsaquo; Rd 4</button>
+            <span style="flex: 1; text-align: center; font-size: 12.5px; color: var(--color-neutral-500);">Round 5 of 14</span>
+            <button type="button" class="btn btn-ghost" style="min-height: 48px; padding: 0 16px; font-size: 14px; color: var(--color-neutral-600);" disabled>Rd 6 &rsaquo;</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">25</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Pre-draft queue</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">No drag-and-drop, same as everywhere else &mdash; each row moves with 44px arrows. If your clock expires, autopick takes the top available name here before falling back to ADP.</span>
+
+      <div data-screen-label="M &middot; Queue" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;">
+              <span style="font-size: 14.5px;">Your queue</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">4 players &middot; draft in 04:11</span>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 14px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div class="card" style="padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-accent-400);">1</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">L. Marchetti <span style="color: var(--color-neutral-600);">MIN</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">RB &middot; ADP 22</span></span>
+                <span style="display: flex; gap: 2px;">
+                  <button type="button" class="btn btn-ghost" aria-label="Move up" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-700);" disabled>&uarr;</button>
+                  <button type="button" class="btn btn-ghost" aria-label="Move down" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&darr;</button>
+                </span>
+              </div>
+              <div style="display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">2</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">K. Osei-Bonsu <span style="color: var(--color-neutral-600);">LV</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">WR &middot; ADP 31</span></span>
+                <span style="display: flex; gap: 2px;">
+                  <button type="button" class="btn btn-ghost" aria-label="Move up" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&uarr;</button>
+                  <button type="button" class="btn btn-ghost" aria-label="Move down" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&darr;</button>
+                </span>
+              </div>
+              <div style="display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">3</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">D. Marchbanks <span style="color: var(--color-neutral-600);">DEN</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">WR &middot; ADP 38</span></span>
+                <span style="display: flex; gap: 2px;">
+                  <button type="button" class="btn btn-ghost" aria-label="Move up" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&uarr;</button>
+                  <button type="button" class="btn btn-ghost" aria-label="Move down" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&darr;</button>
+                </span>
+              </div>
+              <div style="display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px;">
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">4</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">R. Okafor <span style="color: var(--color-neutral-600);">GB</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">RB &middot; ADP 44</span></span>
+                <span style="display: flex; gap: 2px;">
+                  <button type="button" class="btn btn-ghost" aria-label="Move up" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">&uarr;</button>
+                  <button type="button" class="btn btn-ghost" aria-label="Move down" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-700);" disabled>&darr;</button>
+                </span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0; text-wrap: pretty;">A queued player who gets drafted drops off automatically. The queue is yours alone &mdash; nobody else can see it.</p>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Add players</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">26</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Notifications</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The desktop dropdown becomes a page. Needs-you first, with what happens if you do nothing &mdash; then the record.</span>
+
+      <div data-screen-label="M &middot; Notifications" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/notifications</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <span style="display: flex; align-items: center; gap: 12px; min-width: 0;">
+              <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+              <span style="display: flex; flex-direction: column; gap: 1px;">
+                <span style="font-size: 14.5px;">Notifications</span>
+                <span style="font-size: 11px; color: var(--color-neutral-600);">4 unread</span>
+              </span>
+            </span>
+            <button type="button" class="btn btn-ghost" style="min-height: 44px; padding: 0 12px; font-size: 12px; color: var(--color-neutral-400);">Mark all read</button>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 12px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-400);">Needs you</span>
+            <a href="#" class="card" style="display: block; margin-top: 8px; padding: 12px 14px; background: color-mix(in srgb, var(--color-accent) 9%, var(--color-surface)); border-color: var(--color-accent-800); color: inherit;">
+              <span style="display: flex; align-items: baseline; justify-content: space-between; gap: 10px;">
+                <span style="font-size: 13px; color: var(--color-accent-100); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">You are on the clock &middot; pick 3.04</span>
+                <span style="font-family: ui-monospace, monospace; font-size: 12px; color: var(--color-accent-200); font-variant-numeric: tabular-nums; flex: 0 0 auto;">0:47</span>
+              </span>
+              <span style="display: block; margin-top: 4px; font-size: 11.5px; color: var(--color-neutral-400);">Sunday Scaries &middot; autopick takes J. Cook if it expires</span>
+            </a>
+            <a href="#" class="card" style="display: block; margin-top: 8px; padding: 12px 14px; background: color-mix(in srgb, var(--color-accent) 9%, var(--color-surface)); border-color: var(--color-accent-800); color: inherit;">
+              <span style="display: block; font-size: 13px; color: var(--color-accent-100);">A trade is in its veto window</span>
+              <span style="display: block; margin-top: 4px; font-size: 11.5px; color: var(--color-neutral-400);">Dynasty of Dropped Passes &middot; not voting allows it &middot; 41h left</span>
+            </a>
+            <a href="#" class="card" style="display: block; margin-top: 8px; padding: 12px 14px; background: var(--color-surface); color: inherit;">
+              <span style="display: block; font-size: 13px;">Lineup not set for Week 3</span>
+              <span style="display: block; margin-top: 4px; font-size: 11.5px; color: var(--color-neutral-400);">One slot empty &middot; autofill starts T. Kraft at Sunday lock</span>
+            </a>
+            <a href="#" class="card" style="display: block; margin-top: 8px; padding: 12px 14px; background: var(--color-surface); color: inherit;">
+              <span style="display: block; font-size: 13px;">Bye Week Blues invited you</span>
+              <span style="display: block; margin-top: 4px; font-size: 11.5px; color: var(--color-neutral-400);">Private league &middot; drafts Sat 23 Aug, 8:00 PM</span>
+            </a>
+            <span style="display: block; margin-top: 18px; font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Earlier</span>
+            <div style="margin-top: 4px;">
+              <div style="display: flex; flex-direction: column; gap: 3px; padding: 11px 0; border-bottom: 1px solid var(--color-neutral-900);">
+                <span style="font-size: 13px; color: var(--color-neutral-300);">Waivers ran &middot; you won D. Achane</span>
+                <span style="font-size: 11.5px; color: var(--color-neutral-500);">Priority moved to 12 of 12 &middot; Wed 3:04 AM</span>
+              </div>
+              <div style="display: flex; flex-direction: column; gap: 3px; padding: 11px 0;">
+                <span style="font-size: 13px; color: var(--color-neutral-300);">Week 2 finalised &middot; you won 104.2&ndash;98.7</span>
+                <span style="font-size: 11.5px; color: var(--color-neutral-500);">Dynasty of Dropped Passes &middot; Tue 11:30 PM</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">27</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Account menu</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">A sheet over whatever you were doing. Sign out and Finish setting up live here &mdash; the two affordances a header rebuild deletes by accident.</span>
+
+      <div data-screen-label="M &middot; Account menu" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/leagues</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="opacity: 0.35; pointer-events: none;">
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+              <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+              <span style="display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 10px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+            </div>
+            <div style="padding: 16px;">
+              <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Your leagues</span>
+              <div class="card" style="margin-top: 9px; padding: 13px 15px; background: var(--color-surface);">
+                <span style="font-size: 14px;">Sunday Scaries</span>
+              </div>
+              <div class="card" style="margin-top: 9px; padding: 13px 15px; background: var(--color-surface);">
+                <span style="font-size: 14px;">Dynasty of Dropped Passes</span>
+              </div>
+            </div>
+          </div>
+          <div style="position: absolute; inset: 0; background: rgba(10, 11, 20, 0.45);"></div>
+          <div class="card elev-lg" style="position: absolute; left: 0; right: 0; bottom: 0; border-radius: var(--radius-md) var(--radius-md) 0 0; padding: 0; overflow: hidden; background: var(--color-surface);">
+            <div style="display: flex; justify-content: center; padding: 8px 0 0;"><span style="width: 34px; height: 4px; border-radius: 999px; background: var(--color-neutral-800);"></span></div>
+            <div style="display: flex; align-items: center; gap: 12px; padding: 14px 18px; border-bottom: 1px solid var(--color-neutral-900);">
+              <span style="display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: inset 0 0 0 1px var(--color-accent-700); font-size: 12px; font-weight: 600; color: var(--color-accent-100);">R6</span>
+              <span style="display: flex; flex-direction: column; gap: 2px; min-width: 0;">
+                <span style="font-size: 14px;">route66</span>
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-500);">7xKq&hellip;4vNb &middot; wallet linked</span>
+              </span>
+            </div>
+            <a href="#" style="display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 52px; padding: 0 18px; border-bottom: 1px solid var(--color-neutral-900); color: var(--color-accent-200); font-size: 13.5px;">
+              <span>Finish setting up</span>
+              <span class="tag tag-accent" style="font-size: 9.5px; padding: 2px 7px;">If no username</span>
+            </a>
+            <a href="#" style="display: flex; align-items: center; min-height: 52px; padding: 0 18px; border-bottom: 1px solid var(--color-neutral-900); color: var(--color-neutral-300); font-size: 13.5px;">How scoring works</a>
+            <a href="#" style="display: flex; align-items: center; min-height: 52px; padding: 0 18px; border-bottom: 1px solid var(--color-neutral-900); color: var(--color-neutral-300); font-size: 13.5px;">Disconnect wallet</a>
+            <button type="button" style="display: flex; align-items: center; width: 100%; min-height: 52px; padding: 0 18px; border: 0; background: transparent; color: var(--color-neutral-300); font-family: inherit; font-size: 13.5px; cursor: pointer; text-align: left;">Sign out</button>
+            <div style="padding: 10px 18px 16px;">
+              <span style="font-size: 11px; color: var(--color-neutral-600);">Signed in by email &middot; a wallet signs only money and consent</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">28</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">League home, before the draft</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">No matchup, no standings, nothing to score &mdash; so the screen is honest about it: the countdown, the seats, and the one useful thing you can do now.</span>
+
+      <div data-screen-label="M &middot; League home empty" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/bye-week-blues</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+            <div style="display: flex; flex-direction: column; gap: 2px; min-width: 0;">
+              <span style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Bye Week Blues</span>
+              <span style="font-size: 11px; color: var(--color-neutral-500);">Forming &middot; 9 of 12 seats</span>
+            </div>
+            <span class="tag tag-outline" style="font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; white-space: nowrap; flex: 0 0 auto;">Pre-draft</span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 22px 16px 0; position: relative; text-align: center;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-400);">Draft starts in</span>
+            <div style="font-family: var(--font-heading); font-size: 54px; font-weight: 500; letter-spacing: -0.04em; color: var(--color-accent-200); font-variant-numeric: tabular-nums; margin-top: 6px;">2d 06:41</div>
+            <div style="font-size: 12.5px; color: var(--color-neutral-500);">Sat 23 Aug, 8:00 PM ET &middot; snake, 90s per pick</div>
+            <div class="card" style="margin-top: 22px; padding: 14px; background: var(--color-surface); text-align: left;">
+              <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 13.5px;">9 of 12 seats filled</span>
+                <a href="#" style="font-size: 12.5px;">Invite</a>
+              </div>
+              <div style="display: flex; gap: 4px; margin-top: 10px;">
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-accent-600);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-neutral-800);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-neutral-800);"></span>
+                <span style="flex: 1; height: 5px; border-radius: 999px; background: var(--color-neutral-800);"></span>
+              </div>
+              <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 10px 0 0;">The draft runs with whoever is in at 8:00 PM, minimum two managers. One bot squares an odd field.</p>
+            </div>
+            <div class="card" style="margin-top: 12px; padding: 13px 14px; background: var(--color-surface); text-align: left;">
+              <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">While you wait</span>
+              <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 9px; font-size: 12.5px; color: var(--color-neutral-400);">
+                <span>Set your pre-draft queue</span>
+                <span>Read the frozen rule set you signed</span>
+              </div>
+            </div>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Set my pre-draft queue</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">29</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Draft room, connection lost</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The clock does not stop for a dropped connection, so the banner says exactly what is still true and what covers you if it stays down.</span>
+
+      <div data-screen-label="M &middot; Draft reconnect" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 10px; padding: 10px 16px; background: color-mix(in srgb, var(--color-accent) 14%, transparent); border-bottom: 1px solid var(--color-accent-800);">
+            <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-accent-400); flex: 0 0 auto;"></span>
+            <span style="font-size: 12.5px; color: var(--color-accent-100); min-width: 0;">Connection lost &middot; reconnecting&hellip;</span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 22px 16px 0; position: relative; text-align: center;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Your pick &middot; 2.09</span>
+            <div style="font-family: var(--font-heading); font-size: 62px; font-weight: 500; letter-spacing: -0.04em; color: var(--color-neutral-400); font-variant-numeric: tabular-nums; margin-top: 6px;">0:58</div>
+            <div style="font-size: 12.5px; color: var(--color-neutral-500);">as of the last update, 9 seconds ago</div>
+            <div class="card" style="margin-top: 22px; padding: 14px; background: var(--color-surface); text-align: left;">
+              <div style="font-size: 13.5px;">The clock keeps running on the server.</div>
+              <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 8px 0 0; text-wrap: pretty;">Your queue still stands: if the clock expires before you are back, autopick takes <span style="color: var(--color-accent-200);">K. Osei-Bonsu</span>, the top available name on it.</p>
+              <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 10px 0 0;">Nothing you tapped while offline was sent. The board will catch up the moment the connection returns.</p>
+            </div>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px; opacity: 0.45;" disabled>Draft &middot; waiting for connection</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">30</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Claim lost, and why</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Losing a claim costs nothing, and the screen proves it: who won, on what priority, and that your roster and your place in line did not move.</span>
+
+      <div data-screen-label="M &middot; Claim lost" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;">
+              <span style="font-size: 14.5px;">Wednesday run</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">Wed 3:04 AM ET &middot; your claims</span>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 16px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <div class="card" style="padding: 14px; background: var(--color-surface);">
+              <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 12px;">
+                <span style="font-size: 13.5px;">D. Marchbanks <span style="color: var(--color-neutral-600);">WR &middot; DEN</span></span>
+                <span class="tag tag-neutral" style="font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase;">Lost</span>
+              </div>
+              <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 9px 0 0; text-wrap: pretty;">Won by <span style="color: var(--color-neutral-300);">Cover Two</span> on priority 3. You claimed on priority 8 &mdash; when two claims name one player, the better priority takes him. That is the whole rule.</p>
+            </div>
+            <div class="card" style="margin-top: 12px; padding: 13px 14px; background: var(--color-surface);">
+              <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">What did not change</span>
+              <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 9px; font-size: 12.5px; color: var(--color-neutral-400);">
+                <span>T. Kraft stays on your roster &mdash; the drop only fires on a win</span>
+                <span>Your priority stays 8 of 12 &mdash; only winning moves you back</span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 14px 0 0; text-wrap: pretty;">Marchbanks is rostered now, so the claim cannot be refiled. He returns to the pool only if Cover Two drops him &mdash; then he waives for two days like anyone else.</p>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-ghost btn-block" style="min-height: 48px; font-size: 14.5px; color: var(--color-neutral-300);">Browse free agents</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">31</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Trade composer</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Two rosters, tap to toggle. The proposal is not signable until each side gives at least one player, and the veto window is stated before sending.</span>
+
+      <div data-screen-label="M &middot; Trade composer" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+            <button type="button" class="btn btn-ghost" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; font-size: 17px; color: var(--color-neutral-400);">&lsaquo;</button>
+            <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;">
+              <span style="font-size: 14.5px;">Propose a trade</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">with Tuesday Night Regrets</span>
+            </span>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 14px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">You send</span>
+            <div class="card" style="margin-top: 8px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) 44px; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 9%, transparent);">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">TE</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; color: var(--color-accent-200); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">T. Kraft <span style="color: var(--color-neutral-500);">GB</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">avg 8.9 &middot; in the deal</span></span>
+                <button type="button" class="btn btn-ghost" aria-label="Remove from trade" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-accent-300);">&minus;</button>
+              </div>
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) 44px; gap: 10px; align-items: center; padding: 8px 8px 8px 14px;">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">WR</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">K. Osei-Bonsu <span style="color: var(--color-neutral-600);">LV</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">avg 11.8</span></span>
+                <button type="button" class="btn btn-ghost" aria-label="Add to trade" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">+</button>
+              </div>
+            </div>
+            <span style="display: block; margin-top: 16px; font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">You receive</span>
+            <div class="card" style="margin-top: 8px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) 44px; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900); background: color-mix(in srgb, var(--color-accent) 9%, transparent);">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">TE</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; color: var(--color-accent-200); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">M. Delacroix <span style="color: var(--color-neutral-500);">SF</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">avg 12.4 &middot; in the deal</span></span>
+                <button type="button" class="btn btn-ghost" aria-label="Remove from trade" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-accent-300);">&minus;</button>
+              </div>
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) 44px; gap: 10px; align-items: center; padding: 8px 8px 8px 14px;">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">RB</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">R. Okafor <span style="color: var(--color-neutral-600);">GB</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">avg 13.1</span></span>
+                <button type="button" class="btn btn-ghost" aria-label="Add to trade" style="width: 44px; height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; color: var(--color-neutral-400);">+</button>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0; text-wrap: pretty;">If they accept, the trade sits in escrow for 48 hours so the league can veto. Rosters must stay legal on both sides &mdash; an illegal deal cannot be sent.</p>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Send &middot; 1 for 1</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">32</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Team</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The whole roster behind the Team tab &mdash; starters, bench, IR. Drop lives here, one row action, refused with the reason when a game has started.</span>
+
+      <div data-screen-label="M &middot; Team" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/l/dropped-passes</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900);">
+            <div style="display: flex; flex-direction: column; gap: 2px; min-width: 0;">
+              <span style="font-size: 14px;">Route 66</span>
+              <span style="font-size: 11px; color: var(--color-neutral-500);">14 players &middot; 9 starters, 4 bench, 1 IR</span>
+            </div>
+            <a href="#" style="font-size: 12.5px; flex: 0 0 auto;">Edit lineup</a>
+          </div>
+          <div style="flex: 1; overflow: hidden; padding: 14px 16px 0; position: relative;">
+          <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40px; background: linear-gradient(to top, var(--color-bg), transparent); pointer-events: none; z-index: 2;"></div>
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Bench</span>
+            <div class="card" style="margin-top: 8px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">RB</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">S. Villanueva <span style="color: var(--color-neutral-600);">NYJ</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">Sun 1:00 &middot; not locked</span></span>
+                <button type="button" class="btn btn-ghost" style="min-height: 44px; padding: 0 12px; font-size: 12px; color: var(--color-neutral-400);">Drop</button>
+              </div>
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px; border-bottom: 1px solid var(--color-neutral-900);">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">WR</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">B. Whitfield <span style="color: var(--color-neutral-600);">MIA</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">played &middot; 11.6 pts</span></span>
+                <button type="button" class="btn btn-ghost" style="min-height: 44px; padding: 0 12px; font-size: 12px; color: var(--color-neutral-700);" disabled>Locked</button>
+              </div>
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px;">
+                <span class="tag tag-neutral" style="font-size: 9px; padding: 2px 5px; justify-self: start;">QB</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">C. Ashworth <span style="color: var(--color-neutral-600);">TEN</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">bye &middot; week 3</span></span>
+                <button type="button" class="btn btn-ghost" style="min-height: 44px; padding: 0 12px; font-size: 12px; color: var(--color-neutral-400);">Drop</button>
+              </div>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 9px; margin-top: 16px;">
+              <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Injured reserve</span>
+              <span style="font-size: 11px; color: var(--color-neutral-600);">1 of 2 slots</span>
+            </div>
+            <div class="card" style="margin-top: 8px; padding: 0; overflow: hidden; background: var(--color-surface);">
+              <div style="display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 8px 8px 14px;">
+                <span class="tag tag-outline" style="font-size: 9px; padding: 2px 5px; justify-self: start;">IR</span>
+                <span style="display: flex; flex-direction: column; gap: 1px; min-width: 0;"><span style="font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">J. Okonkwo <span style="color: var(--color-neutral-600);">BAL</span></span><span style="font-size: 10.5px; color: var(--color-neutral-600);">RB &middot; out, hamstring &middot; eligible: provider lists Out or IR</span></span>
+                <button type="button" class="btn btn-ghost" style="min-height: 44px; padding: 0 12px; font-size: 12px; color: var(--color-neutral-400);">Activate</button>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-neutral-500); margin: 12px 0 0; text-wrap: pretty;">A drop is refused with GAME_STARTED once that player&rsquo;s game kicks off. Activating from IR needs an open roster spot.</p>
+          </div>
+          <nav style="display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--color-neutral-800); background: var(--color-surface);">
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Home</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Matchup</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-accent-300); box-shadow: inset 0 1px 0 var(--color-accent);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Team</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>Players</a>
+            <a href="#" style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; min-height: 56px; font-size: 10px; color: var(--color-neutral-500);"><span style="width: 15px; height: 15px; border: 1.5px solid currentColor; border-radius: 3px;"></span>League</a>
+          </nav>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">33</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Draft complete</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">The end state the desktop room already has. The numbers are the celebration; the pinned action points at the first thing the season actually needs.</span>
+
+      <div data-screen-label="M &middot; Draft complete" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column; background: radial-gradient(130% 100% at 50% 0%, var(--color-section-glow) 0%, var(--color-section) 52%, var(--color-bg) 100%);">
+          <div style="flex: 1; overflow: hidden; padding: 48px 24px 0; position: relative; text-align: center;">
+            <span style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-accent-300);">Draft complete</span>
+            <h2 style="font-family: var(--font-heading); font-size: 30px; font-weight: 500; letter-spacing: -0.028em; line-height: 1.1; margin: 14px 0 0; color: var(--color-accent-100);">168 picks, 14 rounds,<br>2 hours 41 minutes.</h2>
+            <p style="font-size: 13.5px; line-height: 1.6; color: var(--color-accent-200); margin: 14px 0 0; text-wrap: pretty;">Every pick is on your roster, and no commissioner can take one off it.</p>
+            <div class="card" style="margin-top: 26px; padding: 14px; background: rgba(22, 24, 38, 0.55); border-color: rgba(210, 206, 253, 0.18); text-align: left;">
+              <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-accent-300);">Your first three</span>
+              <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 10px;">
+                <span style="display: flex; align-items: baseline; gap: 10px; font-size: 13px; color: var(--color-accent-100);"><span style="font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-accent-300);">1.03</span>L. Marchetti <span style="color: var(--color-accent-300);">RB &middot; MIN</span></span>
+                <span style="display: flex; align-items: baseline; gap: 10px; font-size: 13px; color: var(--color-accent-100);"><span style="font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-accent-300);">2.10</span>K. Osei-Bonsu <span style="color: var(--color-accent-300);">WR &middot; LV</span></span>
+                <span style="display: flex; align-items: baseline; gap: 10px; font-size: 13px; color: var(--color-accent-100);"><span style="font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-accent-300);">3.03</span>J. Whitcombe <span style="color: var(--color-accent-300);">QB &middot; PIT</span></span>
+              </div>
+            </div>
+            <p style="font-size: 12px; line-height: 1.55; color: var(--color-accent-300); margin: 18px 0 0;">Week 1 kicks off Wed 9 Sep. Your lineup is due before each player&rsquo;s own kickoff.</p>
+          </div>
+          <div style="padding: 12px 16px 14px;">
+            <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px; border-color: var(--color-accent-300); color: var(--color-accent-100);">Set your Week 1 lineup</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 10px;">
+        <span style="font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--color-accent-500);">34</span>
+        <span style="font-family: var(--font-heading); font-size: 15px; font-weight: 500;">Dead invite link</span>
+      </div>
+      <span style="font-size: 12px; color: var(--color-neutral-500); max-width: 390px;">Often the first rostr screen a person ever sees. It says exactly which of the three reasons applies, and leaves a door open instead of a wall.</span>
+
+      <div data-screen-label="M &middot; Dead invite" style="width: 390px; border: 1px solid var(--color-neutral-800); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg);">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--color-surface); border-bottom: 1px solid var(--color-neutral-900);">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--color-neutral-800);"></span>
+          <span style="flex: 1; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--color-neutral-600); text-align: center;">rostr.site/j/7k2p&hellip;q4mv</span>
+        </div>
+        <div style="height: 620px; overflow: hidden; position: relative; display: flex; flex-direction: column;">
+          <div style="display: flex; align-items: center; justify-content: space-between; padding: 13px 18px; border-bottom: 1px solid var(--color-neutral-900);">
+            <span style="font-family: var(--font-heading); font-size: 17px; font-weight: 600; letter-spacing: -0.02em;">rostr</span>
+            <a href="#" style="font-size: 12.5px; padding: 12px 0; margin: -12px 0;">Sign in</a>
+          </div>
+          <div style="flex: 1; padding: 56px 24px 0;">
+            <span class="tag tag-outline" style="font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;">Invite link</span>
+            <h2 style="font-family: var(--font-heading); font-size: 26px; font-weight: 500; letter-spacing: -0.024em; line-height: 1.15; margin: 16px 0 0;">This seat is taken.</h2>
+            <p style="font-size: 13.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 12px 0 0; text-wrap: pretty;"><span style="color: var(--color-neutral-300);">Bye Week Blues</span> filled all 12 seats on 21 Aug, so this link no longer admits anyone. Nothing you did &mdash; invite links die three ways: the league fills, the draft starts, or the commissioner revokes them.</p>
+            <div class="card" style="margin-top: 24px; padding: 13px 14px; background: var(--color-surface);">
+              <span style="font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-neutral-500);">From here</span>
+              <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 9px; font-size: 12.5px; color: var(--color-neutral-400);">
+                <span>Ask whoever sent it &mdash; a seat can reopen if someone leaves before the draft</span>
+                <span>Browse public leagues still taking managers</span>
+                <span>Or start your own; two humans is enough</span>
+              </div>
+            </div>
+          </div>
+          <div style="padding: 12px 16px 14px; border-top: 1px solid var(--color-neutral-900); background: var(--color-bg);">
+            <div style="display: flex; flex-direction: column; gap: 10px;">
+              <button type="button" class="btn btn-primary btn-block" style="min-height: 48px; font-size: 14.5px;">Browse open leagues</button>
+              <button type="button" class="btn btn-ghost btn-block" style="min-height: 48px; font-size: 14.5px; color: var(--color-neutral-300);">Create a league</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 
   <sc-if value="{{ showRationale }}" hint-placeholder-val="{{ true }}">
@@ -1373,7 +2352,7 @@
         <p style="font-size: 13px; line-height: 1.6; color: var(--color-neutral-400); margin: 7px 0 0; text-wrap: pretty;">Every name cell is <span style="font-family: ui-monospace, monospace; font-size: 12px;">minmax(0, 1fr)</span> with ellipsis. "Tuesday Night Regrets" is 21 characters and the field allows more — a wrapping name must never push a score off the row.</p>
       </div>
     </div>
-    <p style="font-size: 13px; line-height: 1.6; color: var(--color-neutral-500); margin: 22px 0 0; max-width: 660px; text-wrap: pretty;">Every desktop screen now has a mobile design. What is still missing on both: player detail, and full standings.</p>
+    <p style="font-size: 13px; line-height: 1.6; color: var(--color-neutral-500); margin: 22px 0 0; max-width: 660px; text-wrap: pretty;">Every shipped route now has a mobile design, including the ones desktop still lacks: the Leagues hub, player detail, full standings, matchup, sign in and account setup.</p>
   </div>
   </sc-if>
 </div>

--- a/docs/design/screens/Rostr Playoffs.dc.html
+++ b/docs/design/screens/Rostr Playoffs.dc.html
@@ -444,7 +444,7 @@
 
           <div class="card" style="padding: 15px 16px; background: var(--color-surface);">
             <div style="font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">Your roster, now</div>
-            <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 8px 0 0; text-wrap: pretty;">Fourteen Token-2022 NFTs, still in your wallet. The transfer restriction relaxed at settlement, so the championship roster can leave the league it was drafted in.</p>
+            <p style="font-size: 12.5px; line-height: 1.6; color: var(--color-neutral-400); margin: 8px 0 0; text-wrap: pretty;">Fourteen players, still yours to the last row. The season is settled, so nothing about this roster can change again — it stands exactly as the frozen rules scored it.</p>
             <div style="display: flex; gap: 10px; margin-top: 14px; flex-wrap: wrap;">
               <button type="button" class="btn btn-secondary" style="font-size: 12.5px; padding: 7px 13px;">View roster</button>
               <button type="button" class="btn btn-ghost" style="font-size: 12.5px; padding: 7px 12px; color: var(--color-neutral-400);">Explorer</button>

--- a/docs/design/screens/Rostr Playoffs.dc.html
+++ b/docs/design/screens/Rostr Playoffs.dc.html
@@ -412,7 +412,7 @@
               </div>
               <div style="display: grid; grid-template-columns: 150px minmax(0, 1fr) 108px; gap: 14px; align-items: baseline; padding: 11px 18px; background: color-mix(in srgb, var(--color-accent) 9%, transparent);">
                 <span style="font-family: ui-monospace, monospace; font-size: 11.5px; color: var(--color-accent-400);">6 Jan, 23:47</span>
-                <span style="font-size: 13px; color: var(--color-accent-200);">Champion derived · trophy transfer restriction relaxed</span>
+                <span style="font-size: 13px; color: var(--color-accent-200);">Champion derived · results final</span>
                 <span style="font-family: ui-monospace, monospace; font-size: 11.5px; color: var(--color-accent-300); text-align: right;">Ym4p…2zLc</span>
               </div>
             </div>

--- a/docs/design/screens/Rostr Trade Veto.dc.html
+++ b/docs/design/screens/Rostr Trade Veto.dc.html
@@ -288,7 +288,7 @@
               </div>
           </div>
           <div style="padding: 12px 20px; border-top: 1px solid var(--color-neutral-900); font-size: 11.5px; color: var(--color-neutral-600);">
-            All three Token-2022 NFTs left the escrow PDA in one transaction. There was no moment where one roster held both sides.
+            All three players moved in one atomic write. There was no moment where one roster held both sides.
           </div>
         </div>
 

--- a/docs/design/screens/Rostr Trade Veto.dc.html
+++ b/docs/design/screens/Rostr Trade Veto.dc.html
@@ -80,7 +80,7 @@
                   <span style="font-size: 14px;">M. Sowande <span style="font-size: 11.5px; color: var(--color-neutral-600);">SEA</span></span>
                   <span style="font-size: 11.5px; color: var(--color-neutral-600);">RB2 · 11.4 per game · drafted 1.06</span>
                 </div>
-                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">NFT 8fJ2…</span>
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">Locked 8fJ2…</span>
               </div>
               </div>
               <div style="display: flex; align-items: baseline; justify-content: space-between; margin-top: 12px; font-size: 12px;">
@@ -101,7 +101,7 @@
                   <span style="font-size: 14px;">J. Prieto <span style="font-size: 11.5px; color: var(--color-neutral-600);">CIN</span></span>
                   <span style="font-size: 11.5px; color: var(--color-neutral-600);">RB1 · 15.8 per game · drafted 1.09</span>
                 </div>
-                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">NFT 3qWm…</span>
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">Locked 3qWm…</span>
               </div>
               <div style="display: grid; grid-template-columns: 54px 1fr auto; align-items: center; gap: 12px; padding: 11px 0; border-bottom: 1px solid var(--color-neutral-900);">
                 <span class="tag tag-neutral" style="font-size: 10px; padding: 2px 7px; justify-self: start;">TE</span>
@@ -109,7 +109,7 @@
                   <span style="font-size: 14px;">L. Beaumont <span style="font-size: 11.5px; color: var(--color-neutral-600);">MIN</span></span>
                   <span style="font-size: 11.5px; color: var(--color-neutral-600);">TE2 · 6.2 per game · drafted 7.09</span>
                 </div>
-                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">NFT 5zBn…</span>
+                <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); text-align: right;">Locked 5zBn…</span>
               </div>
               </div>
               <div style="display: flex; align-items: baseline; justify-content: space-between; margin-top: 12px; font-size: 12px;">
@@ -208,7 +208,7 @@
           <div style="display: flex; flex-direction: column; gap: 13px; margin-top: 13px; font-size: 12.5px; line-height: 1.55;">
             <div>
               <span style="color: var(--color-accent-300);">Four votes against</span>
-              <p style="color: var(--color-neutral-400); margin: 4px 0 0;">Both NFTs return to their origin wallets. Rosters untouched, nobody's fault.</p>
+              <p style="color: var(--color-neutral-400); margin: 4px 0 0;">The lock lifts on both players. Rosters untouched, nobody's fault.</p>
             </div>
             <div>
               <span style="color: var(--color-neutral-300);">Fewer than four</span>
@@ -323,7 +323,7 @@
               <span style="display: flex; align-items: center; justify-content: center; width: 16px; height: 16px; margin-top: 2px; border-radius: 50%; background: color-mix(in srgb, var(--color-accent) 22%, transparent); box-shadow: 0 0 0 1px var(--color-accent-700);"><span style="width: 5px; height: 5px; border-radius: 50%; background: var(--color-accent);"></span></span>
               <div style="display: flex; flex-direction: column; gap: 4px;">
                 <span style="font-size: 13.5px;">Escrowed</span>
-                <span style="font-size: 11.5px; line-height: 1.5; color: var(--color-neutral-600);">All three NFTs moved to the escrow PDA. The 48-hour veto window opened.</span>
+                <span style="font-size: 11.5px; line-height: 1.5; color: var(--color-neutral-600);">All three players locked at acceptance. The 48-hour veto window opened.</span>
               </div>
               <div style="display: flex; flex-direction: column; gap: 4px; text-align: right;">
                 <span style="font-size: 11.5px; color: var(--color-neutral-500);">Mon 15 Aug 09:14</span>
@@ -533,7 +533,7 @@
           <div style="padding: 11px 16px; border-bottom: 1px solid var(--color-neutral-900); font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-neutral-500);">If Cover Two accepts</div>
           <div style="display: flex; gap: 11px; padding: 12px 16px; border-bottom: 1px solid var(--color-neutral-900);">
             <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); flex: 0 0 62px;">At once</span>
-            <span style="font-size: 12.5px; line-height: 1.5; color: var(--color-neutral-400);">All three NFTs move to the escrow account. Nobody's roster has changed yet.</span>
+            <span style="font-size: 12.5px; line-height: 1.5; color: var(--color-neutral-400);">All three players lock when both sides accept. Nobody's roster has changed yet.</span>
           </div>
           <div style="display: flex; gap: 11px; padding: 12px 16px; border-bottom: 1px solid var(--color-neutral-900);">
             <span style="font-family: ui-monospace, monospace; font-size: 11px; color: var(--color-neutral-600); flex: 0 0 62px;">48h</span>

--- a/docs/design/screens/_ds/nocturne-2cbfcdf4-7e1c-4bfa-8626-a61405078160/styles.css
+++ b/docs/design/screens/_ds/nocturne-2cbfcdf4-7e1c-4bfa-8626-a61405078160/styles.css
@@ -1,0 +1,294 @@
+/* Nocturne — design-system tokens and component classes. This file is the source of truth for the system's look; retune it here and see readme.md. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  --color-bg: #161826;
+  --color-surface: #232532;
+  --color-text: #e9e9ed;
+  --color-accent: #9184d9; /* review round 7 (Barron): the accent moves to
+     the product's blurple — OKLCH hue 289.2, the hue of the app's own Pro
+     accent (#9a8fe0, --om-accent-pro) — at the same lightness the steel
+     accent held (L 0.660, so the documented ratios survive) and chroma
+     in the product blurple's own range (its token sits at C 0.118; the
+     accent takes 0.125, from the old steel's 0.030):
+     the accent now reads as an accent rather than another neutral. */
+  --color-accent-2: #a7a1db; /* the machine-derived stand-in follows: same
+     hue, same L 0.734, chroma at the same 2:3 proportion it held */
+  --color-divider: color-mix(in srgb, #e9e9ed 16%, transparent);
+
+  /* Tonal ramps — generated in OKLCH on one shared lightness scale, so the
+     same step of any role matches the others in visual value. */
+  --color-neutral-100: #f3f5fe;
+  --color-neutral-200: #e4e7f5;
+  --color-neutral-300: #cfd3e5;
+  --color-neutral-400: #b2b6ca;
+  --color-neutral-500: #9397ab;
+  --color-neutral-600: #75798c;
+  --color-neutral-700: #595d6c;
+  --color-neutral-800: #3f424d;
+  --color-neutral-900: #292b31;
+
+  --color-accent-100: #f5f4ff;
+  --color-accent-200: #e7e5fe;
+  --color-accent-300: #d2cefd;
+  --color-accent-400: #b5abfc;
+  --color-accent-500: #968ae0;
+  --color-accent-600: #796cbf;
+  --color-accent-700: #5d5294;
+  --color-accent-800: #423a6a;
+  --color-accent-900: #2b2741;
+
+  --color-accent-2-100: #f5f4ff;
+  --color-accent-2-200: #e7e5fe;
+  --color-accent-2-300: #d2cefd;
+  --color-accent-2-400: #b5afe8;
+  --color-accent-2-500: #9690c9;
+  --color-accent-2-600: #7972a9;
+  --color-accent-2-700: #5c5783;
+  --color-accent-2-800: #423e5d;
+  --color-accent-2-900: #2b293a;
+
+  /* Deck section-divider ground — review round 3: saturation as presence.
+     Dividers take a saturated deep indigo (hue 277, the neutral ramp's own
+     family; C 0.094 — written when the accent held C 0.030, before the
+     round-7 blurple raised it past the ground's) with a lighter bloom and
+     a ghost tint of the same hue, while the slide grounds stay
+     desaturated. Deck-scale fills only — not interface colors. */
+  --color-section: #262a60;
+  --color-section-glow: #353b80;
+  --color-section-ghost: #4c5397;
+
+  --font-heading: "Inter", system-ui, sans-serif;
+  --font-heading-weight: 500;
+  --font-body: "Inter", system-ui, sans-serif;
+
+  --space-1: 2.8px;
+  --space-2: 5.6px;
+  --space-3: 8.4px;
+  --space-4: 11.2px;
+  --space-6: 16.8px;
+  --space-8: 22.4px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+
+  /* Elevation — derived from the ground: soft ink-tinted shadows on a
+     light theme, a hairline edge + ambient darkness on a dark one. */
+  --shadow-sm: 0 0 0 1px #3f424d;
+  --shadow-md: 0 0 0 1px #595d6c, 0 6px 18px rgba(0,0,0,0.55);
+  --shadow-lg: 0 0 0 1px #9397ab, 0 16px 40px rgba(0,0,0,0.65);
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-body);
+}
+h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: var(--font-heading-weight); }
+
+.lighten{mix-blend-mode:lighten;background-color:transparent}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Components — built with the tokens above. Plain CSS
+   on plain HTML: no JavaScript, no build step. Each class is documented in
+   readme.md and demonstrated in foundations/ and components/.
+   ══════════════════════════════════════════════════════════════════════ */
+
+*, *::before, *::after { box-sizing: border-box; }
+body { margin: 0; font-size: 15px; line-height: 1.55; font-weight: 400; }
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  line-height: 1.12; letter-spacing: -0.015em; margin: 0 0 var(--space-2);
+}
+h1 { font-size: 42px; }
+h2 { font-size: 32px; }
+h3 { font-size: 25px; }
+h4 { font-size: 20px; }
+h5 { font-size: 16px; }
+h6 { font-size: 13px; }
+h6 { letter-spacing: 0.08em; text-transform: uppercase; }
+p { margin: 0 0 var(--space-3); }
+a { color: var(--color-accent); text-underline-offset: 3px; }
+img { display: block; max-width: 100%; }
+figure { margin: 0; }
+figcaption {
+  font-size: 11px; margin-top: var(--space-1);
+  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+}
+.text-muted { color: color-mix(in srgb, var(--color-text) 55%, transparent); }
+:focus { outline: none; }
+:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+::selection { background: color-mix(in srgb, var(--color-accent) 30%, transparent); }
+
+/* — rules — */
+/* Rules fade to transparent at both ends instead of stopping cleanly — a
+   Nocturne signature. The ramp is 48px an end (one deck baseline unit),
+   painted from the same divider token. Freestanding rules fade; box
+   outlines, in-control separators, and short accent marks stay solid. */
+.hr {
+  height: 1px; border: 0; margin: var(--space-4) 0;
+  background: linear-gradient(to right,
+    transparent, var(--color-divider) 48px,
+    var(--color-divider) calc(100% - 48px), transparent);
+}
+
+/* — buttons — */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  cursor: pointer; text-decoration: none;
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 14px; line-height: 1.2; color: var(--color-text); /* matches the .input's 14px —
+     the pair sits side by side in sign-up rows */
+  background: transparent; border: 1px solid transparent;
+  padding: var(--space-2) calc(var(--space-3) * 1.2);
+  border-radius: var(--radius-md);
+}
+.btn svg { display: block; }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn-primary { color: var(--color-accent); border-color: var(--color-accent); }
+.btn-primary:hover { background: color-mix(in srgb, var(--color-accent) 12%, transparent); }
+.btn-primary:active { background: color-mix(in srgb, var(--color-accent) 22%, transparent); }
+.btn-secondary { border-color: var(--color-divider); }
+.btn-secondary:hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
+.btn-secondary:active { background: color-mix(in srgb, var(--color-text) 14%, transparent); }
+.btn-ghost { color: var(--color-accent); padding-inline: var(--space-1); }
+.btn-ghost:hover { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+.btn-ghost:active { background: color-mix(in srgb, var(--color-accent) 18%, transparent); }
+.btn-icon { width: 36px; height: 36px; padding: 0; }
+.btn-block { width: 100%; margin-top: var(--space-2); }
+
+/* — forms — */
+.field > label {
+  display: block; font-size: 12px; margin-bottom: 5px;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+.input {
+  width: 100%; min-height: 36px; padding: 6px 10px; font: inherit;
+  font-size: 14px; color: var(--color-text); caret-color: var(--color-accent);
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider); border-radius: var(--radius-md);
+}
+.input:hover { border-color: color-mix(in srgb, var(--color-text) 45%, transparent); }
+.input:focus-visible { border-color: var(--color-accent); outline-offset: 0; }
+textarea.input { min-height: 90px; resize: vertical; }
+.radio { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font-size: 14px; }
+.radio input, .seg-opt input {
+  position: absolute; opacity: 0; width: 0; height: 0; pointer-events: none;
+}
+.radio .dot {
+  width: 16px; height: 16px; flex: none; border-radius: 50%;
+  border: 1.5px solid var(--color-divider);
+}
+.radio:hover .dot { border-color: var(--color-accent); }
+.radio input:checked + .dot {
+  border-color: var(--color-accent); background: var(--color-accent);
+  box-shadow: inset 0 0 0 4px var(--color-bg);
+}
+.radio input:focus-visible + .dot { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.seg {
+  display: inline-flex; overflow: hidden;
+  border: 1px solid var(--color-divider); border-radius: var(--radius-md);
+}
+.seg-opt {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 7px 12px; font-size: 13px; cursor: pointer;
+}
+.seg-opt + .seg-opt { border-left: 1px solid var(--color-divider); }
+.seg-opt:has(input:checked) { color: var(--color-accent); box-shadow: inset 0 0 0 1px var(--color-accent); }
+.seg-opt:not(:has(input:checked)):hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
+.seg-opt:has(input:focus-visible) { outline: 2px solid var(--color-accent); outline-offset: -2px; }
+
+/* — cards — */
+.card {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  padding: var(--space-3); border-radius: var(--radius-md); background: var(--color-surface);
+}
+.card-kicker { font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-accent); }
+.card-title {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 17px; line-height: 1.2;
+}
+.card-body { margin: 0; font-size: 13px; opacity: 0.8; flex: 1; }
+.card-meta {
+  display: flex; align-items: center; gap: 6px; font-size: 11px;
+  color: color-mix(in srgb, var(--color-text) 50%, transparent);
+}
+.elev-sm { box-shadow: var(--shadow-sm); }
+.elev-md { box-shadow: var(--shadow-md); }
+.elev-lg { box-shadow: var(--shadow-lg); }
+
+/* — tags — */
+.tag {
+  display: inline-flex; align-items: center; font-size: 11px;
+  letter-spacing: 0.02em; padding: 3px 10px;
+  border-radius: calc(var(--radius-md) * 0.75);
+}
+.tag-accent { background: var(--color-accent-800); color: var(--color-accent-100); }
+.tag-accent-2 { background: var(--color-accent-2-800); color: var(--color-accent-2-100); }
+.tag-neutral { background: var(--color-neutral-800); color: var(--color-neutral-100); }
+.tag-outline { border: 1px solid var(--color-accent); color: var(--color-accent); }
+
+/* — navigation — */
+.nav {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: none;
+}
+.nav-brand {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 18px; margin-right: auto;
+}
+.nav a { color: inherit; text-decoration: none; font-size: 14px; }
+.nav a:hover, .nav a[aria-current='page'] { color: var(--color-accent); }
+
+/* — tables — */
+.table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.table th {
+  text-align: left; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 60%, transparent);
+  padding: var(--space-2); border-bottom: 1px solid transparent; /* keeps layout; the row paints the fading rule */
+}
+.table td {
+  padding: var(--space-2);
+  border-bottom: 1px solid transparent;
+}
+/* Row rules as row-level strips so the end-fade spans the row, not each cell. */
+.table thead tr {
+  background: linear-gradient(to right,
+    transparent, var(--color-divider) 48px,
+    var(--color-divider) calc(100% - 48px), transparent) no-repeat bottom / 100% 1px;
+}
+.table tbody tr {
+  background: linear-gradient(to right,
+    transparent, color-mix(in srgb, var(--color-text) 8%, transparent) 48px,
+    color-mix(in srgb, var(--color-text) 8%, transparent) calc(100% - 48px), transparent) no-repeat bottom / 100% 1px;
+}
+.table tbody tr:hover {
+  /* the hover tint layers over the row rule, which keeps painting */
+  background:
+    linear-gradient(color-mix(in srgb, var(--color-text) 4%, transparent),
+                    color-mix(in srgb, var(--color-text) 4%, transparent)) no-repeat 0 0 / 100% 100%,
+    linear-gradient(to right,
+      transparent, color-mix(in srgb, var(--color-text) 8%, transparent) 48px,
+      color-mix(in srgb, var(--color-text) 8%, transparent) calc(100% - 48px), transparent) no-repeat bottom / 100% 1px;
+}
+
+/* — dialog — */
+.dialog-backdrop {
+  position: fixed; inset: 0; display: grid; place-items: center;
+  padding: var(--space-4);
+  background: color-mix(in srgb, var(--color-neutral-900) 50%, transparent);
+}
+.dialog {
+  width: min(440px, 100%); display: flex; flex-direction: column; gap: var(--space-3);
+  padding: var(--space-4); border-radius: var(--radius-lg);
+  background: var(--color-surface); box-shadow: var(--shadow-lg);
+}
+.dialog-title {
+  font-family: var(--font-heading); font-weight: var(--font-heading-weight);
+  font-size: 20px;
+}
+.dialog-body { font-size: 14px; opacity: 0.85; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-2); }
+


### PR DESCRIPTION
# Design drop 9 — mobile completed, landing made responsive, stale copy retired

Not for immediate merge — review pass pending.

## What changed

### screens/Rostr Mobile.dc.html — 17 frames become 34
Most shipped routes now have a 390px design, plus the edge states. Three do not:
`/scoring`, `/invitations` (folded into frame 18 as a section) and `/ops/stats`.
The bottom nav in these frames is `Home · Matchup · Team · Players · League`, which
does not match the shipped nav (`LeagueChrome.tsx`): `League` is a fifth tab with no
route, and `Trades` and `Standings` are shipped tabs missing from it — so frames 20,
31 and 34 are unreachable from the design's own navigation. Reconcile before building.
Routes are also written `/l/<slug>/…` throughout; shipped is `/leagues/[id]/…`.

New frames, in file order:

- 18 Leagues — the drop-8 hub stacked for a phone (your leagues → invitations → public;
  no join button in any list, every card leads to the rules)
- 19 Player detail — status decides the pinned action; a claim names its drop on the button
- 20 Full standings — twelve rows, three columns, PF on the second line, the cut line drawn
- 21 Matchup — slot against slot, the second line explains any missing number
- 22 Sign in — email code first, wallet second (a wallet signs only money and consent)
- 23 Finish setting up — the username gate, stated as what it unblocks
- 24 Draft board tab — one round at a time as twelve rows, pager at the thumb;
  strict position-identity tags (need-colouring stays on the Draft tab)
- 25 Pre-draft queue — 44px arrows, no drag; autopick fallback stated
- 26 Notifications — the desktop dropdown as a page; needs-you first with the
  do-nothing consequence
- 27 Account menu — bottom sheet carrying Sign out and the Finish-setting-up branch
  (the two affordances STATUS.md warns a header rebuild deletes)
- 28 League home, pre-draft — countdown, seat meter, the one useful action
- 29 Draft room, connection lost — server clock keeps running; queue covers you
- 30 Claim lost — who won on what priority, and what did not change
- 31 Trade composer — tap-to-toggle from both rosters; 48h veto stated before send
- 32 Team tab — bench + IR; Drop refuses with GAME_STARTED after kickoff
- 33 Draft complete — section-glow end state, pinned action is the Week 1 lineup
- 34 Dead invite link — names which of the three death reasons applied, offers
  public leagues / create instead of a wall

### screens/Rostr Landing.dc.html — phone breakpoint added
The design had no rules below 980px; at 390px the nav, hero draft board (min ~470px),
rules table and the two-column close band all overflowed, which is the clipped dark
band on the right. Added a max-width:640px pass: nav compacts (tagline + How-it-works
hidden), hero/section paddings tighten, the board scrolls horizontally instead of
clipping (mask dropped when scrolling), the rules table stacks its label cells, the
close band and week split collapse to one column.
**The shipped page.tsx needs the same treatment — this fixes the design, not the app.**

### Stale copy corrected (per STATUS.md / ANSWERS.md)
- Roster-as-NFT sentences removed: Mobile hero, Draft Room draft-complete,
  Playoffs "Your roster, now", Trade Veto escrow caption. Replaced with the
  no-commissioner claim the app actually ships.
- Kickoff corrected to 9 September (Create League helper text, Draft Room).
- Domain: rostr.gg → rostr.site everywhere (Mobile ×24, Invite and Join ×1).

## Not touched
- Rostr Screens.dc.html is still the drop-8 index (17 mobile frames, stale open
  questions) — update separately or with the next drop.
- Draft room state 6 still exists on desktop; ANSWERS.md says it can be deleted.

## How to land this
```
git checkout -b design-drop-9
cp -r handoff/docs/design/screens/* docs/design/screens/
git add docs/design && git commit -m "Design drop 9: mobile complete (34 frames), responsive landing, retired copy removed"
gh pr create --draft --title "Design drop 9" --body-file docs/design/PULL_REQUEST_DROP9.md
```
Open as a **draft PR** so it is not mergeable until you have been through it.
Note: design-scoring.test.ts guards the Create League table — it was not changed here,
only the kickoff date helper text, so it should stay green.
