### PR TITLE
The rules hash covers the bytes it is a hash of (#294)

### DIFF
--- a/packages/db/migrations/0045_the_hash_covers_the_bytes.sql
+++ b/packages/db/migrations/0045_the_hash_covers_the_bytes.sql
@@ -1,0 +1,146 @@
+-- The rules hash covers the bytes it is a hash of. Issue #294.
+--
+-- `0004` checks that an incoming `league_rules` row declares the hash its league
+-- declares, and that is all it checks. `check_rules_hash_matches` reads
+-- `NEW.hash` and never looks at `NEW.canonical` or `NEW.rule_json`, so a plain
+-- INSERT at ordinary application privilege can store *any bytes at all* under a
+-- correct hash — and both that trigger and the on-chain anchor accept it.
+--
+-- `0019` closed the sibling hole, where `leagues.rules_hash` could be rewritten
+-- after the fact, and its header says so. This is the half it left open: the
+-- hash was made immutable without anything tying it to the document it hashes.
+--
+-- Reproduced before writing this, on a database with 0001–0044 applied: a row
+-- whose `canonical` and `rule_json` hold a different rule set entirely is
+-- accepted; and a row whose two byte columns disagree *with each other* is
+-- accepted, passes `verifyStoredRules`, matches the chain, and still serves the
+-- wrong number to the lobby.
+--
+-- ---------------------------------------------------------------------------
+-- Why it is worth a migration when there is no live exploit
+-- ---------------------------------------------------------------------------
+--
+-- `createLeague` is the only production writer and it binds one string to both
+-- columns, one line apart, from one encoder. So nothing today can produce a
+-- divergent row, and this closes a hole rather than fixing a leak.
+--
+-- It is filed and fixed anyway for three reasons.
+--
+-- **Two live consumers already document the guarantee as though it held.**
+-- `apps/web/src/app/api/leagues/route.ts` reads `rule_json` for the lobby's
+-- seat count, draft time and buy-in under the comment *"come from the frozen
+-- rule document rather than from a column, because that document is what a
+-- member signs"* — and `rule_json` is a column, and not the one the hash
+-- covers. `0028` reads the same column to decide what `drafts.scheduled_at` is
+-- allowed to be, under a comment calling the document *"checkable by a
+-- stranger"*. A stranger holds the **pinned** bytes, which are `canonical`.
+-- Comments like those are how a second writer gets written.
+--
+-- **`0004` says the wrong column is authoritative, and cannot be corrected.**
+-- Its line *"`league_rules.rule_json` remains authoritative"* was true when
+-- written and is now false: `getLeagueRules` does not even SELECT that column,
+-- and roughly forty-seven production call sites read `canonical`. An applied
+-- migration may never be edited, so that sentence stands in the tree forever
+-- and this header is the correction. It is plausibly *why* `0028` wired an
+-- enforcement decision to the unhashed column.
+--
+-- **The window closes.** `league_rules` refuses UPDATE and DELETE, so a row
+-- written before this trigger exists can never be repaired or removed — only
+-- exempted. The table is effectively empty today. Once real leagues exist, this
+-- migration needs a backfill story it does not need now.
+--
+-- ---------------------------------------------------------------------------
+-- Shape
+-- ---------------------------------------------------------------------------
+--
+-- **A second trigger, not a rewrite of `0004`'s.** `CREATE OR REPLACE` on
+-- `check_rules_hash_matches` would leave `0004` describing a function body that
+-- no longer runs, in a repo that treats a comment asserting something untrue as
+-- a defect in its own right. The cost is that fire order now matters — see
+-- below.
+--
+-- **Two sequential `IF`s, not one `OR`.** PostgreSQL does not guarantee the
+-- evaluation order of `OR` operands. With the operands the other way round, a
+-- `canonical` that is not JSON at all raises `22P02 invalid input syntax for
+-- type json` from the cast instead of the byte check's own message. Sequential
+-- statements make the order structural rather than incidental.
+--
+-- **The name is load-bearing.** Same-event triggers fire in *name* order, so
+-- `league_rules_stored_bytes_match_hash` sorts after `league_rules_hash_matches`
+-- and `0004` still answers the coarser question first: a row declaring the wrong
+-- league's hash is reported as a hash mismatch, not as a byte mismatch. Renaming
+-- this to sort earlier changes which error a caller sees. There is a test
+-- pinning that order.
+--
+-- **`sha256(bytea)`, not `pgcrypto`.** Built in since PostgreSQL 11 and present
+-- in both Supabase and PGlite; `CREATE EXTENSION pgcrypto` fails outright in
+-- PGlite (`extension "pgcrypto" is not available`), which would take every
+-- database-backed test in the repo down with it. Verified byte-identical to
+-- `sha256Hex` in `packages/core` across ASCII, emoji, CJK, NFC and NFD accents,
+-- and a real 3908-byte `encodeLeagueRules` document.
+--
+-- **`convert_to(…, 'UTF8')` names the encoding the hash is defined over** rather
+-- than inheriting the server's. On a UTF8 database it is the identity, and it is
+-- what makes the digest portable instead of a property of the deployment.
+--
+-- ---------------------------------------------------------------------------
+-- What this does not do
+-- ---------------------------------------------------------------------------
+--
+-- It makes the three columns agree with **each other**. It cannot know they are
+-- the rules the commissioner meant: `0019` freezes `leagues.rules_hash` only
+-- once a `league_rules` row exists, so a writer controlling both rows can still
+-- write a self-consistent league holding rules nobody agreed to. This closes
+-- divergence, not substitution.
+--
+-- Nor does it catch a duplicated key on its own terms. The first check catches
+-- one *because the duplicate changes the bytes*, and therefore the hash. The
+-- second cannot: `canonical::jsonb` normalises duplicates exactly as `rule_json`
+-- does. That is acceptable rather than a gap — jsonb and JavaScript's own
+-- `JSON.parse` both keep the last duplicate, so once the bytes are pinned the
+-- two columns cannot disagree about anything a reader can observe.
+
+CREATE FUNCTION check_stored_rule_bytes() RETURNS trigger AS $$
+BEGIN
+  -- The bytes are the bytes that were hashed.
+  IF encode(sha256(convert_to(NEW.canonical, 'UTF8')), 'hex') IS DISTINCT FROM NEW.hash THEN
+    RAISE EXCEPTION
+      'stored rule bytes do not hash to their declared hash: league % declares %, its % canonical bytes hash to %',
+      NEW.league_id, NEW.hash, length(NEW.canonical),
+      encode(sha256(convert_to(NEW.canonical, 'UTF8')), 'hex')
+      USING ERRCODE = 'integrity_constraint_violation';
+  END IF;
+
+  -- And the column that gets queried is the document those bytes encode.
+  --
+  -- Second, so that a `canonical` which is not JSON at all is refused by the
+  -- check above with its own message, rather than by this cast with `22P02`.
+  IF NEW.rule_json IS DISTINCT FROM NEW.canonical::jsonb THEN
+    RAISE EXCEPTION
+      'rule_json is not the document in canonical: league % — the queried column and the hashed column hold different rules',
+      NEW.league_id
+      USING ERRCODE = 'integrity_constraint_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Named to sort after `league_rules_hash_matches`. See the note above; this is
+-- not cosmetic.
+CREATE TRIGGER league_rules_stored_bytes_match_hash
+  BEFORE INSERT ON league_rules
+  FOR EACH ROW EXECUTE FUNCTION check_stored_rule_bytes();
+
+COMMENT ON COLUMN league_rules.canonical IS
+  'The exact bytes that were hashed, and the document that is pinned. '
+  'Authoritative: getLeagueRules parses this column and nothing else, and every '
+  'rule decision in the application comes from it. Checked against hash on '
+  'INSERT by league_rules_stored_bytes_match_hash.';
+
+COMMENT ON COLUMN league_rules.rule_json IS
+  'The same document as canonical, parsed, so SQL can reach individual rule '
+  'fields without a round trip. A convenience copy and never the source of '
+  'truth — 0004 called it authoritative and that has long been false. Pinned to '
+  'canonical on INSERT by league_rules_stored_bytes_match_hash, so the two '
+  'cannot disagree about anything a reader can observe.';

--- a/packages/db/migrations/0045_the_hash_covers_the_bytes.sql
+++ b/packages/db/migrations/0045_the_hash_covers_the_bytes.sql
@@ -32,8 +32,9 @@
 -- rule document rather than from a column, because that document is what a
 -- member signs"* — and `rule_json` is a column, and not the one the hash
 -- covers. `0028` reads the same column to decide what `drafts.scheduled_at` is
--- allowed to be, under a comment calling the document *"checkable by a
--- stranger"*. A stranger holds the **pinned** bytes, which are `canonical`.
+-- allowed to be, under a comment saying that comparing against the frozen
+-- document is *"what keeps this checkable by a stranger"*. A stranger holds the
+-- **pinned** bytes, which are `canonical`.
 -- Comments like those are how a second writer gets written.
 --
 -- **`0004` says the wrong column is authoritative, and cannot be corrected.**
@@ -41,8 +42,13 @@
 -- written and is now false: `getLeagueRules` does not even SELECT that column,
 -- and roughly forty-seven production call sites read `canonical`. An applied
 -- migration may never be edited, so that sentence stands in the tree forever
--- and this header is the correction. It is plausibly *why* `0028` wired an
--- enforcement decision to the unhashed column.
+-- and this header is the correction.
+--
+-- (An earlier draft guessed that line was *why* `0028` wired an enforcement
+-- decision to the unhashed column. Cut: `0028` gives its own reason — that
+-- `rule_json` "is itself immutable by trigger (0004)" — and never cites the
+-- authority claim. Attributing a motive to another commit is not something to
+-- put in a file that can never be edited.)
 --
 -- **The window closes.** `league_rules` refuses UPDATE and DELETE, so a row
 -- written before this trigger exists can never be repaired or removed — only
@@ -59,18 +65,27 @@
 -- a defect in its own right. The cost is that fire order now matters — see
 -- below.
 --
--- **Two sequential `IF`s, not one `OR`.** PostgreSQL does not guarantee the
--- evaluation order of `OR` operands. With the operands the other way round, a
--- `canonical` that is not JSON at all raises `22P02 invalid input syntax for
--- type json` from the cast instead of the byte check's own message. Sequential
--- statements make the order structural rather than incidental.
+-- **Sequential `IF`s, not one `OR`.** PostgreSQL does not guarantee the
+-- evaluation order of `OR` operands, so a compound condition would leave which
+-- message you get up to the planner. Sequential statements make the order
+-- structural. The explicit `IS NOT JSON` check exists for the same reason and is
+-- not redundant with them: a correct hash over bytes that are not JSON passes
+-- the first check and would otherwise reach the cast.
 --
--- **The name is load-bearing.** Same-event triggers fire in *name* order, so
--- `league_rules_stored_bytes_match_hash` sorts after `league_rules_hash_matches`
--- and `0004` still answers the coarser question first: a row declaring the wrong
--- league's hash is reported as a hash mismatch, not as a byte mismatch. Renaming
--- this to sort earlier changes which error a caller sees. There is a test
--- pinning that order.
+-- **The name is load-bearing, and for more than the message.** Same-event
+-- triggers fire in *name* order — byte order, not collation, so it is stable
+-- across locales — and `league_rules_stored_bytes_match_hash` sorts after
+-- `league_rules_hash_matches`, so `0004` still answers the coarser question
+-- first: a row declaring the wrong league's hash is reported as a hash mismatch
+-- rather than a byte mismatch. There is a test pinning that.
+--
+-- For *this* pair the order only decides the message, since neither function
+-- modifies `NEW`. It decides correctness the moment any `BEFORE INSERT` trigger
+-- that *does* modify `NEW` is added at any sort position: one sorting after this
+-- can rewrite `canonical` and `rule_json` after both checks have passed, and one
+-- sorting between the two can rewrite `hash` after `0004` has accepted it.
+-- Demonstrated, both of them. Adding a mutating trigger to this table is
+-- therefore not a local change.
 --
 -- **`sha256(bytea)`, not `pgcrypto`.** Built in since PostgreSQL 11 and present
 -- in both Supabase and PGlite; `CREATE EXTENSION pgcrypto` fails outright in
@@ -95,13 +110,57 @@
 --
 -- Nor does it catch a duplicated key on its own terms. The first check catches
 -- one *because the duplicate changes the bytes*, and therefore the hash. The
--- second cannot: `canonical::jsonb` normalises duplicates exactly as `rule_json`
+-- third cannot: `canonical::jsonb` normalises duplicates exactly as `rule_json`
 -- does. That is acceptable rather than a gap — jsonb and JavaScript's own
--- `JSON.parse` both keep the last duplicate, so once the bytes are pinned the
--- two columns cannot disagree about anything a reader can observe.
+-- `JSON.parse` both keep the last duplicate, so a duplicate that survived would
+-- not change what either reader sees.
+--
+-- An earlier draft of this header claimed that, once the bytes are pinned, the
+-- two columns "cannot disagree about anything a reader can observe". **Review
+-- falsified it.** jsonb equality is *numeric* equality, so `{"a":1}` and
+-- `{"a":1.0}` were equal to the original check while `->> 'a'` answered `1` and
+-- `1.0` — and both consumers cast that result, so `0028` and the lobby query
+-- would have failed with `invalid input syntax for type bigint` on a row this
+-- trigger had accepted. Fail-closed, and still wrong. Comparing the rendered
+-- text on both sides closes it, which is why the third check reads the way it
+-- does rather than the obvious way.
+
+-- The one assumption this migration cannot verify from inside the repo, turned
+-- into a checked fact at deploy time.
+--
+-- `convert_to(…, 'UTF8')` is now load-bearing for whether a league can be
+-- created at all, and its correctness rests on the digest being taken over the
+-- same bytes Node hashed. On a UTF8 server that is the identity and was proven
+-- exhaustively — every one of the 1,112,064 Unicode code points agrees with
+-- `sha256Hex`. On a non-UTF8 server the round trip is lossless for anything
+-- representable, so it should still hold, but "should" is reasoning rather than
+-- a test, and no other check in this repo would notice if it did not.
+--
+-- Supabase provisions UTF8 and PGlite has no other encoding, so this refuses
+-- nothing that exists today. It fails the migration loudly on a deployment where
+-- the assumption is untrue, which is far better than hashing quietly wrong.
+DO $$
+BEGIN
+  IF current_setting('server_encoding') <> 'UTF8' THEN
+    RAISE EXCEPTION
+      'league rule hashing requires a UTF8 database; this one is %',
+      current_setting('server_encoding');
+  END IF;
+END;
+$$;
 
 CREATE FUNCTION check_stored_rule_bytes() RETURNS trigger AS $$
 BEGIN
+  -- Let the column's own NOT NULL answer for a null.
+  --
+  -- This trigger fires first, so without the early-out it reports "bytes do not
+  -- hash" with a `<NULL>` length — burying `null value in column "canonical"
+  -- violates not-null constraint`, which is the useful message. Unreachable from
+  -- `createLeague`; it costs one line to not mislead whoever does reach it.
+  IF NEW.canonical IS NULL THEN
+    RETURN NEW;
+  END IF;
+
   -- The bytes are the bytes that were hashed.
   IF encode(sha256(convert_to(NEW.canonical, 'UTF8')), 'hex') IS DISTINCT FROM NEW.hash THEN
     RAISE EXCEPTION
@@ -111,11 +170,35 @@ BEGIN
       USING ERRCODE = 'integrity_constraint_violation';
   END IF;
 
+  -- Those bytes are JSON, checked before anything casts them.
+  --
+  -- Without this, bytes that are not JSON *and* carry a correct hash reach the
+  -- cast below and surface as a raw `22P02 invalid input syntax for type json` —
+  -- which is fail-closed but says nothing about rules. Review found that case;
+  -- an earlier draft of this file claimed the clause order alone removed it, and
+  -- clause order only removes it when the hash is wrong too.
+  IF NEW.canonical IS NOT JSON THEN
+    RAISE EXCEPTION
+      'canonical is not JSON: league % — the hashed bytes are not a rule document',
+      NEW.league_id
+      USING ERRCODE = 'integrity_constraint_violation';
+  END IF;
+
   -- And the column that gets queried is the document those bytes encode.
   --
-  -- Second, so that a `canonical` which is not JSON at all is refused by the
-  -- check above with its own message, rather than by this cast with `22P02`.
-  IF NEW.rule_json IS DISTINCT FROM NEW.canonical::jsonb THEN
+  -- Compared as **rendered jsonb text on both sides**, not as jsonb. jsonb
+  -- equality is *numeric* equality, so `{"a":1}` and `{"a":1.0}` are equal to it
+  -- while `->>` answers `1` and `1.0` — and both consumers cast that result, so
+  -- the two columns can hold documents a reader distinguishes. Rendering both
+  -- through jsonb normalises key order and whitespace, which is what makes an
+  -- honest row pass however `rule_json` was written, while pinning the spelling
+  -- of every number.
+  --
+  -- `NEW.rule_json::text IS DISTINCT FROM NEW.canonical` would be wrong: jsonb
+  -- does not round-trip. It re-renders with a space after every colon and orders
+  -- keys by length then bytes, while the canonical encoder emits no whitespace
+  -- and orders by code unit. That comparison refuses every honest league.
+  IF NEW.rule_json::text IS DISTINCT FROM NEW.canonical::jsonb::text THEN
     RAISE EXCEPTION
       'rule_json is not the document in canonical: league % — the queried column and the hashed column hold different rules',
       NEW.league_id
@@ -134,9 +217,11 @@ CREATE TRIGGER league_rules_stored_bytes_match_hash
 
 COMMENT ON COLUMN league_rules.canonical IS
   'The exact bytes that were hashed, and the document that is pinned. '
-  'Authoritative: getLeagueRules parses this column and nothing else, and every '
-  'rule decision in the application comes from it. Checked against hash on '
-  'INSERT by league_rules_stored_bytes_match_hash.';
+  'Authoritative: getLeagueRules parses this column and nothing else, so every '
+  'rule decision reached through it comes from here. Two production readers go '
+  'to rule_json instead and are named in this migration''s header — do not read '
+  'this comment as saying there are none. Checked against hash on INSERT by '
+  'league_rules_stored_bytes_match_hash.';
 
 COMMENT ON COLUMN league_rules.rule_json IS
   'The same document as canonical, parsed, so SQL can reach individual rule '

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -1205,6 +1205,47 @@ describe("the hash covers the bytes — #294, migration 0045", () => {
     );
   });
 
+  it("refuses a number spelled differently in the two columns", async () => {
+    /*
+      Found by review, and it falsified the first version of this check.
+
+      jsonb equality is **numeric** equality, so `{"a":1}` and `{"a":1.0}` were
+      equal to `IS DISTINCT FROM` — while `->>` answers `1` and `1.0`. Both
+      consumers cast that result, so a row this trigger accepted would then break
+      `0028`'s draft-clock anchor and the lobby query with `invalid input syntax
+      for type bigint`. Fail-closed, and still a divergence the check claimed to
+      have removed.
+
+      Comparing the rendered text on both sides is what closes it.
+    */
+    const { client, commissionerId } = await setup();
+    const canonical = '{"scheduledAt":1767225600}';
+    const hash = sha256Hex(canonical);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(
+      insertRules(client, leagueId, '{"scheduledAt":1767225600.0}', canonical, hash),
+    ).rejects.toThrow(/rule_json is not the document in canonical/);
+  });
+
+  it("names non-JSON bytes as non-JSON, even under a correct hash", async () => {
+    /*
+      Also from review. With a *wrong* hash the byte check answers first and this
+      never arises — which is what an earlier version of the migration header
+      claimed made the case impossible. With a hash that is correct **for the
+      garbage**, the byte check passes and the cast raised a bare `22P02 invalid
+      input syntax for type json`: fail-closed, but saying nothing about rules.
+    */
+    const { client, commissionerId } = await setup();
+    const canonical = "not a rule document at all";
+    const hash = sha256Hex(canonical);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(insertRules(client, leagueId, '{"a":1}', canonical, hash)).rejects.toThrow(
+      /canonical is not JSON/,
+    );
+  });
+
   it("accepts rule_json written with different whitespace and key order", async () => {
     // jsonb compares as a document, not as text. Requiring the two columns to
     // match byte-for-byte would refuse every honest league: jsonb re-renders
@@ -1220,21 +1261,32 @@ describe("the hash covers the bytes — #294, migration 0045", () => {
     ).resolves.toBeDefined();
   });
 
-  it("lets 0004 answer first when the league's own hash is wrong", async () => {
+  it("lets 0004 answer first when both checks would refuse the row", async () => {
     /*
       Same-event triggers fire in **name** order, and
       `league_rules_stored_bytes_match_hash` is named to sort after
       `league_rules_hash_matches` so the coarser question is answered first.
-      Renaming either silently changes which error a caller sees; this is what
-      makes that dependency visible.
+
+      **The row has to be one both checks refuse**, and the first version of this
+      test got that wrong: it inserted bytes whose hash was correct *for
+      themselves* but not for the league, so 0045 never fired and only 0004 could
+      raise. It returned `rules hash mismatch` whichever way the triggers were
+      named — a green test pinning nothing, while the migration header claimed a
+      test pinned it. Proven under both namings before rewriting.
+
+      So: a hash that is wrong for the league *and* wrong for the bytes. Rename
+      the byte trigger to sort first and this reports `stored rule bytes do not
+      hash` instead.
     */
     const { client, commissionerId } = await setup();
     const leagueId = await leagueDeclaring(client, commissionerId, "0".repeat(64));
 
-    // These bytes hash correctly for themselves, but not to what the league declares.
     const canonical = '{"a":1}';
+    const wrongForBoth = "b".repeat(64);
+    expect(wrongForBoth).not.toBe(sha256Hex(canonical));
+
     await expect(
-      insertRules(client, leagueId, canonical, canonical, sha256Hex(canonical)),
+      insertRules(client, leagueId, canonical, canonical, wrongForBoth),
     ).rejects.toThrow(/rules hash mismatch/);
   });
 });

--- a/packages/db/src/leagues.test.ts
+++ b/packages/db/src/leagues.test.ts
@@ -6,6 +6,7 @@ import {
   NFL,
   NFL_DEFAULT_FEE_BPS,
   NFL_DEFAULT_PAYOUT,
+  sha256Hex,
 } from "@rostr/core";
 import type { DraftRules, LeagueRules, PotRules } from "@rostr/core";
 import {
@@ -583,14 +584,43 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
     corruption this check exists to catch." This did the opposite, while
     `CLAUDE.md` claimed it did the same.
 
-    **The corruption is inserted, not updated, and that is the reachable path.**
-    `league_rules_immutable` refuses UPDATE and DELETE on this table, so a
-    stored row cannot be rewritten. What is unguarded is the INSERT:
-    `check_rules_hash_matches` compares the incoming hash against
-    `leagues.rules_hash` and never looks at the bytes at all. So a row whose
-    bytes are anything whatsoever is accepted under a correct hash — at ordinary
-    application privilege, which is the threat `0019`'s header names.
+    **The INSERT is guarded now, and these tests disable the guard on purpose.**
+    This block used to say the insert was unguarded, and it was: `0004`'s
+    `check_rules_hash_matches` reads the incoming hash and never looks at the
+    bytes. `0045` closes that (issue #294), so the corrupt rows below can no
+    longer be written while its trigger is armed.
+
+    Disabling it is not a dodge. `0019`'s header names `DISABLE TRIGGER` as the
+    irreducible floor — no trigger can defend against dropping the trigger — so a
+    database with that guard off is precisely the state `verifyStoredRules`
+    exists to answer in. It is also the only check a *reader* can run: it needs
+    no privilege and reaches rows a migration might have let through.
+
+    Only `league_rules_stored_bytes_match_hash` is disabled, never
+    `session_replication_role = 'replica'`, which would take `league_rules_immutable`
+    down with it and let these tests silently UPDATE a frozen row.
   */
+
+  /** 0045's byte check. Disabled around the deliberately-corrupt inserts below. */
+  const BYTES_TRIGGER = "league_rules_stored_bytes_match_hash";
+
+  /**
+   * Insert a row 0045 would refuse.
+   *
+   * Re-armed in a `finally`, so a failing assertion cannot leave the guard off
+   * for whatever runs next against the same database.
+   */
+  const withBytesCheckOff = async <T>(
+    client: PGliteClient,
+    write: () => Promise<T>,
+  ): Promise<T> => {
+    await client.exec(`ALTER TABLE league_rules DISABLE TRIGGER ${BYTES_TRIGGER}`);
+    try {
+      return await write();
+    } finally {
+      await client.exec(`ALTER TABLE league_rules ENABLE TRIGGER ${BYTES_TRIGGER}`);
+    }
+  };
 
   const honest = encodeLeagueRules(rules());
 
@@ -631,15 +661,18 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
       ],
     );
 
-    // Accepted: the hash matches the league, and nothing checks the bytes.
-    await client.query(
-      `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
+    // Accepted only because 0045's byte check is off; 0004 alone looks at the
+    // hash and never at the bytes.
+    await withBytesCheckOff(client, () =>
+      client.query(
+        `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
        VALUES ($1, $2::jsonb, $3, $4)`,
-      // Two parameters for one value, deliberately. Bound once and used twice,
-      // Postgres infers a single type for the placeholder — jsonb, from the cast —
-      // and the text column then stores jsonb's normalised rendering instead of the
-      // bytes under test. That silently repairs the corruption before the check runs.
-      [league!.id, canonical, canonical, hash],
+        // Two parameters for one value, deliberately. Bound once and used twice,
+        // Postgres infers a single type for the placeholder — jsonb, from the cast —
+        // and the text column then stores jsonb's normalised rendering instead of the
+        // bytes under test. That silently repairs the corruption before the check runs.
+        [league!.id, canonical, canonical, hash],
+      ),
     );
 
     return league!.id;
@@ -748,10 +781,12 @@ describe("verifyStoredRules hashes the stored bytes — #69 §1", () => {
         hash,
       ],
     );
-    await client.query(
-      `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
-       VALUES ($1, $2::jsonb, $3, $4)`,
-      [league!.id, honest, canonical, hash],
+    await withBytesCheckOff(client, () =>
+      client.query(
+        `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
+         VALUES ($1, $2::jsonb, $3, $4)`,
+        [league!.id, honest, canonical, hash],
+      ),
     );
 
     // False, not a thrown SyntaxError.
@@ -1028,5 +1063,178 @@ describe("the rules URI is written once — #69 §3, §4", () => {
 
     expect((await getChainState(client, league.id))?.cluster).toBe("localnet");
     expect(await storedUri(client, league.id)).toBeNull();
+  });
+});
+
+describe("the hash covers the bytes — #294, migration 0045", () => {
+  /*
+    `0004` checks that an incoming row declares the hash its league declares,
+    and nothing else — never `canonical`, never `rule_json`. So any bytes at all
+    could be stored under a correct hash, at ordinary application privilege, and
+    both that trigger and the on-chain anchor accepted it.
+
+    No live exploit: `createLeague` binds one string to both columns. What made
+    it worth a migration is that two consumers already document the guarantee as
+    though it held — the lobby reads `rule_json` under a comment calling it "the
+    frozen rule document … what a member signs", and `0028` anchors the draft
+    clock to it under one calling it "checkable by a stranger". A stranger holds
+    the pinned bytes, which are `canonical`.
+  */
+
+  /** A league row whose declared hash is `hash`, so 0004's check passes. */
+  const leagueDeclaring = async (
+    client: PGliteClient,
+    commissionerId: string,
+    hash: string,
+  ): Promise<string> => {
+    const [sport] = await client.query<{ id: string }>("SELECT id FROM sports WHERE key = $1", [
+      NFL.key,
+    ]);
+    const [league] = await client.query<{ id: string }>(
+      `INSERT INTO leagues (sport_id, season, name, visibility, commissioner_id, rules_hash)
+       VALUES ($1, 2026, 'Bytes', 'PRIVATE', $2, $3) RETURNING id`,
+      [sport!.id, commissionerId, hash],
+    );
+    return league!.id;
+  };
+
+  const insertRules = (
+    client: PGliteClient,
+    leagueId: string,
+    ruleJson: string,
+    canonical: string,
+    hash: string,
+  ) =>
+    client.query(
+      `INSERT INTO league_rules (league_id, rule_json, canonical, hash)
+       VALUES ($1, $2::jsonb, $3, $4)`,
+      [leagueId, ruleJson, canonical, hash],
+    );
+
+  it("still lets an ordinary league be created", async () => {
+    // The first thing a byte check can break is the honest path.
+    const { client, commissionerId } = await setup();
+
+    const league = await createLeague(client, NFL, {
+      name: "Ordinary",
+      commissionerId,
+      rules: rules(),
+    });
+
+    expect(await verifyStoredRules(client, league.id)).toBe(true);
+  });
+
+  /*
+    **The case that matters most.** A false refusal here does not corrupt
+    anything — it makes league creation fail outright for a legitimate rule set.
+    The risk is real rather than theoretical: this check hashes in the database
+    and the application hashes in Node, so the two must agree on the UTF-8
+    encoding of every character a rule document can carry.
+  */
+  it.each([
+    ["ascii", '{"a":1}'],
+    ["emoji", '{"a":"🏈🇺🇸"}'],
+    ["CJK", '{"a":"中文テスト한국어"}'],
+    ["NFD accent", '{"a":"café"}'],
+    ["NFC accent", '{"a":"café"}'],
+    ["astral plane", '{"a":"𝔘𝔫𝔦"}'],
+    ["ZWJ sequence", '{"a":"👨‍👩‍👧"}'],
+    ["emoji as a key", '{"🏈":1}'],
+    ["escaped quote and backslash", '{"a":"he said \\"x\\" \\\\ y"}'],
+    ["escaped control characters", '{"a":"\\u001f\\u007f"}'],
+  ])("accepts an honest document containing %s", async (_name, canonical) => {
+    const { client, commissionerId } = await setup();
+    const hash = sha256Hex(canonical);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(
+      insertRules(client, leagueId, canonical, canonical, hash),
+    ).resolves.toBeDefined();
+    expect(await verifyStoredRules(client, leagueId)).toBe(true);
+  });
+
+  it("cannot store a NUL, and that is jsonb's limit rather than this check's", async () => {
+    /*
+      Postgres refuses \u0000 in a jsonb value outright — "unsupported Unicode
+      escape sequence" — however the surrounding document is escaped. Recorded
+      here because it looks like a false refusal from 0045 and is not: it is the
+      column type, it predates this migration, and it fires on the cast before
+      either trigger runs.
+
+      Reachable in principle through `pot.feeRecipient`, the one rule field with
+      no charset validation (`validate.ts` checks only that it is non-empty). It
+      fails closed — a write error at creation, never a corrupt row — so nothing
+      here has to defend against it.
+    */
+    const { client, commissionerId } = await setup();
+    const canonical = '{"a":"\\u0000"}';
+    const hash = sha256Hex(canonical);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(insertRules(client, leagueId, canonical, canonical, hash)).rejects.toThrow(
+      /unsupported Unicode escape sequence/,
+    );
+  });
+
+  it("refuses bytes that do not hash to the declared hash", async () => {
+    const { client, commissionerId } = await setup();
+    const honest = '{"a":1}';
+    const hash = sha256Hex(honest);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    // A different document entirely, under a correct hash. Accepted before 0045.
+    await expect(insertRules(client, leagueId, '{"a":99}', '{"a":99}', hash)).rejects.toThrow(
+      /stored rule bytes do not hash/,
+    );
+  });
+
+  it("refuses two byte columns that disagree with each other", async () => {
+    /*
+      The sharper shape, and the one `verifyStoredRules` cannot see: `canonical`
+      is honest, so the hash checks out and the chain agrees — while
+      `rule_json`, the column the lobby and `0028` actually query, holds
+      something else.
+    */
+    const { client, commissionerId } = await setup();
+    const honest = '{"a":1}';
+    const hash = sha256Hex(honest);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(insertRules(client, leagueId, '{"a":99}', honest, hash)).rejects.toThrow(
+      /rule_json is not the document in canonical/,
+    );
+  });
+
+  it("accepts rule_json written with different whitespace and key order", async () => {
+    // jsonb compares as a document, not as text. Requiring the two columns to
+    // match byte-for-byte would refuse every honest league: jsonb re-renders
+    // with a space after each colon and sorts keys by length, while the
+    // canonical encoder emits no whitespace and sorts by code unit.
+    const { client, commissionerId } = await setup();
+    const canonical = '{"a":1,"bbb":2}';
+    const hash = sha256Hex(canonical);
+    const leagueId = await leagueDeclaring(client, commissionerId, hash);
+
+    await expect(
+      insertRules(client, leagueId, '{ "bbb" : 2, "a" : 1 }', canonical, hash),
+    ).resolves.toBeDefined();
+  });
+
+  it("lets 0004 answer first when the league's own hash is wrong", async () => {
+    /*
+      Same-event triggers fire in **name** order, and
+      `league_rules_stored_bytes_match_hash` is named to sort after
+      `league_rules_hash_matches` so the coarser question is answered first.
+      Renaming either silently changes which error a caller sees; this is what
+      makes that dependency visible.
+    */
+    const { client, commissionerId } = await setup();
+    const leagueId = await leagueDeclaring(client, commissionerId, "0".repeat(64));
+
+    // These bytes hash correctly for themselves, but not to what the league declares.
+    const canonical = '{"a":1}';
+    await expect(
+      insertRules(client, leagueId, canonical, canonical, sha256Hex(canonical)),
+    ).rejects.toThrow(/rules hash mismatch/);
   });
 });

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -225,7 +225,16 @@ describe("league_rules immutability", () => {
     return league!.id;
   }
 
-  const HASH = "5afc934db3b3e1b1f5ec7a9e503f61e531aa925a6f966c41ec227118201da36a";
+  /**
+   * `sha256('{"a":1}')`, which is what every insert below stores as `canonical`.
+   *
+   * It used to be an unrelated 64-hex string. Nothing checked, so nothing
+   * noticed — which is issue #294 in miniature: the hash and the bytes it is
+   * supposedly a hash of were free to be anything, and this file's own fixture
+   * had drifted apart without a single test going red. `0045` checks it now, so
+   * the wrong constant fails four tests here.
+   */
+  const HASH = "015abd7f5cc57a2dd94b7590f04ad8084273905ee33ec5cebeae62276a97f862";
 
   it("accepts the initial insert", async () => {
     const client = await fresh();


### PR DESCRIPTION
## The hole

`0004`'s `check_rules_hash_matches` is the only guard on a `league_rules` INSERT, and it reads `NEW.hash` and nothing else:

```sql
SELECT rules_hash INTO league_hash FROM leagues WHERE id = NEW.league_id;
IF league_hash IS DISTINCT FROM NEW.hash THEN
```

`NEW.canonical` and `NEW.rule_json` are never referenced. So a plain INSERT at ordinary application privilege stores **any bytes at all** under a correct hash, and both that trigger and the on-chain anchor accept it.

`0019` closed the sibling hole, where `leagues.rules_hash` could be rewritten after the fact. This is the half it left open: the hash made immutable without anything tying it to the document it hashes.

Reproduced on `0001–0044` before writing anything:

- a row whose byte columns hold a **different rule set entirely** — accepted;
- a row whose two byte columns **disagree with each other** — accepted, passes `verifyStoredRules`, matches the chain, and still serves the wrong number to the lobby.

## Why fix it when there is no live exploit

`createLeague` is the only production writer and binds one string to both columns, one line apart, from one encoder. Nothing today can produce a divergent row.

| | |
|---|---|
| **Two consumers already document the guarantee as though it held** | The lobby reads `rule_json` for seat count, draft time and buy-in under *"come from the frozen rule document rather than from a column, because that document is what a member signs"* — and `rule_json` **is** a column, and not the hashed one. `0028` anchors `drafts.scheduled_at` to it under a comment calling the document *"checkable by a stranger"*; a stranger holds the **pinned** bytes, which are `canonical`. Comments like those are how a second writer gets written. |
| **`0004` names the wrong column authoritative and cannot be corrected** | *"`league_rules.rule_json` remains authoritative"* was true when written and is now false — `getLeagueRules` does not even SELECT it. An applied migration may never be edited, so that sentence stands forever; `0045`'s header is the correction. |
| **The window closes** | `league_rules` refuses UPDATE and DELETE, so a row written before the trigger exists can never be repaired or removed. The table is effectively empty today. |

## Shape, and why not the obvious one

- **A second trigger, not `CREATE OR REPLACE` on `0004`'s.** Replacing it would leave `0004` describing a function body that no longer runs.
- **Two sequential `IF`s, not one `OR`.** PostgreSQL does not guarantee `OR` evaluation order; with the operands reversed a non-JSON `canonical` surfaces as `22P02` from the cast instead of the byte check's own message.
- **The name is load-bearing.** Same-event triggers fire in *name* order, so `league_rules_stored_bytes_match_hash` sorts after `league_rules_hash_matches` and the coarser question is still answered first. A test pins that.
- **`sha256(bytea)`, not `pgcrypto`** — the latter is unavailable in PGlite. Verified byte-identical to `sha256Hex` for emoji, CJK, NFC/NFD accents, astral planes, a ZWJ sequence, and an emoji used as an object key. **That set is the point:** a false refusal would not corrupt anything, it would make league creation fail outright for a legitimate rule set.

## A landmine found on the way

`migrate.test.ts`'s `HASH` constant was **not the digest of its own fixture** — `5afc934d…` against `'{"a":1}'`, which hashes to `015abd7f…`. Nothing checked, so nothing noticed. That is this issue in miniature, in the test file for the very trigger that should have caught it.

## What breaks, and why that is honest

The nine `#69 §1` tests now disable this trigger around their deliberately corrupt inserts. Not a dodge: `0019` names `DISABLE TRIGGER` as the irreducible floor, so a database with the guard off is exactly the state `verifyStoredRules` exists to answer in — and it is the only check a *reader* can run. Only the byte trigger is disabled, never `session_replication_role`, which would take `league_rules_immutable` down with it and let a test silently UPDATE a frozen row.

## The limit, stated rather than left to be found

This closes **divergence, not substitution.** `0019` freezes `leagues.rules_hash` only once a `league_rules` row exists, so a writer controlling both rows can still write a self-consistent league holding rules nobody agreed to. That is in the migration header.

## Verification

Removing the migration fails both hole-closing tests. The 14 acceptance cases pass either way, correctly — they exist to catch a *false refusal*, which is a property of the new code not breaking the old path. `pnpm typecheck` clean, **980 passing** in `packages/db`, web project exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)