### PR TITLE
Write the rules URI once, and only for the document that was pinned (#69 §3, §4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2983,6 +2983,32 @@ valid JSON, so the JSON endpoint looks right — but it re-serialises server-sid
 reordering keys and reformatting numbers, which changes the bytes and therefore the hash.
 There is a test asserting the endpoint, so this cannot regress silently.
 
+**Two request fields are load-bearing now, not one.** The second is
+`pinataOptions: { cidVersion: 0 }`, added with `0044`. CIDv0 `Qm…` and CIDv1 `bafy…`
+encode the same multihash, and **which one comes back is an account setting on Pinata's
+side rather than a property of the bytes** — so left to the default, a change nobody here
+made would return a different URI for identical rules. That matters because `0044` makes
+`leagues.rules_uri` **set-once**, and its entire argument is that a CID is a function of
+the bytes: a different URI therefore means different rules, and there is no honest reason
+to repoint. Without the pinned version that premise is false, and a league would be
+unrepointable at the wrong address, correctable only by another migration. A test fails
+if the line is removed.
+
+**`createLeague` does not write `rules_uri`, and must not be given a way to.** It carried
+an optional `rulesUri` input with no producer anywhere in the repo — unpinned,
+unverified, no hash correspondence, no shape check — and since `0044`'s trigger is BEFORE
+UPDATE, a value written at INSERT is the first one and therefore permanent. It was deleted
+rather than guarded. `setRulesUri` is the only writer, it takes `{ uri, hash }` and swaps
+on the league's own `rules_hash`, and it returns whether it wrote.
+
+**That swap guards the document, not the league**, and the two come apart:
+`hashLeagueRules` is a pure function of the rule set, so two leagues built from one
+template share a `rules_hash` and each accepts the other's pin. It is safe for a
+different reason than the predicate — same hash means same bytes means same CID, so the
+URI attached is the one that league should have had. Do not "tighten" this by trusting a
+league id instead; the round-trip check inside `pinLeagueRules` is what makes the first
+write correct by construction.
+
 ### League creation
 
 `createLeague()` in `packages/db/src/leagues.ts` is the only moment a league's rules are

--- a/packages/db/migrations/0044_rules_uri_is_set_once.sql
+++ b/packages/db/migrations/0044_rules_uri_is_set_once.sql
@@ -26,11 +26,17 @@
 -- rewrites are honest.
 --
 -- The one genuine exception is a re-encoding of the same content — CIDv0
--- `Qm…` against CIDv1 `bafy…` — which SQL cannot tell from a substitution
--- without a CID parser. So the format is fixed at write time in `pinLeagueRules`
--- instead, and the escape hatch here is another migration. That is deliberate:
--- moving where a member's rules live should cost as much as changing the schema,
--- because it is the same kind of act.
+-- `Qm…` against CIDv1 `bafy…` are two encodings of the same multihash, and SQL
+-- cannot tell one from a substitution without a CID parser. Which one comes back
+-- is an account setting on the pinning service's side rather than a property of
+-- the bytes, so the request pins it: `pinataOptions: { cidVersion: 0 }` in
+-- `PinataPinningService.pin`. That line is what makes this rule safe, and this
+-- comment asserted it before it existed — it was added in the same change that
+-- added this migration's review, which is the failure this repo names.
+--
+-- The escape hatch here is another migration, deliberately: moving where a
+-- member's rules live should cost as much as changing the schema, because it is
+-- the same kind of act.
 --
 -- Clearing to NULL is refused for the same reason. Otherwise the rewrite is
 -- simply two statements instead of one, and a rule that a second UPDATE defeats

--- a/packages/db/migrations/0044_rules_uri_is_set_once.sql
+++ b/packages/db/migrations/0044_rules_uri_is_set_once.sql
@@ -30,13 +30,18 @@
 -- cannot tell one from a substitution without a CID parser. Which one comes back
 -- is an account setting on the pinning service's side rather than a property of
 -- the bytes, so the request pins it: `pinataOptions: { cidVersion: 0 }` in
--- `PinataPinningService.pin`. That line is what makes this rule safe, and this
--- comment asserted it before it existed — it was added in the same change that
--- added this migration's review, which is the failure this repo names.
+-- `PinataPinningService.pin`. That line is what makes this rule safe, and a
+-- test fails if it is removed.
 --
 -- The escape hatch here is another migration, deliberately: moving where a
 -- member's rules live should cost as much as changing the schema, because it is
 -- the same kind of act.
+--
+-- **This is a new protection, not `CLAUDE.md` invariant 4.** Members sign the
+-- rules *hash* — `buildJoinMessage` carries no URI — so this column is an
+-- address rather than the rules, and freezing it restricts something nobody
+-- signed. That is why a migration is an acceptable escape hatch here and would
+-- not be for the rules themselves.
 --
 -- Clearing to NULL is refused for the same reason. Otherwise the rewrite is
 -- simply two statements instead of one, and a rule that a second UPDATE defeats
@@ -64,11 +69,14 @@ CREATE TRIGGER leagues_rules_uri_set_once
   FOR EACH ROW EXECUTE FUNCTION leagues_rules_uri_is_set_once();
 
 COMMENT ON COLUMN leagues.rules_uri IS
-  'Where the canonical rule document is pinned, as an IPFS URI. Written once by '
-  'setRulesUri after a successful pin and never again — see '
-  'leagues_rules_uri_set_once. NULL means the rules exist and are hashed but '
-  'have not been published yet, which is an ordinary state: pinning is a network '
-  'call that can fail, and a league with no members yet publishes nothing.';
+  'Where the canonical rule document is pinned, as a content-addressed URI. '
+  'Written once by setRulesUri, after a pin that verified its own round trip, '
+  'and never again — see leagues_rules_uri_set_once. createLeague deliberately '
+  'does not write it: this trigger freezes the first value, so an unverified one '
+  'at INSERT would be permanent. NULL means the rules exist and are hashed but '
+  'have not been published yet, which is an ordinary state — pinning is a '
+  'network call that can fail, and a league with no members yet publishes '
+  'nothing.';
 
 -- Leagues whose rules were never published. The mirror of 0014's
 -- `leagues_unanchored_idx`, and a real state for the same reason: the pin is a

--- a/packages/db/migrations/0044_rules_uri_is_set_once.sql
+++ b/packages/db/migrations/0044_rules_uri_is_set_once.sql
@@ -1,0 +1,70 @@
+-- Where a league's rules live is written once. Issue #69.
+--
+-- `rules_hash` is the guarantee and `0004` already protects it: `league_rules`
+-- refuses UPDATE and DELETE outright, and 0014 pins the on-chain anchor that
+-- proves the hash was published. But `rules_uri` — the address a member actually
+-- fetches to *read* the rules — was a plain nullable `text` column that any
+-- UPDATE could move, at any time, to anywhere.
+--
+-- That is the gap. Repointing the URI leaves `rules_hash` untouched, so the
+-- immutability check in `verifyStoredRules`, the trigger in `0004` and the
+-- on-chain account all still agree. Nothing in the system notices. Meanwhile
+-- every member who follows the link after the swap reads a different document
+-- from the one they joined under — and the hash they would need in order to
+-- catch that is the one thing the swap does not touch.
+--
+-- A member who verifies properly is safe: they fetch the document, hash the
+-- bytes, compare to the chain. The point is that this makes the careless path
+-- and the careful path disagree, silently, which is exactly the arrangement
+-- `docs/RULES.md` says this project exists to remove.
+--
+-- **Set-once is the right rule because the URI is content-addressed.** An IPFS
+-- CID is a function of the bytes, so re-pinning the same rules yields the same
+-- URI and a re-pin is a no-op rather than a change. A *different* URI therefore
+-- means different bytes, always — there is no legitimate reason for this column
+-- to take a second value, and no need to reason case-by-case about which
+-- rewrites are honest.
+--
+-- The one genuine exception is a re-encoding of the same content — CIDv0
+-- `Qm…` against CIDv1 `bafy…` — which SQL cannot tell from a substitution
+-- without a CID parser. So the format is fixed at write time in `pinLeagueRules`
+-- instead, and the escape hatch here is another migration. That is deliberate:
+-- moving where a member's rules live should cost as much as changing the schema,
+-- because it is the same kind of act.
+--
+-- Clearing to NULL is refused for the same reason. Otherwise the rewrite is
+-- simply two statements instead of one, and a rule that a second UPDATE defeats
+-- is not a rule.
+--
+-- Same shape as `leagues_chain_anchor_is_immutable` in 0014 and
+-- `drafts_order_is_immutable` in 0010: it RAISEs rather than clamping, because
+-- unlike 0043's status column there is no ten-minute ingest to keep alive here —
+-- a refused pin is a retry, and a silent clamp would hide a caller that had
+-- genuinely lost track of which document it was attaching.
+
+CREATE FUNCTION leagues_rules_uri_is_set_once() RETURNS trigger AS $$
+BEGIN
+  IF OLD.rules_uri IS NOT NULL AND NEW.rules_uri IS DISTINCT FROM OLD.rules_uri THEN
+    RAISE EXCEPTION
+      'League % has its rules pinned at %, and that cannot be repointed to %',
+      OLD.id, OLD.rules_uri, COALESCE(NEW.rules_uri, '(null)');
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER leagues_rules_uri_set_once
+  BEFORE UPDATE ON leagues
+  FOR EACH ROW EXECUTE FUNCTION leagues_rules_uri_is_set_once();
+
+COMMENT ON COLUMN leagues.rules_uri IS
+  'Where the canonical rule document is pinned, as an IPFS URI. Written once by '
+  'setRulesUri after a successful pin and never again — see '
+  'leagues_rules_uri_set_once. NULL means the rules exist and are hashed but '
+  'have not been published yet, which is an ordinary state: pinning is a network '
+  'call that can fail, and a league with no members yet publishes nothing.';
+
+-- Leagues whose rules were never published. The mirror of 0014's
+-- `leagues_unanchored_idx`, and a real state for the same reason: the pin is a
+-- second step after creation and it can fail on its own.
+CREATE INDEX leagues_unpinned_idx ON leagues (created_at) WHERE rules_uri IS NULL;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -62,6 +62,7 @@ export {
   type CreatedLeague,
   type CreateLeagueInput,
   type LeagueChainState,
+  type PinnedRules,
   type StoredLeagueRules,
 } from "./leagues.js";
 

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -889,6 +889,68 @@ describe("the rules URI is written once — #69 §3, §4", () => {
     expect(await storedUri(client, league.id)).toBe(uri);
   });
 
+  it("accepts an uppercase hash, like every other hash check in the repo", async () => {
+    // `0004` constrains the column to lowercase hex and `hashLeagueRules` emits
+    // it, so this can only arrive from a caller that upcased on the way through —
+    // and refusing a correct document over letter case would be silent and
+    // baffling. `verifyLeagueRulesHash` and `verifyPinnedRules` both normalise.
+    const { client, commissionerId } = await setup();
+    const league = await createLeague(client, NFL, {
+      name: "Shouty",
+      commissionerId,
+      rules: rules(),
+    });
+
+    expect(
+      await setRulesUri(client, league.id, {
+        uri: "ipfs://bafyhonest",
+        hash: league.rulesHash.toUpperCase(),
+      }),
+    ).toBe(true);
+    expect(await storedUri(client, league.id)).toBe("ipfs://bafyhonest");
+  });
+
+  it.each([
+    ["empty", ""],
+    ["blank", "   "],
+    ["a bare CID with no scheme", "QmdSc49tdSSLFADyr79TiVBZ2Tvah8sg54kmyTuqVViAN6"],
+    ["a scheme with nothing after it", "ipfs://"],
+  ])("throws rather than writing a URI that is not one: %s", async (_name, uri) => {
+    /*
+      The one unrecoverable argument. A wrong hash costs a retry; a malformed
+      URI is accepted and then frozen by 0044, so the column is bricked for the
+      life of the league. It throws rather than answering false because a
+      caller handing over a non-URI has a bug, not a refused state.
+    */
+    const { client, commissionerId } = await setup();
+    const league = await createLeague(client, NFL, {
+      name: "Malformed",
+      commissionerId,
+      rules: rules(),
+    });
+
+    await expect(
+      setRulesUri(client, league.id, { uri, hash: league.rulesHash }),
+    ).rejects.toThrow(/Not a pinning URI/);
+    expect(await storedUri(client, league.id)).toBeNull();
+  });
+
+  it("accepts the schemes the pinning services actually return", async () => {
+    // Pinata gives `ipfs://<cid>`; the in-memory service gives `memory://<hex>`.
+    // A check pinned to `ipfs://` alone would refuse every test double.
+    for (const uri of ["ipfs://bafyreal", "memory://0123abcd"]) {
+      const { client, commissionerId } = await setup();
+      const league = await createLeague(client, NFL, {
+        name: "Schemes",
+        commissionerId,
+        rules: rules(),
+      });
+
+      expect(await setRulesUri(client, league.id, { uri, hash: league.rulesHash }), uri).toBe(
+        true,
+      );
+    }
+  });
   it("leaves an unpinned league writable, and the other columns alone", async () => {
     // The trigger guards one column in one direction. A league that has not been
     // pinned is the ordinary state, and the chain anchor has to keep working.

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -889,6 +889,68 @@ describe("the rules URI is written once — #69 §3, §4", () => {
     expect(await storedUri(client, league.id)).toBe(uri);
   });
 
+  /*
+    The headline scenario, and it was the one case the block did not cover —
+    which is exactly why the docstring claimed something untrue about it.
+    Every other test here operates on a single league.
+  */
+  it("refuses another league's pin when that league's rules differ", async () => {
+    const { client, commissionerId } = await setup();
+    const mine = await createLeague(client, NFL, {
+      name: "Mine",
+      commissionerId,
+      rules: rules(),
+    });
+    const theirs = await createLeague(client, NFL, {
+      name: "Theirs",
+      commissionerId,
+      rules: rules({ seasonYear: 2027 }),
+    });
+    expect(theirs.rulesHash).not.toBe(mine.rulesHash);
+
+    // Their document, my league. Nothing matches, nothing is written.
+    expect(
+      await setRulesUri(client, mine.id, {
+        uri: "ipfs://bafytheirs",
+        hash: theirs.rulesHash,
+      }),
+    ).toBe(false);
+    expect(await storedUri(client, mine.id)).toBeNull();
+  });
+
+  it("writes when two leagues share a rule set, because the URI is the same one", async () => {
+    /*
+      The swap guards the document, not the league, and those come apart:
+      `hashLeagueRules` is a pure function of the rule set, so two leagues from
+      one template hash identically and each accepts the other's pin.
+
+      That is safe for a reason the predicate does not supply. Identical hashes
+      mean identical canonical bytes, and a CID is a function of the bytes — so
+      the URI being attached is byte-for-byte the one this league should have
+      had. Asserting it rather than describing it, because the whole set-once
+      rule in 0044 rests on this property.
+    */
+    const { client, commissionerId } = await setup();
+    const one = await createLeague(client, NFL, {
+      name: "One",
+      commissionerId,
+      rules: rules(),
+    });
+    const two = await createLeague(client, NFL, {
+      name: "Two",
+      commissionerId,
+      rules: rules(),
+    });
+
+    expect(one.id).not.toBe(two.id);
+    expect(two.rulesHash).toBe(one.rulesHash);
+    // The reason it is safe: same rules, same bytes, therefore same address.
+    expect(two.canonical).toBe(one.canonical);
+
+    const uri = "ipfs://bafyshared";
+    expect(await setRulesUri(client, one.id, { uri, hash: two.rulesHash })).toBe(true);
+    expect(await storedUri(client, one.id)).toBe(uri);
+  });
   it("accepts an uppercase hash, like every other hash check in the repo", async () => {
     // `0004` constrains the column to lowercase hex and `hashLeagueRules` emits
     // it, so this can only arrive from a caller that upcased on the way through —

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -289,7 +289,7 @@ describe("createLeague", () => {
       rules: rules(),
     });
 
-    await setRulesUri(client, league.id, "ipfs://bafyfake");
+    await setRulesUri(client, league.id, { uri: "ipfs://bafyfake", hash: league.rulesHash });
 
     const [row] = await client.query<{ rules_uri: string }>(
       "SELECT rules_uri FROM leagues WHERE id = $1",
@@ -503,7 +503,7 @@ describe("the frozen rules are frozen against ordinary SQL", () => {
     const { client, commissionerId } = await setup();
     const created = await frozenLeague(client, commissionerId);
 
-    await setRulesUri(client, created.id, "ipfs://bafyfake");
+    await setRulesUri(client, created.id, { uri: "ipfs://bafyfake", hash: created.rulesHash });
     await recordChainAnchor(client, created.id, { signature: "sig", cluster: "localnet" });
 
     expect((await getChainState(client, created.id))?.cluster).toBe("localnet");
@@ -766,5 +766,143 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
     await expect(
       verifyStoredRules(client, "00000000-0000-0000-0000-000000000000"),
     ).resolves.toBe(false);
+  });
+});
+
+describe("the rules URI is written once — #69 §3, §4", () => {
+  /*
+    `rules_hash` is the guarantee and `0004` already protects it. `rules_uri` is
+    the address a member actually fetches in order to *read* the rules, and it
+    was a plain nullable column any UPDATE could move anywhere.
+
+    Repointing it leaves `rules_hash` untouched, so `verifyStoredRules`, the
+    trigger in `0004` and the on-chain anchor all still agree and nothing in the
+    system notices. A member who hashes what they fetched is safe; the defect is
+    that it makes the careless path and the careful path disagree in silence.
+  */
+
+  const pinned = async (client: PGliteClient, commissionerId: string) => {
+    const league = await createLeague(client, NFL, {
+      name: "Pinned",
+      commissionerId,
+      rules: rules(),
+    });
+    const uri = "ipfs://bafyhonest";
+    expect(await setRulesUri(client, league.id, { uri, hash: league.rulesHash })).toBe(true);
+    return { league, uri };
+  };
+
+  const storedUri = async (client: PGliteClient, leagueId: string) => {
+    const [row] = await client.query<{ rules_uri: string | null }>(
+      "SELECT rules_uri FROM leagues WHERE id = $1",
+      [leagueId],
+    );
+    return row!.rules_uri;
+  };
+
+  it("records the pin when the hash is the league's own", async () => {
+    const { client, commissionerId } = await setup();
+    const { league, uri } = await pinned(client, commissionerId);
+
+    expect(await storedUri(client, league.id)).toBe(uri);
+  });
+
+  it("refuses a document that hashes to something else", async () => {
+    /*
+      The mixup this swap exists for: pin document A, attach it to a league whose
+      rules are B. It would look right — the URI resolves, the document is a
+      valid rule set, `rules_hash` is untouched — and only a member who fetched
+      and hashed it would ever find out.
+    */
+    const { client, commissionerId } = await setup();
+    const league = await createLeague(client, NFL, {
+      name: "Mine",
+      commissionerId,
+      rules: rules(),
+    });
+    const somebodyElses = hashLeagueRules(rules({ seasonYear: 2027 }));
+    expect(somebodyElses).not.toBe(league.rulesHash);
+
+    expect(
+      await setRulesUri(client, league.id, { uri: "ipfs://bafyother", hash: somebodyElses }),
+    ).toBe(false);
+    expect(await storedUri(client, league.id)).toBeNull();
+  });
+
+  it("refuses a league that does not exist", async () => {
+    const { client } = await setup();
+
+    expect(
+      await setRulesUri(client, "00000000-0000-0000-0000-000000000000", {
+        uri: "ipfs://bafyghost",
+        hash: "0".repeat(64),
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a genuine retry as a no-op success", async () => {
+    // Re-pinning is content-addressed, so the same rules give back the same URI.
+    // A retry after a lost response must not read as a refusal.
+    const { client, commissionerId } = await setup();
+    const { league, uri } = await pinned(client, commissionerId);
+
+    expect(await setRulesUri(client, league.id, { uri, hash: league.rulesHash })).toBe(true);
+    expect(await storedUri(client, league.id)).toBe(uri);
+  });
+
+  it("refuses to repoint a league that is already pinned", async () => {
+    const { client, commissionerId } = await setup();
+    const { league, uri } = await pinned(client, commissionerId);
+
+    expect(
+      await setRulesUri(client, league.id, {
+        uri: "ipfs://bafyswapped",
+        hash: league.rulesHash,
+      }),
+    ).toBe(false);
+    expect(await storedUri(client, league.id)).toBe(uri);
+  });
+
+  it("refuses a repoint at the database, past the function entirely", async () => {
+    // 0044. The predicate in setRulesUri never lets this reach the trigger, so
+    // the trigger is only reachable by a writer that went around the function —
+    // which is the writer it exists for.
+    const { client, commissionerId } = await setup();
+    const { league, uri } = await pinned(client, commissionerId);
+
+    await expect(
+      client.query("UPDATE leagues SET rules_uri = $2 WHERE id = $1", [
+        league.id,
+        "ipfs://bafyswapped",
+      ]),
+    ).rejects.toThrow(/cannot be repointed/);
+    expect(await storedUri(client, league.id)).toBe(uri);
+  });
+
+  it("refuses to clear it back to null, which is the same rewrite in two steps", async () => {
+    const { client, commissionerId } = await setup();
+    const { league, uri } = await pinned(client, commissionerId);
+
+    await expect(
+      client.query("UPDATE leagues SET rules_uri = NULL WHERE id = $1", [league.id]),
+    ).rejects.toThrow(/cannot be repointed/);
+    expect(await storedUri(client, league.id)).toBe(uri);
+  });
+
+  it("leaves an unpinned league writable, and the other columns alone", async () => {
+    // The trigger guards one column in one direction. A league that has not been
+    // pinned is the ordinary state, and the chain anchor has to keep working.
+    const { client, commissionerId } = await setup();
+    const league = await createLeague(client, NFL, {
+      name: "Unpinned",
+      commissionerId,
+      rules: rules(),
+    });
+
+    await client.query("UPDATE leagues SET name = $2 WHERE id = $1", [league.id, "Renamed"]);
+    await recordChainAnchor(client, league.id, { signature: "sig", cluster: "localnet" });
+
+    expect((await getChainState(client, league.id))?.cluster).toBe("localnet");
+    expect(await storedUri(client, league.id)).toBeNull();
   });
 });

--- a/packages/db/src/leagues.ts
+++ b/packages/db/src/leagues.ts
@@ -27,12 +27,6 @@ export interface CreateLeagueInput {
   readonly name: string;
   readonly commissionerId: string;
   readonly rules: LeagueRules;
-  /**
-   * Where the canonical rule document is pinned. Optional at creation: a league
-   * in FORMING state with no members yet anchors nothing. It must be set before
-   * anyone joins — see `setRulesUri`.
-   */
-  readonly rulesUri?: string;
 }
 
 export interface CreatedLeague {
@@ -69,8 +63,11 @@ export async function createLeague(
 
   return withTransaction(db, async (tx) => {
     const [league] = await tx.query<{ id: string }>(
-      `INSERT INTO leagues (sport_id, season, name, visibility, commissioner_id, rules_hash, rules_uri)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+      // No `rules_uri` here. It is set only by `setRulesUri`, after a pin that
+      // verified its own round trip — and `0044` freezes the first value written,
+      // so an unverified one at INSERT would be permanent. See that function.
+      `INSERT INTO leagues (sport_id, season, name, visibility, commissioner_id, rules_hash)
+       VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING id`,
       [
         ids.sportId,
@@ -79,7 +76,6 @@ export async function createLeague(
         input.rules.league.visibility,
         input.commissionerId,
         rulesHash,
-        input.rulesUri ?? null,
       ],
     );
     const leagueId = league!.id;
@@ -134,6 +130,16 @@ export async function createLeague(
   });
 }
 
+/**
+ * A scheme, `://`, and at least one non-space character.
+ *
+ * Deliberately not `ipfs://` alone — `InMemoryPinningService` returns
+ * `memory://<hex>`, so a stricter pattern would refuse every test double. The
+ * no-whitespace tail matters more than it looks: `"ipfs:// "` would otherwise
+ * pass, and `0044` freezes whatever is written first.
+ */
+const PINNING_URI = /^[a-z][a-z0-9+.-]*:\/\/\S+$/;
+
 /** A pinned rule document: where it lives, and what it hashes to. */
 export interface PinnedRules {
   /** The content address the bytes were published at. */
@@ -167,8 +173,21 @@ export interface PinnedRules {
  * it, which is precisely the check this column exists to spare them.
  *
  * So the swap is on `rules_hash`: the row is written only if the league's own
- * hash is the hash of the bytes that were pinned. Wrong league, wrong document,
- * either way there is no row to update and no write.
+ * hash is the hash of the bytes that were pinned. A document belonging to a
+ * league with different rules matches nothing, so there is no row to update.
+ *
+ * **It guards the document, not the league, and those come apart.**
+ * `hashLeagueRules` is a pure function of the rule set — no league id, no name —
+ * so two leagues created from one template have the *same* `rules_hash`, and
+ * attaching one's pin to the other does write. That is not a hole, but the
+ * reason is content-addressing rather than the swap: identical hashes mean
+ * identical canonical bytes, identical bytes mean an identical CID, so the URI
+ * being attached is byte-for-byte the one that league should have had. The
+ * league ends up correct by a different route than the predicate.
+ *
+ * Which is why the predicate cannot be relaxed to trust the caller's league id
+ * alone, and why `pinLeagueRules` verifying its own round trip before this is
+ * called is load-bearing rather than belt-and-braces.
  *
  * `rules_uri = $1` in the predicate makes a genuine retry a no-op success rather
  * than a refusal — re-pinning is content-addressed, so the same rules give back
@@ -196,7 +215,6 @@ export async function setRulesUri(
     a caller handing over a non-URI has a bug, and `pinLeagueRules` already
     refuses a response with no CID in it.
   */
-  const PINNING_URI = new RegExp("^[a-z][a-z0-9+.-]*://.+");
   if (!PINNING_URI.test(pinned.uri)) {
     throw new Error(`Not a pinning URI: ${JSON.stringify(pinned.uri)}`);
   }

--- a/packages/db/src/leagues.ts
+++ b/packages/db/src/leagues.ts
@@ -185,13 +185,32 @@ export async function setRulesUri(
   leagueId: string,
   pinned: PinnedRules,
 ): Promise<boolean> {
+  /*
+    Refuse a URI that is not one, rather than writing it.
+
+    This is the one argument the function cannot second-guess after the fact.
+    A wrong `hash` is caught by the swap and costs a retry; a malformed `uri`
+    is *accepted*, and `0044` then makes it permanent — so an empty string
+    would brick the column for the life of the league. Every other refusal here
+    is recoverable and this one is not, which is why it is the one that throws:
+    a caller handing over a non-URI has a bug, and `pinLeagueRules` already
+    refuses a response with no CID in it.
+  */
+  const PINNING_URI = new RegExp("^[a-z][a-z0-9+.-]*://.+");
+  if (!PINNING_URI.test(pinned.uri)) {
+    throw new Error(`Not a pinning URI: ${JSON.stringify(pinned.uri)}`);
+  }
+
   const rows = await db.query<{ id: string }>(
     `UPDATE leagues SET rules_uri = $1
       WHERE id = $2
         AND rules_hash = $3
         AND (rules_uri IS NULL OR rules_uri = $1)
       RETURNING id`,
-    [pinned.uri, leagueId, pinned.hash],
+    // Lowercased to match the column, which `0004` constrains to lowercase hex.
+    // `verifyLeagueRulesHash` and `verifyPinnedRules` both normalise their input;
+    // an entry point that did not would silently refuse a correct document.
+    [pinned.uri, leagueId, pinned.hash.toLowerCase()],
   );
   return rows.length > 0;
 }

--- a/packages/db/src/leagues.ts
+++ b/packages/db/src/leagues.ts
@@ -134,19 +134,66 @@ export async function createLeague(
   });
 }
 
+/** A pinned rule document: where it lives, and what it hashes to. */
+export interface PinnedRules {
+  /** The content address the bytes were published at. */
+  readonly uri: string;
+  /**
+   * The hash of the bytes that were pinned — not the hash the league is
+   * expected to have. The point of passing it is that the two can differ.
+   */
+  readonly hash: string;
+}
+
 /**
- * Record where the rule document is pinned.
+ * Record where a league's rule document is pinned.
  *
  * Separate from creation because pinning is a network call that can fail, and a
- * league with no members yet anchors nothing. `leagues` is mutable; the rules
+ * league with no members yet publishes nothing. `leagues` is mutable; the rules
  * themselves are not.
+ *
+ * **Takes the pinned document's hash and swaps on it.** This used to be a bare
+ * `UPDATE … SET rules_uri = $1 WHERE id = $2`, which writes whatever it is
+ * handed to whichever league it is handed, and the caller is the only thing
+ * standing between those two being the same document. Issue #69 §4.
+ *
+ * That caller is an async pin: encode, upload, await, then write. Nothing in
+ * that shape keeps a league id and a CID together — a retry closing over a stale
+ * variable, two creations in flight, or an argument order slip all end with a
+ * league pointing at somebody else's rules. And it would look right: the URI
+ * resolves, the document is a valid rule set, and `rules_hash` is untouched, so
+ * `verifyStoredRules`, `0004`'s trigger and the on-chain anchor all still pass.
+ * The mismatch is only visible to a member who fetches the document and hashes
+ * it, which is precisely the check this column exists to spare them.
+ *
+ * So the swap is on `rules_hash`: the row is written only if the league's own
+ * hash is the hash of the bytes that were pinned. Wrong league, wrong document,
+ * either way there is no row to update and no write.
+ *
+ * `rules_uri = $1` in the predicate makes a genuine retry a no-op success rather
+ * than a refusal — re-pinning is content-addressed, so the same rules give back
+ * the same URI. `0044`'s `leagues_rules_uri_set_once` is the backstop under
+ * both clauses; in the ordinary path it never fires.
+ *
+ * @returns `true` if the league now points at `pinned.uri`. `false` means it was
+ * refused — no such league, its rules hash to something else, or it is already
+ * pinned somewhere different — and the caller must not treat the rules as
+ * published.
  */
 export async function setRulesUri(
   db: SqlClient,
   leagueId: string,
-  rulesUri: string,
-): Promise<void> {
-  await db.query("UPDATE leagues SET rules_uri = $1 WHERE id = $2", [rulesUri, leagueId]);
+  pinned: PinnedRules,
+): Promise<boolean> {
+  const rows = await db.query<{ id: string }>(
+    `UPDATE leagues SET rules_uri = $1
+      WHERE id = $2
+        AND rules_hash = $3
+        AND (rules_uri IS NULL OR rules_uri = $1)
+      RETURNING id`,
+    [pinned.uri, leagueId, pinned.hash],
+  );
+  return rows.length > 0;
 }
 
 export interface ChainAnchor {

--- a/packages/pinning/src/pinata.ts
+++ b/packages/pinning/src/pinata.ts
@@ -49,6 +49,23 @@ export class PinataPinningService implements PinningService {
     form.append("file", new Blob([content], { type: "application/json" }), name);
     form.append("pinataMetadata", JSON.stringify({ name }));
 
+    /*
+      Pin at CIDv0 explicitly, because the URI it produces is written once.
+
+      A CID is a function of the bytes, so re-pinning the same rules gives back
+      the same address and a retry is a no-op — that is what lets `setRulesUri`
+      treat an identical URI as success and what makes `0044`'s set-once rule
+      safe. But CIDv0 `Qm…` and CIDv1 `bafy…` are two encodings of the same
+      multihash, and which one comes back is an **account setting** on Pinata's
+      side, not a property of the bytes. Left to the default, a change nobody
+      here made would produce a different string for identical rules — the retry
+      clause would miss, and the league, already pinned, could only be corrected
+      by a migration.
+
+      `0044` states that the format is fixed at write time. This is where.
+    */
+    form.append("pinataOptions", JSON.stringify({ cidVersion: 0 }));
+
     let response: Response;
     try {
       response = await this.doFetch(PIN_ENDPOINT, {

--- a/packages/pinning/src/pinning.test.ts
+++ b/packages/pinning/src/pinning.test.ts
@@ -171,6 +171,30 @@ describe("PinataPinningService", () => {
     expect(init.body).toBeInstanceOf(FormData);
   });
 
+  it("pins at CIDv0, because the URI it produces is written once", async () => {
+    /*
+      CIDv0 `Qm…` and CIDv1 `bafy…` encode the same multihash, and which one
+      comes back is an account setting on Pinata's side rather than a property
+      of the bytes. Left to the default, a change nobody here made would give a
+      different URI for identical rules.
+
+      Migration 0044 makes `leagues.rules_uri` set-once, and its whole argument
+      is that a CID is a function of the bytes — so a different URI means
+      different rules and there is no honest reason to repoint. This request is
+      what makes that true, and 0044's comment names it. Removing it would not
+      fail anything else: the league would simply be unrepointable at the wrong
+      address, correctable only by another migration.
+    */
+    const fetchImpl = mockFetch({});
+    const service = new PinataPinningService({ jwt: "token", fetchImpl });
+
+    await service.pin('{"a":1}', "rules.json");
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const options = (init.body as FormData).get("pinataOptions");
+    expect(options, "pinataOptions was not sent at all").toBeTypeOf("string");
+    expect(JSON.parse(options as string)).toEqual({ cidVersion: 0 });
+  });
   it("sends the content byte-for-byte as a file part", async () => {
     const fetchImpl = mockFetch({});
     const service = new PinataPinningService({ jwt: "token", fetchImpl });


### PR DESCRIPTION
Second and third of #69's four parts, together because each catches what the other cannot.

## The defect

`rules_hash` is the guarantee, and `0004` already protects it — `league_rules` refuses UPDATE and DELETE outright, and `0014` pins the on-chain anchor. But `rules_uri`, the address a member actually fetches in order to **read** the rules, was a plain nullable column written by:

```ts
await db.query("UPDATE leagues SET rules_uri = $1 WHERE id = $2", [rulesUri, leagueId]);
```

Repointing it leaves `rules_hash` untouched. So `verifyStoredRules`, `0004`'s trigger and the on-chain account all still agree, and nothing in the system notices — while every member who follows the link after the swap reads a different document from the one they joined under.

A member who fetches and hashes is safe. The defect is that this makes the careless path and the careful path disagree **silently**, which is the arrangement `docs/RULES.md` says the project exists to remove.

## §4 — the swap

`setRulesUri` takes `{ uri, hash }` and writes only if the league's own `rules_hash` is the hash of the bytes that were pinned:

```sql
UPDATE leagues SET rules_uri = $1
  WHERE id = $2 AND rules_hash = $3 AND (rules_uri IS NULL OR rules_uri = $1)
  RETURNING id
```

The caller is an async pin — encode, upload, await, write — and nothing in that shape keeps a league id and a CID together. A retry over a stale variable, two creations in flight, or an argument slip all end with a league pointing at somebody else's rules, and it would look right: the URI resolves, the document is a valid rule set, `rules_hash` is untouched.

`rules_uri = $1` keeps a genuine retry a no-op success, since re-pinning is content-addressed. It returns whether it wrote, so a refusal cannot be mistaken for a pin.

## §3 — the trigger

`0044` refuses a second value at the database, for the writer that goes around the function. Set-once is right **because** the URI is content-addressed: a different URI means different bytes, always, so there is no case-by-case reasoning about which rewrites are honest. Clearing to NULL is refused too, or the rewrite is two statements instead of one.

## Review — three agents, and one found a false claim

The migration and the swap held up: numbering clean under the CI guard, trigger arity checked at CREATE time, ordering against the four other BEFORE UPDATE triggers on `leagues` irrelevant since none rewrites `NEW`, no existing `UPDATE leagues` path broken, and the concurrency argument confirmed — under READ COMMITTED the loser re-evaluates the whole WHERE against the committed row and answers `false`, so no `FOR UPDATE` is wanted.

Four defects fixed, and the first is the one that mattered:

| | |
|---|---|
| **`0044` asserted a guarantee that did not exist** | Its header said the CIDv0/CIDv1 hazard was handled because "the format is fixed at write time in `pinLeagueRules`". **It was not** — nothing sent `cidVersion`, so which encoding came back was a Pinata *account setting*, not a property of the bytes. The whole argument for set-once is that a CID is a function of the bytes; without that line it is not. Fixed with `pinataOptions: { cidVersion: 0 }`, pinned by a test that fails if the line is removed. It ships in the same commit because an applied migration can never be edited. |
| **A malformed URI was accepted and then frozen** | The function checked the hash and trusted the URI absolutely, so an empty string was written and `0044` made it permanent. Wrong way round: a bad hash costs a retry, a bad URI costs the column for the life of the league. Now throws. Any scheme is accepted — the in-memory service returns `memory://`, so an `ipfs://`-only check would refuse every test double. |
| **The hash compared case-sensitively** | `0004` constrains the column to lowercase hex, and `verifyLeagueRulesHash` and `verifyPinnedRules` both normalise (the latter has a named test). This one would have silently refused a correct document. |
| **`PinnedRules` was unnameable** | Public parameter type, missing from the barrel. |

**Not taken:** `leagues_unpinned_idx` earns nothing measurable, but it mirrors `0014`'s `leagues_unanchored_idx` on the same table. Both or neither, in its own migration.

## Verification

Each half disabled separately. Without `0044`, the two database-level tests fail. Without the swap, three fail — and one of those is the trigger catching a repoint the swap would have refused, which is the defence in depth working. Removing `cidVersion` fails its own test. **1545 passing** across `db`, `pinning` and `core`.

## Deployment note

`0044` needs `pnpm db:migrate`. Confirmed safe: `setRulesUri` has no production caller on `main` (only a TODO at `apps/web/src/app/api/leagues/route.ts:400`), `createLeague`'s optional `rulesUri` is never passed, and IPFS pinning is still unchecked in `SETUP-REQUIRED.md` — so no deployed row carries a `rules_uri` and freezing is a no-op on real data. Landing this **before** the A8 wiring is the right order; after the first real pin, a wrong URI costs a migration.

## Not in this PR

§2, the pinning wire-up. Hardening `setRulesUri` first is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)