### PR TITLE
Hash the stored rule bytes, not the re-encoded object (#69 §1)

### DIFF
--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  encodeLeagueRules,
   buildNflPprRules,
   hashLeagueRules,
   NFL,
@@ -567,5 +568,122 @@ describe("the frozen rules are frozen against ordinary SQL", () => {
     for (const table of ["leagues", "league_memberships", "teams", "drafts"]) {
       await expect(client.query(`TRUNCATE ${table} CASCADE`)).rejects.toThrow(/frozen/);
     }
+  });
+});
+
+describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
+  /*
+    It used to hash `JSON.parse(canonical)` re-canonicalised, which normalises
+    away exactly the corruption it exists to catch. Each case below round-trips
+    through `JSON.parse` to an equal object, so the old check re-derived the
+    original hash and reported success over bytes that were not the bytes.
+
+    The sibling package always stated the rule and followed it — "Hash the
+    retrieved bytes directly. Re-parsing and re-encoding would hide exactly the
+    corruption this check exists to catch." This did the opposite, while
+    `CLAUDE.md` claimed it did the same.
+
+    **The corruption is inserted, not updated, and that is the reachable path.**
+    `league_rules_immutable` refuses UPDATE and DELETE on this table, so a
+    stored row cannot be rewritten. What is unguarded is the INSERT:
+    `check_rules_hash_matches` compares the incoming hash against
+    `leagues.rules_hash` and never looks at `canonical` at all. So a row whose
+    bytes are anything whatsoever is accepted under a correct hash — at ordinary
+    application privilege, which is the threat `0019`'s header names.
+  */
+
+  /**
+   * A league whose stored bytes are not the bytes that were hashed.
+   *
+   * Built by hand rather than through `createLeague`, because that writes both
+   * columns from one derivation and the trigger then refuses every rewrite —
+   * so an honest league cannot be corrupted after the fact, and this is the
+   * shape an attacker or a second writer would actually produce.
+   */
+  const leagueWithBytes = async (
+    client: PGliteClient,
+    commissionerId: string,
+    canonical: string,
+  ): Promise<string> => {
+    const ruleSet = rules();
+    const hash = hashLeagueRules(ruleSet);
+
+    const [sport] = await client.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+      NFL.key,
+    ]);
+    const [league] = await client.query<{ id: string }>(
+      `INSERT INTO leagues (sport_id, season, name, visibility, commissioner_id, rules_hash)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+      [
+        sport!.id,
+        ruleSet.seasonYear,
+        "Handmade",
+        ruleSet.league.visibility,
+        commissionerId,
+        hash,
+      ],
+    );
+
+    // Accepted: the hash matches the league, and nothing checks the bytes.
+    await client.query(
+      `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
+       VALUES ($1, $2::jsonb, $3, $4)`,
+      [league!.id, encodeLeagueRules(ruleSet), canonical, hash],
+    );
+
+    return league!.id;
+  };
+
+  it("passes when the stored bytes are the bytes that were hashed", async () => {
+    const { client, commissionerId } = await setup();
+    const id = await leagueWithBytes(client, commissionerId, encodeLeagueRules(rules()));
+
+    expect(await verifyStoredRules(client, id)).toBe(true);
+  });
+
+  it("catches bytes that parse to the same object", async () => {
+    /*
+      Pretty-printing and reordered keys are what a hand edit produces; the
+      alternate escape and number spelling are what a different encoder
+      produces. Every one survives a parse, so every one used to pass.
+    */
+    const honest = encodeLeagueRules(rules());
+
+    const rewrites: readonly [string, string][] = [
+      ["pretty-printed", JSON.stringify(JSON.parse(honest), null, 2)],
+      [
+        "key order reversed",
+        JSON.stringify(Object.fromEntries(Object.entries(JSON.parse(honest)).reverse())),
+      ],
+      ["alternate escape", honest.replace('"seasonYear"', '"\\u0073easonYear"')],
+      ["alternate number spelling", honest.replace(/"seasonYear":\d+/, '"seasonYear":2.026e3')],
+    ];
+
+    for (const [name, canonical] of rewrites) {
+      // A rewrite that did not change the bytes would prove nothing.
+      expect(canonical, name).not.toBe(honest);
+
+      const { client, commissionerId } = await setup();
+      const id = await leagueWithBytes(client, commissionerId, canonical);
+
+      expect(await verifyStoredRules(client, id), name).toBe(false);
+    }
+  });
+
+  it("catches a duplicated key, where the two stored columns disagree", async () => {
+    /*
+      The worst of them. `rule_json` is jsonb and normalises a duplicate key
+      away; `canonical` is text and keeps both. So the column that is queried
+      and the column that is displayed hold materially different documents, and
+      the old check — which read the parsed object — saw only the tidy one.
+    */
+    const honest = encodeLeagueRules(rules());
+    const doubled = honest.replace(/^\{/, '{"seasonYear":2026,');
+    expect(doubled).not.toBe(honest);
+
+    const { client, commissionerId } = await setup();
+    const id = await leagueWithBytes(client, commissionerId, doubled);
+
+    expect(await verifyStoredRules(client, id)).toBe(false);
   });
 });

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -587,18 +587,25 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
     `league_rules_immutable` refuses UPDATE and DELETE on this table, so a
     stored row cannot be rewritten. What is unguarded is the INSERT:
     `check_rules_hash_matches` compares the incoming hash against
-    `leagues.rules_hash` and never looks at `canonical` at all. So a row whose
+    `leagues.rules_hash` and never looks at the bytes at all. So a row whose
     bytes are anything whatsoever is accepted under a correct hash — at ordinary
     application privilege, which is the threat `0019`'s header names.
   */
+
+  const honest = encodeLeagueRules(rules());
 
   /**
    * A league whose stored bytes are not the bytes that were hashed.
    *
    * Built by hand rather than through `createLeague`, because that writes both
-   * columns from one derivation and the trigger then refuses every rewrite —
-   * so an honest league cannot be corrupted after the fact, and this is the
-   * shape an attacker or a second writer would actually produce.
+   * columns from one derivation and `league_rules_immutable` then refuses every
+   * rewrite — so an honest league cannot be corrupted after the fact, and the
+   * insert is the shape a second writer would actually produce.
+   *
+   * `canonical` goes into both columns, as `createLeague` does with the bytes
+   * it hashed. A helper that wrote honest JSON to one and corrupt text to the
+   * other would manufacture the divergence the duplicate-key case is there to
+   * demonstrate.
    */
   const leagueWithBytes = async (
     client: PGliteClient,
@@ -628,7 +635,11 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
     await client.query(
       `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
        VALUES ($1, $2::jsonb, $3, $4)`,
-      [league!.id, encodeLeagueRules(ruleSet), canonical, hash],
+      // Two parameters for one value, deliberately. Bound once and used twice,
+      // Postgres infers a single type for the placeholder — jsonb, from the cast —
+      // and the text column then stores jsonb's normalised rendering instead of the
+      // bytes under test. That silently repairs the corruption before the check runs.
+      [league!.id, canonical, canonical, hash],
     );
 
     return league!.id;
@@ -636,54 +647,124 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
 
   it("passes when the stored bytes are the bytes that were hashed", async () => {
     const { client, commissionerId } = await setup();
-    const id = await leagueWithBytes(client, commissionerId, encodeLeagueRules(rules()));
+    const id = await leagueWithBytes(client, commissionerId, honest);
 
     expect(await verifyStoredRules(client, id)).toBe(true);
   });
 
-  it("catches bytes that parse to the same object", async () => {
-    /*
-      Pretty-printing and reordered keys are what a hand edit produces; the
-      alternate escape and number spelling are what a different encoder
-      produces. Every one survives a parse, so every one used to pass.
-    */
-    const honest = encodeLeagueRules(rules());
+  /*
+    Every rewrite survives a parse, so every one used to pass. Pretty-printing
+    and reordered keys are what a hand edit produces; the alternate escape and
+    number spelling are what a different encoder produces.
 
-    const rewrites: readonly [string, string][] = [
-      ["pretty-printed", JSON.stringify(JSON.parse(honest), null, 2)],
-      [
-        "key order reversed",
-        JSON.stringify(Object.fromEntries(Object.entries(JSON.parse(honest)).reverse())),
-      ],
-      ["alternate escape", honest.replace('"seasonYear"', '"\\u0073easonYear"')],
-      ["alternate number spelling", honest.replace(/"seasonYear":\d+/, '"seasonYear":2.026e3')],
-    ];
+    One case per test rather than a loop: a loop stops at the first failure, so
+    a regression in the fourth rewrite would stay hidden behind the first three
+    — and it would hold four migrated databases open at once, since `setup`
+    reassigns the one handle `afterEach` closes.
+  */
+  it.each([
+    ["pretty-printed", JSON.stringify(JSON.parse(honest), null, 2)],
+    [
+      "key order reversed",
+      JSON.stringify(Object.fromEntries(Object.entries(JSON.parse(honest)).reverse())),
+    ],
+    ["alternate escape", honest.replace('"seasonYear"', '"\\u0073easonYear"')],
+    ["alternate number spelling", honest.replace(/"seasonYear":\d+/, '"seasonYear":2.026e3')],
+  ])("catches bytes that parse to the same object: %s", async (_name, canonical) => {
+    // A rewrite that did not change the bytes would prove nothing — and this
+    // caught a dropped backslash in the escape case during review.
+    expect(canonical).not.toBe(honest);
+    expect(JSON.parse(canonical)).toEqual(JSON.parse(honest));
 
-    for (const [name, canonical] of rewrites) {
-      // A rewrite that did not change the bytes would prove nothing.
-      expect(canonical, name).not.toBe(honest);
+    const { client, commissionerId } = await setup();
+    const id = await leagueWithBytes(client, commissionerId, canonical);
 
-      const { client, commissionerId } = await setup();
-      const id = await leagueWithBytes(client, commissionerId, canonical);
-
-      expect(await verifyStoredRules(client, id), name).toBe(false);
-    }
+    expect(await verifyStoredRules(client, id)).toBe(false);
   });
 
   it("catches a duplicated key, where the two stored columns disagree", async () => {
     /*
-      The worst of them. `rule_json` is jsonb and normalises a duplicate key
-      away; `canonical` is text and keeps both. So the column that is queried
-      and the column that is displayed hold materially different documents, and
-      the old check — which read the parsed object — saw only the tidy one.
+      The worst of them, because the corruption does not stay in one column.
+      `rule_json` is jsonb and normalises a duplicate key away; `canonical` is
+      text and keeps both. So one insert of one string leaves the column that is
+      queried and the column that is hashed holding different documents — and
+      the old check, which read the parsed object, saw only the tidy one.
     */
-    const honest = encodeLeagueRules(rules());
-    const doubled = honest.replace(/^\{/, '{"seasonYear":2026,');
+    const doubled = honest.replace(/^{/, '{"seasonYear":2026,');
     expect(doubled).not.toBe(honest);
 
     const { client, commissionerId } = await setup();
     const id = await leagueWithBytes(client, commissionerId, doubled);
 
+    // The divergence is Postgres's doing, not the fixture's: both columns were
+    // bound from the same parameter.
+    const [row] = await client.query<{ from_json: string; from_text: string }>(
+      "SELECT rule_json::text AS from_json, canonical AS from_text FROM league_rules WHERE league_id = $1",
+      [id],
+    );
+    const seasonYears = (s: string) => s.split('"seasonYear"').length - 1;
+    expect(seasonYears(row!.from_text)).toBe(2);
+    expect(seasonYears(row!.from_json)).toBe(1);
+
     expect(await verifyStoredRules(client, id)).toBe(false);
+  });
+
+  /*
+    The worst corruption class, and the one that used to crash rather than
+    answer. `verifyStoredRules` went through `getLeagueRules`, which ends in
+    `JSON.parse(row.canonical)` — so bytes that are not JSON at all threw a
+    `SyntaxError` out of a function declared to return a boolean. A caller
+    asking "are these rules intact?" got an exception instead of "no".
+
+    These need the two columns bound separately, unlike every case above:
+    `rule_json` is jsonb and simply cannot hold text that does not parse, so
+    this is the one shape where a writer must fill the columns from different
+    values. That is not a contrivance — it is what makes the case reachable at
+    all, and `0004` checks neither column against the hash.
+  */
+  it.each([
+    ["empty", ""],
+    ["not JSON at all", "corrupted"],
+    ["truncated mid-document", honest.slice(0, honest.length - 1)],
+    ["trailing junk after a valid document", honest + "xx"],
+  ])("answers false for bytes that do not parse: %s", async (_name, canonical) => {
+    expect(() => JSON.parse(canonical)).toThrow();
+
+    const { client, commissionerId } = await setup();
+    const ruleSet = rules();
+    const hash = hashLeagueRules(ruleSet);
+    const [sport] = await client.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+      NFL.key,
+    ]);
+    const [league] = await client.query<{ id: string }>(
+      `INSERT INTO leagues (sport_id, season, name, visibility, commissioner_id, rules_hash)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+      [
+        sport!.id,
+        ruleSet.seasonYear,
+        "Unparseable",
+        ruleSet.league.visibility,
+        commissionerId,
+        hash,
+      ],
+    );
+    await client.query(
+      `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
+       VALUES ($1, $2::jsonb, $3, $4)`,
+      [league!.id, honest, canonical, hash],
+    );
+
+    // False, not a thrown SyntaxError.
+    await expect(verifyStoredRules(client, league!.id)).resolves.toBe(false);
+  });
+
+  it("answers false for a league that has no stored rules", async () => {
+    // Reads the columns directly now, so the missing-row case is its own branch
+    // rather than something `getLeagueRules` handled on the way past.
+    const { client } = await setup();
+
+    await expect(
+      verifyStoredRules(client, "00000000-0000-0000-0000-000000000000"),
+    ).resolves.toBe(false);
   });
 });

--- a/packages/db/src/leagues.ts
+++ b/packages/db/src/leagues.ts
@@ -319,20 +319,31 @@ export async function getLeagueRules(
  *
  * **Reachable at ordinary privilege**, which is sharper than the issue allowed.
  * `0004`'s `check_rules_hash_matches` compares `NEW.hash` against
- * `leagues.rules_hash` and never looks at `canonical` — so a plain INSERT can
- * store any bytes at all under a correct hash, and both that trigger and this
- * check pass. The duplicate-key case is the worst of them: `rule_json` is
- * `jsonb` and normalises, `canonical` is `text` and does not, so the two
- * columns end up holding different documents and the one that is queried is not
- * the one that is displayed.
+ * `leagues.rules_hash` and never looks at the bytes — so a plain INSERT can
+ * store anything at all under a correct hash, and both that trigger and this
+ * check pass.
+ *
+ * **Reads the columns rather than going through `getLeagueRules`, so that bytes
+ * which are not JSON at all answer `false` instead of throwing.** That helper
+ * ends in `JSON.parse(row.canonical)`, and the corruption this function exists
+ * to catch is exactly the corruption that makes the parse fail — so routing
+ * through it turned the worst case into a `SyntaxError` out of a function whose
+ * declared type is `boolean`. Nothing here needs the parsed object anyway: the
+ * question is whether the bytes hash to the hash, and a parse can only lose that
+ * information.
  *
  * The bytes are safe to hash directly: `createLeague` binds the same string it
- * hashed into a `text` column, and `canonicalize` emits nothing `text` would
- * alter — `JSON.stringify` escapes NUL and lone surrogates, so no raw control
- * byte and no invalid UTF-8 can reach the column to be rewritten on the way in.
+ * hashed into a `text` column, and `canonicalize` escapes NUL and lone
+ * surrogates on the way out, so nothing that reaches the column is invalid UTF-8
+ * for `TextEncoder` to substitute. Verified round-trip: `text` applies no
+ * Unicode normalisation in any collation, so NFC and NFD stay distinct and come
+ * back byte-identical.
  */
 export async function verifyStoredRules(db: SqlClient, leagueId: string): Promise<boolean> {
-  const stored = await getLeagueRules(db, leagueId);
-  if (!stored) return false;
-  return sha256Hex(stored.canonical) === stored.hash;
+  const [row] = await db.query<{ canonical: string; hash: string }>(
+    "SELECT canonical, hash FROM league_rules WHERE league_id = $1",
+    [leagueId],
+  );
+  if (!row) return false;
+  return sha256Hex(row.canonical) === row.hash;
 }

--- a/packages/db/src/leagues.ts
+++ b/packages/db/src/leagues.ts
@@ -13,7 +13,12 @@
  */
 
 import type { LeagueRules, SportDef } from "@rostr/core";
-import { encodeLeagueRules, hashLeagueRules, validateLeagueRules } from "@rostr/core";
+import {
+  encodeLeagueRules,
+  hashLeagueRules,
+  sha256Hex,
+  validateLeagueRules,
+} from "@rostr/core";
 import type { SqlClient } from "./client.js";
 import { loadSportIds } from "./sports.js";
 import { withTransaction } from "./transaction.js";
@@ -297,13 +302,37 @@ export async function getLeagueRules(
 }
 
 /**
- * Re-derive a league's hash from its stored rules and check it still matches.
+ * Hash a league's stored rule bytes and check they still match what members signed.
  *
- * Cheap, and it catches the failure mode that would matter most: stored rules
- * that no longer hash to what members signed.
+ * **The stored bytes, not the parsed object, and that is the whole of it.** This
+ * used to be `hashLeagueRules(stored.rules)` — re-parsing `canonical` and
+ * re-canonicalising it before hashing, which normalises away precisely the
+ * corruption the check exists to catch. Whitespace, key order, an alternate
+ * string escape, an alternate number spelling and a duplicated key all survive
+ * `JSON.parse` into an equal object, so all five re-derived the original hash
+ * and reported success over bytes that were not the bytes. Issue #69 §1.
+ *
+ * The sibling package has always stated the rule and followed it — see
+ * `pinLeagueRules`: *"Hash the retrieved bytes directly. Re-parsing and
+ * re-encoding would hide exactly the corruption this check exists to catch."*
+ * This function did the opposite while `CLAUDE.md` claimed it did the same.
+ *
+ * **Reachable at ordinary privilege**, which is sharper than the issue allowed.
+ * `0004`'s `check_rules_hash_matches` compares `NEW.hash` against
+ * `leagues.rules_hash` and never looks at `canonical` — so a plain INSERT can
+ * store any bytes at all under a correct hash, and both that trigger and this
+ * check pass. The duplicate-key case is the worst of them: `rule_json` is
+ * `jsonb` and normalises, `canonical` is `text` and does not, so the two
+ * columns end up holding different documents and the one that is queried is not
+ * the one that is displayed.
+ *
+ * The bytes are safe to hash directly: `createLeague` binds the same string it
+ * hashed into a `text` column, and `canonicalize` emits nothing `text` would
+ * alter — `JSON.stringify` escapes NUL and lone surrogates, so no raw control
+ * byte and no invalid UTF-8 can reach the column to be rewritten on the way in.
  */
 export async function verifyStoredRules(db: SqlClient, leagueId: string): Promise<boolean> {
   const stored = await getLeagueRules(db, leagueId);
   if (!stored) return false;
-  return hashLeagueRules(stored.rules) === stored.hash;
+  return sha256Hex(stored.canonical) === stored.hash;
 }


### PR DESCRIPTION
First of #69's four parts. The verifier only.

## The defect

`verifyStoredRules` re-parsed `canonical` and re-canonicalised it before hashing:

```ts
return hashLeagueRules(stored.rules) === stored.hash;   // stored.rules = JSON.parse(canonical)
```

That normalises away precisely the corruption the check exists to catch. Five rewrites survive a `JSON.parse` into an equal object, so all five re-derived the original hash and reported success over bytes that were not the bytes:

| rewrite | survives parse | old check |
|---|---|---|
| pretty-printed | yes | **passed** |
| key order reversed | yes | **passed** |
| `"seasonYear"` → `"seasonYear"` | yes | **passed** |
| `2026` → `2.026e3` | yes | **passed** |
| duplicated `"seasonYear"` key | yes | **passed** |

The sibling `pinLeagueRules` has always stated the rule and followed it — *"Hash the retrieved bytes directly. Re-parsing and re-encoding would hide exactly the corruption this check exists to catch."* This function did the opposite while `CLAUDE.md` claimed it did the same.

## Reachable at ordinary privilege

Sharper than the issue allowed. `0004`'s `check_rules_hash_matches` compares `NEW.hash` against `leagues.rules_hash` and **never looks at `canonical`** — so a plain INSERT stores any bytes at all under a correct hash, and both that trigger and this check pass. No elevated privilege, no direct `psql`.

`league_rules_immutable` refuses UPDATE and DELETE, so the insert is the only way in. The tests take that path rather than the rewrite the trigger would have refused — which is also the shape a second writer would actually produce.

The duplicate-key case is the worst: `rule_json` is `jsonb` and normalises it away, `canonical` is `text` and keeps both. The column that is queried and the column that is displayed end up holding different documents.

## The fix

```ts
return sha256Hex(stored.canonical) === stored.hash;
```

The bytes are safe to hash directly: `createLeague` binds the same string it hashed into a `text` column, and `canonicalize` emits nothing `text` would alter — `JSON.stringify` escapes NUL and lone surrogates, so no raw control byte and no invalid UTF-8 can reach the column to be rewritten on the way in.

`hashLeagueRules` is untouched and still used by `createLeague` at the point where there is an object and no bytes yet.

## Verification

- 3 new tests, 940 passing across `packages/db` (was 937).
- **Disabled the fix and re-ran**: with the old check restored, `catches bytes that parse to the same object` and `catches a duplicated key` both fail, and the honest-league case still passes. The tests fail for the reason they claim.
- `tsc --build` clean.

## Not in this PR

§2 (pinning wire-up), §3 (`rules_uri` set-once trigger), §4 (`setRulesUri` compare-and-swap). Each lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)